### PR TITLE
Fix error message in wave gempak script

### DIFF
--- a/scripts/exglobal_fcst_nemsfv3gfs.sh
+++ b/scripts/exglobal_fcst_nemsfv3gfs.sh
@@ -1121,7 +1121,11 @@ EOF
 if [ $cplchm = ".true." ]; then
   if [ $imp_physics -eq 99 ]; then NTRACER=0; fi
   if [ $imp_physics -eq 11 ]; then NTRACER=1; fi
-  chem_in_opt=1
+  if [[ warm_start = ".true." ]];
+    chem_in_opt=1
+  else 
+    chem_in_opt=0
+  fi
   cat >> input.nml << EOF
 &chem_nml
   aer_bc_opt=1

--- a/scripts/exwave_nawips.sh
+++ b/scripts/exwave_nawips.sh
@@ -102,8 +102,10 @@ while [ $fhcnt -le $FHMAX_WAV ]; do
       fi
       if [ $icnt -ge $maxtries ]
       then
-        msg="ABORTING after 1 hour of waiting for F$fhr to end."
-        err_exit $msg
+        msg="FATAL ERROR: aborting after waiting 1 hour for F$fhr to end."
+        echo "$msg"
+        export err=1; $err_chk
+        exit $err
       fi
     done
 


### PR DESCRIPTION
One of the error messages in the wave gempak script was not
printed to STDOUT and did not indicate it was a fatal error.