### PR TITLE
Update GLDAS tag to gldas_gfsv16_release.v1.13.0

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -59,7 +59,7 @@ if [[ ! -d gldas.fd ]] ; then
     rm -f ${topdir}/checkout-gldas.log
     git clone https://github.com/NOAA-EMC/GLDAS.git gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
     cd gldas.fd
-    git checkout gldas_gfsv16_release.v1.12.0
+    git checkout gldas_gfsv16_release.v1.13.0 
     cd ${topdir}
 else
     echo 'Skip.  Directory gldas.fd already exists.'

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -59,7 +59,7 @@ if [[ ! -d gldas.fd ]] ; then
     rm -f ${topdir}/checkout-gldas.log
     git clone https://github.com/NOAA-EMC/GLDAS.git gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
     cd gldas.fd
-    git checkout gldas_gfsv16_release.v1.13.0 
+    git checkout gldas_gfsv16_release.v1.13.0
     cd ${topdir}
 else
     echo 'Skip.  Directory gldas.fd already exists.'


### PR DESCRIPTION
This PR updates the GLDAS tag to gldas_gfsv16_release.v1.13.0. This new tag updates the following compared to the prior tag:

1. fix Orion build issue
2. update PRCP file settings to use early file when needed

Tested build and functionality on Orion. Worked as intended.

This PR will close issue #233 