### PR TITLE
Update miscellaneous pieces for GEFS v12 NCO parallel

### DIFF
--- a/modulefiles/module_base.hera
+++ b/modulefiles/module_base.hera
@@ -22,4 +22,4 @@ module load prod_util/1.1.0
 
 #Load from emc.nemspara
 module use -a /scratch1/NCEPDEV/nems/emc.nemspara/soft/modulefiles
-module load esmf/8.0.0bs48
+module load esmf/8.0.0

--- a/modulefiles/module_base.wcoss_c
+++ b/modulefiles/module_base.wcoss_c
@@ -57,4 +57,4 @@ module use -a /gpfs/hps3/emc/nems/noscrub/emc.nemspara/soft/modulefiles
 module unload intel
 module load intel/16.3.210
 module load cray-netcdf
-module load esmf/8.0.0bs48
+module load ESMF/8.0.1

--- a/modulefiles/module_base.wcoss_dell_p3
+++ b/modulefiles/module_base.wcoss_dell_p3
@@ -30,6 +30,5 @@ module load pm5
 module use -a /gpfs/dell1/nco/ops/nwprod/modulefiles/
 module load gempak/7.3.1
 
-module use /gpfs/dell2/emc/modeling/noscrub/emc.nemspara/soft/modulefiles
-module load esmf/8.0.0bs48
+module load ESMF/8.0.0
 

--- a/scripts/exwave_stat.sh
+++ b/scripts/exwave_stat.sh
@@ -678,7 +678,7 @@
   if [ "$SENDDBN" = 'YES' ]
   then
        MODCOM=$(echo ${NET}_${COMPONENT} | tr '[a-z]' '[A-Z]')
-       $DBNROOT/bin/dbn_alert MODEL ${MODCOM}_GB2 $job $COMOUT/gridded/${WAV_MOD_TAG}.t${cyc}z.bull_tar
+       $DBNROOT/bin/dbn_alert MODEL ${MODCOM}_GB2 $job $COMOUT/station/${WAV_MOD_TAG}.t${cyc}z.bull_tar
        $DBNROOT/bin/dbn_alert MODEL ${MODCOM}_GB2 $job $COMOUT/station/${WAV_MOD_TAG}.t${cyc}z.station_tar
   fi
 #

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -7,8 +7,6 @@ set -eu
 #                   Anything other than "true"  will use libraries locally.
 #------------------------------------
 
-export USE_PREINST_LIBS="true"
-
 #------------------------------------
 # END USER DEFINED STUFF
 #------------------------------------

--- a/sorc/build_enkf_chgres_recenter.sh
+++ b/sorc/build_enkf_chgres_recenter.sh
@@ -4,18 +4,7 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-  source ../modulefiles/fv3gfs/enkf_chgres_recenter.$target             > /dev/null 2>&1
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-  if [ $target = wcoss_cray ]; then
-    source ../modulefiles/fv3gfs/enkf_chgres_recenter.${target}_userlib > /dev/null 2>&1
-  else
-    source ../modulefiles/fv3gfs/enkf_chgres_recenter.$target           > /dev/null 2>&1
-  fi
-fi
+source ../modulefiles/fv3gfs/enkf_chgres_recenter.$target             > /dev/null 2>&1
 module list
 
 # Check final exec folder exists

--- a/sorc/build_fv3.sh
+++ b/sorc/build_fv3.sh
@@ -4,13 +4,6 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-fi
-
 # Check final exec folder exists
 if [ ! -d "../exec" ]; then
   mkdir ../exec

--- a/sorc/build_fv3nc2nemsio.sh
+++ b/sorc/build_fv3nc2nemsio.sh
@@ -4,18 +4,7 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-  source ../modulefiles/modulefile.fv3nc2nemsio.$target             > /dev/null 2>&1
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-  if [ $target = wcoss_cray ]; then
-    source ../modulefiles/modulefile.fv3nc2nemsio.${target}_userlib > /dev/null 2>&1
-  else
-    source ../modulefiles/modulefile.fv3nc2nemsio.$target           > /dev/null 2>&1
-  fi
-fi
+source ../modulefiles/modulefile.fv3nc2nemsio.$target             > /dev/null 2>&1
 
 # Check final exec folder exists
 if [ ! -d "../exec" ]; then

--- a/sorc/build_gdas.sh
+++ b/sorc/build_gdas.sh
@@ -20,16 +20,11 @@ source ../modulefiles/gdas_gridbull.$target             > /dev/null 2>&1
 ### navybull
  cd $cwd
  source ./machine-setup.sh > /dev/null 2>&1
- if [ $USE_PREINST_LIBS = true ]; then
-   export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-   source ../modulefiles/gdas_navybull.$target             > /dev/null 2>&1
+ export MOD_PATH=${cwd}/lib/modulefiles
+ if [ $target = wcoss_cray ]; then
+   source ../modulefiles/gdas_navybull.${target}_userlib > /dev/null 2>&1
  else
-   export MOD_PATH=${cwd}/lib/modulefiles
-   if [ $target = wcoss_cray ]; then
-     source ../modulefiles/gdas_navybull.${target}_userlib > /dev/null 2>&1
-   else
-     source ../modulefiles/gdas_navybull.$target           > /dev/null 2>&1
-   fi
+   source ../modulefiles/gdas_navybull.$target           > /dev/null 2>&1
  fi
  cd $cwd/navybull.fd
  make -f makefile.$target
@@ -41,16 +36,11 @@ source ../modulefiles/gdas_gridbull.$target             > /dev/null 2>&1
  source $cwd/ncl.setup                   > /dev/null 2>&1
  export NCARG_LIB=$NCARG_ROOT/lib        > /dev/null 2>&1
 
- if [ $USE_PREINST_LIBS = true ]; then
-   export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-   source ../modulefiles/gdas_trpsfcmv.$target             > /dev/null 2>&1
+ export MOD_PATH=${cwd}/lib/modulefiles
+ if [ $target = wcoss_cray ]; then
+   source ../modulefiles/gdas_trpsfcmv.${target}_userlib > /dev/null 2>&1
  else
-   export MOD_PATH=${cwd}/lib/modulefiles
-   if [ $target = wcoss_cray ]; then
-     source ../modulefiles/gdas_trpsfcmv.${target}_userlib > /dev/null 2>&1
-   else
-     source ../modulefiles/gdas_trpsfcmv.$target           > /dev/null 2>&1
-   fi
+   source ../modulefiles/gdas_trpsfcmv.$target           > /dev/null 2>&1
  fi
  cd $cwd/gdas_trpsfcmv.fd
  make -f makefile.$target

--- a/sorc/build_gdas.sh
+++ b/sorc/build_gdas.sh
@@ -9,18 +9,7 @@ if [ ! -d "../exec" ]; then
   mkdir ../exec
 fi
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-  source ../modulefiles/gdas_gridbull.$target             > /dev/null 2>&1
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-  if [ $target = wcoss_cray ]; then
-    source ../modulefiles/gdas_gridbull.${target}_userlib > /dev/null 2>&1
-  else
-    source ../modulefiles/gdas_gridbull.$target           > /dev/null 2>&1
-  fi
-fi
+source ../modulefiles/gdas_gridbull.$target             > /dev/null 2>&1
 
 ### gridbull
  cd $cwd/gridbull.fd

--- a/sorc/build_gfs_bufrsnd.sh
+++ b/sorc/build_gfs_bufrsnd.sh
@@ -4,18 +4,7 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-  source ../modulefiles/gfs_bufr.$target             > /dev/null 2>&1
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-  if [ $target = wcoss_cray ]; then
-    source ../modulefiles/gfs_bufr.${target}_userlib > /dev/null 2>&1
-  else
-    source ../modulefiles/gfs_bufr.$target           > /dev/null 2>&1
-  fi
-fi
+source ../modulefiles/gfs_bufr.$target             > /dev/null 2>&1
 module list
 
 # Check final exec folder exists

--- a/sorc/build_gfs_fbwndgfs.sh
+++ b/sorc/build_gfs_fbwndgfs.sh
@@ -4,18 +4,7 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-  source ../modulefiles/gfs_fbwndgfs.$target             > /dev/null 2>&1
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-  if [ $target = wcoss_cray ]; then
-    source ../modulefiles/gfs_fbwndgfs.${target}_userlib > /dev/null 2>&1
-  else
-    source ../modulefiles/gfs_fbwndgfs.$target           > /dev/null 2>&1
-  fi
-fi
+source ../modulefiles/gfs_fbwndgfs.$target             > /dev/null 2>&1
 module list
 
 # Check final exec folder exists

--- a/sorc/build_gfs_overpdtg2.sh
+++ b/sorc/build_gfs_overpdtg2.sh
@@ -4,18 +4,7 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-  source ../modulefiles/gfs_overpdtg2.$target             > /dev/null 2>&1
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-  if [ $target = wcoss_cray ]; then
-    source ../modulefiles/gfs_overpdtg2.${target}_userlib > /dev/null 2>&1
-  else
-    source ../modulefiles/gfs_overpdtg2.$target           > /dev/null 2>&1
-  fi
-fi
+source ../modulefiles/gfs_overpdtg2.$target             > /dev/null 2>&1
 module list
 
 # Check final exec folder exists

--- a/sorc/build_gfs_wafs.sh
+++ b/sorc/build_gfs_wafs.sh
@@ -4,13 +4,6 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-fi
-
 # Check final exec folder exists
 if [ ! -d "../exec" ]; then
   mkdir ../exec

--- a/sorc/build_gfs_wintemv.sh
+++ b/sorc/build_gfs_wintemv.sh
@@ -4,18 +4,7 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-  source ../modulefiles/gfs_wintemv.$target             > /dev/null 2>&1
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-  if [ $target = wcoss_cray ]; then
-    source ../modulefiles/gfs_wintemv.${target}_userlib > /dev/null 2>&1
-  else
-    source ../modulefiles/gfs_wintemv.$target           > /dev/null 2>&1
-  fi
-fi
+source ../modulefiles/gfs_wintemv.$target             > /dev/null 2>&1
 module list
 
 # Check final exec folder exists

--- a/sorc/build_grib_util.sh
+++ b/sorc/build_grib_util.sh
@@ -4,18 +4,7 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-  source ../modulefiles/modulefile.grib_util.$target             > /dev/null 2>&1
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-  if [ $target = wcoss_cray ]; then
-    source ../modulefiles/modulefile.grib_util.${target}_userlib > /dev/null 2>&1
-  else
-    source ../modulefiles/modulefile.grib_util.$target           > /dev/null 2>&1
-  fi
-fi
+source ../modulefiles/modulefile.grib_util.$target             > /dev/null 2>&1
 
 # Move to util/sorc folder
 cd ../util/sorc

--- a/sorc/build_gsd_prep_chem.sh
+++ b/sorc/build_gsd_prep_chem.sh
@@ -4,13 +4,6 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-fi
-
 # Check final exec folder exists
 if [ ! -d "../exec" ]; then
   mkdir ../exec

--- a/sorc/build_gsi.sh
+++ b/sorc/build_gsi.sh
@@ -4,13 +4,6 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-fi
-
 gsitarget=$target
 [[ "$target" == wcoss_cray ]] && gsitarget=cray
 

--- a/sorc/build_ncep_post.sh
+++ b/sorc/build_ncep_post.sh
@@ -4,13 +4,6 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-fi
-
 # Check final exec folder exists
 if [ ! -d "../exec" ]; then
   mkdir ../exec

--- a/sorc/build_prod_util.sh
+++ b/sorc/build_prod_util.sh
@@ -4,18 +4,7 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-  source ../modulefiles/modulefile.prod_util.$target             > /dev/null 2>&1
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-  if [ $target = wcoss_cray ]; then
-    source ../modulefiles/modulefile.prod_util.${target}_userlib > /dev/null 2>&1
-  else
-    source ../modulefiles/modulefile.prod_util.$target           > /dev/null 2>&1
-  fi
-fi
+source ../modulefiles/modulefile.prod_util.$target             > /dev/null 2>&1
 
 # Move to util/sorc folder
 cd ../util/sorc

--- a/sorc/build_regrid_nemsio.sh
+++ b/sorc/build_regrid_nemsio.sh
@@ -4,18 +4,7 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-  source ../modulefiles/modulefile.regrid_nemsio.$target             > /dev/null 2>&1
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-  if [ $target = wcoss_cray ]; then
-    source ../modulefiles/modulefile.regrid_nemsio.${target}_userlib > /dev/null 2>&1
-  else
-    source ../modulefiles/modulefile.regrid_nemsio.$target           > /dev/null 2>&1
-  fi
-fi
+source ../modulefiles/modulefile.regrid_nemsio.$target             > /dev/null 2>&1
 
 # Check final exec folder exists
 if [ ! -d "../exec" ]; then

--- a/sorc/build_sfcanl_nsttfchg.sh
+++ b/sorc/build_sfcanl_nsttfchg.sh
@@ -4,18 +4,7 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-  source ../modulefiles/fv3gfs/gaussian_sfcanl.$target             > /dev/null 2>&1
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-  if [ $target = wcoss_cray ]; then
-    source ../modulefiles/fv3gfs/gaussian_sfcanl.${target}_userlib > /dev/null 2>&1
-  else
-    source ../modulefiles/fv3gfs/gaussian_sfcanl.$target           > /dev/null 2>&1
-  fi
-fi
+source ../modulefiles/fv3gfs/gaussian_sfcanl.$target             > /dev/null 2>&1
 module list
 
 cd ${cwd}/gaussian_sfcanl.fd

--- a/sorc/build_tropcy_NEMS.sh
+++ b/sorc/build_tropcy_NEMS.sh
@@ -22,13 +22,6 @@ if [ ! -d "../exec" ]; then
   mkdir ../exec
 fi
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-fi
-
 source ../modulefiles/modulefile.storm_reloc_v6.0.0.$target
 export FC=mpiifort
 

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -56,13 +56,11 @@ fi
 echo ufs_utils checkout ...
 if [[ ! -d ufs_utils.fd ]] ; then
     rm -f ${topdir}/checkout-ufs_utils.log
-    # git clone https://github.com/NOAA-EMC/UFS_UTILS.git ufs_utils.fd >> ${LOG_DIR}/checkout-ufs_utils.fd.log 2>&1
-    git clone https://github.com/WalterKolczynski-NOAA/UFS_UTILS.git ufs_utils.fd >> ${LOG_DIR}/checkout-ufs_utils.fd.log 2>&1
+    git clone https://github.com/NOAA-EMC/UFS_UTILS.git ufs_utils.fd >> ${LOG_DIR}/checkout-ufs_utils.fd.log 2>&1
     rc=$?
     ((err+=$rc))
     cd ufs_utils.fd
-    # git checkout ops-gefsv12
-    git checkout 94803c7
+    git checkout ops-gefsv12.0.1
     cd ${topdir}
 else
     echo 'Skip.  Directory ufs_utils.fd already exists.'

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -56,11 +56,13 @@ fi
 echo ufs_utils checkout ...
 if [[ ! -d ufs_utils.fd ]] ; then
     rm -f ${topdir}/checkout-ufs_utils.log
-    git clone https://github.com/NOAA-EMC/UFS_UTILS.git ufs_utils.fd >> ${LOG_DIR}/checkout-ufs_utils.fd.log 2>&1
+    # git clone https://github.com/NOAA-EMC/UFS_UTILS.git ufs_utils.fd >> ${LOG_DIR}/checkout-ufs_utils.fd.log 2>&1
+    git clone https://github.com/WalterKolczynski-NOAA/UFS_UTILS.git ufs_utils.fd >> ${LOG_DIR}/checkout-ufs_utils.fd.log 2>&1
     rc=$?
     ((err+=$rc))
     cd ufs_utils.fd
-    git checkout ops-gefsv12
+    # git checkout ops-gefsv12
+    git checkout 94803c7
     cd ${topdir}
 else
     echo 'Skip.  Directory ufs_utils.fd already exists.'

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -30,7 +30,7 @@ if [[ ! -d fv3gfs.fd ]] ; then
     rc=$?
     ((err+=$rc))
     cd fv3gfs.fd
-	git checkout gefs_v12.0.0
+	git checkout gefs_v12.0.1
 	git submodule update --init --recursive
     rc=$?
     ((err+=$rc))

--- a/ush/wave_grib2_sbs.sh
+++ b/ush/wave_grib2_sbs.sh
@@ -223,8 +223,9 @@
         echo "   Alerting GRIB file as $COMOUT/gridded/${outfile}"
         echo "   Alerting GRIB index file as $COMOUT/gridded/${outfile}.idx"
         [[ "$LOUD" = YES ]] && set -x
-        $DBNROOT/bin/dbn_alert MODEL WAVE_GRIB_GB2 $job $COMOUT/gridded/${outfile}
-        $DBNROOT/bin/dbn_alert MODEL WAVE_GRIB_GB2_WIDX $job $COMOUT/gridded/${outfile}.idx
+        MODCOM=$(echo ${NET}_${COMPONENT} | tr '[a-z]' '[A-Z]')
+        $DBNROOT/bin/dbn_alert MODEL ${MODCOM}_GB2 $job $COMOUT/gridded/${outfile}
+        $DBNROOT/bin/dbn_alert MODEL ${MODCOM}_GB2_WIDX $job $COMOUT/gridded/${outfile}.idx
       fi
   
    


### PR DESCRIPTION
A couple small changes before GEFS heads to NCO's real-time parallel:

1. Removed deprecated USE_PREINST_LIBS, which included specifying non-NCO (and non-WCOSS). NCO disliked these, even if they weren't used

2. Updated the ESMF module to an NCO-installed version for production now that it is available.