### PR TITLE
issue #257 shorten run time on Mars Dell1 file system

### DIFF
--- a/sorc/gfs_bufr.fd/meteorg.f
+++ b/sorc/gfs_bufr.fd/meteorg.f
@@ -115,8 +115,8 @@
       integer :: n3dfercld,iseedl
       integer :: istat(npoint)
       logical :: trace
-      logical, parameter :: debugprint=.true.
-!!      logical, parameter :: debugprint=.false.
+!!      logical, parameter :: debugprint=.true.
+      logical, parameter :: debugprint=.false.
       character             lprecip_accu*3
       real, parameter :: ERAD=6.371E6
       real, parameter :: DTR=3.1415926/180.
@@ -1108,6 +1108,7 @@ CC due to rounding and interpolation errors, correct it here -G.P. Lou:
 !
 !  prepare buffer data
 !
+        if(iope == 0) then
         do np = 1, npoint
           pi3(np,1)=psn(np)*1000
           do k=1,levs
@@ -1305,6 +1306,7 @@ C        print *, 'in meteorg nfile1= ', nfile1
 !!          write(nfile) data
           write(nfile) data2
         enddo  !End loop over stations np
+       endif
       call date_and_time(date,time,zone,clocking)
 !      print *,'13reading write data end= ', clocking
       print *,'13date, time, zone',date, time, zone


### PR DESCRIPTION
The new version of postsnd overcomes slowness on Mars Dell1 file systems while this was not an issue on other file systems.  It will take about 30-36 minutes to complete on Mars Dell1 and under 30 minutes on other Dell file systems without waiting for model data.