### PR TITLE
update wave post pnt dependency 

### DIFF
--- a/ush/rocoto/setup_workflow.py
+++ b/ush/rocoto/setup_workflow.py
@@ -587,7 +587,15 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
         dict_tasks['%swavepostbndpnt' % cdump] = task
 
     # wavepostpnt
-    if do_wave in ['Y', 'YES'] and cdump in cdumps:
+    if do_wave in ['Y', 'YES'] and cdump in ['gdas']:
+        deps = []
+        dep_dict = {'type':'task', 'name':'%sfcst' % cdump}
+        deps.append(rocoto.add_dependency(dep_dict))
+        dependencies = rocoto.create_dependency(dep=deps)
+        task = wfu.create_wf_task('wavepostpnt', cdump=cdump, envar=envars, dependency=dependencies)
+        dict_tasks['%swavepostpnt' % cdump] = task
+
+    if do_wave in ['Y', 'YES'] and cdump in ['gfs']:
         deps = []
         dep_dict = {'type':'task', 'name':'%sfcst' % cdump}
         deps.append(rocoto.add_dependency(dep_dict))


### PR DESCRIPTION
Updating the earlier commit that added a dependency for the wavepostpnt on the completion of the wave post bnd pnt job.  This job does not exist for gdas, so I made 2 parts, one for gdas w/no dependency on boundary points and one for gfs that has a dependency on the boundary points. 

This should be double checked before merged,  I made an xml file (/gpfs/dell2/emc/modeling/noscrub/Jessica.Meixner/EXPDIR/exp/exp.xml) that looks good to me, but there were lots of diffs with the parallel xml, so ? 