### PR TITLE
Build workflow utilities with CMake.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,14 @@
 #--------------------------
 __pycache__
 *.pyc
-*.o
+*.[aox]
 *.mod
 
-# Ignore exec folder
+# Ignore folders
 #-------------------
 exec/
+build*/
+install*/
 
 # Ignore fix directory symlinks
 #------------------------------

--- a/modulefiles/workflow_utils.hera
+++ b/modulefiles/workflow_utils.hera
@@ -9,7 +9,7 @@ module load hpc/1.1.0
 module load hpc-intel/18.0.5.274
 module load hpc-impi/2018.0.4
 
-module load jasper/2.0.22
+module load jasper/2.0.25
 module load zlib/1.2.11
 module load png/1.6.35
 

--- a/modulefiles/workflow_utils.hera
+++ b/modulefiles/workflow_utils.hera
@@ -1,0 +1,29 @@
+#%Module#####################################################
+## Workflow Utilities - hera
+#############################################################
+
+module load cmake/3.16.1
+
+module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack
+module load hpc/1.1.0
+module load hpc-intel/18.0.5.274
+module load hpc-impi/2018.0.4
+
+module load jasper/2.0.22
+module load zlib/1.2.11
+module load png/1.6.35
+
+module load bacio/2.4.1
+module load w3nco/2.4.1
+module load w3emc/2.7.3
+module load sp/2.3.3
+module load ip/3.3.3
+module load nemsio/2.5.2
+module load nemsiogfs/2.5.3
+#module load ncio/1.0.0
+module load sigio/2.3.2
+module load g2/3.4.1
+module load bufr/11.4.0
+
+module load hdf5/1.10.6
+module load netcdf/4.7.4

--- a/modulefiles/workflow_utils.orion
+++ b/modulefiles/workflow_utils.orion
@@ -9,7 +9,7 @@ module load hpc/1.1.0
 module load hpc-intel/2018.4
 module load hpc-impi/2018.4
 
-module load jasper/2.0.22
+module load jasper/2.0.25
 module load zlib/1.2.11
 module load png/1.6.35
 

--- a/modulefiles/workflow_utils.orion
+++ b/modulefiles/workflow_utils.orion
@@ -1,0 +1,29 @@
+#%Module#####################################################
+## Workflow Utilities - orion
+#############################################################
+
+module load cmake/3.17.3
+
+module use /apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack
+module load hpc/1.1.0
+module load hpc-intel/2018.4
+module load hpc-impi/2018.4
+
+module load jasper/2.0.22
+module load zlib/1.2.11
+module load png/1.6.35
+
+module load bacio/2.4.1
+module load w3nco/2.4.1
+module load w3emc/2.7.3
+module load sp/2.3.3
+module load ip/3.3.3
+module load nemsio/2.5.2
+module load nemsiogfs/2.5.3
+#module load ncio/1.0.0
+module load sigio/2.3.2
+module load g2/3.4.1
+module load bufr/11.4.0
+
+module load hdf5/1.10.6
+module load netcdf/4.7.4

--- a/modulefiles/workflow_utils.wcoss_dell_p3
+++ b/modulefiles/workflow_utils.wcoss_dell_p3
@@ -1,0 +1,29 @@
+#%Module#####################################################
+## Workflow Utilities - wcoss_dell_p3
+#############################################################
+
+module load cmake/3.16.2
+
+module use /usrx/local/nceplibs/dev/hpc-stack/libs/hpc-stack/modulefiles/stack
+module load hpc/1.1.0
+module load hpc-ips/18.0.1.163
+module load hpc-impi/18.0.1
+
+module load jasper/2.0.22
+module load zlib/1.2.11
+module load png/1.6.35
+
+module load bacio/2.4.1
+module load w3nco/2.4.1
+module load w3emc/2.7.3
+module load sp/2.3.3
+module load ip/3.3.3
+module load nemsio/2.5.2
+module load nemsiogfs/2.5.3
+#module load ncio/1.0.0
+module load sigio/2.3.2
+module load g2/3.4.1
+module load bufr/11.4.0
+
+module load hdf5/1.10.6
+module load netcdf/4.7.4

--- a/modulefiles/workflow_utils.wcoss_dell_p3
+++ b/modulefiles/workflow_utils.wcoss_dell_p3
@@ -9,7 +9,7 @@ module load hpc/1.1.0
 module load hpc-ips/18.0.1.163
 module load hpc-impi/18.0.1
 
-module load jasper/2.0.22
+module load jasper/2.0.25
 module load zlib/1.2.11
 module load png/1.6.35
 

--- a/sorc/CMakeLists.txt
+++ b/sorc/CMakeLists.txt
@@ -1,0 +1,72 @@
+cmake_minimum_required(VERSION 3.15)
+
+# Get the version from the VERSION file.
+#file(STRINGS "VERSION" pVersion)
+set(pVersion 1.0.0)
+
+project(
+  workflow_utils
+  VERSION ${pVersion}
+  LANGUAGES Fortran)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+include(GNUInstallDirs)
+
+# User options.
+option(OPENMP "use OpenMP threading" ON)
+
+# Build type
+if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
+  message(STATUS "Setting build type to 'Release' as none was specified.")
+  set(CMAKE_BUILD_TYPE
+      "Release"
+      CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+                                               "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# Set compiler flags.
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check -check noarg_temp_created -check nopointer -fp-stack-check -fstack-protector-all -fpe0 -debug -ftrapuv")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -fbacktrace")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -ggdb -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -ffpe-trap=invalid,zero,overflow -fbounds-check")
+endif()
+
+# Find packages.
+find_package(MPI REQUIRED)
+find_package(NetCDF REQUIRED Fortran)
+
+if(OPENMP)
+  find_package(OpenMP REQUIRED COMPONENTS Fortran)
+endif()
+
+find_package(bacio REQUIRED)
+find_package(w3nco REQUIRED)
+find_package(w3emc REQUIRED)
+find_package(sp REQUIRED)
+find_package(ip REQUIRED)
+find_package(ncio REQUIRED)
+find_package(nemsio REQUIRED)
+find_package(nemsiogfs REQUIRED)
+find_package(sigio REQUIRED)
+find_package(g2 REQUIRED)
+find_package(bufr REQUIRED)
+
+add_subdirectory(enkf_chgres_recenter.fd)
+add_subdirectory(enkf_chgres_recenter_nc.fd)
+add_subdirectory(fv3nc2nemsio.fd)
+add_subdirectory(regrid_nemsio.fd)
+add_subdirectory(gaussian_sfcanl.fd)
+add_subdirectory(gfs_bufr.fd)
+add_subdirectory(tocsbufr.fd)
+add_subdirectory(fbwndgfs.fd)
+add_subdirectory(vint.fd)
+add_subdirectory(tave.fd)
+add_subdirectory(syndat_qctropcy.fd)
+add_subdirectory(syndat_maksynrc.fd)
+add_subdirectory(syndat_getjtbul.fd)
+add_subdirectory(supvit.fd)

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -271,7 +271,7 @@ fi
 #------------------------------------
 $Build_workflow_utils && {
 echo " .... Building workflow_utils .... "
-./build_workflow_utils.sh > $logs_dir/build_workflow_utils.log 2>&1
+target=$target ./build_workflow_utils.sh > $logs_dir/build_workflow_utils.log 2>&1
 rc=$?
 if [[ $rc -ne 0 ]] ; then
     echo "Fatal error in building workflow_utils."

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -267,6 +267,20 @@ fi
 }
 
 #------------------------------------
+# build workflow_utils
+#------------------------------------
+$Build_workflow_utils && {
+echo " .... Building workflow_utils .... "
+./build_workflow_utils.sh > $logs_dir/build_workflow_utils.log 2>&1
+rc=$?
+if [[ $rc -ne 0 ]] ; then
+    echo "Fatal error in building workflow_utils."
+    echo "The log file is in $logs_dir/build_workflow_utils.log"
+fi
+((err+=$rc))
+}
+
+#------------------------------------
 # build gfs_util       
 #------------------------------------
 # Only build on WCOSS

--- a/sorc/build_workflow_utils.sh
+++ b/sorc/build_workflow_utils.sh
@@ -5,11 +5,11 @@ set -eux
 readonly UTILS_DIR=$(cd "$(dirname "$($cmd -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
 
 # Adapt for global-workflow structure.
+source ${UTILS_DIR}/machine-setup.sh > /dev/null 2>&1
 target=${target:-"NULL"}
 modulefile=${UTILS_DIR}/../modulefiles/workflow_utils.$target
 if [[ -f $modulefile ]]; then
   set +x
-  source ${UTILS_DIR}/machine-setup.sh > /dev/null 2>&1
   source $modulefile
   module list
   set -x

--- a/sorc/build_workflow_utils.sh
+++ b/sorc/build_workflow_utils.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eux
+
+[[ $(uname -s) == Darwin ]] && cmd=$(which greadlink) || cmd=$(which readlink)
+readonly UTILS_DIR=$(cd "$(dirname "$($cmd -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
+
+# Adapt for global-workflow structure.
+target=${target:-"NULL"}
+modulefile=${UTILS_DIR}/../modulefiles/workflow_utils.$target
+if [[ -f $modulefile ]]; then
+  set +x
+  source ${UTILS_DIR}/machine-setup.sh > /dev/null 2>&1
+  source $modulefile
+  module list
+  set -x
+fi
+# End adaptation
+
+# Begin hack
+# In place until nceplibs-ncio is in hpc-stack and available as a module
+# After nceplibs-ncio is in hpc-stack, add the following line to
+# ${UTILS_DIR}/../modulefiles/workflow_utils.<platform>
+# "module load ncio/<ncio-version>"
+# and remove this hack
+
+[[ -d nceplibs-ncio ]] && rm -rf nceplibs-ncio
+git clone -b develop https://github.com/noaa-emc/nceplibs-ncio
+cd nceplibs-ncio
+mkdir -p build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=../install
+make -j ${BUILD_JOBS:-4} VERBOSE=${BUILD_VERBOSE:-}
+make install
+cd ../..
+export ncio_ROOT=$PWD/nceplibs-ncio/install
+# End hack
+
+BUILD_DIR=${BUILD_DIR:-${UTILS_DIR}/build}
+[[ -d $BUILD_DIR ]] && rm -rf $BUILD_DIR
+mkdir -p ${BUILD_DIR}
+cd $BUILD_DIR
+
+INSTALL_DIR=${INSTALL_DIR:-${UTILS_DIR}/install}
+
+CMAKE_FLAGS+=" -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR"
+
+cmake ${UTILS_DIR} ${CMAKE_FLAGS}
+make -j ${BUILD_JOBS:-4} VERBOSE=${BUILD_VERBOSE:-}
+make install

--- a/sorc/build_workflow_utils.sh
+++ b/sorc/build_workflow_utils.sh
@@ -5,11 +5,11 @@ set -eux
 readonly UTILS_DIR=$(cd "$(dirname "$($cmd -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
 
 # Adapt for global-workflow structure.
-source ${UTILS_DIR}/machine-setup.sh > /dev/null 2>&1
 target=${target:-"NULL"}
 modulefile=${UTILS_DIR}/../modulefiles/workflow_utils.$target
 if [[ -f $modulefile ]]; then
   set +x
+  source ${UTILS_DIR}/machine-setup.sh > /dev/null 2>&1
   source $modulefile
   module list
   set -x

--- a/sorc/build_workflow_utils.sh
+++ b/sorc/build_workflow_utils.sh
@@ -27,7 +27,7 @@ fi
 git clone -b develop https://github.com/noaa-emc/nceplibs-ncio
 cd nceplibs-ncio
 mkdir -p build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=../install
+cmake -DCMAKE_INSTALL_PREFIX=../install ..
 make -j ${BUILD_JOBS:-4} VERBOSE=${BUILD_VERBOSE:-}
 make install
 cd ../..

--- a/sorc/cmake/FindNetCDF.cmake
+++ b/sorc/cmake/FindNetCDF.cmake
@@ -1,0 +1,347 @@
+# (C) Copyright 2011- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+# Try to find NetCDF includes and library.
+# Supports static and shared libaries and allows each component to be found in sepearte prefixes.
+#
+# This module defines
+#
+#   - NetCDF_FOUND                - System has NetCDF
+#   - NetCDF_INCLUDE_DIRS         - the NetCDF include directories
+#   - NetCDF_VERSION              - the version of NetCDF
+#   - NetCDF_CONFIG_EXECUTABLE    - the netcdf-config executable if found
+#   - NetCDF_PARALLEL             - Boolean True if NetCDF4 has parallel IO support via hdf5 and/or pnetcdf
+#   - NetCDF_HAS_PNETCDF          - Boolean True if NetCDF4 has pnetcdf support
+#
+# Deprecated Defines
+#   - NetCDF_LIBRARIES            - [Deprecated] Use NetCDF::NetCDF_<LANG> targets instead.
+#
+#
+# Following components are available:
+#
+#   - C                           - C interface to NetCDF          (netcdf)
+#   - CXX                         - CXX4 interface to NetCDF       (netcdf_c++4)
+#   - Fortran                     - Fortran interface to NetCDF    (netcdff)
+#
+# For each component the following are defined:
+#
+#   - NetCDF_<comp>_FOUND         - whether the component is found
+#   - NetCDF_<comp>_LIBRARIES     - the libraries for the component
+#   - NetCDF_<comp>_LIBRARY_SHARED - Boolean is true if libraries for component are shared
+#   - NetCDF_<comp>_INCLUDE_DIRS  - the include directories for specified component
+#   - NetCDF::NetCDF_<comp>       - target of component to be used with target_link_libraries()
+#
+# The following paths will be searched in order if set in CMake (first priority) or environment (second priority)
+#
+#   - NetCDF_ROOT                 - root of NetCDF installation
+#   - NetCDF_PATH                 - root of NetCDF installation
+#
+# The search process begins with locating NetCDF Include headers.  If these are in a non-standard location,
+# set one of the following CMake or environment variables to point to the location:
+#
+#  - NetCDF_INCLUDE_DIR or NetCDF_${comp}_INCLUDE_DIR
+#  - NetCDF_INCLUDE_DIRS or NetCDF_${comp}_INCLUDE_DIR
+#
+# Notes:
+#
+#   - Use "NetCDF::NetCDF_<LANG>" targets only.  NetCDF_LIBRARIES exists for backwards compatibility and should not be used.
+#     - These targets have all the knowledge of include directories and library search directories, and a single
+#       call to target_link_libraries will provide all these transitive properties to your target.  Normally all that is
+#       needed to build and link against NetCDF is, e.g.:
+#           target_link_libraries(my_c_tgt PUBLIC NetCDF::NetCDF_C)
+#   - "NetCDF" is always the preferred naming for this package, its targets, variables, and environment variables
+#     - For compatibility, some variables are also set/checked using alternate names NetCDF4, NETCDF, or NETCDF4
+#     - Environments relying on these older environment variable names should move to using a "NetCDF_ROOT" environment variable
+#   - Preferred component capitalization follows the CMake LANGUAGES variables: i.e., C, Fortran, CXX
+#     - For compatibility, alternate capitalizations are supported but should not be used.
+#   - If no components are defined, all components will be searched
+#
+
+list( APPEND _possible_components C CXX Fortran )
+
+## Include names for each component
+set( NetCDF_C_INCLUDE_NAME          netcdf.h )
+set( NetCDF_CXX_INCLUDE_NAME        netcdf )
+set( NetCDF_Fortran_INCLUDE_NAME    netcdf.mod )
+
+## Library names for each component
+set( NetCDF_C_LIBRARY_NAME          netcdf )
+set( NetCDF_CXX_LIBRARY_NAME        netcdf_c++4 )
+set( NetCDF_Fortran_LIBRARY_NAME    netcdff )
+
+## Enumerate search components
+foreach( _comp ${_possible_components} )
+  string( TOUPPER "${_comp}" _COMP )
+  set( _arg_${_COMP} ${_comp} )
+  set( _name_${_COMP} ${_comp} )
+endforeach()
+
+set( _search_components C)
+foreach( _comp ${${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS} )
+  string( TOUPPER "${_comp}" _COMP )
+  set( _arg_${_COMP} ${_comp} )
+  list( APPEND _search_components ${_name_${_COMP}} )
+  if( NOT _name_${_COMP} )
+    message(SEND_ERROR "Find${CMAKE_FIND_PACKAGE_NAME}: COMPONENT ${_comp} is not a valid component. Valid components: ${_possible_components}" )
+  endif()
+endforeach()
+list( REMOVE_DUPLICATES _search_components )
+
+## Search hints for finding include directories and libraries
+foreach( _comp IN ITEMS "_" "_C_" "_Fortran_" "_CXX_" )
+  foreach( _name IN ITEMS NetCDF4 NetCDF NETCDF4 NETCDF )
+    foreach( _var IN ITEMS ROOT PATH )
+      list(APPEND _search_hints ${${_name}${_comp}${_var}} $ENV{${_name}${_comp}${_var}} )
+      list(APPEND _include_search_hints
+                ${${_name}${_comp}INCLUDE_DIR} $ENV{${_name}${_comp}INCLUDE_DIR}
+                ${${_name}${_comp}INCLUDE_DIRS} $ENV{${_name}${_comp}INCLUDE_DIRS} )
+    endforeach()
+  endforeach()
+endforeach()
+#Old-school HPC module env variable names
+foreach( _name IN ITEMS NetCDF4 NetCDF NETCDF4 NETCDF )
+  foreach( _comp IN ITEMS "_C" "_Fortran" "_CXX" )
+    list(APPEND _search_hints ${${_name}}         $ENV{${_name}})
+    list(APPEND _search_hints ${${_name}${_comp}} $ENV{${_name}${_comp}})
+  endforeach()
+endforeach()
+
+## Find headers for each component
+set(NetCDF_INCLUDE_DIRS)
+set(_new_search_components)
+foreach( _comp IN LISTS _search_components )
+  if(NOT ${PROJECT_NAME}_NetCDF_${_comp}_FOUND)
+      list(APPEND _new_search_components ${_comp})
+  endif()
+  find_file(NetCDF_${_comp}_INCLUDE_FILE
+    NAMES ${NetCDF_${_comp}_INCLUDE_NAME}
+    DOC "NetCDF ${_comp} include directory"
+    HINTS ${_include_search_hints} ${_search_hints}
+    PATH_SUFFIXES include include/netcdf
+  )
+  mark_as_advanced(NetCDF_${_comp}_INCLUDE_FILE)
+  message(DEBUG "NetCDF_${_comp}_INCLUDE_FILE: ${NetCDF_${_comp}_INCLUDE_FILE}")
+  if( NetCDF_${_comp}_INCLUDE_FILE )
+    get_filename_component(NetCDF_${_comp}_INCLUDE_FILE ${NetCDF_${_comp}_INCLUDE_FILE} ABSOLUTE)
+    get_filename_component(NetCDF_${_comp}_INCLUDE_DIR ${NetCDF_${_comp}_INCLUDE_FILE} DIRECTORY)
+    list(APPEND NetCDF_INCLUDE_DIRS ${NetCDF_${_comp}_INCLUDE_DIR})
+  endif()
+endforeach()
+if(NetCDF_INCLUDE_DIRS)
+    list(REMOVE_DUPLICATES NetCDF_INCLUDE_DIRS)
+endif()
+set(NetCDF_INCLUDE_DIRS "${NetCDF_INCLUDE_DIRS}" CACHE STRING "NetCDF Include directory paths" FORCE)
+
+## Find n*-config executables for search components
+foreach( _comp IN LISTS _search_components )
+  if( _comp MATCHES "^(C)$" )
+    set(_conf "c")
+  elseif( _comp MATCHES "^(Fortran)$" )
+    set(_conf "f")
+  elseif( _comp MATCHES "^(CXX)$" )
+    set(_conf "cxx4")
+  endif()
+  find_program( NetCDF_${_comp}_CONFIG_EXECUTABLE
+      NAMES n${_conf}-config
+    HINTS ${NetCDF_INCLUDE_DIRS} ${_include_search_hints} ${_search_hints}
+    PATH_SUFFIXES bin Bin ../bin ../../bin
+      DOC "NetCDF n${_conf}-config helper" )
+    message(DEBUG "NetCDF_${_comp}_CONFIG_EXECUTABLE: ${NetCDF_${_comp}_CONFIG_EXECUTABLE}")
+endforeach()
+
+set(_C_libs_flag --libs)
+set(_Fortran_libs_flag --flibs)
+set(_CXX_libs_flag --libs)
+set(_C_includes_flag --includedir)
+set(_Fortran_includes_flag --includedir)
+set(_CXX_includes_flag --includedir)
+function(netcdf_config exec flag output_var)
+  set(${output_var} False PARENT_SCOPE)
+  if( exec )
+    execute_process( COMMAND ${exec} ${flag} RESULT_VARIABLE _ret OUTPUT_VARIABLE _val)
+    if( _ret EQUAL 0 )
+      string( STRIP ${_val} _val )
+      set( ${output_var} ${_val} PARENT_SCOPE )
+    endif()
+  endif()
+endfunction()
+
+## Detect additional package properties
+netcdf_config(${NetCDF_C_CONFIG_EXECUTABLE} --has-parallel4 _val)
+if( NOT _val MATCHES "^(yes|no)$" )
+  netcdf_config(${NetCDF_C_CONFIG_EXECUTABLE} --has-parallel _val)
+endif()
+if( _val MATCHES "^(yes)$" )
+  set(NetCDF_PARALLEL TRUE CACHE STRING "NetCDF has parallel IO capability via pnetcdf or hdf5." FORCE)
+else()
+  set(NetCDF_PARALLEL FALSE CACHE STRING "NetCDF has no parallel IO capability." FORCE)
+endif()
+
+if(NetCDF_PARALLEL)
+  find_package(MPI REQUIRED)
+endif()
+
+## Find libraries for each component
+set( NetCDF_LIBRARIES )
+foreach( _comp IN LISTS _search_components )
+  string( TOUPPER "${_comp}" _COMP )
+
+  find_library( NetCDF_${_comp}_LIBRARY
+    NAMES ${NetCDF_${_comp}_LIBRARY_NAME}
+    DOC "NetCDF ${_comp} library"
+    HINTS ${NetCDF_${_comp}_INCLUDE_DIRS} ${_search_hints}
+    PATH_SUFFIXES lib64 lib ../lib64 ../lib ../../lib64 ../../lib )
+  mark_as_advanced( NetCDF_${_comp}_LIBRARY )
+  get_filename_component(NetCDF_${_comp}_LIBRARY ${NetCDF_${_comp}_LIBRARY} ABSOLUTE)
+  set(NetCDF_${_comp}_LIBRARY ${NetCDF_${_comp}_LIBRARY} CACHE STRING "NetCDF ${_comp} library" FORCE)
+  message(DEBUG "NetCDF_${_comp}_LIBRARY: ${NetCDF_${_comp}_LIBRARY}")
+
+  if( NetCDF_${_comp}_LIBRARY )
+    if( NetCDF_${_comp}_LIBRARY MATCHES ".a$" )
+      set( NetCDF_${_comp}_LIBRARY_SHARED FALSE )
+      set( _library_type STATIC)
+    else()
+      list( APPEND NetCDF_LIBRARIES ${NetCDF_${_comp}_LIBRARY} )
+      set( NetCDF_${_comp}_LIBRARY_SHARED TRUE )
+      set( _library_type SHARED)
+    endif()
+  endif()
+
+  #Use nc-config to set per-component LIBRARIES variable if possible
+  netcdf_config( ${NetCDF_${_comp}_CONFIG_EXECUTABLE} ${_${_comp}_libs_flag} _val )
+  if( _val )
+    set( NetCDF_${_comp}_LIBRARIES ${_val} )
+    if(NOT NetCDF_${_comp}_LIBRARY_SHARED AND NOT NetCDF_${_comp}_FOUND) #Static targets should use nc_config to get a proper link line with all necessary static targets.
+      list( APPEND NetCDF_LIBRARIES ${NetCDF_${_comp}_LIBRARIES} )
+    endif()
+  else()
+    set( NetCDF_${_comp}_LIBRARIES ${NetCDF_${_comp}_LIBRARY} )
+    if(NOT NetCDF_${_comp}_LIBRARY_SHARED)
+      message(SEND_ERROR "Unable to properly find NetCDF.  Found static libraries at: ${NetCDF_${_comp}_LIBRARY} but could not run nc-config: ${NetCDF_CONFIG_EXECUTABLE}")
+    endif()
+  endif()
+
+  #Use nc-config to set per-component INCLUDE_DIRS variable if possible
+  netcdf_config( ${NetCDF_${_comp}_CONFIG_EXECUTABLE} ${_${_comp}_includes_flag} _val )
+  if( _val )
+    string( REPLACE " " ";" _val ${_val} )
+    set( NetCDF_${_comp}_INCLUDE_DIRS ${_val} )
+  else()
+    set( NetCDF_${_comp}_INCLUDE_DIRS ${NetCDF_${_comp}_INCLUDE_DIR} )
+  endif()
+
+  if( NetCDF_${_comp}_LIBRARIES AND NetCDF_${_comp}_INCLUDE_DIRS )
+    set( ${CMAKE_FIND_PACKAGE_NAME}_${_arg_${_COMP}}_FOUND TRUE )
+    if (NOT TARGET NetCDF::NetCDF_${_comp})
+      add_library(NetCDF::NetCDF_${_comp} ${_library_type} IMPORTED)
+      set_target_properties(NetCDF::NetCDF_${_comp} PROPERTIES
+        IMPORTED_LOCATION ${NetCDF_${_comp}_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES "${NetCDF_${_comp}_INCLUDE_DIRS}"
+        INTERFACE_LINK_LIBRARIES ${NetCDF_${_comp}_LIBRARIES} )
+      if( NOT _comp MATCHES "^(C)$" )
+        target_link_libraries(NetCDF::NetCDF_${_comp} INTERFACE NetCDF::NetCDF_C)
+      endif()
+      if(MPI_${_comp}_FOUND)
+        target_link_libraries(NetCDF::NetCDF_${_comp} INTERFACE MPI::MPI_${_comp})
+      endif()
+    endif()
+  endif()
+endforeach()
+if(NetCDF_LIBRARIES AND NetCDF_${_comp}_LIBRARY_SHARED)
+    list(REMOVE_DUPLICATES NetCDF_LIBRARIES)
+endif()
+set(NetCDF_LIBRARIES "${NetCDF_LIBRARIES}" CACHE STRING "NetCDF library targets" FORCE)
+
+## Find version via netcdf-config if possible
+if (NetCDF_INCLUDE_DIRS)
+  if( NetCDF_C_CONFIG_EXECUTABLE )
+    netcdf_config( ${NetCDF_C_CONFIG_EXECUTABLE} --version _vers )
+    if( _vers )
+      string(REGEX REPLACE ".* ((([0-9]+)\\.)+([0-9]+)).*" "\\1" NetCDF_VERSION "${_vers}" )
+    endif()
+  else()
+    foreach( _dir IN LISTS NetCDF_INCLUDE_DIRS)
+      if( EXISTS "${_dir}/netcdf_meta.h" )
+        file(STRINGS "${_dir}/netcdf_meta.h" _netcdf_version_lines
+        REGEX "#define[ \t]+NC_VERSION_(MAJOR|MINOR|PATCH|NOTE)")
+        string(REGEX REPLACE ".*NC_VERSION_MAJOR *\([0-9]*\).*" "\\1" _netcdf_version_major "${_netcdf_version_lines}")
+        string(REGEX REPLACE ".*NC_VERSION_MINOR *\([0-9]*\).*" "\\1" _netcdf_version_minor "${_netcdf_version_lines}")
+        string(REGEX REPLACE ".*NC_VERSION_PATCH *\([0-9]*\).*" "\\1" _netcdf_version_patch "${_netcdf_version_lines}")
+        string(REGEX REPLACE ".*NC_VERSION_NOTE *\"\([^\"]*\)\".*" "\\1" _netcdf_version_note "${_netcdf_version_lines}")
+        set(NetCDF_VERSION "${_netcdf_version_major}.${_netcdf_version_minor}.${_netcdf_version_patch}${_netcdf_version_note}")
+        unset(_netcdf_version_major)
+        unset(_netcdf_version_minor)
+        unset(_netcdf_version_patch)
+        unset(_netcdf_version_note)
+        unset(_netcdf_version_lines)
+      endif()
+    endforeach()
+  endif()
+endif ()
+
+## Finalize find_package
+include(FindPackageHandleStandardArgs)
+
+if(NOT NetCDF_FOUND OR _new_search_components)
+    find_package_handle_standard_args( ${CMAKE_FIND_PACKAGE_NAME}
+        REQUIRED_VARS NetCDF_INCLUDE_DIRS NetCDF_LIBRARIES
+        VERSION_VAR NetCDF_VERSION
+        HANDLE_COMPONENTS )
+endif()
+
+foreach( _comp IN LISTS _search_components )
+    if( NetCDF_${_comp}_FOUND )
+        #Record found components to avoid duplication in NetCDF_LIBRARIES for static libraries
+        set(NetCDF_${_comp}_FOUND ${NetCDF_${_comp}_FOUND} CACHE BOOL "NetCDF ${_comp} Found" FORCE)
+        #Set a per-package, per-component found variable to communicate between multiple calls to find_package()
+        set(${PROJECT_NAME}_NetCDF_${_comp}_FOUND True)
+    endif()
+endforeach()
+
+if( ${CMAKE_FIND_PACKAGE_NAME}_FOUND AND NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY AND _new_search_components)
+  message( STATUS "Find${CMAKE_FIND_PACKAGE_NAME} defines targets:" )
+  message( STATUS "  - NetCDF_VERSION [${NetCDF_VERSION}]")
+  message( STATUS "  - NetCDF_PARALLEL [${NetCDF_PARALLEL}]")
+  foreach( _comp IN LISTS _new_search_components )
+    string( TOUPPER "${_comp}" _COMP )
+    message( STATUS "  - NetCDF_${_comp}_CONFIG_EXECUTABLE [${NetCDF_${_comp}_CONFIG_EXECUTABLE}]")
+    if( ${CMAKE_FIND_PACKAGE_NAME}_${_arg_${_COMP}}_FOUND )
+      get_filename_component(_root ${NetCDF_${_comp}_INCLUDE_DIR}/.. ABSOLUTE)
+      if( NetCDF_${_comp}_LIBRARY_SHARED )
+        message( STATUS "  - NetCDF::NetCDF_${_comp} [SHARED] [Root: ${_root}] Lib: ${NetCDF_${_comp}_LIBRARY} ")
+      else()
+        message( STATUS "  - NetCDF::NetCDF_${_comp} [STATIC] [Root: ${_root}] Lib: ${NetCDF_${_comp}_LIBRARY} ")
+      endif()
+    endif()
+  endforeach()
+endif()
+
+foreach( _prefix NetCDF NetCDF4 NETCDF NETCDF4 ${CMAKE_FIND_PACKAGE_NAME} )
+  set( ${_prefix}_INCLUDE_DIRS ${NetCDF_INCLUDE_DIRS} )
+  set( ${_prefix}_LIBRARIES    ${NetCDF_LIBRARIES})
+  set( ${_prefix}_VERSION      ${NetCDF_VERSION} )
+  set( ${_prefix}_FOUND        ${${CMAKE_FIND_PACKAGE_NAME}_FOUND} )
+  set( ${_prefix}_CONFIG_EXECUTABLE ${NetCDF_CONFIG_EXECUTABLE} )
+  set( ${_prefix}_PARALLEL ${NetCDF_PARALLEL} )
+
+  foreach( _comp ${_search_components} )
+    string( TOUPPER "${_comp}" _COMP )
+    set( _arg_comp ${_arg_${_COMP}} )
+    set( ${_prefix}_${_comp}_FOUND     ${${CMAKE_FIND_PACKAGE_NAME}_${_arg_comp}_FOUND} )
+    set( ${_prefix}_${_COMP}_FOUND     ${${CMAKE_FIND_PACKAGE_NAME}_${_arg_comp}_FOUND} )
+    set( ${_prefix}_${_arg_comp}_FOUND ${${CMAKE_FIND_PACKAGE_NAME}_${_arg_comp}_FOUND} )
+
+    set( ${_prefix}_${_comp}_LIBRARIES     ${NetCDF_${_comp}_LIBRARIES} )
+    set( ${_prefix}_${_COMP}_LIBRARIES     ${NetCDF_${_comp}_LIBRARIES} )
+    set( ${_prefix}_${_arg_comp}_LIBRARIES ${NetCDF_${_comp}_LIBRARIES} )
+
+    set( ${_prefix}_${_comp}_INCLUDE_DIRS     ${NetCDF_${_comp}_INCLUDE_DIRS} )
+    set( ${_prefix}_${_COMP}_INCLUDE_DIRS     ${NetCDF_${_comp}_INCLUDE_DIRS} )
+    set( ${_prefix}_${_arg_comp}_INCLUDE_DIRS ${NetCDF_${_comp}_INCLUDE_DIRS} )
+  endforeach()
+endforeach()

--- a/sorc/enkf_chgres_recenter.fd/CMakeLists.txt
+++ b/sorc/enkf_chgres_recenter.fd/CMakeLists.txt
@@ -1,0 +1,29 @@
+list(APPEND fortran_src
+driver.f90
+input_data.f90
+interp.f90
+output_data.f90
+setup.f90
+utils.f90
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -i4 -fp-model precise")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8")
+endif()
+
+set(exe_name enkf_chgres_recenter.x)
+add_executable(${exe_name} ${fortran_src})
+target_link_libraries(
+  ${exe_name}
+  nemsio::nemsio
+  bacio::bacio_4
+  ip::ip_d
+  sp::sp_d
+  w3nco::w3nco_d)
+if(OpenMP_Fortran_FOUND)
+  target_link_libraries(${exe_name} OpenMP::OpenMP_Fortran)
+endif()
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sorc/enkf_chgres_recenter_nc.fd/CMakeLists.txt
+++ b/sorc/enkf_chgres_recenter_nc.fd/CMakeLists.txt
@@ -1,0 +1,29 @@
+list(APPEND fortran_src
+driver.f90
+input_data.f90
+interp.f90
+output_data.f90
+setup.f90
+utils.f90
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model precise")
+endif()
+
+set(exe_name enkf_chgres_recenter_nc.x)
+add_executable(${exe_name} ${fortran_src})
+target_link_libraries(
+  ${exe_name}
+  nemsio::nemsio
+  bacio::bacio_4
+  ip::ip_d
+  sp::sp_d
+  w3nco::w3nco_d
+  ncio::ncio
+  NetCDF::NetCDF_Fortran)
+if(OpenMP_Fortran_FOUND)
+  target_link_libraries(${exe_name} OpenMP::OpenMP_Fortran)
+endif()
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sorc/enkf_chgres_recenter_nc.fd/CMakeLists.txt
+++ b/sorc/enkf_chgres_recenter_nc.fd/CMakeLists.txt
@@ -15,11 +15,10 @@ set(exe_name enkf_chgres_recenter_nc.x)
 add_executable(${exe_name} ${fortran_src})
 target_link_libraries(
   ${exe_name}
-  nemsio::nemsio
   bacio::bacio_4
-  ip::ip_d
-  sp::sp_d
-  w3nco::w3nco_d
+  ip::ip_4
+  sp::sp_4
+  w3nco::w3nco_4
   ncio::ncio
   NetCDF::NetCDF_Fortran)
 if(OpenMP_Fortran_FOUND)

--- a/sorc/enkf_chgres_recenter_nc.fd/input_data.f90
+++ b/sorc/enkf_chgres_recenter_nc.fd/input_data.f90
@@ -2,7 +2,7 @@
 
  use utils
  use setup
- use module_fv3gfs_ncio
+ use module_ncio
 
  implicit none
 
@@ -23,7 +23,7 @@
  real, allocatable, public                    :: clwmr_input(:,:)
  real, allocatable, public                    :: dzdt_input(:,:)
  real, allocatable, public                    :: grle_input(:,:)
- real, allocatable, public                    :: cldamt_input(:,:) 
+ real, allocatable, public                    :: cldamt_input(:,:)
  real, allocatable, public                    :: hgt_input(:)
  real, allocatable, public                    :: icmr_input(:,:)
  real, allocatable, public                    :: o3mr_input(:,:)
@@ -80,7 +80,7 @@
 
  call read_attribute(indset, 'ak', ak)
  call read_attribute(indset, 'bk', bk)
- 
+
  nvcoord_input = 2
  allocate(vcoord_input(lev+1,nvcoord_input))
  do k = 1, lev+1
@@ -114,7 +114,7 @@
  call read_vardata(indset, 'ugrd', work3d)
  do vlev = 1, lev
    rvlev = lev+1-vlev
-   ugrd_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/)) 
+   ugrd_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/))
    print*,'MAX/MIN U WIND AT LEVEL ',vlev, "IS: ", maxval(ugrd_input(:,vlev)), minval(ugrd_input(:,vlev))
  enddo
 
@@ -124,7 +124,7 @@
  call read_vardata(indset, 'vgrd', work3d)
  do vlev = 1, lev
    rvlev = lev+1-vlev
-   vgrd_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/)) 
+   vgrd_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/))
    print*,'MAX/MIN V WIND AT LEVEL ', vlev, "IS: ", maxval(vgrd_input(:,vlev)), minval(vgrd_input(:,vlev))
  enddo
 
@@ -134,7 +134,7 @@
  call read_vardata(indset, 'tmp', work3d)
  do vlev = 1, lev
    rvlev = lev+1-vlev
-   tmp_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/)) 
+   tmp_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/))
    print*,'MAX/MIN TEMPERATURE AT LEVEL ', vlev, 'IS: ', maxval(tmp_input(:,vlev)), minval(tmp_input(:,vlev))
  enddo
 
@@ -144,7 +144,7 @@
  call read_vardata(indset, 'spfh', work3d)
  do vlev = 1, lev
    rvlev = lev+1-vlev
-   spfh_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/)) 
+   spfh_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/))
    print*,'MAX/MIN SPECIFIC HUMIDITY AT LEVEL ', vlev, 'IS: ', maxval(spfh_input(:,vlev)), minval(spfh_input(:,vlev))
  enddo
 
@@ -154,7 +154,7 @@
  call read_vardata(indset, 'clwmr', work3d)
  do vlev = 1, lev
    rvlev = lev+1-vlev
-   clwmr_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/)) 
+   clwmr_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/))
    print*,'MAX/MIN CLOUD LIQUID WATER AT LEVEL ', vlev, 'IS: ', maxval(clwmr_input(:,vlev)), minval(clwmr_input(:,vlev))
  enddo
 
@@ -182,7 +182,7 @@
  else
     dzdt_input = missing_value
     print*,'DZDT NOT IN INPUT FILE'
-    idzdt = 0 
+    idzdt = 0
  endif
 
 
@@ -200,7 +200,7 @@
  else
     rwmr_input = missing_value
     print*,'RWMR NOT IN INPUT FILE'
-    irwmr = 0 
+    irwmr = 0
  endif
 
  print*
@@ -210,14 +210,14 @@
  if (iret == 0) then
     do vlev = 1, lev
       rvlev = lev+1-vlev
-      icmr_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/)) 
+      icmr_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/))
       print*,'MAX/MIN ICMR AT LEVEL ', vlev, 'IS: ', maxval(icmr_input(:,vlev)), minval(icmr_input(:,vlev))
     enddo
     iicmr = 1
  else
     icmr_input = missing_value
     print*,'ICMR NOT IN INPUT FILE'
-    iicmr = 0 
+    iicmr = 0
  endif
 
  print*
@@ -227,14 +227,14 @@
  if (iret == 0) then
     do vlev = 1, lev
       rvlev = lev+1-vlev
-      snmr_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/)) 
+      snmr_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/))
       print*,'MAX/MIN SNMR AT LEVEL ', vlev, 'IS: ', maxval(snmr_input(:,vlev)), minval(snmr_input(:,vlev))
     enddo
     isnmr = 1
  else
     snmr_input = missing_value
     print*,'SNMR NOT IN INPUT FILE'
-    isnmr = 0 
+    isnmr = 0
  endif
 
  print*
@@ -244,14 +244,14 @@
  if (iret == 0) then
     do vlev = 1, lev
       rvlev = lev+1-vlev
-      grle_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/)) 
+      grle_input(:,vlev) = reshape(work3d(:,:,rvlev),(/ij_input/))
       print*,'MAX/MIN GRLE AT LEVEL ', vlev, 'IS: ', maxval(grle_input(:,vlev)), minval(grle_input(:,vlev))
     enddo
     igrle = 1
  else
     grle_input = missing_value
     print*,'GRLE NOT IN INPUT FILE'
-    igrle = 0 
+    igrle = 0
  endif
 
  print*
@@ -269,12 +269,12 @@
     else
        cldamt_input = missing_value
        print*,'CLDAMT NOT IN INPUT FILE'
-       icldamt = 0 
+       icldamt = 0
     endif
  else
     cldamt_input = missing_value
     print*,'CLDAMT NOT READ - CLD_AMT NAMELIST OPTION NOT SET TO TRUE'
-    icldamt = 0 
+    icldamt = 0
  end if
 
  call read_vardata(indset, 'dpres', work3d, errcode=iret)
@@ -325,7 +325,7 @@
  call read_attribute(refdset, 'ak', ak)
  call read_attribute(refdset, 'bk', bk)
  call close_dataset(refdset)
- 
+
  lev_output = size(bk) - 1
 
  nvcoord=2

--- a/sorc/enkf_chgres_recenter_nc.fd/output_data.f90
+++ b/sorc/enkf_chgres_recenter_nc.fd/output_data.f90
@@ -1,6 +1,6 @@
  module output_data
 
- use module_fv3gfs_ncio
+ use module_ncio
 
  implicit none
 
@@ -81,7 +81,7 @@
  print*,"READ SURFACE HEIGHT"
  call read_vardata(indset, 'hgtsfc', work2d)
 
- hgt_external_output = reshape(work2d,(/ij_output/)) 
+ hgt_external_output = reshape(work2d,(/ij_output/))
 
  call close_dataset(indset)
 

--- a/sorc/fbwndgfs.fd/CMakeLists.txt
+++ b/sorc/fbwndgfs.fd/CMakeLists.txt
@@ -1,0 +1,21 @@
+list(APPEND fortran_src
+  fbwndgfs.f
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -i8 -convert big_endian -assume byterecl")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8 -fdefault-integer-8 -fconvert=big-endian")
+endif()
+
+set(exe_name fbwndgfs.x)
+add_executable(${exe_name} ${fortran_src})
+target_link_libraries(
+  ${exe_name}
+  bacio::bacio_8
+  ip::ip_8
+  sp::sp_8
+  w3emc::w3emc_8
+  w3nco::w3nco_8)
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sorc/fv3gfs_build.cfg
+++ b/sorc/fv3gfs_build.cfg
@@ -9,14 +9,15 @@
  Building ufs_utils (ufs_utils) ........................ yes
  Building gldas (gldas) ................................ yes
  Building gfs_wafs (gfs_wafs) .......................... yes
- Building gaussian_sfcanl (gaussian_sfcanl)............. yes
- Building enkf_chgres_recenter (enkf_chgres_recenter) .. yes
- Building enkf_chgres_recenter_nc (enkf_chgres_recenter_nc) .. yes
- Building tropcy_NEMS (tropcy) ......................... yes
- Building gfs_fbwndgfs (gfs_fbwndgfs) .................. yes
- Building gfs_bufrsnd (gfs_bufrsnd) .................... yes
- Building fv3nc2nemsio (fv3nc2nemsio) .................. yes
- Building regrid_nemsio (regrid_nemsio) ................ yes
+ Building gaussian_sfcanl (gaussian_sfcanl)............. no
+ Building enkf_chgres_recenter (enkf_chgres_recenter) .. no
+ Building enkf_chgres_recenter_nc (enkf_chgres_recenter_nc) .. no
+ Building tropcy_NEMS (tropcy) ......................... no
+ Building gfs_fbwndgfs (gfs_fbwndgfs) .................. no
+ Building gfs_bufrsnd (gfs_bufrsnd) .................... no
+ Building fv3nc2nemsio (fv3nc2nemsio) .................. no
+ Building regrid_nemsio (regrid_nemsio) ................ no
+ Building workflow_utils (workflow_utils)................yes
  Building gfs_util (gfs_util) .......................... yes
  
 # -- END --

--- a/sorc/fv3nc2nemsio.fd/CMakeLists.txt
+++ b/sorc/fv3nc2nemsio.fd/CMakeLists.txt
@@ -1,0 +1,21 @@
+list(APPEND fortran_src
+constants.f90
+fv3_main.f90
+fv3_module.f90
+kinds.f90
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model precise")
+endif()
+
+set(exe_name fv3nc2nemsio.x)
+add_executable(${exe_name} ${fortran_src})
+target_link_libraries(
+  ${exe_name}
+  nemsio::nemsio
+  bacio::bacio_4
+  w3nco::w3nco_d
+  NetCDF::NetCDF_Fortran)
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sorc/fv3nc2nemsio.fd/CMakeLists.txt
+++ b/sorc/fv3nc2nemsio.fd/CMakeLists.txt
@@ -5,10 +5,6 @@ fv3_module.f90
 kinds.f90
 )
 
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model precise")
-endif()
-
 set(exe_name fv3nc2nemsio.x)
 add_executable(${exe_name} ${fortran_src})
 target_link_libraries(

--- a/sorc/fv3nc2nemsio.fd/fv3_main.f90
+++ b/sorc/fv3nc2nemsio.fd/fv3_main.f90
@@ -63,13 +63,13 @@ program fv3_main
    if (nhcas == 0 ) then  !non-hydrostatic case
     nvar3d=9
     allocate (name3din(nvar3d), name3dout(nvar3d))
-    name3din=(/'ucomp','vcomp','temp','sphum','o3mr','nhpres','w','clwmr','delp'/)
-    name3dout=(/'ugrd','vgrd','tmp','spfh','o3mr','pres','vvel','clwmr','dpres'/)
+    name3din=(/'ucomp ','vcomp ','temp  ','sphum ','o3mr  ','nhpres','w     ','clwmr ','delp  '/)
+    name3dout=(/'ugrd ','vgrd ','tmp  ','spfh ','o3mr ','pres ','vvel ','clwmr','dpres'/)
    else
     nvar3d=8
     allocate (name3din(nvar3d), name3dout(nvar3d))
-    name3din=(/'ucomp','vcomp','temp','sphum','o3mr','hypres','clwmr','delp'/)
-    name3dout=(/'ugrd','vgrd','tmp','spfh','o3mr','pres','clwmr','dpres'/)
+    name3din=(/'ucomp ','vcomp ','temp  ','sphum ','o3mr  ','hypres','clwmr ','delp  '/)
+    name3dout=(/'ugrd ','vgrd ','tmp  ','spfh ','o3mr ','pres ','clwmr','dpres'/)
    endif
     
     ! open netcdf files

--- a/sorc/gaussian_sfcanl.fd/CMakeLists.txt
+++ b/sorc/gaussian_sfcanl.fd/CMakeLists.txt
@@ -1,0 +1,21 @@
+list(APPEND fortran_src
+  gaussian_sfcanl.f90
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -i4 -fp-model precise")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8")
+endif()
+
+set(exe_name gaussian_sfcanl.x)
+add_executable(${exe_name} ${fortran_src})
+target_link_libraries(
+  ${exe_name}
+  nemsio::nemsio
+  bacio::bacio_4
+  sp::sp_d
+  w3nco::w3nco_d
+  NetCDF::NetCDF_Fortran)
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sorc/gaussian_sfcanl.fd/CMakeLists.txt
+++ b/sorc/gaussian_sfcanl.fd/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(
   ${exe_name}
   nemsio::nemsio
   bacio::bacio_4
-  sp::sp_d
+  sp::sp_4
   w3nco::w3nco_d
   NetCDF::NetCDF_Fortran)
 

--- a/sorc/gfs_bufr.fd/CMakeLists.txt
+++ b/sorc/gfs_bufr.fd/CMakeLists.txt
@@ -1,0 +1,55 @@
+list(APPEND fortran_src
+  bfrhdr.f
+  bfrize.f
+  buff.f
+  #calwxt_gfs_baldwin.f
+  #calwxt_gfs_ramer.f
+  gfsbufr.f
+  lcl.f
+  meteorg.f
+  mstadb.f
+  newsig1.f
+  read_nemsio.f
+  #read_netcdf.f
+  read_netcdf_p.f
+  rsearch.f
+  svp.f
+  tdew.f
+  terp3.f
+  vintg.f
+)
+
+list(APPEND fortran_src_free
+  calpreciptype.f
+  funcphys.f
+  gslp.f
+  machine.f
+  modstuff1.f
+  physcons.f
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -convert big_endian -fp-model source")
+  set_source_files_properties(${fortran_src_free} PROPERTIES COMPILE_FLAGS "-free")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fconvert=big-endian")
+  set_source_files_properties(${fortran_src_free} PROPERTIES COMPILE_FLAGS "-ffree-form")
+endif()
+
+set(exe_name gfs_bufr.x)
+add_executable(${exe_name} ${fortran_src} ${fortran_src_free})
+target_link_libraries(
+  ${exe_name}
+  nemsio::nemsio
+  bacio::bacio_4
+  sigio::sigio
+  sp::sp_4
+  w3emc::w3emc_4
+  w3nco::w3nco_4
+  bufr::bufr_4_DA
+  NetCDF::NetCDF_Fortran)
+if(OpenMP_Fortran_FOUND)
+  target_link_libraries(${exe_name} OpenMP::OpenMP_Fortran)
+endif()
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sorc/link_fv3gfs.sh
+++ b/sorc/link_fv3gfs.sh
@@ -195,7 +195,22 @@ cd ${pwd}/../ush                ||exit 8
 #--link executables 
 #------------------------------
 
+if [ ! -d $pwd/../exec ]; then mkdir $pwd/../exec ; fi
 cd $pwd/../exec
+
+[[ -s gaussian_sfcanl.exe ]] && rm -f gaussian_sfcanl.exe
+$LINK ../sorc/install/bin/gaussian_sfcanl.x gaussian_sfcanl.exe
+for workflowexec in fbwndgfs gfs_bufr regrid_nemsio supvit syndat_getjtbul \
+    syndat_maksynrc syndat_qctropcy tocsbufr ; do
+  [[ -s $workflowexec ]] && rm -f $workflowexec
+  $LINK ../sorc/install/bin/${workflowexec}.x $workflowexec
+done
+for workflowexec in enkf_chgres_recenter.x enkf_chgres_recenter_nc.x fv3nc2nemsio.x \
+    tave.x vint.x ; do
+  [[ -s $workflowexec ]] && rm -f $workflowexec
+  $LINK ../sorc/install/bin/$workflowexec .
+done
+
 [[ -s global_fv3gfs.x ]] && rm -f global_fv3gfs.x
 $LINK ../sorc/fv3gfs.fd/NEMS/exe/global_fv3gfs.x .
 if [ -d ../sorc/fv3gfs.fd/WW3/exec ]; then # Wave execs

--- a/sorc/partial_build.sh
+++ b/sorc/partial_build.sh
@@ -16,6 +16,7 @@
                        "Build_gfs_bufrsnd" \
                        "Build_fv3nc2nemsio" \
                        "Build_regrid_nemsio" \
+                       "Build_workflow_utils" \
                        "Build_gfs_util")
 
 #

--- a/sorc/regrid_nemsio.fd/CMakeLists.txt
+++ b/sorc/regrid_nemsio.fd/CMakeLists.txt
@@ -1,0 +1,31 @@
+list(APPEND fortran_src
+constants.f90
+fv3_interface.f90
+gfs_nems_interface.f90
+interpolation_interface.f90
+kinds.f90
+main.f90
+mpi_interface.f90
+namelist_def.f90
+netcdfio_interface.f90
+physcons.f90
+regrid_nemsio_interface.f90
+variable_interface.f90
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model precise")
+endif()
+
+set(exe_name regrid_nemsio.x)
+add_executable(${exe_name} ${fortran_src})
+target_link_libraries(
+  ${exe_name}
+  nemsio::nemsio
+  bacio::bacio_4
+  sp::sp_d
+  w3nco::w3nco_d
+  NetCDF::NetCDF_Fortran
+  MPI::MPI_Fortran)
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sorc/regrid_nemsio.fd/CMakeLists.txt
+++ b/sorc/regrid_nemsio.fd/CMakeLists.txt
@@ -13,10 +13,6 @@ regrid_nemsio_interface.f90
 variable_interface.f90
 )
 
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fp-model precise")
-endif()
-
 set(exe_name regrid_nemsio.x)
 add_executable(${exe_name} ${fortran_src})
 target_link_libraries(

--- a/sorc/supvit.fd/CMakeLists.txt
+++ b/sorc/supvit.fd/CMakeLists.txt
@@ -1,0 +1,19 @@
+list(APPEND fortran_src
+  supvit_modules.f
+  supvit_main.f
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -i4 -r8 -assume byterecl -assume noold_ldout_format")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8")
+endif()
+
+set(exe_name supvit.x)
+add_executable(${exe_name} ${fortran_src})
+target_link_libraries(
+  ${exe_name}
+  w3emc::w3emc_d
+  w3nco::w3nco_d)
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sorc/supvit.fd/CMakeLists.txt
+++ b/sorc/supvit.fd/CMakeLists.txt
@@ -4,7 +4,7 @@ list(APPEND fortran_src
 )
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -i4 -r8 -assume byterecl -assume noold_ldout_format")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -i4 -r8")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8")
 endif()

--- a/sorc/syndat_getjtbul.fd/CMakeLists.txt
+++ b/sorc/syndat_getjtbul.fd/CMakeLists.txt
@@ -1,0 +1,15 @@
+list(APPEND fortran_src
+  getjtbul.f
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -assume noold_ldout_format")
+endif()
+
+set(exe_name syndat_getjtbul.x)
+add_executable(${exe_name} ${fortran_src})
+target_link_libraries(
+  ${exe_name}
+  w3nco::w3nco_4)
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sorc/syndat_maksynrc.fd/CMakeLists.txt
+++ b/sorc/syndat_maksynrc.fd/CMakeLists.txt
@@ -1,0 +1,15 @@
+list(APPEND fortran_src
+  maksynrc.f
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -assume noold_ldout_format")
+endif()
+
+set(exe_name syndat_maksynrc.x)
+add_executable(${exe_name} ${fortran_src})
+target_link_libraries(
+  ${exe_name}
+  w3nco::w3nco_4)
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sorc/syndat_qctropcy.fd/CMakeLists.txt
+++ b/sorc/syndat_qctropcy.fd/CMakeLists.txt
@@ -1,0 +1,17 @@
+list(APPEND fortran_src
+  qctropcy.f
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -i8 -r8 -assume byterecl -assume noold_ldout_format")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-integer-8 -fdefault-real-8")
+endif()
+
+set(exe_name syndat_qctropcy.x)
+add_executable(${exe_name} ${fortran_src})
+target_link_libraries(
+  ${exe_name}
+  w3nco::w3nco_8)
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sorc/syndat_qctropcy.fd/qctropcy.f
+++ b/sorc/syndat_qctropcy.fd/qctropcy.f
@@ -1160,7 +1160,7 @@ C ... NO CONVERSION NECESSARY SINCE THIS SUBSEQUENT LOGIC EXPECTS THIS
          PRINT '(a,a,a)', '==> Read in RECORD from tcvitals file -- ',
      $    ' contains a 4-digit year "',OVRREC(MAXOVR-NRECHO)(20:23),'"'
          PRINT *, ' '
-         PRINT '(a,i,a,a)',
+         PRINT '(a,i2,a,a)',
      $    'From unit ',iuntho,'; OVRREC(MAXOVR-NRECHO)-2: ',
      $    OVRREC(MAXOVR-NRECHO)
          PRINT *, ' '

--- a/sorc/tave.fd/CMakeLists.txt
+++ b/sorc/tave.fd/CMakeLists.txt
@@ -1,0 +1,19 @@
+list(APPEND fortran_src
+  tave.f
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -i4 -r8")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8")
+endif()
+
+set(exe_name tave.x)
+add_executable(${exe_name} ${fortran_src})
+target_link_libraries(
+  ${exe_name}
+  bacio::bacio_4
+  w3nco::w3nco_d
+  g2::g2_d)
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sorc/tocsbufr.fd/CMakeLists.txt
+++ b/sorc/tocsbufr.fd/CMakeLists.txt
@@ -1,0 +1,22 @@
+list(APPEND fortran_src
+  tocsbufr.f
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -convert big_endian -fp-model source")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fconvert=big-endian")
+endif()
+
+set(exe_name tocsbufr.x)
+add_executable(${exe_name} ${fortran_src})
+target_link_libraries(
+  ${exe_name}
+  bacio::bacio_4
+  sigio::sigio
+  sp::sp_4
+  w3emc::w3emc_4
+  w3nco::w3nco_4
+  bufr::bufr_4_DA)
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sorc/vint.fd/CMakeLists.txt
+++ b/sorc/vint.fd/CMakeLists.txt
@@ -1,0 +1,19 @@
+list(APPEND fortran_src
+  vint.f
+)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -i4 -r8")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8")
+endif()
+
+set(exe_name vint.x)
+add_executable(${exe_name} ${fortran_src})
+target_link_libraries(
+  ${exe_name}
+  bacio::bacio_4
+  w3nco::w3nco_d
+  g2::g2_d)
+
+install(TARGETS ${exe_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
This PR enables the utilities under `sorc/` to be built using `cmake`.  modulefiles for `hera`, `orion` and `wcoss_dell_p3` are added that load hpc-stack.

These workflow utilities were compiled on `hera` and `orion`, but not on` wcoss_dell_p3`
These workflow utilities were compiled on `macOS`, EMC Linux box (RHEL7), Docker with GNU and IntelOneAPI containers.
All utilities built as expected. They were not tested against the hand-written makefiles on the supported HPC's for reproducibility.

Minor changes in 3 Fortran source codes `syndat_qctropcy.fd/qctropcy.f`, `gfs_bufr.fd/meteorg.f`, and `fv3nc2nemsio.fd/fv3_main.f90` were required to get these utilities to be compiled with GNU Fortran.

