### PR TITLE
Change config.resources for eobs for low resolution cases

### DIFF
--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -265,11 +265,11 @@ elif [ $step = "eobs" -o $step = "eomg" ]; then
     if [ $CASE = "C768" ]; then
       export npe_eobs=100
     elif [ $CASE = "C384" ]; then
-      export npe_eobs=42
+      export npe_eobs=60
     elif [ $CASE = "C192" ]; then
-      export npe_eobs=28
+      export npe_eobs=40
     elif [ $CASE = "C96" -o $CASE = "C48" ]; then
-      export npe_eobs=14
+      export npe_eobs=20
     fi
     export nth_eobs=2
     if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_eobs=7; fi


### PR DESCRIPTION
There was a mismatch between the npe_eobs set in config.resources and what is written to the rocoto XML file by the rocoto python scripts. For example, the config.resources file was setting npe_eobs to 42 for C384DET case, but the XML file said 3 nodes, 20 ppn, requesting 60 tasks from Slurm. This is because 42 is not evenly divisible by 20. This causes (on Hera) for there to be missing obs not retained from the eobs step at the ediag step.

Changing these values to be divisible by 20 (for Hera), 4 (Dell) and 5 (Dell P3.5)

npe_eobs needs to remain 480 for CASE 768 for GFSv16 operations/real-time parallel