### PR TITLE
Copy stochastic pattern state on restart

### DIFF
--- a/scripts/exglobal_fcst_nemsfv3gfs.sh
+++ b/scripts/exglobal_fcst_nemsfv3gfs.sh
@@ -288,6 +288,14 @@ if [ $warm_start = ".true." -o $RERUN = "YES" ]; then
           $NLN $file $DATA/INPUT/$file2
       fi
     done
+
+    # Copy stochastic pattern state if it exists
+    if [[ $DO_SPPT = "YES" || $DO_SHUM = "YES" || $DO_SKEB = "YES" ]]; then
+      FH3=$(printf "%03.0f" $( $NHOUR $CDATE_RST $CDATE ) )
+      stoch_in=$RSTDIR_TMP/stoch_out.F000${FH3}
+      if [[ -s $stoch_in ]]; then $NCP $stoch_in $DATA/stoch_ini; fi
+    fi
+
     FHROT=`$NHOUR $CDATE_RST $CDATE`
 
   fi


### PR DESCRIPTION
To maintain consistency, the stochastic pattern must be preserved
when restarting. Now the stochastic pattern saved at restart times
will be copied for use in the restart.