### PR TITLE
feature/coupled-crow: Update module files for orion 

### DIFF
--- a/modulefiles/module_base.orion
+++ b/modulefiles/module_base.orion
@@ -9,54 +9,38 @@
 module load contrib noaatools
 
 ##
-module load cmake/3.17.3
-setenv CMAKE_C_COMPILER mpiicc
-setenv CMAKE_CXX_COMPILER mpiicpc
-setenv CMAKE_Fortran_COMPILER mpiifort
-setenv CMAKE_Platform orion.intel
-
-
-module use /apps/contrib/NCEP/libs/hpc-stack/v1.0.0-beta1/modulefiles/stack
-
-module load hpc/1.0.0-beta1
-module load hpc-intel/2018.4
-module load hpc-impi/2018.4
-
+## load programming environment
+## this typically includes compiler, MPI and job scheduler
+##
+module load intel/2018
+module load impi/2018
 
 #For ocean post: 
 module load ncl/6.6.2
 module load nco/4.8.1
 
-module load jasper/2.0.15
-module load zlib/1.2.11
-module load png/1.6.35
-
-module load hdf5/1.10.6
-module load netcdf/4.7.4
-module load pio/2.5.1
-module load esmf/8_1_0_beta_snapshot_27
-
-module load bacio/2.4.1
-module load crtm/2.3.0
-module load g2/3.4.1
-module load g2tmpl/1.9.1
-module load ip/3.3.3
-module load nceppost/dceca26
-module load nemsio/2.5.2
-module load sp/2.3.3
-module load w3emc/2.7.3
-module load w3nco/2.4.1
-
 ##
-## NCEP libraries for atm post and other 
+## NCEP libraries (temporary version to match the CCPP requirements)
 ##
 module use -a /apps/contrib/NCEPLIBS/orion/cmake/install/NCEPLIBS/modules
+module load bacio/2.4.0
+module load crtm_dev/2.3.0
+module load g2/3.4.0
+module load g2tmpl/1.9.0
+module load ip/3.3.0
+module load nceppost/dceca26
+module load nemsio/2.5.1
+module load sp/2.3.0
+module load w3emc/2.7.0
+module load w3nco/2.4.0
 
 module load gfsio/1.4.0
 module load sfcio/1.4.0
 module load sigio/2.3.0
 
 module use /apps/contrib/NCEPLIBS/orion/modulefiles
+module load jasper/1.900.2
+module load png/1.2.44
 module load z/1.2.6
 
 module load prod_util/1.2.0
@@ -74,3 +58,11 @@ module load grib_util/1.2.0
 
 module load slurm/19.05.3-2
 
+##
+### load cmake
+###
+module load cmake/3.15.4
+setenv CMAKE_C_COMPILER mpiicc
+setenv CMAKE_CXX_COMPILER mpiicpc
+setenv CMAKE_Fortran_COMPILER mpiifort
+setenv CMAKE_Platform orion.intel


### PR DESCRIPTION
The atm post is currently not working on orion due to an attempt to move to hpc-stack modules.  Reverting back to the modules used in prototype 5 fixed this issue.  This will close issue #212 

See output on orion at: 
/work/noaa/marine/jmeixner/p6atmpost/test01/COMROOT/test01/gfs.20130401/00
 