### PR TITLE
Issue #41 - Update PRODUTIL paths for WCOSS in viewer

### DIFF
--- a/ush/rocoto/rocoto_viewer.py
+++ b/ush/rocoto/rocoto_viewer.py
@@ -194,9 +194,10 @@ def load_produtil_pythonpath():
     PRODUTIL = collections.defaultdict(list) 
     PRODUTIL['hera'] = '/scratch1/NCEPDEV/global/glopara/svn/nceplibs/produtil/trunk/ush'
     PRODUTIL['luna']  = '/gpfs/hps3/emc/global/noscrub/emc.glopara/svn/nceplibs/produtil/trunk/ush'
-    PRODUTIL['tide']  = '/gpfs/td1/emc/global/save/emc.glopara/svn/nceplibs/produtil/trunk/ush'
-    PRODUTIL['gyre']  = '/gpfs/gd1/emc/global/save/emc.glopara/svn/nceplibs/produtil/trunk/ush'
-    try_clusters = ('hera','luna','tide','gyre')
+    PRODUTIL['surge']  = '/gpfs/hps3/emc/global/noscrub/emc.glopara/svn/nceplibs/produtil/trunk/ush'
+    PRODUTIL['mars']  = '/gpfs/dell2/emc/modeling/noscrub/emc.glopara/svn/nceplibs/produtil/trunk/ush'
+    PRODUTIL['venus']  = '/gpfs/dell2/emc/modeling/noscrub/emc.glopara/svn/nceplibs/produtil/trunk/ush'
+    try_clusters = ('hera','luna','surge','mars','venus')
 
     for cluster in try_clusters:
         sys.path.append(PRODUTIL[cluster])


### PR DESCRIPTION
Issue with viewer appeared when Surge was unmounted on WCOSS. Paths to PRODUTIL in viewer needs updating to retire Gyre/Tide and add paths for Mars/Venus (resolve issue with inability to reach Surge copy).

Branch: hotfix/viewer
Issue: #41

Changes:

```
[Kate.Friedman@v72a3 hotfix-viewer]$ git diff ush/rocoto/rocoto_viewer.py
diff --git a/ush/rocoto/rocoto_viewer.py b/ush/rocoto/rocoto_viewer.py
index 1a8e62ad..8dfad728 100755
--- a/ush/rocoto/rocoto_viewer.py
+++ b/ush/rocoto/rocoto_viewer.py
@@ -194,9 +194,10 @@ def load_produtil_pythonpath():
     PRODUTIL = collections.defaultdict(list)
     PRODUTIL['hera'] = '/scratch1/NCEPDEV/global/glopara/svn/nceplibs/produtil/trunk/ush'
     PRODUTIL['luna']  = '/gpfs/hps3/emc/global/noscrub/emc.glopara/svn/nceplibs/produtil/trunk/ush'
-    PRODUTIL['tide']  = '/gpfs/td1/emc/global/save/emc.glopara/svn/nceplibs/produtil/trunk/ush'
-    PRODUTIL['gyre']  = '/gpfs/gd1/emc/global/save/emc.glopara/svn/nceplibs/produtil/trunk/ush'
-    try_clusters = ('hera','luna','tide','gyre')
+    PRODUTIL['surge']  = '/gpfs/hps3/emc/global/noscrub/emc.glopara/svn/nceplibs/produtil/trunk/ush'
+    PRODUTIL['mars']  = '/gpfs/dell2/emc/modeling/noscrub/emc.glopara/svn/nceplibs/produtil/trunk/ush'
+    PRODUTIL['venus']  = '/gpfs/dell2/emc/modeling/noscrub/emc.glopara/svn/nceplibs/produtil/trunk/ush'
+    try_clusters = ('hera','luna','surge','mars','venus')

     for cluster in try_clusters:
         sys.path.append(PRODUTIL[cluster])
```