### PR TITLE
Fixed reg2grb2 build on WCOSS

### DIFF
--- a/modulefiles/modulefile.reg2grb2.wcoss_dell_p3
+++ b/modulefiles/modulefile.reg2grb2.wcoss_dell_p3
@@ -4,6 +4,7 @@ module use /usrx/local/nceplibs/dev/hpc-stack/libs/hpc-stack/modulefiles/stack
 module load hpc/1.1.0
 module load hpc-ips/18.0.1.163
 module load hpc-impi/18.0.1
+export FCMP=$MPI_FC
 
 module load jasper/2.0.25
 module load zlib/1.2.11


### PR DESCRIPTION
The build of reg2grb2 was not linking the MPI libraries on WCOSS-Dell,
causing the build to fail (I don't know why this wasn't an issue before).
Modified the modulefile to now set the fortran compiler to the $MPI_FC
set by the impi module (which should be mpiifort) instead of ifort.

Refs: #273