### PR TITLE
revive GFS forecast break-point restart capability with IAU turned on

### DIFF
--- a/parm/config/config.fcst
+++ b/parm/config/config.fcst
@@ -214,8 +214,22 @@ elif [[ "$CDUMP" == "gfs" ]] ; then # GFS cycle specific parameters
     fi
 
     # Write gfs restart files to rerun fcst from any break point         
-     export restart_interval=${restart_interval_gfs:-0}
+    export restart_interval_gfs=${restart_interval_gfs:-0}
+    if [ $restart_interval_gfs -le 0 ]; then
+        export restart_interval=0
+    else
+        rst_list=""
+        IAU_OFFSET=${IAU_OFFSET:-0}
+        [[ $DOIAU = "NO" ]] && export IAU_OFFSET=0
+        xfh=$((restart_interval_gfs+(IAU_OFFSET/2)))
+        while [ $xfh -le $FHMAX_GFS ]; do
+          rst_list="$rst_list $xfh"
+          xfh=$((xfh+restart_interval_gfs))
+        done
+        export restart_interval="$rst_list"
+    fi
 
+    
     # Choose coupling with wave
     if [ $DO_WAVE = "YES" -a "$WAVE_CDUMP" != "gdas" ]; then 
         export cplwav=".true."


### PR DESCRIPTION
modified:   scripts/exglobal_fcst_nemsfv3gfs.sh and  parm/config/config.fcst

GFS forecast restrat capability from a breakpoint is no longer working
with IAU turned on.  This function has been overhauled to make it more
general and works for cases with and without IAU

So far both atmf and sfcf data reproduced after restart, but netCDF file headers seems to differ. Now running another test with UPP turned on.  May need to run more tests with vrfy turned on as well.