### PR TITLE
coupled-crow: updates for WW3 

### DIFF
--- a/sorc/build_ww3prepost.sh
+++ b/sorc/build_ww3prepost.sh
@@ -15,6 +15,11 @@ source ../modulefiles/modulefile.ww3.$target
 #source ../modulefiles/module_base.$target
 set -x 
 
+
+if [ $target = hera ]; then target=hera.intel ; fi
+if [ $target = orion ]; then target=orion.intel ; fi
+if [ $target = stampede ]; then target=stampede.intel ; fi
+
 cd ufs_coupled.fd/WW3
 export WW3_DIR=$( pwd -P )/model
 export WW3_BINDIR="${WW3_DIR}/bin"

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -42,7 +42,7 @@ else
   if [[ ! -d ufs_coupled.fd ]] ; then
     git clone https://github.com/ufs-community/ufs-weather-model ufs_coupled.fd >> ${topdir}/checkout-ufs_coupled.log 2>&1
     cd ufs_coupled.fd
-    git checkout Prototype-6.0beta 
+    git checkout 3be851d55572221d81a807d1c53dc909a4866154 
     git submodule update --init --recursive
     cd ${topdir} 
   else 

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -42,7 +42,7 @@ else
   if [[ ! -d ufs_coupled.fd ]] ; then
     git clone https://github.com/ufs-community/ufs-weather-model ufs_coupled.fd >> ${topdir}/checkout-ufs_coupled.log 2>&1
     cd ufs_coupled.fd
-    git checkout 3be851d55572221d81a807d1c53dc909a4866154 
+    git checkout 3e46f5b7050e18884a0bed13691823ad88d443c3 
     git submodule update --init --recursive
     cd ${topdir} 
   else 


### PR DESCRIPTION
In the last update to ufs-weather-model https://github.com/ufs-community/ufs-weather-model/pull/383 WW3 was updated to match the target versions more closely to those used in ufs-weather-model.  However, this means we need an update in the build script for the pre-and post-exes from WW3.  

This PR was not fully tested as the queues are currently backed up but I did test the build on hera. 


@MinsukJi-NOAA hopefully this takes care of things on stampede as well. 