### PR TITLE
adding definition of errchk which was undefined in these scripts

### DIFF
--- a/scripts/exgfs_wave_nawips.sh
+++ b/scripts/exgfs_wave_nawips.sh
@@ -25,6 +25,9 @@ export cycle=${cycle:-t${cyc}z}
 export GEMwave=${GEMwave:-$HOMEgfs/gempak}
 export FIXwave=${FIXwave:-HOMEgfs/fix}
 export DATA=${DATA:-${DATAROOT:?}/${jobid}}
+
+export errchk=${errchk:-err_chk}
+
 if [ ! -d $DATA ];then
   mkdir -p $DATA
 fi

--- a/scripts/exgfs_wave_prdgen_bulls.sh
+++ b/scripts/exgfs_wave_prdgen_bulls.sh
@@ -36,6 +36,8 @@
  export USHwave=${USHwave:-$HOMEgfs/ush}
  #export EXECcode=${EXECcode:-CODEwave/exec}
 
+ export errchk=${errchk:-err_chk}
+
  mkdir -p $DATA
  cd $DATA
  export wavelog=${DATA}/${RUNwave}_prdgbulls.log

--- a/scripts/exgfs_wave_prdgen_gridded.sh
+++ b/scripts/exgfs_wave_prdgen_gridded.sh
@@ -41,6 +41,8 @@
  mkdir -p $DATA
  cd $DATA
  export wavelog=${DATA}/${COMPONENTwave}_prdggridded.log
+
+ export errchk=${errchk:-err_chk}
  
  postmsg "$jlogfile" "HAS BEGUN on `hostname`"
  msg="Starting MWW3 GRIDDED PRODUCTS SCRIPT"


### PR DESCRIPTION
It was reported by Jen that the following wave scripts had undefined errchk in: 

scripts/exgfs_wave_nawips.sh                  
scripts/exgfs_wave_prdgen_bulls.sh             
scripts/exgfs_wave_prdgen_gridded.sh          

This PR adds this definition in each of these scripts.    