### PR TITLE
add building of WW3 pre and prep jobs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ sh checkout.sh coupled                                    # Check out the couple
 ## Compile code used in ufs-s2s-model and EMC_post and link fixed files and executable programs:
 ```
 sh build_ncep_post.sh        #This command will build ncep_post
+sh build_ww3prepost.sh       #This command will build ww3 prep and post exes
 sh build_fv3_coupled.sh      #This command will build ufs-s2s-model
 sh build_reg2grb2.sh         #This command will build exes for ocean-ice post
 

--- a/modulefiles/module_base.orion
+++ b/modulefiles/module_base.orion
@@ -22,16 +22,23 @@ module load nco/4.8.1
 ##
 ## NCEP libraries (temporary version to match the CCPP requirements)
 ##
+module use -a /apps/contrib/NCEPLIBS/orion/cmake/install/NCEPLIBS/modules
+module load bacio/2.4.0
+module load crtm_dev/2.3.0
+module load g2/3.4.0
+module load g2tmpl/1.9.0
+module load ip/3.3.0
+module load nceppost/dceca26
+module load nemsio/2.5.1
+module load sp/2.3.0
+module load w3emc/2.7.0
+module load w3nco/2.4.0
+
+module load gfsio/1.4.0
+module load sfcio/1.4.0
+module load sigio/2.3.0
+
 module use /apps/contrib/NCEPLIBS/orion/modulefiles
-module load bacio/2.0.3
-module load ip/3.0.2
-module load nemsio/2.2.4
-module load sp/2.0.3
-module load w3emc/2.4.0
-module load w3nco/2.0.7
-module load g2/3.1.1
-module load g2tmpl/1.6.0
-module load crtm/2.3.0
 module load jasper/1.900.2
 module load png/1.2.44
 module load z/1.2.6
@@ -42,13 +49,10 @@ module load prod_util/1.2.0
 ## use pre-compiled EMSF library for above compiler / MPI combination
 ##
 module use /apps/contrib/NCEPLIBS/lib/modulefiles
-module load netcdfp/4.7.4
-module load esmflocal/8.0.0.para
+module load netcdfp/4.7.4.release
+module load esmflocal/8.1.0.21bs.release
 module load post-intel-sandybridge/8.0.5
 
-
-module load netcdf_parallel/4.7.4
-module load hdf5_parallel/1.10.6
 module load wgrib/2.0.8
 module load grib_util/1.2.0
 

--- a/modulefiles/modulefile.ww3.hera
+++ b/modulefiles/modulefile.ww3.hera
@@ -1,0 +1,31 @@
+#%Module######################################################################
+## module for ww3 before base uses hpc-stack
+module use /contrib/sutils/modulefiles
+module load sutils
+
+module load cmake/3.16.1
+
+module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/modulefiles/stack
+
+module load hpc/1.0.0
+module load hpc-intel/18.0.5.274
+module load hpc-impi/2018.0.4
+
+module load jasper/2.0.15
+module load zlib/1.2.11
+module load png/1.6.35
+
+module load hdf5/1.10.6
+module load netcdf/4.7.4
+module load esmf/8_1_0_beta_snapshot_21
+
+module load bacio/2.4.0
+module load crtm/2.3.0
+module load g2/3.4.0
+module load g2tmpl/1.9.0
+module load ip/3.3.0
+module load nceppost/dceca26
+module load nemsio/2.5.1
+module load sp/2.3.0
+module load w3emc/2.7.0
+module load w3nco/2.4.0

--- a/modulefiles/modulefile.ww3.orion
+++ b/modulefiles/modulefile.ww3.orion
@@ -1,0 +1,30 @@
+#%Module######################################################################
+# module for ww3 before base uses hpc-stack
+module load contrib noaatools
+
+module load cmake/3.17.3
+
+module use /apps/contrib/NCEP/libs/modulefiles/stack
+
+module load hpc/1.0.0
+module load hpc-intel/2018.4
+module load hpc-impi/2018.4
+
+module load jasper/2.0.15
+module load zlib/1.2.11
+module load png/1.6.35
+
+module load hdf5/1.10.6
+module load netcdf/4.7.4
+module load esmf/8_1_0_beta_snapshot_21
+
+module load bacio/2.4.0
+module load crtm/2.3.0
+module load g2/3.4.0
+module load g2tmpl/1.9.0
+module load ip/3.3.0
+module load nceppost/dceca26
+module load nemsio/2.5.1
+module load sp/2.3.0
+module load w3emc/2.7.0
+module load w3nco/2.4.0

--- a/sorc/build_ww3prepost.sh
+++ b/sorc/build_ww3prepost.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -x
+
+# Check final exec folder exists
+if [ ! -d "../exec" ]; then
+  mkdir ../exec
+fi
+
+finalexecdir=$( pwd -P )/../exec
+
+set +x
+source ./machine-setup.sh > /dev/null 2>&1
+
+source ../modulefiles/modulefile.ww3.$target
+set -x 
+
+
+cd fv3_coupled.fd/WW3
+export WW3_DIR=$( pwd -P )/model
+export WW3_BINDIR="${WW3_DIR}/bin"
+export WW3_TMPDIR=${WW3_DIR}/tmp
+export WW3_EXEDIR=${WW3_DIR}/exe
+export WW3_COMP=$target 
+export WW3_CC=gcc
+export WW3_F90=gfortran
+export SWITCHFILE="${WW3_DIR}/esmf/switch"
+
+export WWATCH3_ENV=${WW3_BINDIR}/wwatch3.env
+export PNG_LIB=$PNG_ROOT/lib64/libpng.a
+export Z_LIB=$ZLIB_ROOT/lib/libz.a
+export JASPER_LIB=$JASPER_ROOT/lib64/libjasper.a
+export WWATCH3_NETCDF=NC4
+export NETCDF_CONFIG=$NETCDF_ROOT/bin/nc-config
+
+rm  $WWATCH3_ENV
+echo '#'                                              > $WWATCH3_ENV
+echo '# ---------------------------------------'      >> $WWATCH3_ENV
+echo '# Environment variables for wavewatch III'      >> $WWATCH3_ENV
+echo '# ---------------------------------------'      >> $WWATCH3_ENV
+echo '#'                                              >> $WWATCH3_ENV
+echo "WWATCH3_LPR      $PRINTER"                      >> $WWATCH3_ENV
+echo "WWATCH3_F90      $WW3_F90"                      >> $WWATCH3_ENV
+echo "WWATCH3_CC       $WW3_CC"                       >> $WWATCH3_ENV
+echo "WWATCH3_DIR      $WW3_DIR"                      >> $WWATCH3_ENV
+echo "WWATCH3_TMP      $WW3_TMPDIR"                   >> $WWATCH3_ENV
+echo 'WWATCH3_SOURCE   yes'                           >> $WWATCH3_ENV
+echo 'WWATCH3_LIST     yes'                           >> $WWATCH3_ENV
+echo ''                                               >> $WWATCH3_ENV
+
+${WW3_BINDIR}/w3_clean -m 
+${WW3_BINDIR}/w3_setup -q -c $WW3_COMP $WW3_DIR
+
+echo $(cat ${SWITCHFILE}) > ${WW3_BINDIR}/tempswitch
+
+sed -e "s/DIST/SHRD/g"\
+    -e "s/OMPG/ /g"\
+    -e "s/OMPH/ /g"\
+    -e "s/MPIT/ /g"\
+    -e "s/MPI/ /g"\
+    -e "s/PDLIB/ /g"\
+       ${WW3_BINDIR}/tempswitch > ${WW3_BINDIR}/switch
+
+#Build exes for prep jobs: 
+${WW3_BINDIR}/w3_make ww3_grid 
+
+#Build exes for post jobs (except grib)"
+${WW3_BINDIR}/w3_make ww3_outp 
+
+#Update switch for grib: 
+echo $(cat ${SWITCHFILE}) > ${WW3_BINDIR}/tempswitch
+
+sed -e "s/DIST/SHRD/g"\
+    -e "s/OMPG/ /g"\
+    -e "s/OMPH/ /g"\
+    -e "s/MPIT/ /g"\
+    -e "s/MPI/ /g"\
+    -e "s/PDLIB/ /g"\
+    -e "s/NOGRB/NCEP2 NCO/g"\
+       ${WW3_BINDIR}/tempswitch > ${WW3_BINDIR}/switch
+#Build exe for grib
+${WW3_BINDIR}/w3_make ww3_grib
+
+cp $WW3_EXEDIR/ww3_* $finalexecdir/
+${WW3_BINDIR}/w3_clean -c

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -16,7 +16,7 @@ rm -f ${topdir}/checkout-fv3_coupled.log
 if [[ ! -d fv3_coupled.fd ]] ; then
     git clone https://github.com/ufs-community/ufs-s2s-model fv3_coupled.fd >> ${topdir}/checkout-fv3_coupled.log 2>&1
     cd fv3_coupled.fd
-    git checkout ufss2s_cmeps_v0.7 
+    git checkout d7b7081f410eb84902a43c7479e14d44dfed0144 
     git submodule update --init --recursive
     cd ${topdir}
 else

--- a/workflow/config/wave.yaml
+++ b/workflow/config/wave.yaml
@@ -130,7 +130,6 @@ config_wave:
       export FIXwave="{doc.places.FIXwave}"
       export PARMwave="{doc.places.HOMEgfs}/parm/wave"
       export USHwave="{doc.places.HOMEgfs}/ush"
-      export EXECwave="{doc.places.HOMEgfs}/sorc/fv3_coupled.fd/WW3/exec"
       #
       export MP_PULSE=0
       


### PR DESCRIPTION
For feature/coupled-crow adds a build script for WW3 prep and post jobs (@arunchawla-NOAA @aliabdolali).  Currently this requires extra module files, but this can be reverted to using the base modules after hpc-stack is used throughout. 

This uses the last commit of ufs-s2s-model before CICE6 was added.  The base modules are made to be consistent with this commit.  

Tested that the wave prep/post exes build on orion and hera.  On orion, the wave prep and mediator cold start job ran.  