### PR TITLE
Issue # 131 EE2 compliance for postsnd in Feature/gfsv16b

### DIFF
--- a/jobs/JGFS_POSTSND
+++ b/jobs/JGFS_POSTSND
@@ -58,6 +58,7 @@ export COMIN=${COMIN:-$COMROOT/${NET}/${envir}/${RUN}.${PDY}/${cyc}/$COMPONENT}
 export COMOUT=${COMOUT:-$COMROOT/${NET}/${envir}/${RUN}.${PDY}/${cyc}/$COMPONENT}
 export pcom=${pcom:-${COMOUT}/wmo}
 export COMAWP=${COMAWP:-${COMOUT}/gempak}
+export DBNROOT=${DBNROOT:-/iodprod_dell/dbnet_siphon}
 mkdir -p $COMOUT $pcom $COMAWP
 env
 

--- a/ush/gfs_sndp.sh
+++ b/ush/gfs_sndp.sh
@@ -16,6 +16,7 @@ export m=$1
 mkdir $DATA/$m
 cd $DATA/$m
   cp $FIXbufrsnd/gfs_collective${m}.list $DATA/$m/. 
+set +x
   CCCC=KWBC
     file_list=gfs_collective${m}.list
 
@@ -59,6 +60,7 @@ EOF
        rm $DATA/${m}/bufrout
     done
 
+set -x
 #    if test $SENDCOM = 'NO'
     if test $SENDCOM = 'YES'
     then 


### PR DESCRIPTION
As stated in issue #131 the dbn_alert need a path to it when running in EMC real time parallel. It was not an issue when it runs on operations. The path is grandfathered in to JGFS_POSTSND. There were suggestions to remove excessive output to the jlogfile, hence gfs_sndp.sh is modified. Tests were performed under rocoto workflow and results were validated.
