### PR TITLE
Issue #52 - GFSv15.2.10 updates for develop from RFC 6652

### DIFF
--- a/gempak/fix/nagrib.tbl
+++ b/gempak/fix/nagrib.tbl
@@ -1,0 +1,122 @@
+########################################################################
+#
+#  Filename: nagrib.tbl
+#
+#  Used by: NA_format
+#
+#  Description:  This table is used by the NA_format script to get
+#                parameters for the different models that are to be
+#                GEMPAK grid formatted.  The parameters are used as
+#                model specific settings to the NAWIPS nagrib program.
+#
+########################################################################
+#
+#  The format of the table entries is as follows:
+#
+#  MODEL|CPYFIL|GAREA|GBTBLS|MAXGRD|KXKY|GRDAREA|PROJ|OUTPUT
+#
+#  NOTES: 1. Lines with a pound (#) sign in the first column
+#            are treated as comments.  
+#         2. Valid entries cannot have leading whitespace.
+#         3. Valid entries are pipe (|) delimited.
+#         4. Blank lines are ignored.
+#
+########################################################################
+#
+#MODEL     |CPYFIL|GAREA|GBTBLS      |MAXGRD|KXKY  |GRDAREA       |PROJ     |OUTPUT
+#----------|------|-----|------------|------|------|--------------|---------|------
+gfs        |gds   |dset |            |4999  |      |              |         |T
+gfshd      |gds   |dset |            |4999  |      |              |         |T
+gfs_asbkup |gds   |dset |            |4999  |      |              |         |T
+gfs_special|gds   |dset |            |4999  |      |              |         |T
+nam        |#104  |dset |            |4999  |      |              |         |T
+nam20      |gds   |dset |            |4999  |      |              |         |T
+nam44      |gds   |dset |            |4999  |      |              |         |T
+nam40      |gds   |dset |            |4999  |      |              |         |T
+dgex       |gds   |dset |            |4999  |      |              |         |T
+threats    |gds   |dset |            |4999  |      |              |         |T
+hiresw     |gds   |dset |            |4999  |      |              |         |T
+fw         |gds   |dset |            |4999  |      |              |         |T
+fwfull     |gds   |dset |            |4999  |      |              |         |T
+gdas       |gds   |dset |            |4999  |      |              |         |T
+ice        |gds   |40;130;75;10 |wmogrib2.tbl|10    |      |40;130;75;10  |         |T
+ecmwf_glob |      |dset |            |4999  |144;73|-90;0;90;-2.5 |ced/0;0;0|T
+ecmwf_trop |      |dset |            |4999  |144;29|-35;0;35;357.5|ced/0;0;0|T
+ecmwf_hr   |gds   |dset |            |4999  |      |              |         |T
+ecmwf_wave |gds   |dset |ecmwf_wave_grib.tbl|4999  |      |              |         |T
+ghm        |gds   |dset |            |4999  |      |              |         |T
+ghmc       |gds   |dset |            |4999  |      |              |         |T
+fog        |gds   |dset |            |4999  |      |              |         |T
+sice       |gds   |dset |            |4999  |      |              |         |T
+mrf        |gds   |dset |            |4999  |      |              |         |T
+mrfx       |gds   |dset |            |4999  |      |              |         |T
+ngm        |#104  |dset |            |4999  |      |              |         |T
+ofs        |gds   |dset | wmogrib2.tbl;ncepgrib2.tbl;vcrdgrib1.tbl |10  |      | dset           |         |T
+nww3       |gds   |dset |            |4999  |      |              |         |T
+mww3       |gds   |dset |            |4999  |      |              |         |T
+akw        |gds   |dset |            |4999  |      |              |         |T
+wna        |gds   |dset |            |4999  |      |              |         |T
+nah        |gds   |dset |            |4999  |      |              |         |T
+nph        |gds   |dset |            |4999  |      |              |         |T
+enp        |gds   |dset |            |4999  |      |              |         |T
+rucs       |#87   |dset |            |20    |      |              |         |T
+ruc2       |gds   |dset |            |4999  |      |              |         |T
+ruc20      |gds   |dset |            |4999  |      |              |         |T
+ukmet      |gds   |dset |            |200   |      |              |         |T
+ukmet2     |gds   |dset |            |200   |      |              |         |T
+vaftad     |gds   |dset |            |500   |      |              |         |T
+hysplit    |gds   |dset |            |500   |      |              |         |T
+#
+ensgfs     |gds   |dset |            |3500  |      |              |         |T
+enscnt     |gds   |dset |            |3500  |      |              |         |T
+ensmrf     |gds   |dset |            |3500  |      |              |         |T
+ensn1      |gds   |dset |            |3500  |      |              |         |T
+ensn2      |gds   |dset |            |3500  |      |              |         |T
+ensn3      |gds   |dset |            |3500  |      |              |         |T
+ensn4      |gds   |dset |            |3500  |      |              |         |T
+ensn5      |gds   |dset |            |3500  |      |              |         |T
+ensp1      |gds   |dset |            |3500  |      |              |         |T
+ensp2      |gds   |dset |            |3500  |      |              |         |T
+ensp3      |gds   |dset |            |3500  |      |              |         |T
+ensp4      |gds   |dset |            |3500  |      |              |         |T
+ensp5      |gds   |dset |            |3500  |      |              |         |T
+#
+gep01      |gds   |dset |            |3500  |      |              |         |T
+gep02      |gds   |dset |            |3500  |      |              |         |T
+gep03      |gds   |dset |            |3500  |      |              |         |T
+gep04      |gds   |dset |            |3500  |      |              |         |T
+gep05      |gds   |dset |            |3500  |      |              |         |T
+gep06      |gds   |dset |            |3500  |      |              |         |T
+gep07      |gds   |dset |            |3500  |      |              |         |T
+gep08      |gds   |dset |            |3500  |      |              |         |T
+gep09      |gds   |dset |            |3500  |      |              |         |T
+gep10      |gds   |dset |            |3500  |      |              |         |T
+gep11      |gds   |dset |            |3500  |      |              |         |T
+gep12      |gds   |dset |            |3500  |      |              |         |T
+gep13      |gds   |dset |            |3500  |      |              |         |T
+gep14      |gds   |dset |            |3500  |      |              |         |T
+gep15      |gds   |dset |            |3500  |      |              |         |T
+gep16      |gds   |dset |            |3500  |      |              |         |T
+gep17      |gds   |dset |            |3500  |      |              |         |T
+gep18      |gds   |dset |            |3500  |      |              |         |T
+gep19      |gds   |dset |            |3500  |      |              |         |T
+gep20      |gds   |dset |            |3500  |      |              |         |T
+geavg      |gds   |dset |            |3500  |      |              |         |T
+gespr      |gds   |dset |            |3500  |      |              |         |T
+#
+sref       |gds   |dset |            |6000  |      |              |         |T
+spcsref    |gds   |dset |            |6000  |      |              |         |T
+#
+mdlgfs     |gds   |dset |            |3500  |      |              |         |T
+mdlmrf     |gds   |dset |            |3500  |      |              |         |T
+mdlngm     |gds   |dset |            |3500  |      |              |         |T
+mdlngmsvr  |#212  |dset |            |3500  |      |              |         |T
+mdlngmfltwx|gds   |dset |            |3500  |      |              |         |T
+mdlmrfplt  |gds   |dset |            |3500  |      |              |         |T
+mdlens     |gds   |dset |            |3500  |      |              |         |T
+mdlgfssvr  |gds   |dset |            |3500  |      |              |         |T
+mdlnamsvr  |gds   |dset |            |3500  |      |              |         |T
+mdlnamcns  |gds   |dset |            |3500  |      |              |         |T
+mdlmrfsvr  |gds   |dset |            |3500  |      |              |         |T
+#
+rtma       |gds   |dset |            |3500  |      |              |         |T

--- a/parm/transfer_gdas_misc.list
+++ b/parm/transfer_gdas_misc.list
@@ -22,13 +22,16 @@
 # Rules higher in the list take precedence over lower ones.  By default, all files in a
 # directory are included, so if no exclude patterns match that file, it will be
 # transferred.
+#com/arch/_ENVIR_/VOS/
+#+ ship_names
+#+ activeShiprev
+#- *
+#B 4500000
+
 
 com/gfs/_ENVIR_/syndat/
 B 180
  
-com/realtime/_ENVIR_/gds._PDY_/
-B 11000000
-
 com/gfs/_ENVIR_/gdascounts/
 + /data_counts._MONPREV_/***
 - *
@@ -70,12 +73,3 @@ com/gfs/_ENVIR_/gdascounts/
 - *
 B 6
 
-com/arch/_ENVIR_/VOS/
-+ ship_names
-+ activeShiprev
-- *
-B 4500000
-
-com/realtime/_ENVIR_/gds._PDYm1_/
-B 11000000
- 

--- a/parm/transfer_gfs_misc.list
+++ b/parm/transfer_gfs_misc.list
@@ -40,11 +40,3 @@ com/gfs/_ENVIR_/sdm_rtdm/
 B 2000000
  
 
-com/realtime/_ENVIR_/gfs._PDY_/
-B 10000000
- 
-
-com/realtime/_ENVIR_/gfs._PDYm1_/
-B 10000000
- 
-

--- a/scripts/exgoes_nawips.sh.ecf
+++ b/scripts/exgoes_nawips.sh.ecf
@@ -23,7 +23,7 @@ msg="Begin job for $job"
 postmsg "$jlogfile" "$msg"
 
 #
-NAGRIB_TABLE=${NAGRIB_TABLE:-$NWROOTp1/gempak/fix/nagrib.tbl}
+NAGRIB_TABLE=${NAGRIB_TABLE:-${FIXgempak}/nagrib.tbl}
 NAGRIB=$GEMEXE/nagrib2
 #
 

--- a/scripts/exnawips.sh.ecf
+++ b/scripts/exnawips.sh.ecf
@@ -30,7 +30,7 @@ msg="Begin job for $job"
 postmsg "$jlogfile" "$msg"
 
 #
-NAGRIB_TABLE=${NWROOTp1}/gempak/fix/nagrib.tbl
+NAGRIB_TABLE=${FIXgempak}/nagrib.tbl
 utilfix_nam=$FIXshared
 NAGRIB=$GEMEXE/nagrib_nc
 #


### PR DESCRIPTION
Incoming changes for v15.2.10 into develop branch from RFC 6652. SVN log below.

SVN Log:
r113 | simon.hsiao@noaa.gov | 2020-04-07 12:52:04 +0000 (Tue, 07 Apr 2020) | 1 line
Changed paths:
A /trunk/gempak/fix/nagrib.tbl
M /trunk/parm/transfer_gdas_misc.list
M /trunk/parm/transfer_gfs_misc.list
M /trunk/scripts/exgoes_nawips.sh.ecf
M /trunk/scripts/exnawips.sh.ecf

RFC 6652 - WCOSS Ecflow Upgrade to v4.17.0 and end transition off tide/gyre