### PR TITLE
Fix syntax error when checking warm start

### DIFF
--- a/scripts/exglobal_fcst_nemsfv3gfs.sh
+++ b/scripts/exglobal_fcst_nemsfv3gfs.sh
@@ -1121,7 +1121,7 @@ EOF
 if [ $cplchm = ".true." ]; then
   if [ $imp_physics -eq 99 ]; then NTRACER=0; fi
   if [ $imp_physics -eq 11 ]; then NTRACER=1; fi
-  if [[ warm_start = ".true." ]]; then
+  if [[ $warm_start = ".true." ]]; then
     chem_in_opt=1
   else 
     chem_in_opt=0


### PR DESCRIPTION
Prior commit had a syntax error when checking warm start to
determine the seting of chem_in_opt when using chemistry.