### PR TITLE
Issue #52 - updates for GFSv15.2.11 from RFC 6745

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -21,7 +21,7 @@ if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
     git clone --recursive gerrit:ProdGSI gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
-    git checkout fv3da_gfsv15.2.9
+    git checkout fv3da_gfsv15.2.11
     git submodule update
     cd ${topdir}
 else


### PR DESCRIPTION
RFC 6745 – GFS v15.2.11 – On WCOSS, updated two fix files to assimilate more aircraft data. The GFS and GDAS have seen a significant decrease in aircraft data due to fewer commercial flights during the Coronavirus outbreak. This change allows for assimilation of aircraft data from other sources. Implemented on April 7 at 1930Z.

This PR submits single change to ProdGSI tag for v15.2.11 in ops.

From NCO SVN trunk update email:

> SVN Log:
> r115 | diane.stokes@noaa.gov | 2020-04-13 18:59:43 +0000 (Mon, 13 Apr 2020) | 1 line
> Changed paths:
> M /trunk/fix/fix_gsi/global_convinfo.txt
> M /trunk/fix/fix_gsi/prepobs_errtable.global
> 
> GFS/GDAS emergency fix to assimilate additional aircraft data (ARFC 07Apr2020)