### PR TITLE
Bugfix for rtofs

### DIFF
--- a/jobs/JGLOBAL_WAVE_PREP
+++ b/jobs/JGLOBAL_WAVE_PREP
@@ -76,7 +76,8 @@ if [ $RUN_ENVIR = "nco" ]; then
     export RPDY=`$NDATE -24 ${PDY}00 | cut -c1-8`
     export COMIN_WAV_CUR=$(compath.py ${WAVECUR_DID}/prod)/${WAVECUR_DID}.${RPDY}
   fi
-else 
+else
+  if [ ! -d $DMPDIR/${WAVECUR_DID}.${RPDY} ]; then export RPDY=`$NDATE -24 ${PDY}00 | cut -c1-8`; fi 
   if [ ! -L $ROTDIR/${WAVECUR_DID}.${RPDY} ]; then # Check if symlink already exists in ROTDIR
     $NLN $DMPDIR/${WAVECUR_DID}.${RPDY} $ROTDIR/${WAVECUR_DID}.${RPDY}
   fi


### PR DESCRIPTION
This adds back the check to go back to the previous day instead of failing for the if not NCO section.  This is needed because in real-time RTOFS will not be ready until 06 cycle.  

This was originally removed for reproducibility reasons.  To address that and the fact that RTOFS does not exist at 00 cycle, a different fix will be needed but this will address the para failures that just occurred. 