### PR TITLE
fix for exiting properly with error for wave prep/init scripts

### DIFF
--- a/scripts/exwave_init.sh
+++ b/scripts/exwave_init.sh
@@ -231,7 +231,6 @@
   echo ' '
   [[ "$LOUD" = YES ]] && set -x
 
-  msg="$job completed normally"
-  postmsg "$jlogfile" "$msg"
+  exit $err
 
 # End of MWW3 init config script ------------------------------------------- #

--- a/scripts/exwave_prep.sh
+++ b/scripts/exwave_prep.sh
@@ -1020,7 +1020,6 @@
   echo ' '
   [[ "$LOUD" = YES ]] && set -x
 
-  msg="$job completed normally"
-  postmsg "$jlogfile" "$msg"
+  exit $err
 
 # End of MWW3 preprocessor script ------------------------------------------- #


### PR DESCRIPTION
The postmsg was deleted because it seems odd to exit with error and have a message "completed normally".  It's my understanding that this is no longer a EE2 requirement. 