### PR TITLE
Issue #52 - GFSv15.2.12 update to obsproc_global version in develop from RFC 6789

### DIFF
--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -67,7 +67,7 @@ export FIXgsi="$HOMEgfs/fix/fix_gsi"
 export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
 export HOMEpost="$HOMEgfs"
 export HOMEobsproc_prep="$BASE_GIT/obsproc/obsproc_prep_RB-5.2.0"
-export HOMEobsproc_network="$BASE_GIT/obsproc/obsproc_global.v3.2.3"
+export HOMEobsproc_network="$BASE_GIT/obsproc/obsproc_global.v3.2.6"
 export HOMEobsproc_global=$HOMEobsproc_network
 export BASE_VERIF="$BASE_SVN/verif/global/tags/vsdb"
 


### PR DESCRIPTION
Update to obsproc_global version from production update from RFC 6789.

New version: obsproc_global.v3.2.6

Installed on supported platforms.