### PR TITLE
Feature/ww3 modules post

### DIFF
--- a/modulefiles/modulefile.ww3.hera
+++ b/modulefiles/modulefile.ww3.hera
@@ -1,31 +1,42 @@
 #%Module######################################################################
-## module for ww3 before base uses hpc-stack
-module use /contrib/sutils/modulefiles
-module load sutils
+##
+##      S2S prerequisites
+##
 
-module load cmake/3.16.1
+module load intel/18.0.5.274
+module load impi/2018.0.4
+module load wgrib2/2.0.8
+module load hpss/hpss
+module use -a /scratch2/NCEPDEV/nwprod/NCEPLIBS/modulefiles
+module load hdf5_parallel/1.10.6
+module load netcdf_parallel/4.7.4
+module load netcdf/4.7.0
+module load nco/4.7.0
 
-module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/modulefiles/stack
+module load gempak/7.4.2
+module load ncl/6.5.0
 
-module load hpc/1.0.0
-module load hpc-intel/18.0.5.274
-module load hpc-impi/2018.0.4
+#Load from official NCEPLIBS
+module load g2tmpl/1.6.0
+module load grib_util/1.1.1
+module load crtm/2.2.6
+module load prod_util/1.1.0
 
-module load jasper/2.0.15
-module load zlib/1.2.11
-module load png/1.6.35
+module load bacio/2.0.3
+module load ip/3.0.2
+module load nemsio/2.2.4
+module load sp/2.0.3
+module load w3emc/2.3.1
+module load w3nco/2.0.7
+module load g2/3.1.1
+module load jasper/1.900.1
+module load png/1.2.44
+module load z/1.2.11
 
-module load hdf5/1.10.6
-module load netcdf/4.7.4
-module load esmf/8_1_0_beta_snapshot_21
 
-module load bacio/2.4.0
-module load crtm/2.3.0
-module load g2/3.4.0
-module load g2tmpl/1.9.0
-module load ip/3.3.0
-module load nceppost/dceca26
-module load nemsio/2.5.1
-module load sp/2.3.0
-module load w3emc/2.7.0
-module load w3nco/2.4.0
+#Load from emc.nemspara
+module use -a /scratch1/NCEPDEV/nems/emc.nemspara/soft/modulefiles
+module load netcdf_parallel/4.7.4.release
+module load esmf/8.1.0bs27
+module load hdf5_parallel/1.10.6.release
+

--- a/modulefiles/modulefile.ww3.orion
+++ b/modulefiles/modulefile.ww3.orion
@@ -10,7 +10,8 @@ module load hpc/1.0.0
 module load hpc-intel/2018.4
 module load hpc-impi/2018.4
 
-module load jasper/2.0.15
+#module load jasper/2.0.15
+module load jasper/1.900.1
 module load zlib/1.2.11
 module load png/1.6.35
 

--- a/sorc/build_ww3prepost.sh
+++ b/sorc/build_ww3prepost.sh
@@ -12,10 +12,11 @@ set +x
 source ./machine-setup.sh > /dev/null 2>&1
 
 source ../modulefiles/modulefile.ww3.$target
+#source ../modulefiles/module_base.$target
 set -x 
 
 
-cd ufs_coupled.fd/WW3
+cd fv3_coupled.fd/WW3
 export WW3_DIR=$( pwd -P )/model
 export WW3_BINDIR="${WW3_DIR}/bin"
 export WW3_TMPDIR=${WW3_DIR}/tmp
@@ -26,12 +27,13 @@ export WW3_F90=gfortran
 export SWITCHFILE="${WW3_DIR}/esmf/switch"
 
 export WWATCH3_ENV=${WW3_BINDIR}/wwatch3.env
-export PNG_LIB=$PNG_ROOT/lib64/libpng.a
-export Z_LIB=$ZLIB_ROOT/lib/libz.a
-export JASPER_LIB=$JASPER_ROOT/lib64/libjasper.a
-export WWATCH3_NETCDF=NC4
-export NETCDF_CONFIG=$NETCDF_ROOT/bin/nc-config
-
+if [ $target = orion ]; then
+  export PNG_LIB=$PNG_ROOT/lib64/libpng.a
+  export Z_LIB=$ZLIB_ROOT/lib/libz.a
+  export JASPER_LIB=$JASPER_ROOT/lib/libjasper.a
+ export WWATCH3_NETCDF=NC4
+ export NETCDF_CONFIG=$NETCDF_ROOT/bin/nc-config
+fi
 rm  $WWATCH3_ENV
 echo '#'                                              > $WWATCH3_ENV
 echo '# ---------------------------------------'      >> $WWATCH3_ENV

--- a/sorc/build_ww3prepost.sh
+++ b/sorc/build_ww3prepost.sh
@@ -15,8 +15,7 @@ source ../modulefiles/modulefile.ww3.$target
 #source ../modulefiles/module_base.$target
 set -x 
 
-
-cd fv3_coupled.fd/WW3
+cd ufs_coupled.fd/WW3
 export WW3_DIR=$( pwd -P )/model
 export WW3_BINDIR="${WW3_DIR}/bin"
 export WW3_TMPDIR=${WW3_DIR}/tmp


### PR DESCRIPTION
WW3 was producing empty grib2 files.
To solve this issue:
On Orion, the hpc-stack is used but the version of jasper has to be changed from 2.0.15 to 1.900.0
On Hera,  the hpc-stack is not used and and all modules has to be loaded outside of hpc-stack.

Now  WW3 is producing valid grib2 files on Hera and Orion.