### PR TITLE
Updates for RTOFS preprocessing for wave model 

### DIFF
--- a/jobs/JGLOBAL_WAVE_PREP
+++ b/jobs/JGLOBAL_WAVE_PREP
@@ -71,11 +71,7 @@ export COMOUT=${COMOUT:-${ROTDIR}/${CDUMP}.${PDY}/${cyc}/$COMPONENT}
 
 if [ $RUN_ENVIR = "nco" ]; then
   export COMIN_WAV_ICE=${COMIN_WAV_ICE:-$(compath.py gfs/prod)}/${CDUMP}.${PDY}/${cyc}/atmos
-  export COMIN_WAV_CUR=${COMIN_WAV_CUR:-$(compath.py ${WAVECUR_DID}/prod)}/${WAVECUR_DID}.${RPDY}
-  if [ ! -d $COMIN_WAV_CUR ]; then
-    export RPDY=`$NDATE -24 ${PDY}00 | cut -c1-8`
-    export COMIN_WAV_CUR=$(compath.py ${WAVECUR_DID}/prod)/${WAVECUR_DID}.${RPDY}
-  fi
+  export COMIN_WAV_RTOFS=${COMIN_WAV_RTOFS:-$(compath.py ${WAVECUR_DID}/prod)}
 else
   if [ ! -d $DMPDIR/${WAVECUR_DID}.${RPDY} ]; then export RPDY=`$NDATE -24 ${PDY}00 | cut -c1-8`; fi 
   if [ ! -L $ROTDIR/${WAVECUR_DID}.${RPDY} ]; then # Check if symlink already exists in ROTDIR
@@ -85,7 +81,7 @@ else
     $NLN $DMPDIR/$CDUMP.${PDY}/$cyc/${WAVICEFILE} $ROTDIR/$CDUMP.${PDY}/$cyc/atmos/${WAVICEFILE}
   fi
   export COMIN_WAV_ICE=${COMIN_WAV_ICE:-$ROTDIR/$RUN.$PDY/$cyc/atmos}
-  export COMIN_WAV_CUR=${ROTDIR}/${WAVECUR_DID}.${RPDY}
+  export COMIN_WAV_RTOFS=${ROTDIR}
 fi
 
 # Execute the Script  

--- a/ush/wave_prnc_cur.sh
+++ b/ush/wave_prnc_cur.sh
@@ -27,6 +27,7 @@ set -x
 ymdh_rtofs=$1
 curfile=$2
 fhr=$3
+flagfirst=$4
 fh3=`printf "%03d" "${fhr#0}"`
 
 # Timing has to be made relative to the single 00z RTOFS cycle for that PDY
@@ -61,11 +62,11 @@ fi
 # Cleanup
 rm -f cur_temp[123].nc cur_5min_??.nc cur_glo_uv_${PDY}_${fext}${fh3}.nc weights.nc
 
-if [ ${fhr} -gt 0 ] 
+if [ ${flagfirst}  = "T" ] 
 then
-  sed -e "s/HDRFL/F/g" ${FIXwave}/ww3_prnc.cur.${WAVECUR_FID}.inp.tmpl > ww3_prnc.inp
-else
   sed -e "s/HDRFL/T/g" ${FIXwave}/ww3_prnc.cur.${WAVECUR_FID}.inp.tmpl > ww3_prnc.inp
+else
+  sed -e "s/HDRFL/F/g" ${FIXwave}/ww3_prnc.cur.${WAVECUR_FID}.inp.tmpl > ww3_prnc.inp
 fi
 
 rm -f cur.nc


### PR DESCRIPTION
In NCO testing it was found that the current way of checking for if RTOFS files existed was insufficient.  
Instead we now look for the files from each day (depending on if it's gdas, the 06z RTOFS files or if gfs the last of each day for the 12z RTOFS files).  

In addition, it was discovered that no matter what the model cycle was, we were starting at the 00z for RTOFS.  The starting time for processing in wave prep of the RTOFS files is now based on the starting time of the forecast (including making sure to use the previous RTOFS forecast if the beginning time is not included) and ending at the end of the forecast time if it happens to be shorter than GFS. 

This means we can reduce the number of nodes gdaswaveprep needs to 1. The gfswaveprep job still needs 65 processors so 3 nodes.   However, the resources have not been changed.   

This uses the new RTOFS naming conventions. 