### PR TITLE
[DRAFT]switch to "stack" NCEP libraries;

### DIFF
--- a/modulefiles/module_base.orion
+++ b/modulefiles/module_base.orion
@@ -26,17 +26,16 @@ module use /apps/contrib/NCEP/libs/modulefiles/stack
 module load hpc/1.0.0
 module load hpc-intel/2018.4
 module load prod_util/develop
-#module load hpc-impi/2018.4
-module load bacio
-#module load prod_util
-module load crtm
-module load ip
-module load sp
-module load w3nco
-module load g2
-module load g2tmpl
-module load jasper
-module load png
+module load hpc-impi/2018.4
+module load bacio/2.4.0
+module load crtm/2.3.0
+module load ip/3.3.0
+module load sp/2.3.0
+module load w3nco/2.4.0
+module load g2/3.4.0
+module load g2tmpl/1.9.0
+module load jasper/2.0.15
+module load png/1.6.35
 module load netcdf_parallel/4.7.4
 module load hdf5_parallel/1.10.6
 module load wgrib/2.0.8
@@ -50,11 +49,7 @@ module use /apps/contrib/NCEPLIBS/lib/modulefiles
 module load netcdfp/4.7.4
 module load esmflocal/8.0.0.para
 module load post-intel-sandybridge/8.0.5
-#module load netcdf_parallel/4.7.4
-#module load hdf5_parallel/1.10.6
-#module load wgrib/2.0.8
 module load grib_util/1.2.0
-#module load slurm/19.05.3-2
 
 ##
 ### load cmake

--- a/modulefiles/module_base.orion
+++ b/modulefiles/module_base.orion
@@ -12,47 +12,49 @@ module load contrib noaatools
 ## load programming environment
 ## this typically includes compiler, MPI and job scheduler
 ##
+# Core modules
 module load intel/2018
 module load impi/2018
 
-#For ocean post: 
 module load ncl/6.6.2
 module load nco/4.8.1
 
-##
-## NCEP libraries (temporary version to match the CCPP requirements)
-##
-module use /apps/contrib/NCEPLIBS/orion/modulefiles
-module load bacio/2.0.3
-module load ip/3.0.2
-module load nemsio/2.2.4
-module load sp/2.0.3
-module load w3emc/2.4.0
-module load w3nco/2.0.7
-module load g2/3.1.1
-module load g2tmpl/1.6.0
-module load crtm/2.3.0
-module load jasper/1.900.2
-module load png/1.2.44
-module load z/1.2.6
+module load slurm/19.05.3-2
+# Stack modules
 
+module use /apps/contrib/NCEP/libs/modulefiles/stack
+module load hpc/1.0.0
+module load hpc-intel/2018.4
+module load prod_util/develop
+#module load hpc-impi/2018.4
+module load bacio
+#module load prod_util
+module load crtm
+module load ip
+module load sp
+module load w3nco
+module load g2
+module load g2tmpl
+module load jasper
+module load png
+module load netcdf_parallel/4.7.4
+module load hdf5_parallel/1.10.6
+module load wgrib/2.0.8
+
+module use /apps/contrib/NCEPLIBS/orion/modulefiles
+module load w3emc/2.4.0
+module load z/1.2.6
 module load prod_util/1.2.0
-##
-## load ESMF library for above compiler / MPI combination
-## use pre-compiled EMSF library for above compiler / MPI combination
-##
+
 module use /apps/contrib/NCEPLIBS/lib/modulefiles
 module load netcdfp/4.7.4
 module load esmflocal/8.0.0.para
 module load post-intel-sandybridge/8.0.5
-
-
-module load netcdf_parallel/4.7.4
-module load hdf5_parallel/1.10.6
-module load wgrib/2.0.8
+#module load netcdf_parallel/4.7.4
+#module load hdf5_parallel/1.10.6
+#module load wgrib/2.0.8
 module load grib_util/1.2.0
-
-module load slurm/19.05.3-2
+#module load slurm/19.05.3-2
 
 ##
 ### load cmake

--- a/modulefiles/module_base.orion
+++ b/modulefiles/module_base.orion
@@ -36,8 +36,8 @@ module load g2/3.4.0
 module load g2tmpl/1.9.0
 module load jasper/2.0.15
 module load png/1.6.35
-module load netcdf_parallel/4.7.4
-module load hdf5_parallel/1.10.6
+module load netcdf/4.7.4
+module load hdf5/1.10.6
 module load wgrib/2.0.8
 
 module use /apps/contrib/NCEPLIBS/orion/modulefiles

--- a/modulefiles/module_base.orion
+++ b/modulefiles/module_base.orion
@@ -13,8 +13,8 @@ module load contrib noaatools
 ## this typically includes compiler, MPI and job scheduler
 ##
 # Core modules
-module load intel/2018
-module load impi/2018
+#module load intel/2018
+#module load impi/2018
 
 module load ncl/6.6.2
 module load nco/4.8.1


### PR DESCRIPTION
This PR is designed to update modules for feature/coupled-crow to the stack build NCEP libs.

prod_util still not working, so legacy module is being called. 

Also, The following modules are not found in stack build directory:

module use /apps/contrib/NCEPLIBS/orion/modulefiles
module load w3emc/2.4.0
module load z/1.2.6

module use /apps/contrib/NCEPLIBS/lib/modulefiles
module load netcdfp/4.7.4
module load esmflocal/8.0.0.para
module load post-intel-sandybridge/8.0.5