### PR TITLE
modified exglobal_forecast.sh to enable multiple reruns from breakpoint restart initial conditions

### DIFF
--- a/scripts/exglobal_forecast.sh
+++ b/scripts/exglobal_forecast.sh
@@ -338,6 +338,13 @@ EOF
       IAU_INC_FILES="''"
     fi
 
+    rst_list_rerun=""
+    xfh=$restart_interval_gfs
+    while [ $xfh -le $FHMAX_GFS ]; do
+      rst_list_rerun="$rst_list_rerun $xfh"
+      xfh=$((xfh+restart_interval_gfs))
+    done
+    restart_interval="$rst_list_rerun"
 
   fi
 #.............................


### PR DESCRIPTION
The breakpoint restart only works for the first restart from a breakpoint. Restart files written
in RERUN_RESTRAT after the first restart has a 3-hour time shift for DO_IAU=YES cases.
Forecasts starting from the 2nd breakpoint and beyond will fail becasue of incorrect initial
conditions.  This commit fixes this bug.

This fix has been tested and verified in two forecast cases, at C192L127 and C768L127 resolutions.  