### PR TITLE
Issue #189 - update ufs-weather-model hash

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -34,7 +34,7 @@ if [[ ! -d fv3gfs.fd ]] ; then
     if [ ${run_ccpp:-"NO"} = "NO" ]; then
      git checkout GFS.v16.0.14
     else
-     git checkout 2e25df5fe952d27355ed58963148f46b82565469
+     git checkout b771e5be7e35eaea5ee7f762d644afccab019ed3
     fi
     git submodule update --init --recursive
     cd ${topdir}


### PR DESCRIPTION
Per request from @yangfanglin this PR updates the ufs-weather-model develop branch hash in checkout.sh to an updated version which "has been shown to be able to reproduce gfs.v16 results and maintain restart reproducibility". 

Updated hash in sorc/checkout.sh and ran checkout/build/link installation steps on WCOSS-Venus. No issues encountered. Forecast job test run on Hera in free-forecast mode by Fanglin. No issues encountered.

This will close issue #189