### PR TITLE
Feature/gfsv16b BUFR sounding EE2 compliance with a unified dbn_alert approach

### DIFF
--- a/jobs/JGFS_POSTSND
+++ b/jobs/JGFS_POSTSND
@@ -58,6 +58,7 @@ export COMIN=${COMIN:-$COMROOT/${NET}/${envir}/${RUN}.${PDY}/${cyc}/$COMPONENT}
 export COMOUT=${COMOUT:-$COMROOT/${NET}/${envir}/${RUN}.${PDY}/${cyc}/$COMPONENT}
 export pcom=${pcom:-${COMOUT}/wmo}
 export COMAWP=${COMAWP:-${COMOUT}/gempak}
+export DBNROOT=${DBNROOT:-/iodprod_dell/dbnet_siphon}
 mkdir -p $COMOUT $pcom $COMAWP
 env
 

--- a/jobs/JGFS_POSTSND
+++ b/jobs/JGFS_POSTSND
@@ -58,7 +58,7 @@ export COMIN=${COMIN:-$COMROOT/${NET}/${envir}/${RUN}.${PDY}/${cyc}/$COMPONENT}
 export COMOUT=${COMOUT:-$COMROOT/${NET}/${envir}/${RUN}.${PDY}/${cyc}/$COMPONENT}
 export pcom=${pcom:-${COMOUT}/wmo}
 export COMAWP=${COMAWP:-${COMOUT}/gempak}
-export DBNROOT=${DBNROOT:-/iodprod_dell/dbnet_siphon}
+export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 mkdir -p $COMOUT $pcom $COMAWP
 env
 

--- a/ush/gfs_sndp.sh
+++ b/ush/gfs_sndp.sh
@@ -16,6 +16,7 @@ export m=$1
 mkdir $DATA/$m
 cd $DATA/$m
   cp $FIXbufrsnd/gfs_collective${m}.list $DATA/$m/. 
+set +x
   CCCC=KWBC
     file_list=gfs_collective${m}.list
 
@@ -59,6 +60,7 @@ EOF
        rm $DATA/${m}/bufrout
     done
 
+set -x
 #    if test $SENDCOM = 'NO'
     if test $SENDCOM = 'YES'
     then 


### PR DESCRIPTION
It was decided all GFS V16 dbn_alerts use the same statement in the jjob scripts: 
export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}