### PR TITLE
Issue #52 - updates for GFSv15.2.12 from RFC 6789

### DIFF
--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -150,7 +150,7 @@ export FIXgsi="$HOMEgfs/fix/fix_gsi"
 export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
 export HOMEpost="$HOMEgfs"
 export HOMEobsproc_prep="$BASE_GIT/obsproc/obsproc_prep_RB-5.2.0"
-export HOMEobsproc_network="$BASE_GIT/obsproc/obsproc_global.v3.2.5"
+export HOMEobsproc_network="$BASE_GIT/obsproc/obsproc_global.v3.2.6"
 export HOMEobsproc_global=$HOMEobsproc_network
 export BASE_VERIF="$BASE_SVN/verif/global/tags/vsdb"
 

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -21,7 +21,7 @@ if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
     git clone --recursive gerrit:ProdGSI gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
-    git checkout fv3da_gfsv15.2.11
+    git checkout fv3da_gfs.v15.2.12
     git submodule update
     cd ${topdir}
 else


### PR DESCRIPTION
From April 17th RFC memo:

> RFC 6789 – GFS v15.2.12, obsproc_globalv3.2.6, obsproc_shared/bufr_dumplist/2.2.0 - Implement name changes for the WCOSS NPP CrIS FSR (Full Spectral Resolution) bufr dumps. The NPP CrIS FSR bufr dump "escris" will be renamed as "escrsf" and "crisdb" will be renamed as "crsfdb". To be implemented on April 22 at 1130Z.

Email with Russ April 13th:

> Next week NCO implements GFS v15.2.12. This version updates exglobal_analysis_fv3gfs.sh.ecf and read_cris.f90. There are now fix file changes in GFS v15.2.12. Tag fv3da_gfs.v15.2.12 was passed to NCO for this implementation.

The v15.2.12 changes:

* updates in GDA (done)
* new ProdGSI tag in checkout.sh: fv3da_gfs.v15.2.12
* change obsproc_global version to 3.2.6 in config.base.emc.dyn