### PR TITLE
Merge NCO updates for GFSv16.0.4[5][6] into develop

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -36,7 +36,7 @@ protocol = git
 required = True
 
 [EMC_verif-global]
-tag = verif_global_v1.13.1
+tag = verif_global_v1.13.2
 local_path = sorc/verif-global.fd
 repo_url = https://github.com/NOAA-EMC/EMC_verif-global.git
 protocol = git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -15,7 +15,7 @@ protocol = git
 required = True
 
 [GLDAS]
-tag = gldas_gfsv16_release.v1.12.0
+tag = gldas_gfsv16_release.v1.13.0
 local_path = sorc/gldas.fd
 repo_url = https://github.com/NOAA-EMC/GLDAS.git
 protocol = git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -36,7 +36,7 @@ protocol = git
 required = True
 
 [EMC_verif-global]
-tag = verif_global_v1.11.0
+tag = verif_global_v1.13.1
 local_path = sorc/verif-global.fd
 repo_url = https://github.com/NOAA-EMC/EMC_verif-global.git
 protocol = git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -22,7 +22,7 @@ protocol = git
 required = True
 
 [EMC_post]
-tag = upp_gfsv16_release.v1.1.2
+tag = upp_gfsv16_release.v1.1.3
 local_path = sorc/gfs_post.fd
 repo_url = https://github.com/NOAA-EMC/EMC_post.git
 protocol = git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,7 @@
 # External sub-modules of global-workflow
 
 [FV3GFS]
-tag = GFS.v16.0.14
+tag = GFS.v16.0.15
 local_path = sorc/fv3gfs.fd
 repo_url = https://github.com/ufs-community/ufs-weather-model.git
 protocol = git
@@ -43,7 +43,7 @@ protocol = git
 required = True
 
 [EMC_gfs_wafs]
-tag = gfs_wafs.v6.0.17
+tag = gfs_wafs.v6.0.18
 local_path = sorc/gfs_wafs.fd
 repo_url = https://github.com/NOAA-EMC/EMC_gfs_wafs.git
 protocol = git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -22,7 +22,7 @@ protocol = git
 required = True
 
 [EMC_post]
-tag = upp_gfsv16_release.v1.1.1
+tag = upp_gfsv16_release.v1.1.2
 local_path = sorc/gfs_post.fd
 repo_url = https://github.com/NOAA-EMC/EMC_post.git
 protocol = git

--- a/ecflow/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis.ecf
@@ -3,7 +3,6 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_analysis_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-##BSUB -W 0:45   # 11/02/2020 temporarily change
 #BSUB -W 1:00
 #BSUB -n 1000
 #BSUB -R affinity[core(7)]

--- a/ecflow/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak.ecf
@@ -3,9 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_gempak_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-## JY temporarily increase wall clock as the submit time is long 
-##BSUB -W 0:15
-#BSUB -W 0:30
+#BSUB -W 0:15
 #BSUB -n 2
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gdas/atmos/init/jgdas_atmos_gldas.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/init/jgdas_atmos_gldas.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_gldas_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 2:00
+#BSUB -W 0:20
 #BSUB -n 112
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=28]

--- a/ecflow/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_emcsfc_sfc_prep.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_emcsfc_sfc_prep.ecf
@@ -3,7 +3,7 @@
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
 #BSUB -L /bin/sh
-#BSUB -W 0:10
+#BSUB -W 0:08
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_anl.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_anl.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_post_%FHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:20
+#BSUB -W 0:12
 #BSUB -n 98
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=14]

--- a/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f000.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f000.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_post_%FHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:20
+#BSUB -W 0:12
 #BSUB -n 98
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=14]

--- a/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f001.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f001.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_post_%FHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:20
+#BSUB -W 0:12
 #BSUB -n 98
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=14]

--- a/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f002.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f002.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_post_%FHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:20
+#BSUB -W 0:12
 #BSUB -n 98
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=14]

--- a/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f003.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f003.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_post_%FHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:20
+#BSUB -W 0:12
 #BSUB -n 98
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=14]

--- a/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f004.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f004.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_post_%FHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:20
+#BSUB -W 0:12
 #BSUB -n 98
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=14]

--- a/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f005.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f005.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_post_%FHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:20
+#BSUB -W 0:12
 #BSUB -n 98
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=14]

--- a/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f006.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f006.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_post_%FHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:20
+#BSUB -W 0:12
 #BSUB -n 98
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=14]

--- a/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f007.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f007.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_post_%FHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:20
+#BSUB -W 0:12
 #BSUB -n 98
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=14]

--- a/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f008.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f008.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_post_%FHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:20
+#BSUB -W 0:12
 #BSUB -n 98
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=14]

--- a/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f009.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f009.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_post_%FHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:20
+#BSUB -W 0:12
 #BSUB -n 98
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=14]

--- a/ecflow/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfozn.ecf
+++ b/ecflow/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfozn.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gdas_atmos_verfozn_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:10
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f003.ecf
+++ b/ecflow/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f003.ecf
@@ -1,0 +1,62 @@
+#BSUB -L /bin/sh
+#BSUB -J %E%gdas_enkf_post_f%FHOUT_EPOS%_%CYC%
+#BSUB -o %COM%/output/%ENVIR%/today/gdas_enkf_post_f%FHOUT_EPOS%_%CYC%.o%J
+#BSUB -q %QUEUE%
+#BSUB -P %PROJ%
+#BSUB -W 0:15
+#BSUB -n 80
+#BSUB -R affinity[core(7)]
+#BSUB -R span[ptile=4]
+#BSUB -cwd /tmp
+
+%include <head.h>
+%include <envir-p3.h>
+
+set -x
+
+export NODES=20
+export ntasks=80
+export ptile=4
+
+export NET=%NET:gfs%
+export RUN=%RUN%
+export CDUMP=%RUN%
+
+model=gfs
+%include <model_ver.h>
+
+############################################################
+# Load modules
+############################################################
+module load lsf/$lsf_ver
+module load impi/$impi_ver
+module load NetCDF-parallel/${netcdf_parallel_ver}
+module load HDF5-parallel/${hdf5_parallel_ver}
+
+module list
+
+#############################################################
+# WCOSS environment settings
+#############################################################
+export FHMIN_EPOS=%FHOUT_EPOS%
+export FHMAX_EPOS=%FHOUT_EPOS%
+export FHOUT_EPOS=%FHOUT_EPOS%
+export cyc=%CYC%
+export cycle=t%CYC%z
+export USE_CFP=YES
+
+############################################################
+# CALL executable job script here
+############################################################
+$HOMEgfs/jobs/JGDAS_ENKF_POST
+
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+
+%end

--- a/ecflow/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f004.ecf
+++ b/ecflow/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f004.ecf
@@ -1,0 +1,62 @@
+#BSUB -L /bin/sh
+#BSUB -J %E%gdas_enkf_post_f%FHOUT_EPOS%_%CYC%
+#BSUB -o %COM%/output/%ENVIR%/today/gdas_enkf_post_f%FHOUT_EPOS%_%CYC%.o%J
+#BSUB -q %QUEUE%
+#BSUB -P %PROJ%
+#BSUB -W 0:15
+#BSUB -n 80
+#BSUB -R affinity[core(7)]
+#BSUB -R span[ptile=4]
+#BSUB -cwd /tmp
+
+%include <head.h>
+%include <envir-p3.h>
+
+set -x
+
+export NODES=20
+export ntasks=80
+export ptile=4
+
+export NET=%NET:gfs%
+export RUN=%RUN%
+export CDUMP=%RUN%
+
+model=gfs
+%include <model_ver.h>
+
+############################################################
+# Load modules
+############################################################
+module load lsf/$lsf_ver
+module load impi/$impi_ver
+module load NetCDF-parallel/${netcdf_parallel_ver}
+module load HDF5-parallel/${hdf5_parallel_ver}
+
+module list
+
+#############################################################
+# WCOSS environment settings
+#############################################################
+export FHMIN_EPOS=%FHOUT_EPOS%
+export FHMAX_EPOS=%FHOUT_EPOS%
+export FHOUT_EPOS=%FHOUT_EPOS%
+export cyc=%CYC%
+export cycle=t%CYC%z
+export USE_CFP=YES
+
+############################################################
+# CALL executable job script here
+############################################################
+$HOMEgfs/jobs/JGDAS_ENKF_POST
+
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+
+%end

--- a/ecflow/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f005.ecf
+++ b/ecflow/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f005.ecf
@@ -1,0 +1,62 @@
+#BSUB -L /bin/sh
+#BSUB -J %E%gdas_enkf_post_f%FHOUT_EPOS%_%CYC%
+#BSUB -o %COM%/output/%ENVIR%/today/gdas_enkf_post_f%FHOUT_EPOS%_%CYC%.o%J
+#BSUB -q %QUEUE%
+#BSUB -P %PROJ%
+#BSUB -W 0:15
+#BSUB -n 80
+#BSUB -R affinity[core(7)]
+#BSUB -R span[ptile=4]
+#BSUB -cwd /tmp
+
+%include <head.h>
+%include <envir-p3.h>
+
+set -x
+
+export NODES=20
+export ntasks=80
+export ptile=4
+
+export NET=%NET:gfs%
+export RUN=%RUN%
+export CDUMP=%RUN%
+
+model=gfs
+%include <model_ver.h>
+
+############################################################
+# Load modules
+############################################################
+module load lsf/$lsf_ver
+module load impi/$impi_ver
+module load NetCDF-parallel/${netcdf_parallel_ver}
+module load HDF5-parallel/${hdf5_parallel_ver}
+
+module list
+
+#############################################################
+# WCOSS environment settings
+#############################################################
+export FHMIN_EPOS=%FHOUT_EPOS%
+export FHMAX_EPOS=%FHOUT_EPOS%
+export FHOUT_EPOS=%FHOUT_EPOS%
+export cyc=%CYC%
+export cycle=t%CYC%z
+export USE_CFP=YES
+
+############################################################
+# CALL executable job script here
+############################################################
+$HOMEgfs/jobs/JGDAS_ENKF_POST
+
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+
+%end

--- a/ecflow/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f006.ecf
+++ b/ecflow/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f006.ecf
@@ -1,0 +1,62 @@
+#BSUB -L /bin/sh
+#BSUB -J %E%gdas_enkf_post_f%FHOUT_EPOS%_%CYC%
+#BSUB -o %COM%/output/%ENVIR%/today/gdas_enkf_post_f%FHOUT_EPOS%_%CYC%.o%J
+#BSUB -q %QUEUE%
+#BSUB -P %PROJ%
+#BSUB -W 0:15
+#BSUB -n 80
+#BSUB -R affinity[core(7)]
+#BSUB -R span[ptile=4]
+#BSUB -cwd /tmp
+
+%include <head.h>
+%include <envir-p3.h>
+
+set -x
+
+export NODES=20
+export ntasks=80
+export ptile=4
+
+export NET=%NET:gfs%
+export RUN=%RUN%
+export CDUMP=%RUN%
+
+model=gfs
+%include <model_ver.h>
+
+############################################################
+# Load modules
+############################################################
+module load lsf/$lsf_ver
+module load impi/$impi_ver
+module load NetCDF-parallel/${netcdf_parallel_ver}
+module load HDF5-parallel/${hdf5_parallel_ver}
+
+module list
+
+#############################################################
+# WCOSS environment settings
+#############################################################
+export FHMIN_EPOS=%FHOUT_EPOS%
+export FHMAX_EPOS=%FHOUT_EPOS%
+export FHOUT_EPOS=%FHOUT_EPOS%
+export cyc=%CYC%
+export cycle=t%CYC%z
+export USE_CFP=YES
+
+############################################################
+# CALL executable job script here
+############################################################
+$HOMEgfs/jobs/JGDAS_ENKF_POST
+
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+
+%end

--- a/ecflow/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f007.ecf
+++ b/ecflow/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f007.ecf
@@ -1,0 +1,62 @@
+#BSUB -L /bin/sh
+#BSUB -J %E%gdas_enkf_post_f%FHOUT_EPOS%_%CYC%
+#BSUB -o %COM%/output/%ENVIR%/today/gdas_enkf_post_f%FHOUT_EPOS%_%CYC%.o%J
+#BSUB -q %QUEUE%
+#BSUB -P %PROJ%
+#BSUB -W 0:15
+#BSUB -n 80
+#BSUB -R affinity[core(7)]
+#BSUB -R span[ptile=4]
+#BSUB -cwd /tmp
+
+%include <head.h>
+%include <envir-p3.h>
+
+set -x
+
+export NODES=20
+export ntasks=80
+export ptile=4
+
+export NET=%NET:gfs%
+export RUN=%RUN%
+export CDUMP=%RUN%
+
+model=gfs
+%include <model_ver.h>
+
+############################################################
+# Load modules
+############################################################
+module load lsf/$lsf_ver
+module load impi/$impi_ver
+module load NetCDF-parallel/${netcdf_parallel_ver}
+module load HDF5-parallel/${hdf5_parallel_ver}
+
+module list
+
+#############################################################
+# WCOSS environment settings
+#############################################################
+export FHMIN_EPOS=%FHOUT_EPOS%
+export FHMAX_EPOS=%FHOUT_EPOS%
+export FHOUT_EPOS=%FHOUT_EPOS%
+export cyc=%CYC%
+export cycle=t%CYC%z
+export USE_CFP=YES
+
+############################################################
+# CALL executable job script here
+############################################################
+$HOMEgfs/jobs/JGDAS_ENKF_POST
+
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+
+%end

--- a/ecflow/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f008.ecf
+++ b/ecflow/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f008.ecf
@@ -1,0 +1,62 @@
+#BSUB -L /bin/sh
+#BSUB -J %E%gdas_enkf_post_f%FHOUT_EPOS%_%CYC%
+#BSUB -o %COM%/output/%ENVIR%/today/gdas_enkf_post_f%FHOUT_EPOS%_%CYC%.o%J
+#BSUB -q %QUEUE%
+#BSUB -P %PROJ%
+#BSUB -W 0:15
+#BSUB -n 80
+#BSUB -R affinity[core(7)]
+#BSUB -R span[ptile=4]
+#BSUB -cwd /tmp
+
+%include <head.h>
+%include <envir-p3.h>
+
+set -x
+
+export NODES=20
+export ntasks=80
+export ptile=4
+
+export NET=%NET:gfs%
+export RUN=%RUN%
+export CDUMP=%RUN%
+
+model=gfs
+%include <model_ver.h>
+
+############################################################
+# Load modules
+############################################################
+module load lsf/$lsf_ver
+module load impi/$impi_ver
+module load NetCDF-parallel/${netcdf_parallel_ver}
+module load HDF5-parallel/${hdf5_parallel_ver}
+
+module list
+
+#############################################################
+# WCOSS environment settings
+#############################################################
+export FHMIN_EPOS=%FHOUT_EPOS%
+export FHMAX_EPOS=%FHOUT_EPOS%
+export FHOUT_EPOS=%FHOUT_EPOS%
+export cyc=%CYC%
+export cycle=t%CYC%z
+export USE_CFP=YES
+
+############################################################
+# CALL executable job script here
+############################################################
+$HOMEgfs/jobs/JGDAS_ENKF_POST
+
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+
+%end

--- a/ecflow/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f009.ecf
+++ b/ecflow/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f009.ecf
@@ -1,0 +1,62 @@
+#BSUB -L /bin/sh
+#BSUB -J %E%gdas_enkf_post_f%FHOUT_EPOS%_%CYC%
+#BSUB -o %COM%/output/%ENVIR%/today/gdas_enkf_post_f%FHOUT_EPOS%_%CYC%.o%J
+#BSUB -q %QUEUE%
+#BSUB -P %PROJ%
+#BSUB -W 0:15
+#BSUB -n 80
+#BSUB -R affinity[core(7)]
+#BSUB -R span[ptile=4]
+#BSUB -cwd /tmp
+
+%include <head.h>
+%include <envir-p3.h>
+
+set -x
+
+export NODES=20
+export ntasks=80
+export ptile=4
+
+export NET=%NET:gfs%
+export RUN=%RUN%
+export CDUMP=%RUN%
+
+model=gfs
+%include <model_ver.h>
+
+############################################################
+# Load modules
+############################################################
+module load lsf/$lsf_ver
+module load impi/$impi_ver
+module load NetCDF-parallel/${netcdf_parallel_ver}
+module load HDF5-parallel/${hdf5_parallel_ver}
+
+module list
+
+#############################################################
+# WCOSS environment settings
+#############################################################
+export FHMIN_EPOS=%FHOUT_EPOS%
+export FHMAX_EPOS=%FHOUT_EPOS%
+export FHOUT_EPOS=%FHOUT_EPOS%
+export cyc=%CYC%
+export cycle=t%CYC%z
+export USE_CFP=YES
+
+############################################################
+# CALL executable job script here
+############################################################
+$HOMEgfs/jobs/JGDAS_ENKF_POST
+
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+
+%end

--- a/ecflow/ecf/scripts/gdas/wave/post/jgdas_wave_postpnt.ecf
+++ b/ecflow/ecf/scripts/gdas/wave/post/jgdas_wave_postpnt.ecf
@@ -4,7 +4,7 @@
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
 #BSUB -cwd /tmp
-#BSUB -W 01:00
+#BSUB -W 0:12
 #BSUB -R span[ptile=28]; -R affinity[core]
 #BSUB -n 280
 

--- a/ecflow/ecf/scripts/gdas/wave/post/jgdas_wave_postsbs.ecf
+++ b/ecflow/ecf/scripts/gdas/wave/post/jgdas_wave_postsbs.ecf
@@ -4,7 +4,7 @@
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
 #BSUB -cwd /tmp
-#BSUB -W 06:00
+#BSUB -W 0:20
 #BSUB -R span[ptile=28]; -R affinity[core(1)]
 #BSUB -n 28
 

--- a/ecflow/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
+++ b/ecflow/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
@@ -4,7 +4,7 @@
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
 #BSUB -cwd /tmp
-#BSUB -W 00:30
+#BSUB -W 0:10
 #BSUB -R span[ptile=28]; -R affinity[core(1)]
 #BSUB -n 84
 

--- a/ecflow/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis.ecf
@@ -3,8 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_analysis_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-##BSUB -W 0:40  #11/02/2020 temporarily change
-#BSUB -W 1:00
+#BSUB -W 0:40
 #BSUB -n 1000
 #BSUB -R affinity[core(7)]
 #BSUB -R span[ptile=4]

--- a/ecflow/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_ncdc_upapgif.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_ncdc_upapgif.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_gempak_upapgif_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 3:00
+#BSUB -W 2:00
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_dump.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_dump.ecf
@@ -2,8 +2,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/%RUN%_atmos_dump_%CYC%.o%J
 #BSUB -cwd /tmp
 #BSUB -q %QUEUE%
-##BSUB -W 00:20
-#BSUB -W 00:30
+#BSUB -W 00:20
 #BSUB -P %PROJ%
 #BSUB -n 14
 #BSUB -R span[ptile=14]

--- a/ecflow/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_dump_alert.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_dump_alert.ecf
@@ -4,7 +4,7 @@
 #BSUB -R rusage[mem=1000]
 #BSUB -R affinity[core]
 #BSUB -cwd /tmp
-#BSUB -W 00:10
+#BSUB -W 00:05
 #BSUB -P %PROJ%
 
 %include <head.h>

--- a/ecflow/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_tropcy_qc_reloc.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_tropcy_qc_reloc.ecf
@@ -2,7 +2,7 @@
 #BSUB -P %PROJ%
 #BSUB -J %E%gfs_atmos_tropcy_qc_reloc_%CYC%
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_tropcy_qc_reloc_%CYC%.o%J
-#BSUB -W 0:10
+#BSUB -W 0:05
 #BSUB -L /bin/sh
 #BSUB -n 1
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_emcsfc_sfc_prep.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_emcsfc_sfc_prep.ecf
@@ -3,7 +3,7 @@
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
 #BSUB -L /bin/sh
-#BSUB -W 0:10
+#BSUB -W 0:07
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_prep_post.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_prep_post.ecf
@@ -2,7 +2,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/%RUN%_atmos_prep_post_%CYC%.o%J
 #BSUB -q %QUEUESERV%
 #BSUB -cwd /tmp
-#BSUB -W 00:10
+#BSUB -W 00:05
 #BSUB -P %PROJ%
 #BSUB -M 1000
 #BSUB -R affinity[core]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f000.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f000.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f003.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f003.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f006.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f006.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f009.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f009.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f012.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f012.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f015.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f015.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f018.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f018.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f021.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f021.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f024.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f024.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f027.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f027.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f030.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f030.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f033.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f033.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f036.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f036.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f039.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f039.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f042.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f042.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f045.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f045.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f048.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f048.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f051.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f051.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f054.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f054.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f057.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f057.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f060.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f060.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f063.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f063.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f066.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f066.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f069.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f069.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f072.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f072.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f075.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f075.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f078.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f078.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f081.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f081.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f084.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f084.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f090.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f090.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f096.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f096.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f102.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f102.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f108.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f108.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f114.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f114.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f120.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f120.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f126.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f126.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f132.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f132.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f138.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f138.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f144.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f144.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f150.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f150.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f156.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f156.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f162.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f162.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f168.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f168.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f174.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f174.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f180.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f180.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f186.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f186.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f192.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f192.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f198.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f198.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f204.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f204.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f210.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f210.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f216.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f216.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f222.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f222.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f228.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f228.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f234.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f234.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f240.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f240.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:10
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f000.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f000.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f003.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f003.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f006.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f006.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f009.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f009.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f012.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f012.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f015.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f015.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f018.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f018.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f021.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f021.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f024.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f024.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f027.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f027.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f030.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f030.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f033.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f033.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f036.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f036.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f039.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f039.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f042.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f042.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f045.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f045.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f048.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f048.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f051.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f051.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f054.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f054.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f057.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f057.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f060.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f060.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f063.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f063.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f066.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f066.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f069.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f069.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f072.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f072.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f075.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f075.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f078.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f078.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f081.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f081.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f084.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f084.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f090.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f090.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f096.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f096.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f102.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f102.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f108.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f108.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f114.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f114.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f120.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f120.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f126.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f126.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f132.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f132.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f138.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f138.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f144.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f144.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f150.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f150.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f156.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f156.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f162.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f162.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f168.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f168.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f174.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f174.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f180.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f180.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f186.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f186.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f192.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f192.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f198.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f198.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f204.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f204.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f210.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f210.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f216.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f216.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f222.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f222.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f228.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f228.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f234.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f234.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f240.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f240.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_awips_g2_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUESHARED%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -M 1000
 #BSUB -R affinity[core(1)]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f00.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f00.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f06.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f06.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f102.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f102.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f108.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f108.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f114.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f114.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f12.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f12.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f120.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f120.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f18.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f18.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f24.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f24.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f30.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f30.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f36.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f36.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f42.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f42.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f48.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f48.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f54.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f54.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f60.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f60.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f66.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f66.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f72.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f72.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f78.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f78.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f84.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f84.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f90.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f90.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f96.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f96.ecf
@@ -3,7 +3,7 @@
 #BSUB -o %COM%/output/%ENVIR%/today/gfs_atmos_wafs_%FCSTHR%_%CYC%.o%J
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
-#BSUB -W 0:30
+#BSUB -W 0:05
 #BSUB -n 1
 #BSUB -R affinity[core(1)]
 #BSUB -R span[ptile=1]

--- a/ecflow/ecf/scripts/gfs/atmos/verf/jgfs_atmos_vminmon.ecf
+++ b/ecflow/ecf/scripts/gfs/atmos/verf/jgfs_atmos_vminmon.ecf
@@ -31,7 +31,7 @@ model=gfs
 ############################################################
 module load lsf/${lsf_ver}
 module load pm5/${pm5_ver}
-# module load metplus/${metplus_ver}
+#module load metplus/${metplus_ver}
 module load util_shared/${util_shared_ver}
 
 module list

--- a/ecflow/ecf/scripts/gfs/wave/post/jgfs_wave_postsbs.ecf
+++ b/ecflow/ecf/scripts/gfs/wave/post/jgfs_wave_postsbs.ecf
@@ -4,7 +4,7 @@
 #BSUB -q %QUEUE%
 #BSUB -P %PROJ%
 #BSUB -cwd /tmp
-#BSUB -W 06:00
+#BSUB -W 03:00
 #BSUB -R span[ptile=28]; -R affinity[core]
 #BSUB -n 280
 

--- a/jobs/JGLOBAL_WAVE_GEMPAK
+++ b/jobs/JGLOBAL_WAVE_GEMPAK
@@ -30,6 +30,9 @@ export COMPONENT=${COMPONENT:-wave}
 export machine=${machine:-WCOSS_DELL_P3}
 export HOMEgfs=${HOMEgfs:-$(dirname $(dirname $0))} 
 
+# Add default errchk = err_chk
+export errchk=${errchk:-err_chk}
+
 ###################################
 # Set COM Paths
 export COMIN=${COMIN:-$(compath.py ${NET}/${envir}/${RUN}.${PDY})/${cyc}/$COMPONENT}

--- a/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
+++ b/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
@@ -23,6 +23,9 @@ export RUN=${RUN:-gfs}
 export COMPONENT=${COMPONENT:-wave}
 export HOMEgfs=${HOMEgfs:-$(dirname $(dirname $0))} # parent directory of current job card
 
+# Add default errchk = err_chk
+export errchk=${errchk:-err_chk}
+
 ###################################
 # Set COM Paths
 export COMIN=${COMIN:-$(compath.py ${NET}/${envir}/${RUN}.${PDY})/${cyc}/$COMPONENT}

--- a/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
+++ b/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
@@ -24,6 +24,9 @@ export RUN=${RUN:-gfs}
 export COMPONENT=${COMPONENT:-wave}
 export HOMEgfs=${HOMEgfs:-$(dirname $(dirname $0))} # parent directory of current job card
 
+# Add default errchk = err_chk
+export errchk=${errchk:-err_chk}
+
 ###################################
 # Set COM Paths
 ###################################

--- a/parm/config/config.vrfy
+++ b/parm/config/config.vrfy
@@ -47,11 +47,10 @@ if [ $VRFYFITS = "YES" ]; then
         export fitdir="$BASE_GIT/verif/global/parafits.fv3nems/batrun"
         export PREPQFITSH="$fitdir/subfits_cray_nems"
     elif [ $machine = "WCOSS_DELL_P3" ]; then
-        export fitdir="$BASE_GIT/verif/global/Fit2Obs/ncf-vqc/batrun"
+        export fitdir="$BASE_GIT/verif/global/Fit2Obs/newm.1.3/batrun"
         export PREPQFITSH="$fitdir/subfits_dell_nems"
     elif [ $machine = "HERA" ]; then
-        #export fitdir="$BASE_GIT/Fit2Obs/batrun"
-        export fitdir="$BASE_GIT/verif/global/Fit2Obs/ncf-vqc/batrun"
+        export fitdir="$BASE_GIT/verif/global/Fit2Obs/newm.1.3/batrun"
         export PREPQFITSH="$fitdir/subfits_hera_slurm"
     fi
 

--- a/parm/config/config.wave
+++ b/parm/config/config.wave
@@ -38,7 +38,7 @@ export WAVEWND_FID=
 
 # Grids for output fields (used in all steps)
 export waveuoutpGRD=points
-export waveinterpGRD='glo_15mxt at_10m ep_10m wc_10m ak_10m glo_30m' # Grids that need to be interpolated from native
+export waveinterpGRD='glo_15mxt at_10m ep_10m wc_10m glo_30m' # Grids that need to be interpolated from native
                              # in POST will generate grib unless gribOK not set
 export wavesbsGRD=''  # side-by-side grids generated as wave model runs, writes to com
 export wavepostGRD='gnh_10m aoc_9km gsh_15m' # Native grids that will be post-processed (grib2)

--- a/scripts/exgfs_atmos_awips_20km_1p0deg.sh
+++ b/scripts/exgfs_atmos_awips_20km_1p0deg.sh
@@ -89,6 +89,7 @@ export opt26=' -set_grib_max_bits 25 -fi -if '
 export opt27=":(APCP|ACPCP|PRATE|CPRAT|DZDT):"
 export opt28=' -new_grid_interpolation budget -fi '
 export TRIMRH=${TRIMRH:-$USHgfs/trim_rh.sh}
+export SCALEDEC=${SCALDEC:-$USHgfs/scale_dec.sh}
 
 ###############################################################
 #    Process GFS GRIB AWIP PRODUCTS IN GRIB2                  #
@@ -161,6 +162,7 @@ do
         ;;
    esac
    $TRIMRH awps_file_f${fcsthrs}_${GRID}   
+   $SCALEDEC awps_file_f${fcsthrs}_${GRID}   
    $GRB2INDEX awps_file_f${fcsthrs}_${GRID}  awps_file_fi${fcsthrs}_${GRID}
 
 ###########################################################################

--- a/scripts/exgfs_atmos_grib2_special_npoess.sh
+++ b/scripts/exgfs_atmos_grib2_special_npoess.sh
@@ -194,8 +194,8 @@ do
 
        if test $SENDDBN = "YES"
        then
-          $DBNROOT/bin/dbn_alert MODEL GFS_GOESSIMPGB2_1P0 $job $COMOUT/${RUN}.${cycle}.goessimpgrb2.0p25.f${fhr}
-          $DBNROOT/bin/dbn_alert MODEL GFS_GOESSIMPGB2_1P0_WIDX $job $COMOUT/${RUN}.${cycle}.goessimpgrb2.0p25.f${fhr}.idx
+          $DBNROOT/bin/dbn_alert MODEL GFS_GOESSIMPGB2_0P25 $job $COMOUT/${RUN}.${cycle}.goessimpgrb2.0p25.f${fhr}
+          $DBNROOT/bin/dbn_alert MODEL GFS_GOESSIMPGB2_0P25_WIDX $job $COMOUT/${RUN}.${cycle}.goessimpgrb2.0p25.f${fhr}.idx
           $DBNROOT/bin/dbn_alert MODEL GFS_GOESSIMGRD221_PGB2 $job $COMOUT/${RUN}.${cycle}.goessimpgrb2f${fhr}.grd221
        fi
 

--- a/scripts/exgfs_atmos_grib_awips.sh
+++ b/scripts/exgfs_atmos_grib_awips.sh
@@ -27,6 +27,7 @@ job_name=`echo $job|sed 's/[jpt]gfs/gfs/'`
 typeset -Z3 fcsthrs
 
 export PS4='gfs_grib_awips:f$fcsthrs:$SECONDS + '
+export SCALEDEC=${SCALDEC:-$USHgfs/scale_dec.sh}
 
 #if [ $fhcsthrs -t 100 ]; then
 #  fcsthrs=0$fcsthrs
@@ -91,6 +92,7 @@ set -x
    cp $COMIN/gfs.t${cyc}z.pgrb2b.0p25.f${fcsthrs}  tmpfile2b
    cat tmpfile2    tmpfile2b   >  tmpfile
    $WGRIB2 tmpfile | grep  -F -f $PARMproduct/gfs_awips_parmlist_g2 | $WGRIB2 -i -grib masterfile  tmpfile
+   $SCALEDEC masterfile
    $CNVGRIB -g21  masterfile  masterfile.grib1
 
    ln -s masterfile.grib1   fort.11

--- a/scripts/exgfs_wave_nawips.sh
+++ b/scripts/exgfs_wave_nawips.sh
@@ -25,6 +25,9 @@ export cycle=${cycle:-t${cyc}z}
 export GEMwave=${GEMwave:-$HOMEgfs/gempak}
 export FIXwave=${FIXwave:-HOMEgfs/fix}
 export DATA=${DATA:-${DATAROOT:?}/${jobid}}
+
+export errchk=${errchk:-err_chk}
+
 if [ ! -d $DATA ];then
   mkdir -p $DATA
 fi

--- a/scripts/exgfs_wave_nawips.sh
+++ b/scripts/exgfs_wave_nawips.sh
@@ -25,9 +25,6 @@ export cycle=${cycle:-t${cyc}z}
 export GEMwave=${GEMwave:-$HOMEgfs/gempak}
 export FIXwave=${FIXwave:-HOMEgfs/fix}
 export DATA=${DATA:-${DATAROOT:?}/${jobid}}
-
-export errchk=${errchk:-err_chk}
-
 if [ ! -d $DATA ];then
   mkdir -p $DATA
 fi

--- a/scripts/exgfs_wave_prdgen_bulls.sh
+++ b/scripts/exgfs_wave_prdgen_bulls.sh
@@ -36,8 +36,6 @@
  export USHwave=${USHwave:-$HOMEgfs/ush}
  #export EXECcode=${EXECcode:-CODEwave/exec}
 
- export errchk=${errchk:-err_chk}
-
  mkdir -p $DATA
  cd $DATA
  export wavelog=${DATA}/${RUNwave}_prdgbulls.log

--- a/scripts/exgfs_wave_prdgen_bulls.sh
+++ b/scripts/exgfs_wave_prdgen_bulls.sh
@@ -36,6 +36,8 @@
  export USHwave=${USHwave:-$HOMEgfs/ush}
  #export EXECcode=${EXECcode:-CODEwave/exec}
 
+ export errchk=${errchk:-err_chk}
+
  mkdir -p $DATA
  cd $DATA
  export wavelog=${DATA}/${RUNwave}_prdgbulls.log

--- a/scripts/exgfs_wave_prdgen_gridded.sh
+++ b/scripts/exgfs_wave_prdgen_gridded.sh
@@ -41,6 +41,8 @@
  mkdir -p $DATA
  cd $DATA
  export wavelog=${DATA}/${COMPONENTwave}_prdggridded.log
+
+ export errchk=${errchk:-err_chk}
  
  postmsg "$jlogfile" "HAS BEGUN on `hostname`"
  msg="Starting MWW3 GRIDDED PRODUCTS SCRIPT"

--- a/scripts/exgfs_wave_prdgen_gridded.sh
+++ b/scripts/exgfs_wave_prdgen_gridded.sh
@@ -41,8 +41,6 @@
  mkdir -p $DATA
  cd $DATA
  export wavelog=${DATA}/${COMPONENTwave}_prdggridded.log
-
- export errchk=${errchk:-err_chk}
  
  postmsg "$jlogfile" "HAS BEGUN on `hostname`"
  msg="Starting MWW3 GRIDDED PRODUCTS SCRIPT"

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -72,7 +72,7 @@ if [[ ! -d gfs_post.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_post.log
     git clone https://github.com/NOAA-EMC/EMC_post.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
     cd gfs_post.fd
-    git checkout upp_gfsv16_release.v1.1.1
+    git checkout upp_gfsv16_release.v1.1.2
     ################################################################################
     # checkout_gtg
     ## yes: The gtg code at NCAR private repository is available for ops. GFS only.

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -72,7 +72,7 @@ if [[ ! -d gfs_post.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_post.log
     git clone https://github.com/NOAA-EMC/EMC_post.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
     cd gfs_post.fd
-    git checkout upp_gfsv16_release.v1.1.2
+    git checkout upp_gfsv16_release.v1.1.3
     ################################################################################
     # checkout_gtg
     ## yes: The gtg code at NCAR private repository is available for ops. GFS only.

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -50,7 +50,7 @@ if [[ ! -d gldas.fd ]] ; then
     rm -f ${topdir}/checkout-gldas.log
     git clone https://github.com/NOAA-EMC/GLDAS  gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
     cd gldas.fd
-    git checkout gldas_gfsv16_release.v1.12.0
+    git checkout gldas_gfsv16_release.v1.13.0
     cd ${topdir}
 else
     echo 'Skip.  Directory gldas.fd already exists.'

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -106,7 +106,7 @@ if [[ ! -d verif-global.fd ]] ; then
     rm -f ${topdir}/checkout-verif-global.log
     git clone --recursive https://github.com/NOAA-EMC/EMC_verif-global.git verif-global.fd >> ${topdir}/checkout-verif-global.log 2>&1
     cd verif-global.fd
-    git checkout verif_global_v1.11.0
+    git checkout verif_global_v1.13.1
     cd ${topdir}
 else
     echo 'Skip. Directory verif-global.fd already exist.'

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -26,7 +26,7 @@ if [[ ! -d fv3gfs.fd ]] ; then
     rm -f ${topdir}/checkout-fv3gfs.log
     git clone https://github.com/ufs-community/ufs-weather-model fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
     cd fv3gfs.fd
-    git checkout GFS.v16.0.14
+    git checkout GFS.v16.0.15
     git submodule update --init --recursive
     cd ${topdir}
 else
@@ -95,7 +95,7 @@ if [[ ! -d gfs_wafs.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_wafs.log
     git clone --recursive https://github.com/NOAA-EMC/EMC_gfs_wafs.git gfs_wafs.fd >> ${topdir}/checkout-gfs_wafs.log 2>&1
     cd gfs_wafs.fd
-    git checkout gfs_wafs.v6.0.17
+    git checkout gfs_wafs.v6.0.18
     cd ${topdir}
 else
     echo 'Skip.  Directory gfs_wafs.fd already exists.'

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -106,7 +106,7 @@ if [[ ! -d verif-global.fd ]] ; then
     rm -f ${topdir}/checkout-verif-global.log
     git clone --recursive https://github.com/NOAA-EMC/EMC_verif-global.git verif-global.fd >> ${topdir}/checkout-verif-global.log 2>&1
     cd verif-global.fd
-    git checkout verif_global_v1.13.1
+    git checkout verif_global_v1.13.2
     cd ${topdir}
 else
     echo 'Skip. Directory verif-global.fd already exist.'

--- a/sorc/gfs_bufr.fd/gfsbufr.f
+++ b/sorc/gfs_bufr.fd/gfsbufr.f
@@ -49,6 +49,7 @@ C$$$
 !!      include 'mpif.h'
       integer,parameter:: nsta=3000
       integer,parameter:: ifile=11
+      integer,parameter:: levso=64
       integer(sigio_intkind):: irets
       type(nemsio_gfile) :: gfile
       integer ncfsig, nsig
@@ -251,7 +252,7 @@ c     do nf = nss, nend, nint
           call meteorg(npoint,rlat,rlon,istat,cstat,elevstn,
      &             nf,nfile,fnsig,jdate,idate,
      &      levs,im,jm,nsfc,
-     &      landwater,nend1, nint1, nint3, iidum,jjdum,
+     &      landwater,nend1, nint1, nint3, iidum,jjdum,np1,
      &      fformat,iocomms(ntask),iope,ionproc)
         endif  
         endif  
@@ -267,7 +268,7 @@ c     do nf = nss, nend, nint
       if(makebufr) then
           nend3 = nend
          call buff(nint1,nend1,nint3,nend3,
-     &        npoint,idate,jdate,levs,
+     &        npoint,idate,jdate,levso,
      &        dird,lss,istat,sbset,seqflg,clist,npp,wrkd)
       CALL W3TAGE('METEOMRF')
       endif

--- a/ush/parse-storm-type.pl
+++ b/ush/parse-storm-type.pl
@@ -5,7 +5,7 @@ use strict;
 
 while(defined($_=<>)) {
     chomp;
-    /^((?:NHC |JTWC) [0-59]\d[A-Z]) (\S+)\s+(.*\d\d\d\d\d\d\d\d \d\d\d\d.{34} .. .*)/ or do {
+    /^((?:NHC |JTWC) [0-589]\d[A-Z]) (\S+)\s+(.*\d\d\d\d\d\d\d\d \d\d\d\d.{34} .. .*)/ or do {
         warn "Ignoring invalid line: \"$_\"\n";
         next;
     };
@@ -19,7 +19,8 @@ while(defined($_=<>)) {
     if(length($line)>=152) {
 	$tctype=substr($_,150,2);
     } else {
-	warn "MISSING STORM TYPE (ASSUME XX): $_\n";
+	# warn "MISSING STORM TYPE (ASSUME XX): $_\n";
+	warn "NO STORM TYPE: $_\n";
     }
     if($tctype =~ /DB|EX|LO|WV|XX/i) {
         warn "Ignoring line due to TC type $tctype: $_";

--- a/ush/scale_dec.sh
+++ b/ush/scale_dec.sh
@@ -16,8 +16,10 @@ export WGRIB2=${WGRIB2:-${NWROOT}/grib_util.v1.1.0/exec/wgrib2}
 # export WGRIB2=/gpfs/dell1/nco/ops/nwprod/grib_util.v1.1.0/exec/wgrib2
 
 $WGRIB2 $f -not_if ':(TMP|PWAT|WEASD):' -grib $f.new \
-        -if ':(TMP|PWAT|WEASD):' -set_grib_type same \
-        -set_scaling -1 0 -grib_out $f.new
+        -if ':(TMP|PWAT):' -set_grib_type same \
+        -set_scaling -1 0 -grib_out $f.new \
+        -if ':(WEASD):' -set_grib_type same \
+        -set_scaling 0 0 -grib_out $f.new
 export err=$?; err_chk
 mv $f.new $f
 exit 0

--- a/ush/scale_dec.sh
+++ b/ush/scale_dec.sh
@@ -1,0 +1,23 @@
+#!/bin/ksh
+#
+#  This script uses WGRIB2 to change binary scale factor
+#  and Decimal scale factor in GRIB2 file
+#
+#      -set_scaling D B
+#  D = decimal scaling or the text 'same' with no quotes
+#  B = binary scaling or the text 'same' with no quotes
+#
+set -x
+
+f=$1
+
+export WGRIB2=${WGRIB2:-${NWROOT}/grib_util.v1.1.0/exec/wgrib2}
+
+# export WGRIB2=/gpfs/dell1/nco/ops/nwprod/grib_util.v1.1.0/exec/wgrib2
+
+$WGRIB2 $f -not_if ':(TMP|PWAT|WEASD):' -grib $f.new \
+        -if ':(TMP|PWAT|WEASD):' -set_grib_type same \
+        -set_scaling -1 0 -grib_out $f.new
+export err=$?; err_chk
+mv $f.new $f
+exit 0


### PR DESCRIPTION
Changes from NCO for v16.0.4, v16.0.5, and v16.0.6:

* FV3/ufs-weather-model tag update to GFS.v16.0.15 for running v16 (no impact to RUN_CCPP=YES checkout develop hash)
* GLDAS tag update to gldas_gfsv16_release.v1.13.0
* UPP tag update to upp_gfsv16_release.v1.1.3
* EMC_gfs_wafs tag update to gfs_wafs.v6.0.18
* series of ecflow job walltime refinements
* add a few enkf post ecf scripts
* gfs_bufr code updates
* fix in ush/parse-storm-type.pl
* wave scripts updates, including: add needed wave script ush/scale_dec.sh and add missing errchk to several wave job scripts

Tested branch issue240 on WCOSS-Dell and reproduced NCO parallel output.

This will close issue #240 