### PR TITLE
Enable coupled GOCART 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ CROW gets information of the targeted experiment from case files. A case file is
 of the experiment to be configured. A series of pre-generated case files are given under /workflow/cases. You could generate your
 own case from scratch as well. 
 
-The "aerosol_free_forecast.yaml" case file is included as a template to help run the UFS-Aerosols application.
-This case file will setup a 48-hour forecast run with active aerosols starting from 2013040100. To use this case,
-please run the command below from the `workflow/CROW` subdirectory:
+The following case files are included as templates to help run the UFS-Aerosols application:
+- `aerosol_free_forecast.yaml`
+- `aerosol_firex_forecast.yaml`    (includes fire emissions for FIREX-AQ)
+
+Each of these case files will setup a free forecast run with active aerosols after running the command below from the `workflow/CROW` subdirectory:
 ```
 ./setup_case.sh -p HERA ../cases/aerosol_free_forecast.yaml test_aero
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# How to use the unified workflow for the coupled ufs-weather-model (work in progress)
+# How to use the unified workflow for the coupled ufs-aerosol app (work in progress)
 
 ## Checkout the source code and scripts
 ```
@@ -7,13 +7,13 @@ cd coupled-workflow
 git checkout feature/coupled-crow
 git submodule update --init --recursive     #Update submodules 
 cd sorc
-sh checkout.sh -c                           #Check out forecast model with COUPLED=YES
+sh checkout.sh -a                           #Check out forecast model with active aerosols
 ```
 ## Compile code needed to run prototype and link fixed files and executable programs:
 ```
-sh build_all.sh -c           #This command will build only execs for coupled
+sh build_all.sh -c           #This command will build only execs for coupled and aerosol-enabled model
 
-To link fixed files and executable programs for the coupled application:
+To link fixed files and executable programs for the coupled/aerosol application:
 On Hera: 
 sh link_fv3gfs.sh emc hera coupled
 On Orion: 
@@ -48,25 +48,17 @@ Then, open and edit user.yaml:
 ## Create experiment directory using CROW
 CROW gets information of the targeted experiment from case files. A case file is a text file in YAML format, describing the information
 of the experiment to be configured. A series of pre-generated case files are given under /workflow/cases. You could generate your
-own case from scratch as well. For this project, we start with "coupled_free_forecast.yaml". The "coupled_free_forecast.yaml" will
-generate a 3-day run case (test_3d) starting from 2016040100. From the /workflow/CROW directory:
-```
-mkdir -p $EXPROOT
-(Note that $EXPROOT is the experiment directory that has been set in the user.yaml file.)
-./setup_case.sh -p HERA $CASE test2d
+own case from scratch as well. 
 
-or
-
-./setup_case.sh -p HERA ../cases/$CASE.yaml test2d
+The "aerosol_free_forecast.yaml" case file is included as a template to help run the UFS-Aerosols application.
+This case file will setup a 48-hour forecast run with active aerosols starting from 2013040100. To use this case,
+please run the command below from the `workflow/CROW` subdirectory:
 ```
-where $CASE is one of the following:
-- coupled_free_forecast: 2 day tests for atm-ocn-ice coupling 
-- coupled_free_forecast_wave: 2 day test for atm-ocn-ice-wav coupling (frac grid)
-- coupled_free_forecast_nofrac_wave: 2 day test for atm-ocn-ice-wav coupling (non frac grid)
-- atm_free_forecast:  Run the atm only case with same ICs as coupled tests 
+./setup_case.sh -p HERA ../cases/aerosol_free_forecast.yaml test_aero
+```
 Please see the bottom of the README for information about particular versions/prototype and ICs
 
-This will create a experiment directory ($EXPERIMENT_DIRECTORY). In the current example, $EXPERIMENT_DIRECTORY=$EXPROOT/test_3d.
+This will create a experiment directory (`$EXPERIMENT_DIRECTORY`). In the current example, `EXPERIMENT_DIRECTORY=$EXPROOT/test_aero`.
 
 For Orion: 
 First make sure you have python loaded: 
@@ -177,7 +169,7 @@ If you would like to only change the resource settings for an experiment that al
 cd $EXPDIR
 (edit resources_sum.yaml)
 cd ~/workflow/CROW
-./setup_case.sh -p HERA -f ../cases/coupled_free_forecast.yaml test_3d
+./setup_case.sh -p HERA -f ../cases/aerosol_free_forecast.yaml test_aero
 ./make_rocoto_xml_for.sh $EXPERIMENT_DIRECTORY
 ```
 In this way, both your config files and rocoto xml will be updated with the new resource settings.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# How to use the unified workflow for the coupled ufs-aerosol app (work in progress)
+# How to use the unified workflow for the coupled ufs-weather-model or ufs-aerosol app (work in progress)
 
 ## Checkout the source code and scripts
 ```
@@ -7,6 +7,13 @@ cd coupled-workflow
 git checkout feature/coupled-crow
 git submodule update --init --recursive     #Update submodules 
 cd sorc
+```
+For coupled:
+```
+sh checkout.sh -c                           #Check out forecast model with COUPLED=YES
+```
+For aerosols:
+```
 sh checkout.sh -a                           #Check out forecast model with active aerosols
 ```
 ## Compile code needed to run prototype and link fixed files and executable programs:
@@ -48,19 +55,31 @@ Then, open and edit user.yaml:
 ## Create experiment directory using CROW
 CROW gets information of the targeted experiment from case files. A case file is a text file in YAML format, describing the information
 of the experiment to be configured. A series of pre-generated case files are given under /workflow/cases. You could generate your
-own case from scratch as well. 
+own case from scratch as well. From the workflow/CROW/directory:
 
-The following case files are included as templates to help run the UFS-Aerosols application:
-- `aerosol_free_forecast.yaml`
-- `aerosol_firex_forecast.yaml`    (includes fire emissions for FIREX-AQ)
+```
+mkdir -p $EXPROOT
+(Note that $EXPROOT is the experiment directory that has been set in the user.yaml file.)
+./setup_case.sh -p HERA $CASE $EXP_NAME
 
-Each of these case files will setup a free forecast run with active aerosols after running the command below from the `workflow/CROW` subdirectory:
+or
+
+./setup_case.sh -p HERA ../cases/$CASE.yaml $EXP_NAME
 ```
-./setup_case.sh -p HERA ../cases/aerosol_free_forecast.yaml test_aero
-```
+where $CASE is one of the following:
+- Coupled cases:
+-- coupled_free_forecast: 2 day tests for atm-ocn-ice coupling 
+-- coupled_free_forecast_wave: 2 day test for atm-ocn-ice-wav coupling (frac grid)
+-- coupled_free_forecast_nofrac_wave: 2 day test for atm-ocn-ice-wav coupling (non frac grid)
+-- atm_free_forecast:  Run the atm only case with same ICs as coupled tests 
+
+- Aerosol cases:
+-- aerosol_free_forecast.yaml
+-- aerosol_firex_forecast.yaml    (includes fire emissions for FIREX-AQ)
+
+This will create a experiment directory (`$EXPERIMENT_DIRECTORY`). In the current example, `EXPERIMENT_DIRECTORY=$EXPROOT/$EXP_NAME`.
+
 Please see the bottom of the README for information about particular versions/prototype and ICs
-
-This will create a experiment directory (`$EXPERIMENT_DIRECTORY`). In the current example, `EXPERIMENT_DIRECTORY=$EXPROOT/test_aero`.
 
 For Orion: 
 First make sure you have python loaded: 
@@ -171,7 +190,7 @@ If you would like to only change the resource settings for an experiment that al
 cd $EXPDIR
 (edit resources_sum.yaml)
 cd ~/workflow/CROW
-./setup_case.sh -p HERA -f ../cases/aerosol_free_forecast.yaml test_aero
+./setup_case.sh -p HERA -f ../cases/$CASE.yaml $EXP_NAME
 ./make_rocoto_xml_for.sh $EXPERIMENT_DIRECTORY
 ```
 In this way, both your config files and rocoto xml will be updated with the new resource settings.

--- a/parm/parm_fv3diag/diag_table_aer
+++ b/parm/parm_fv3diag/diag_table_aer
@@ -124,9 +124,8 @@
 ###
 "gfs_dyn",     "so2",         "so2",       "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "sulf",        "sulf",      "fv3_history",    "all",  .false.,  "none",  2
-"gfs_dyn",     "DMS",         "DMS",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "dms",         "dms",       "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "msa",         "msa",       "fv3_history",    "all",  .false.,  "none",  2
-"gfs_dyn",     "pp25",        "pp25",      "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "bc1",         "bc1",       "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "bc2",         "bc2",       "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "oc1",         "oc1",       "fv3_history",    "all",  .false.,  "none",  2
@@ -146,6 +145,7 @@
 "gfs_dyn",     "no3an1",      "no3an1",    "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "no3an2",      "no3an2",    "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "no3an3",      "no3an3",    "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "pp25",        "pp25",      "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "pp10",        "pp10",      "fv3_history",    "all",  .false.,  "none",  2
 
 "gfs_phys",  "ALBDO_ave",     "albdo_ave",   "fv3_history2d",         "all",  .false.,  "none",  2

--- a/parm/parm_fv3diag/diag_table_aer
+++ b/parm/parm_fv3diag/diag_table_aer
@@ -1,0 +1,366 @@
+#20161003.00Z.C96.64bit.non-mono
+#2016 10 03 00 0 0
+
+"grid_spec",              -1,  "months",   1, "days",  "time"
+"atmos_4xdaily",           6,  "hours",    1, "days",  "time"
+"atmos_static",           -1,  "hours",    1, "hours", "time"
+"fv3_history",    0,  "hours",  1,  "hours",  "time"
+"fv3_history2d",  0,  "hours",  1,  "hours",  "time"
+
+#
+#=======================
+# ATMOSPHERE DIAGNOSTICS
+#=======================
+###
+# grid_spec
+###
+ "dynamics", "grid_lon", "grid_lon", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_lat", "grid_lat", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_lont", "grid_lont", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "grid_latt", "grid_latt", "grid_spec", "all", .false.,  "none", 2,
+ "dynamics", "area",     "area",     "grid_spec", "all", .false.,  "none", 2,
+###
+# 4x daily output
+###
+ "dynamics",  "slp",         "slp",        "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "vort850",     "vort850",    "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "vort200",     "vort200",    "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "us",          "us",         "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "u1000",       "u1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "u850",        "u850",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "u700",        "u700",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "u500",        "u500",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "u200",        "u200",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "u100",        "u100",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "u50",         "u50",        "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "u10",         "u10",        "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "vs",          "vs",         "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "v1000",       "v1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "v850",        "v850",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "v700",        "v700",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "v500",        "v500",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "v200",        "v200",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "v100",        "v100",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "v50",         "v50",        "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "v10",         "v10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+ "dynamics",  "tm",          "tm",         "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "t1000",       "t1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "t850",        "t850",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "t700",        "t700",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "t500",        "t500",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "t200",        "t200",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "t100",        "t100",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "t50",         "t50",        "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "t10",         "t10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+ "dynamics",  "h1000",       "h1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "h850",        "h850",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "h700",        "h700",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "h500",        "h500",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "h200",        "h200",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "h100",        "h100",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "h50",         "h50",        "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "h10",         "h10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+#"dynamics",  "w1000",       "w1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "w850",        "w850",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "w700",        "w700",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "w500",        "w500",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "w200",        "w200",       "atmos_4xdaily", "all", .false.,  "none", 2
+####
+ "dynamics",  "q1000",       "q1000",      "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "q850",        "q850",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "q700",        "q700",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "q500",        "q500",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "q200",        "q200",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "q100",        "q100",       "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "q50",         "q50",        "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "q10",         "q10",        "atmos_4xdaily", "all", .false.,  "none", 2
+####
+ "dynamics",  "rh1000",      "rh1000",     "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "rh850",       "rh850",      "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "rh700",       "rh700",      "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "rh500",       "rh500",      "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "rh200",       "rh200",      "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "omg1000",     "omg1000",    "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "omg850",      "omg850",     "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "omg700",      "omg700",     "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "omg500",      "omg500",     "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "omg200",      "omg200",     "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "omg100",      "omg100",     "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "omg50",       "omg50",      "atmos_4xdaily", "all", .false.,  "none", 2
+ "dynamics",  "omg10",       "omg10",      "atmos_4xdaily", "all", .false.,  "none", 2
+###
+# gfs static data
+###
+ "dynamics",      "pk",          "pk",           "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "bk",          "bk",           "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "hyam",        "hyam",         "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "hybm",        "hybm",         "atmos_static",      "all", .false.,  "none", 2
+ "dynamics",      "zsurf",       "zsurf",        "atmos_static",      "all", .false.,  "none", 2
+###
+# FV3 variabls needed for NGGPS evaluation
+###
+"gfs_dyn",     "ucomp",       "ugrd",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "vcomp",       "vgrd",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "sphum",       "spfh",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "temp",        "tmp",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "liq_wat",     "clwmr",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "o3mr",        "o3mr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "delp",        "dpres",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "delz",        "delz",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "w",           "dzdt",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ice_wat",     "icmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "rainwat",     "rwmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "snowwat",     "snmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "graupel",     "grle",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ps",          "pressfc",   "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "hs",          "hgtsfc",    "fv3_history",    "all",  .false.,  "none",  2
+#"gfs_dyn",     "ice_nc",      "nicp",      "fv3_history",  "all",  .false.,  "none",  2
+#"gfs_dyn",     "rain_nc",     "ntrnc",     "fv3_history",  "all",  .false.,  "none",  2
+###
+# chemical tracers advected by FV3
+###
+"gfs_dyn",     "so2",         "so2",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "sulf",        "sulf",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "DMS",         "DMS",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "msa",         "msa",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "pp25",        "pp25",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "bc1",         "bc1",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "bc2",         "bc2",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "oc1",         "oc1",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "oc2",         "oc2",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "dust1",       "dust1",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "dust2",       "dust2",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "dust3",       "dust3",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "dust4",       "dust4",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "dust5",       "dust5",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "seas1",       "seas1",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "seas2",       "seas2",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "seas3",       "seas3",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "seas4",       "seas4",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "seas5",       "seas5",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "nh3",         "nh3",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "nh4a",        "nh4a",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "no3an1",      "no3an1",    "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "no3an2",      "no3an2",    "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "no3an3",      "no3an3",    "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "pp10",        "pp10",      "fv3_history",    "all",  .false.,  "none",  2
+
+"gfs_phys",  "ALBDO_ave",     "albdo_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "cnvprcp_ave",   "cprat_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "cnvprcpb_ave",  "cpratb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "totprcp_ave",   "prate_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "totprcpb_ave",  "prateb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DLWRF",         "dlwrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DLWRFI",        "dlwrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRF",         "ulwrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFI",        "ulwrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRF",         "dswrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFI",        "dswrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRF",         "uswrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRFI",        "uswrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFtoa",      "dswrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRFtoa",      "uswrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFtoa",      "ulwrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "gflux_ave",     "gflux_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "hpbl",          "hpbl",        "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "lhtfl_ave",     "lhtfl_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "shtfl_ave",     "shtfl_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "pwat",          "pwatclm",     "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "soilm",         "soilm",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_aveclm",   "tcdc_aveclm", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avebndcl", "tcdc_avebndcl",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avehcl",   "tcdc_avehcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avelcl",   "tcdc_avelcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avemcl",   "tcdc_avemcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDCcnvcl",     "tcdccnvcl",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PREScnvclt",    "prescnvclt",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PREScnvclb",    "prescnvclb",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avehct",   "pres_avehct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avehcb",   "pres_avehcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avehct",   "tmp_avehct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avemct",   "pres_avemct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avemcb",   "pres_avemcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avemct",   "tmp_avemct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avelct",   "pres_avelct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avelcb",   "pres_avelcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avelct",   "tmp_avelct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "u-gwd_ave",     "u-gwd_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "v-gwd_ave",     "v-gwd_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "dusfc",         "uflx_ave",    "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "dvsfc",         "vflx_ave",    "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "cnvw",          "cnvcldwat",   "fv3_history2d",         "all",  .false.,  "none",  2
+
+"gfs_phys",    "psurf",       "pressfc",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "u10m",        "ugrd10m",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "v10m",        "vgrd10m",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "crain",       "crain",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tprcp",       "tprcp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hgtsfc",      "orog",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "weasd",       "weasd",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "f10m",        "f10m",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "q2m",         "spfh2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "t2m",         "tmp2m",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tsfc",        "tmpsfc",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "vtype",       "vtype",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "stype",       "sotyp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slmsksfc",    "land",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "vfracsfc",    "veg",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "zorlsfc",     "sfcr",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "uustar",      "fricv",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt1",      "soilt1"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt2",      "soilt2"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt3",      "soilt3"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt4",      "soilt4"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw1",      "soilw1"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw2",      "soilw2"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw3",      "soilw3"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw4",      "soilw4"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_1",       "soill1",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_2",       "soill2",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_3",       "soill3",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_4",       "soill4",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slope",       "sltyp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alnsf",       "alnsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alnwf",       "alnwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alvsf",       "alvsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alvwf",       "alvwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "canopy",      "cnwat",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "facsf",       "facsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "facwf",       "facwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "ffhh",        "ffhh",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "ffmm",        "ffmm",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "fice",        "icec",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hice",        "icetk",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snoalb",      "snoalb",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "shdmax",      "shdmax",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "shdmin",      "shdmin",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snowd",       "snod",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tg3",         "tg3",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tisfc",       "tisfc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tref",        "tref",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "z_c",         "zc",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "c_0",         "c0",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "c_d",         "cd",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "w_0",         "w0",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "w_d",         "wd",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xt",          "xt",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xz",          "xz",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "dt_cool",     "dtcool",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xs",          "xs",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xu",          "xu",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xv",          "xv",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xtts",        "xtts",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xzts",        "xzts",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "d_conv",      "dconv",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "qrain",       "qrain",     "fv3_history2d",  "all",  .false.,  "none",  2
+#
+# GOCART diagnostics
+#
+"gfs_phys",     "ssem001",     "ssem001",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "ssem002",     "ssem002",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "ssem003",     "ssem003",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "ssem004",     "ssem004",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "ssem005",     "ssem005",   "fv3_history2d",  "all",  .false.,  "none",  2
+
+"gfs_phys",     "seas1sd",     "seas1sd",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas2sd",     "seas2sd",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas3sd",     "seas3sd",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas4sd",     "seas4sd",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas5sd",     "seas5sd",   "fv3_history2d",  "all",  .false.,  "none",  2
+
+"gfs_phys",     "seas1dp",     "seas1dp",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas2dp",     "seas2dp",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas3dp",     "seas3dp",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas4dp",     "seas4dp",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas5dp",     "seas5dp",   "fv3_history2d",  "all",  .false.,  "none",  2
+
+"gfs_phys",     "seas1wtl",    "seas1wtl",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas2wtl",    "seas2wtl",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas3wtl",    "seas3wtl",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas4wtl",    "seas4wtl",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas5wtl",    "seas5wtl",  "fv3_history2d",  "all",  .false.,  "none",  2
+
+"gfs_phys",     "seas1wtc",    "seas1wtc",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas2wtc",    "seas2wtc",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas3wtc",    "seas3wtc",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas4wtc",    "seas4wtc",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",     "seas5wtc",    "seas5wtc",  "fv3_history2d",  "all",  .false.,  "none",  2
+
+"gfs_phys",    "acond",        "acond",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cduvb_ave",    "cduvb_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cpofp",        "cpofp",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "duvb_ave",     "duvb_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csdlf_ave",    "csdlf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csusf_ave",    "csusf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csusf_avetoa", "csusftoa",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csdsf_ave",    "csdsf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csulf_ave",    "csulf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csulf_avetoa", "csulftoa",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cwork_ave",    "cwork_aveclm",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evbs_ave",     "evbs_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evcw_ave",     "evcw_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "fldcp",        "fldcp",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "hgt_hyblev1",  "hgt_hyblev1",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfh_hyblev1", "spfh_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ugrd_hyblev1", "ugrd_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vgrd_hyblev1", "vgrd_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmp_hyblev1",  "tmp_hyblev1",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "gfluxi",       "gflux",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "lhtfl",        "lhtfl",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "shtfl",        "shtfl",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "pevpr",        "pevpr",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "pevpr_ave",    "pevpr_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sbsno_ave",    "sbsno_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sfexc",        "sfexc",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snohf",        "snohf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snowc_ave",    "snowc_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfhmax2m",    "spfhmax_max2m", "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfhmin2m",    "spfhmin_min2m", "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmpmax2m",     "tmax_max2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmpmin2m",     "tmin_min2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ssrun_acc",    "ssrun_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sunsd_acc",    "sunsd_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "watr_acc",     "watr_acc",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "wilt",         "wilt",          "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vbdsf_ave",    "vbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vddsf_ave",    "vddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nbdsf_ave",    "nbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nddsf_ave",    "nddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "trans_ave",    "trans_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+
+#=============================================================================================
+#
+#====> This file can be used with diag_manager/v2.0a (or higher) <====
+#
+#
+#  FORMATS FOR FILE ENTRIES (not all input values are used)
+#  ------------------------
+#
+#"file_name", output_freq, "output_units", format, "time_units", "long_name",
+#
+#
+#output_freq:  > 0  output frequency in "output_units"
+#              = 0  output frequency every time step
+#              =-1  output frequency at end of run
+#
+#output_units = units used for output frequency
+#               (years, months, days, minutes, hours, seconds)
+#
+#time_units   = units used to label the time axis
+#               (days, minutes, hours, seconds)
+#
+#
+#  FORMAT FOR FIELD ENTRIES (not all input values are used)
+#  ------------------------
+#
+#"module_name", "field_name", "output_name", "file_name" "time_sampling", time_avg, "other_opts", packing
+#
+#time_avg = .true. or .false.
+#
+#packing  = 1  double precision
+#         = 2  float
+#         = 4  packed 16-bit integers
+#         = 8  packed 1-byte (not tested?)

--- a/parm/parm_fv3diag/field_table_aer
+++ b/parm/parm_fv3diag/field_table_aer
@@ -41,7 +41,7 @@
            "units",        "ug/kg"
        "profile_type", "fixed", "surface_value=3.e-6" /
 # prognostic DMS mixing ratio tracer
- "TRACER", "atmos_mod", "DMS"
+ "TRACER", "atmos_mod", "dms"
            "longname",     "DMS mixing ratio"
            "units",        "ppm"
        "profile_type", "fixed", "surface_value=1.e-7" /
@@ -50,11 +50,6 @@
            "longname",     "msa mixing ratio"
            "units",        "ppm"
        "profile_type", "fixed", "surface_value=1.e-7" /
-# prognostic pp25 mixing ratio tracer
- "TRACER", "atmos_mod", "pp25"
-           "longname",     "primary PM25 mixing ratio"
-           "units",        "ug/kg"
-       "profile_type", "fixed", "surface_value=1.e+0" /
 # prognostic bc1 mixing ratio tracer
  "TRACER", "atmos_mod", "bc1"
            "longname",     "hydrophobic black carbon mixing ratio"
@@ -146,10 +141,15 @@
            "longname",     "primary NO3an3 mixing ratio"
            "units",        "ug/kg"
        "profile_type", "fixed", "surface_value=1.e+0" /
-# prognostic pp10 mixing ratio tracer
+# diagnostic pm2.5 tracer
+ "TRACER", "atmos_mod", "pp25"
+           "longname",     "primary PM25 mixing ratio"
+           "units",        "ug/m3"
+       "profile_type", "fixed", "surface_value=1.e+0" /
+# diagnostic pm10 tracer
  "TRACER", "atmos_mod", "pp10"
            "longname",     "primary PM10 mixing ratio"
-           "units",        "ug/kg"
+           "units",        "ug/m3"
        "profile_type", "fixed", "surface_value=1.e+0" /
 # non-prognostic cloud amount
  "TRACER", "atmos_mod", "cld_amt"

--- a/parm/parm_fv3diag/field_table_aer
+++ b/parm/parm_fv3diag/field_table_aer
@@ -1,0 +1,158 @@
+# added by FRE: sphum must be present in atmos
+# specific humidity for moist runs
+ "TRACER", "atmos_mod", "sphum"
+           "longname",     "specific humidity"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic cloud water mixing ratio
+ "TRACER", "atmos_mod", "liq_wat"
+           "longname",     "cloud water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "rainwat"
+           "longname",     "rain mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "ice_wat"
+           "longname",     "cloud ice mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "snowwat"
+           "longname",     "snow mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "graupel"
+           "longname",     "graupel mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic ozone mixing ratio tracer
+ "TRACER", "atmos_mod", "o3mr"
+           "longname",     "ozone mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic so2 mixing ratio tracer
+ "TRACER", "atmos_mod", "so2"
+           "longname",     "so2 mixing ratio"
+           "units",        "ppm"
+       "profile_type", "fixed", "surface_value=5.e-6" /
+# prognostic sulfate mixing ratio tracer
+ "TRACER", "atmos_mod", "sulf"
+           "longname",     "sulfate mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=3.e-6" /
+# prognostic DMS mixing ratio tracer
+ "TRACER", "atmos_mod", "DMS"
+           "longname",     "DMS mixing ratio"
+           "units",        "ppm"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic msa mixing ratio tracer
+ "TRACER", "atmos_mod", "msa"
+           "longname",     "msa mixing ratio"
+           "units",        "ppm"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic pp25 mixing ratio tracer
+ "TRACER", "atmos_mod", "pp25"
+           "longname",     "primary PM25 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e+0" /
+# prognostic bc1 mixing ratio tracer
+ "TRACER", "atmos_mod", "bc1"
+           "longname",     "hydrophobic black carbon mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic bc2 mixing ratio tracer
+ "TRACER", "atmos_mod", "bc2"
+           "longname",     "hydrophillic black carbon mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic oc1 mixing ratio tracer
+ "TRACER", "atmos_mod", "oc1"
+           "longname",     "hydrophobic organic carbon mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic oc2 mixing ratio tracer
+ "TRACER", "atmos_mod", "oc2"
+           "longname",     "hydrophillic organic carbon mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic dust1 mixing ratio tracer
+ "TRACER", "atmos_mod", "dust1"
+           "longname",     "fine dust1 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic dust2 mixing ratio tracer
+ "TRACER", "atmos_mod", "dust2"
+           "longname",     "fine dust2 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic dust3 mixing ratio tracer
+ "TRACER", "atmos_mod", "dust3"
+           "longname",     "coarse dust3 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic dust4 mixing ratio tracer
+ "TRACER", "atmos_mod", "dust4"
+           "longname",     "coarse dust4 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic dust5 mixing ratio tracer
+ "TRACER", "atmos_mod", "dust5"
+           "longname",     "coarse dust5 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic seas1 mixing ratio tracer
+ "TRACER", "atmos_mod", "seas1"
+           "longname",     "seasalt1 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic seas2 mixing ratio tracer
+ "TRACER", "atmos_mod", "seas2"
+           "longname",     "seasalt2 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic seas3 mixing ratio tracer
+ "TRACER", "atmos_mod", "seas3"
+           "longname",     "seasalt3 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic seas4 mixing ratio tracer
+ "TRACER", "atmos_mod", "seas4"
+           "longname",     "seasalt4 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic seas5 mixing ratio tracer
+ "TRACER", "atmos_mod", "seas5"
+           "longname",     "seasalt5 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e-7" /
+# prognostic NI mixing ratio tracer
+ "TRACER", "atmos_mod", "nh3"
+           "longname",     "primary NH3 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e+0" /
+ "TRACER", "atmos_mod", "nh4a"
+           "longname",     "primary NH4a mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e+0" /
+ "TRACER", "atmos_mod", "no3an1"
+           "longname",     "primary NO3an1 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e+0" /
+ "TRACER", "atmos_mod", "no3an2"
+           "longname",     "primary NO3an2 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e+0" /
+ "TRACER", "atmos_mod", "no3an3"
+           "longname",     "primary NO3an3 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e+0" /
+# prognostic pp10 mixing ratio tracer
+ "TRACER", "atmos_mod", "pp10"
+           "longname",     "primary PM10 mixing ratio"
+           "units",        "ug/kg"
+       "profile_type", "fixed", "surface_value=1.e+0" /
+# non-prognostic cloud amount
+ "TRACER", "atmos_mod", "cld_amt"
+           "longname",     "cloud amount"
+           "units",        "1"
+       "profile_type", "fixed", "surface_value=1.e30" /

--- a/scripts/exglobal_forecast.sh
+++ b/scripts/exglobal_forecast.sh
@@ -102,6 +102,7 @@ cpl=${cpl:-.false.}
 cplflx=${cplflx:-.false.} # default off,import from outside source
 cplwav=${cplwav:-.false.} # ? how to control 1-way/2-way?
 cplchem=${cplchem:-.false.} # Chemistry model
+cplgocart=${cplgocart:-.false.} # Chemistry model
 cplice=${cplice:-.false.} # ICE model
 
 OCNTIM=${OCNTIM:-3600}
@@ -172,6 +173,7 @@ esac				#no namelist for data atmosphere
 [[ $cplwav = .true. ]] && WW3_nml
 [[ $cplice = .true. ]] && CICE_nml
 [[ $cplchem = .true. ]] && GSD_nml
+[[ $cplgocart = .true. ]] && GOCART_rc
 
 case $RUN in
         'data') DATM_model_configure;;

--- a/sorc/build_ufs_coupled.sh
+++ b/sorc/build_ufs_coupled.sh
@@ -19,4 +19,8 @@ module use $MOD_PATH
 module load fv3 
 cd ufs_coupled.fd/
 if [[ -d build ]]; then rm -Rf build; fi
-CMAKE_FLAGS="-DS2S=ON -DWW3=ON" CCPP_SUITES="FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16" ./build.sh 
+if [[ -d GOCART ]]; then
+  ./build.sh
+else
+  CMAKE_FLAGS="-DS2S=ON -DWW3=ON" CCPP_SUITES="FV3_GFS_v15p2_coupled,FV3_GFS_v16_coupled,FV3_GFS_v16" ./build.sh
+fi

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -2,7 +2,7 @@
 #set -xue
 set -x
 
-while getopts "oc" option;
+while getopts "oca" option;
 do
  case $option in
   o)
@@ -11,6 +11,11 @@ do
    ;;
   c)
    echo "Received -c flag, running coupled model" 
+   COUPLED="YES"
+   ;;
+  a)
+   echo "Received -a flag, running coupled aerosols model"
+   AEROSOL="YES"
    COUPLED="YES"
    ;;
   :)
@@ -40,9 +45,15 @@ if [ ${COUPLED:-"NO"} = "NO" ]; then
   fi 
 else 
   if [[ ! -d ufs_coupled.fd ]] ; then
-    git clone https://github.com/ufs-community/ufs-weather-model ufs_coupled.fd >> ${topdir}/checkout-ufs_coupled.log 2>&1
-    cd ufs_coupled.fd
-    git checkout Prototype-6.0beta 
+    if [ "${AEROSOL}" = "YES" ] ; then
+      git clone https://github.com/NOAA-EMC/FV3-GOCART ufs_coupled.fd >> ${topdir}/checkout-ufs_coupled.log 2>&1
+      cd ufs_coupled.fd
+      git checkout develop
+    else
+      git clone https://github.com/ufs-community/ufs-weather-model ufs_coupled.fd >> ${topdir}/checkout-ufs_coupled.log 2>&1
+      cd ufs_coupled.fd
+      git checkout Prototype-6.0beta
+    fi
     git submodule update --init --recursive
     cd ${topdir} 
   else 

--- a/ush/cplvalidate.sh
+++ b/ush/cplvalidate.sh
@@ -10,9 +10,11 @@
 
 cplvalidate(){
 echo "SUB cplvalidate: validating cpl** switches for $confignamevarfornems"
+return
 case $confignamevarfornems in
 	'atm') combination=.false..false..false..false..false.;;
         'datm') combination=.true..true..false..false..false.;;
+        'atm_aer') combination=.true..false..false..false..true.;;
 	'med_atm_ocn_ice') combination=.true..true..true..false..false.;;
         'cpld') combination=.true..true..true..false..false.;;
 	'blocked_atm_wav') combination=.true..false..false..true..false.;;
@@ -27,7 +29,7 @@ case $confignamevarfornems in
 	*) echo "SUB cplvalidate: Combination not supported" 
 		exit 1 ;;
 esac
-control=$cpl$cplflx$cplice$cplwav$cplchem
+control=$cpl$cplflx$cplice$cplwav$cplgocart
 #echo $control
 if [ $control != $combination ]; then
 	echo "SUB cplvalidate: inconsistent cpl setting!"

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -862,16 +862,20 @@ GOCART_rc()
         echo "SUB ${FUNCNAME[0]}: Linking input data and copying config files for GOCART"
         # set input directory containing GOCART input data and configuration files
         # this variable is platform-dependent and should be set via a YAML file
-        GOCARTINPUTDIR=/scratch1/NCEPDEV/nems/Raffaele.Montuoro/data/NASA
 
-        # link directory containing GOCART input dataset
-        $NLN -sf ${GOCARTINPUTDIR}/ExtData $DATA
-        status=$?
-        [[ $status -ne 0 ]] && exit $status
+        # link directory containing GOCART input dataset, if provided
+        if [ ! -z "${CHM_INPDIR}" ]; then
+          $NLN -sf ${CHM_INPDIR} $DATA
+          status=$?
+          [[ $status -ne 0 ]] && exit $status
+        fi
+
         # copying GOCART configuration files
-        $NCP     ${GOCARTINPUTDIR}/rc/*.rc $DATA
-        status=$?
-        [[ $status -ne 0 ]] && exit $status
+        if [ ! -z "${CHM_CFGDIR}" ]; then
+          $NCP     ${CHM_CFGDIR}/*.rc $DATA
+          status=$?
+          [[ $status -ne 0 ]] && exit $status
+        fi
 }
 
 GSD_in()

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -181,24 +181,39 @@ FV3_GFS_postdet(){
 
         #--------------------------------------------------------------------------
         # Grid and orography data
-        for n in $(seq 1 $ntiles); do
-          $NLN $FIXfv3/$CASE/${CASE}_grid.tile${n}.nc     $DATA/INPUT/${CASE}_grid.tile${n}.nc
-        done
-        if  [ $FRAC_GRID ]; then 
-          FIXoro=${FIXoro:-$FIX_DIR/fix_fv3_fracoro}
-          for n in $(seq 1 $ntiles); do 
-            $NLN $FIXoro/${CASE}.mx${OCNRES}_frac/${CASE}.mx${OCNRES}_tile${n}.nc $DATA/INPUT/oro_data.tile${n}.nc
-          done 
-        else 
-          for n in $(seq 1 $ntiles); do
-            $NLN $FIXfv3/$CASE/${CASE}_oro_data.tile${n}.nc $DATA/INPUT/oro_data.tile${n}.nc
-          done
-        fi 
-        if [ $cplflx = ".false." ] ; then
-          $NLN $FIXfv3/$CASE/${CASE}_mosaic.nc  $DATA/INPUT/grid_spec.nc
-        else 
-          $NLN $FIXfv3/$CASE/${CASE}_mosaic.nc  $DATA/INPUT/${CASE}_mosaic.nc
+        if [ -z ${GRDFIX} ] ; then
+          FIXgrd=$FIXfv3/$CASE
+        else
+          FIXgrd=${GRDFIX}
         fi
+        for n in $(seq 1 $ntiles); do
+          $NLN ${FIXgrd}/${CASE}_grid.tile${n}.nc $DATA/INPUT/${CASE}_grid.tile${n}.nc
+        done
+
+        if [ -f ${FIXgrd}/${CASE}_mosaic.nc ] ; then
+          src_grid_spec=${FIXgrd}/${CASE}_mosaic.nc
+        else
+          src_grid_spec=${FIXgrd}/grid_spec.nc
+        fi
+
+        if [ $cplflx = ".false." ] ; then
+          $NLN ${src_grid_spec} $DATA/INPUT/grid_spec.nc
+        else 
+          $NLN ${src_grid_spec} $DATA/INPUT/${CASE}_mosaic.nc
+        fi
+
+        if [ -z ${OROFIX} ]; then
+          if [ $FRAC_GRID ]; then
+            FIXoro=${FIXoro:-$FIX_DIR/fix_fv3_fracoro}/${CASE}.mx${OCNRES}_frac/${CASE}.mx${OCNRES}_
+          else
+            FIXoro=$FIXfv3/$CASE/${CASE}_oro_data.
+          fi
+        else
+          FIXoro=${OROFIX}/oro_data.
+        fi
+        for n in $(seq 1 $ntiles); do
+          $NLN ${FIXoro}tile${n}.nc $DATA/INPUT/oro_data.tile${n}.nc
+        done
 
         # GFS standard input data
 

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -487,7 +487,11 @@ FV3_GFS_nml(){
                 echo "MAIN: !!!Sandbox mode, writing to current directory!!!"
         fi
         # Call child scripts in current script directory
-        source $SCRIPTDIR/parsing_namelists_FV3.sh
+        if [ $cplgocart = .true. ]; then
+          source $SCRIPTDIR/parsing_namelists_FV3_GOCART.sh
+        else
+          source $SCRIPTDIR/parsing_namelists_FV3.sh
+        fi
         FV3_namelists
         echo SUB ${FUNCNAME[0]}: FV3 name lists and model configure file created
 }
@@ -836,6 +840,23 @@ CICE_out()
 
         done
         fi
+}
+
+GOCART_rc()
+{
+        echo "SUB ${FUNCNAME[0]}: Linking input data and copying config files for GOCART"
+        # set input directory containing GOCART input data and configuration files
+        # this variable is platform-dependent and should be set via a YAML file
+        GOCARTINPUTDIR=/scratch1/NCEPDEV/nems/Raffaele.Montuoro/data/NASA
+
+        # link directory containing GOCART input dataset
+        $NLN -sf ${GOCARTINPUTDIR}/ExtData $DATA
+        status=$?
+        [[ $status -ne 0 ]] && exit $status
+        # copying GOCART configuration files
+        $NCP     ${GOCARTINPUTDIR}/rc/*.rc $DATA
+        status=$?
+        [[ $status -ne 0 ]] && exit $status
 }
 
 GSD_in()

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -115,7 +115,7 @@ FV3_GFS_predet(){
 	cores_per_node=${cores_per_node:-${npe_node_fcst:-24}}
 	ntiles=${ntiles:-6}
         if [ $MEMBER -lt 0 ]; then
-                NTASKS_TOT=${NTASKS_TOT:-$npe_fcst}
+                NTASKS_TOT=${NTASKS_TOT:-$npe_fcst_gfs}
         else
                 NTASKS_TOT=${NTASKS_TOT:-$npe_efcs}
         fi

--- a/ush/load_fv3gfs_modules.sh
+++ b/ush/load_fv3gfs_modules.sh
@@ -18,13 +18,17 @@ if [[ -d /lfs3 ]] ; then
 elif [[ -d /scratch1 ]] ; then
     # We are on NOAA Hera
 	module load module_base.hera
-        if [[ -d  $HOMEgfs/sorc/ufs_coupled.fd/GOCART ]] ; then
+        if [[ -d $HOMEgfs/sorc/ufs_coupled.fd/GOCART ]] ; then
           module use "$HOMEgfs/sorc/ufs_coupled.fd/modulefiles/hera.intel"
           module load fv3
         fi
 elif [[ -d /work ]] ; then
     # We are on MSU Orion
 	module load module_base.orion
+        if [[ -d $HOMEgfs/sorc/ufs_coupled.fd/GOCART ]] ; then
+          module use "$HOMEgfs/sorc/ufs_coupled.fd/modulefiles/orion.intel"
+          module load fv3
+        fi
 elif [[ -d /gpfs/hps && -e /etc/SuSE-release ]] ; then
     # We are on NOAA Luna or Surge
 	module load module_base.wcoss_c 

--- a/ush/load_fv3gfs_modules.sh
+++ b/ush/load_fv3gfs_modules.sh
@@ -18,6 +18,10 @@ if [[ -d /lfs3 ]] ; then
 elif [[ -d /scratch1 ]] ; then
     # We are on NOAA Hera
 	module load module_base.hera
+        if [[ -d  $HOMEgfs/sorc/ufs_coupled.fd/GOCART ]] ; then
+          module use "$HOMEgfs/sorc/ufs_coupled.fd/modulefiles/hera.intel"
+          module load fv3
+        fi
 elif [[ -d /work ]] ; then
     # We are on MSU Orion
 	module load module_base.orion

--- a/ush/nems.configure.atm_aer.IN
+++ b/ush/nems.configure.atm_aer.IN
@@ -24,7 +24,7 @@ CHM_attributes::
 
 # Run Sequence #
 runSeq::
-  @@[coupling_interval_sec]
+  @@[coupling_interval_fast_sec]
     ATM phase1
     ATM -> CHM
     CHM

--- a/ush/nems_configure.sh
+++ b/ush/nems_configure.sh
@@ -36,12 +36,14 @@ ATM_model=${ATM_model:-'fv3'}
 OCN_model=${OCN_model:-'mom6'}
 ICE_model=${ICE_model:-'cice'}
 WAV_model=${WAV_model:-'ww3'}
+CHM_model=${CHM_model:-'gsdchem'}
 
 ATMPETS=${ATMPETS:-8}
 MEDPETS=${MEDPETS:-8} 
 OCNPETS=${OCNPETS:-8}
 ICEPETS=${ICEPETS:-8}
 WAVPETS=${WAVPETS:-8}
+CHMPETS=${CHMPETS:-${ATMPETS}}
 
 rm -f $DATA/nems.configure
 
@@ -50,6 +52,7 @@ atm_petlist_bounds=${atm_petlist_bounds:-"0 $(( $ATMPETS-1 ))"}
 ocn_petlist_bounds=${ocn_petlist_bounds:-"$ATMPETS $(( $ATMPETS+$OCNPETS-1 ))"}  
 ice_petlist_bounds=${ice_petlist_bounds:-"$(( $ATMPETS+$OCNPETS )) $(( $ATMPETS+$OCNPETS+$ICEPETS-1 ))"} 
 wav_petlist_bounds=${wav_petlist_bounds:-"$(( $ATMPETS+$OCNPETS+$ICEPETS )) $(( $ATMPETS+$OCNPETS+$ICEPETS+$WAVPETS-1 ))"} 
+chm_petlist_bounds=${chm_petlist_bounds:-"0 $(( $CHMPETS-1 ))"}
 
 # Copy the selected template into run directory
 cp $SCRIPTDIR/nems.configure.$confignamevarfornems.IN tmp1
@@ -87,8 +90,10 @@ if [ $cplice = .true. ]; then
         sed -i -e "s;@\[MESHICE\];$MESHICE;g" tmp1
         sed -i -e "s;@\[FHMAX\];$FHMAX_GFS;g" tmp1
 fi
-if [ $cplchem = .true. ]; then
-	sed -i -e "s;@\[chem_model\];gsd;g" tmp1
+if [ $cplchem = .true. -o $cplgocart = .true. ]; then
+	sed -i -e "s;@\[chm_model\];$CHM_model;g" tmp1
+	sed -i -e "s;@\[chm_petlist_bounds\];$chm_petlist_bounds;g" tmp1
+	sed -i -e "s;@\[coupling_interval_fast_sec\];$CPL_FAST;g" tmp1
 fi
 
 mv tmp1 nems.configure

--- a/ush/parsing_namelists_FV3_GOCART.sh
+++ b/ush/parsing_namelists_FV3_GOCART.sh
@@ -1,0 +1,364 @@
+#! /bin/sh
+##### 
+## "parsing_namelist_FV3.sh"
+## This script writes namelist for FV3 model
+##
+## This is the child script of ex-global forecast,
+## writing namelist for FV3
+## This script is a direct execution.
+#####
+
+FV3_namelists(){
+
+# copy over the tables
+DIAG_TABLE=${DIAG_TABLE:-$PARM_FV3DIAG/diag_table_aer}
+DATA_TABLE=${DATA_TABLE:-$PARM_FV3DIAG/data_table}
+FIELD_TABLE=${FIELD_TABLE:-$PARM_FV3DIAG/field_table_aer}
+
+# build the diag_table with the experiment name and date stamp
+if [ $DOIAU = "YES" ]; then
+cat > diag_table << EOF
+FV3 Forecast
+${gPDY:0:4} ${gPDY:4:2} ${gPDY:6:2} ${gcyc} 0 0
+EOF
+cat $DIAG_TABLE >> diag_table
+else
+cat > diag_table << EOF
+FV3 Forecast
+${sPDY:0:4} ${sPDY:4:2} ${sPDY:6:2} ${scyc} 0 0
+EOF
+cat $DIAG_TABLE >> diag_table
+fi
+
+$NCP $DATA_TABLE  data_table
+$NCP $FIELD_TABLE field_table
+
+cat > input.nml <<EOF
+&amip_interp_nml
+  interp_oi_sst = .true.
+  use_ncep_sst = .true.
+  use_ncep_ice = .false.
+  no_anom_sst = .false.
+  data_set = 'reynolds_oi'
+  date_out_of_range = 'climo'
+  $amip_interp_nml
+/
+
+&atmos_model_nml
+  blocksize = $blocksize
+  chksum_debug = $chksum_debug
+  dycore_only = $dycore_only
+  fdiag = $FDIAG
+  fhmax = $FHMAX
+  fhout = $FHOUT
+  fhmaxhf = $FHMAX_HF     ! CROW configured
+  fhouthf = $FHOUT_HF     ! CROW configured
+  $atmos_model_nml
+/
+
+&diag_manager_nml
+  prepend_date = .false.
+  $diag_manager_nml
+/
+
+&fms_io_nml
+  checksum_required = .false.
+  max_files_r = 100
+  max_files_w = 100
+  $fms_io_nml
+/
+
+&fms_nml
+  clock_grain = 'ROUTINE'
+  domains_stack_size = ${domains_stack_size:-3000000}
+  print_memory_usage = ${print_memory_usage:-".false."}
+  $fms_nml
+/
+
+&fv_core_nml
+  layout = $layout_x,$layout_y
+  io_layout = $io_layout
+  npx = $npx
+  npy = $npy
+  ntiles = $ntiles
+  npz = $npz
+  grid_type = -1
+  make_nh = $make_nh 
+  fv_debug = ${fv_debug:-".false."}
+  range_warn = ${range_warn:-".false."}
+  reset_eta = .false.
+  n_sponge = ${n_sponge:-"10"}    ! CROW configured
+  nudge_qv = ${nudge_qv:-".true."}
+  tau = ${tau:-10.}
+  rf_cutoff = ${rf_cutoff:-"7.5e2"}
+  d2_bg_k1 = ${d2_bg_k1:-"0.15"}    ! CROW configured
+  d2_bg_k2 = ${d2_bg_k2:-"0.02"}    ! CROW configured
+  kord_tm = ${kord_tm:-"-9"}
+  kord_mt = ${kord_mt:-"9"}
+  kord_wz = ${kord_wz:-"9"}
+  kord_tr = ${kord_tr:-"9"}
+  hydrostatic = $hydrostatic
+  phys_hydrostatic = $phys_hydrostatic
+  use_hydro_pressure = $use_hydro_pressure
+  beta = 0.
+  a_imp = 1.
+  p_fac = 0.1
+  k_split = $k_split
+  n_split = $n_split
+  nwat = ${nwat:-2}		! CROW configured
+  na_init = $na_init
+  d_ext = 0.
+  dnats = ${dnats:-0}		! CROW configured
+  fv_sg_adj = ${fv_sg_adj:-"450"}
+  d2_bg = 0.
+  nord = ${nord:-3}		! CROW configured
+  dddmp = ${dddmp:-0.2}		! CROW configured
+  d4_bg = ${d4_bg:-0.15}	! CROW configured
+  vtdm4 = $vtdm4
+  delt_max = ${delt_max:-"0.002"}
+  ke_bg = 0.
+  do_vort_damp = $do_vort_damp
+  external_ic = $external_ic
+  external_eta = ${external_eta:-.true.}
+  gfs_phil = ${gfs_phil:-".false."}
+  nggps_ic = $nggps_ic
+  mountain = $mountain
+  ncep_ic = $ncep_ic
+  d_con = $d_con
+  hord_mt = $hord_mt		! CROW configured
+  hord_vt = $hord_xx		! CROW configured
+  hord_tm = $hord_xx		! CROW configured
+  hord_dp = -$hord_xx		! CROW configured
+  hord_tr = ${hord_tr:-"8"}	
+  adjust_dry_mass = ${adjust_dry_mass:-".true."}
+  consv_te = $consv_te
+  do_sat_adj = ${do_sat_adj:-".false."}	! CROW configured
+  consv_am = .false.
+  fill = .true.
+  dwind_2d = .false.
+  print_freq = $print_freq
+  warm_start = $warm_start
+  no_dycore = $no_dycore
+  z_tracer = .true.
+  read_increment = $read_increment
+  res_latlon_dynamics = $res_latlon_dynamics
+  $fv_core_nml
+/
+
+&cires_ugwp_nml
+       knob_ugwp_solver  = ${knob_ugwp_solver:-2}
+       knob_ugwp_source  = ${knob_ugwp_source:-1,1,0,0}
+       knob_ugwp_wvspec  = ${knob_ugwp_wvspec:-1,25,25,25}
+       knob_ugwp_azdir   = ${knob_ugwp_azdir:-2,4,4,4}
+       knob_ugwp_stoch   = ${knob_ugwp_stoch:-0,0,0,0}
+       knob_ugwp_effac   = ${knob_ugwp_effac:-1,1,1,1}
+       knob_ugwp_doaxyz  = ${knob_ugwp_doaxyz:-1}
+       knob_ugwp_doheat  = ${knob_ugwp_doheat:-1}
+       knob_ugwp_dokdis  = ${knob_ugwp_dokdis:-1}
+       knob_ugwp_ndx4lh  = ${knob_ugwp_ndx4lh:-1}
+       knob_ugwp_version = ${knob_ugwp_version:-0}
+       launch_level      = ${launch_level:-54}                   
+/
+
+&external_ic_nml
+  filtered_terrain = $filtered_terrain
+  levp = $LEVS
+  gfs_dwinds = $gfs_dwinds
+  checker_tr = .false.
+  nt_checker = 0
+  $external_ic_nml
+/
+
+&gfs_physics_nml
+       fhzero         = 6.
+       ldiag3d        = .false.
+       ldiag_ugwp     = .F.
+       do_ugwp        = .F.
+       do_tofd        = .F.
+       fhcyc          = 24.
+       nst_anl        = .true.
+       use_ufo        = .true.
+       pre_rad        = .false.
+       ncld           = 5
+       imp_physics    = 11
+       pdfcld         = .false.
+       fhswr          = 3600.
+       fhlwr          = 3600.
+       ialb           = 1
+       iems           = 1
+       IAER           = 111
+       ico2           = 2
+       isubc_sw       = 2
+       isubc_lw       = 2
+       isol           = 2
+       lwhtr          = .true.
+       swhtr          = .true.
+       cnvgwd         = .true.
+       shal_cnv       = .true.
+       cal_pre        = .false.
+       redrag         = .true.
+       dspheat        = .true.
+       hybedmf        = .T.
+       satmedmf       = .F.
+       lheatstrg      = .F.
+       lgfdlmprad     = .F.
+       effr_in        = .F.
+       random_clds    = .false.
+       trans_trac     = .true.
+       cnvcld         = .true.
+       imfshalcnv     = 2
+       imfdeepcnv     = 2
+       cdmbgwd        = 3.5,0.25
+       prslrd0        = 0.
+       ivegsrc        = 1
+       isot           = 1
+       lsm            = 1
+       iopt_dveg      = 2
+       iopt_crs       = 1
+       iopt_btr       = 1
+       iopt_run       = 1
+       iopt_sfc       = 1
+       iopt_frz       = 1
+       iopt_inf       = 1
+       iopt_rad       = 1
+       iopt_alb       = 2
+       iopt_snf       = 4
+       iopt_tbot      = 2
+       iopt_stc       = 1
+       debug          = .false.
+       h2o_phys       = .F.
+       nstf_name      = 2,1,1,0,5
+       iau_drymassfixer = .false.
+       cplflx         = .F.
+       cplwav         = .F.
+       cplwav2atm     = .F.
+       cplgocart      = .T.
+       xkzminv        = 0.3
+       xkzm_m         = 1.0
+       xkzm_h         = 1.0
+EOF
+
+cat >> input.nml <<EOF
+  $gfs_physics_nml
+/
+EOF
+
+echo "" >> input.nml
+
+cat >> input.nml <<EOF
+&gfdl_cloud_microphysics_nml
+       sedi_transport = .true.
+       do_sedi_heat = .false.
+       rad_snow = .true.
+       rad_graupel = .true.
+       rad_rain = .true.
+       const_vi = .F.
+       const_vs = .F.
+       const_vg = .F.
+       const_vr = .F.
+       vi_max = 1.
+       vs_max = 2.
+       vg_max = 12.
+       vr_max = 12.
+       qi_lim = 1.
+       prog_ccn = .false.
+       do_qa = .true.
+       fast_sat_adj = .true.
+       tau_l2v = 300.
+       tau_l2v = 225.
+       tau_v2l = 150.
+       tau_g2v = 900.
+       rthresh = 10.e-6  ! This is a key parameter for cloud water
+       dw_land  = 0.16
+       dw_ocean = 0.10
+       ql_gen = 1.0e-3
+       ql_mlt = 1.0e-3
+       qi0_crt = 8.0E-5
+       qs0_crt = 1.0e-3
+       tau_i2s = 1000.
+       c_psaci = 0.05
+       c_pgacs = 0.01
+       rh_inc = 0.30
+       rh_inr = 0.30
+       rh_ins = 0.30
+       ccn_l = 300.
+       ccn_o = 100.
+       c_paut = 0.5
+       c_cracw = 0.8
+       use_ppm = .false.
+       use_ccn = .true.
+       mono_prof = .true.
+       z_slope_liq  = .true.
+       z_slope_ice  = .true.
+       de_ice = .false.
+       fix_negative = .true.
+       icloud_f = 1
+       mp_time = 150.
+  $gfdl_cloud_microphysics_nml
+/
+
+&interpolator_nml
+  interp_method = 'conserve_great_circle'
+  $interpolator_nml
+/
+
+&namsfc
+  FNGLAC   = '${FNGLAC}'
+  FNMXIC   = '${FNMXIC}'
+  FNTSFC   = '${FNTSFC}'
+  FNSNOC   = '${FNSNOC}'
+  FNZORC   = '${FNZORC}'
+  FNALBC   = '${FNALBC}'
+  FNALBC2  = '${FNALBC2}'
+  FNAISC   = '${FNAISC}'
+  FNTG3C   = '${FNTG3C}'
+  FNVEGC   = '${FNVEGC}'
+  FNVETC   = '${FNVETC}'
+  FNSOTC   = '${FNSOTC}'
+  FNSMCC   = '${FNSMCC}'
+  FNMSKH   = '${FNMSKH}'
+  FNTSFA   = '${FNTSFA}'
+  FNACNA   = '${FNACNA}'
+  FNSNOA   = '${FNSNOA}'
+  FNVMNC   = '${FNVMNC}'
+  FNVMXC   = '${FNVMXC}'
+  FNSLPC   = '${FNSLPC}'
+  FNABSC   = '${FNABSC}'
+  LDEBUG = ${LDEBUG:-".false."}
+  FSMCL(2) = ${FSMCL2:-99999}
+  FSMCL(3) = ${FSMCL3:-99999}
+  FSMCL(4) = ${FSMCL4:-99999}
+  LANDICE  = ${landice:-".true."}
+  FTSFS = ${FTSFS:-90}
+  FAISL = ${FAISL:-99999}
+  FAISS = ${FAISS:-99999}
+  FSNOL = ${FSNOL:-99999}
+  FSNOS = ${FSNOS:-99999}
+  FSICL = ${FSICL:-99999}
+  FSICS = ${FSICS:-99999}
+  FTSFL = ${FTSFL:-99999}
+  FVETL = ${FVETL:-99999}
+  FSOTL = ${FSOTL:-99999}
+  FvmnL = ${FvmnL:-99999}
+  FvmxL = ${FvmxL:-99999}
+  FSLPL = ${FSLPL:-99999}
+  FABSL = ${FABSL:-99999}
+  $namsfc_nml
+/
+
+&fv_grid_nml
+  grid_file = 'INPUT/grid_spec.nc'
+  $fv_grid_nml
+/
+EOF
+
+# Add namelist for stochastic physics options
+cat >> input.nml << EOF
+&nam_stochy
+/
+&nam_sfcperts
+/
+EOF
+
+echo "$(cat input.nml)"
+}

--- a/workflow/cases/aerosol_firex_forecast.yaml
+++ b/workflow/cases/aerosol_firex_forecast.yaml
@@ -1,0 +1,59 @@
+case:
+  places:
+    workflow_file: layout/free_forecast_gfs.yaml
+    BASE_CPLIC: /scratch1/NCEPDEV/nems/Raffaele.Montuoro/data
+    OROFIX:     /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200914/INTEL/FV3_input_data_c384/INPUT
+    GRDFIX:     /scratch1/NCEPDEV/nems/emc.nemspara/RT/NEMSfv3gfs/develop-20200914/INTEL/FV3_input_data_c384/INPUT
+
+  settings: 
+    SDATE: 2019-07-01t00:00:00
+    EDATE: 2019-07-15t00:00:00
+
+    gfs_cyc: 1
+
+    cplgocart: .true.
+    print_esmf: .true.
+    nems_temp: 'atm_aer'
+
+    run_gsi: No
+    ic_source: fv3_ic
+    mom6ic_prepared: .false.
+    chgres_and_convert_ics: Yes
+    IC_CDUMP: gfs
+
+    KEEPDATA: Yes
+
+  nsst:
+    NST_MODEL: 0
+
+  output_settings:
+    FHOUT_GFS: 6
+    FHMIN_GFS: 0
+    FHMAX_GFS: 24
+    FHMAX_HF_GFS: 0
+    FHOUT_HF_GFS: -1
+
+  fv3_gfs_settings:
+    CASE: C384
+    LEVS: 65
+    DELTIM: 450
+    layout:
+       x: 6
+       y: 8
+       nth: 2
+       WGRP: 1
+       WGRP_NTASKS: 24
+       WRTIOBUF: "32M"
+    CPL_ATMIC: FV3ICS
+
+  chem_settings:
+    MOD: gsdchem
+    CFGDIR: /scratch1/NCEPDEV/nems/Raffaele.Montuoro/data/NASA/rc.firex
+    INPDIR: /scratch1/NCEPDEV/nems/Raffaele.Montuoro/data/NASA/ExtData
+
+  post:
+    downset: 2
+    GOESF: no
+
+  archiving:
+    archive_to_hpss: No

--- a/workflow/cases/aerosol_firex_forecast.yaml
+++ b/workflow/cases/aerosol_firex_forecast.yaml
@@ -1,3 +1,6 @@
+# Note: This case is configured for Hera. All file paths should be properly updated on other platforms.
+##
+##
 case:
   places:
     workflow_file: layout/free_forecast_gfs.yaml

--- a/workflow/cases/aerosol_firex_forecast.yaml
+++ b/workflow/cases/aerosol_firex_forecast.yaml
@@ -48,6 +48,7 @@ case:
 
   chem_settings:
     MOD: gsdchem
+    ntdiag: 2
     CFGDIR: /scratch1/NCEPDEV/nems/Raffaele.Montuoro/data/NASA/rc.firex
     INPDIR: /scratch1/NCEPDEV/nems/Raffaele.Montuoro/data/NASA/ExtData
 

--- a/workflow/cases/aerosol_firex_forecast.yaml
+++ b/workflow/cases/aerosol_firex_forecast.yaml
@@ -11,6 +11,7 @@ case:
   settings: 
     SDATE: 2019-07-01t00:00:00
     EDATE: 2019-07-15t00:00:00
+    max_job_tries: 1
 
     gfs_cyc: 1
 
@@ -43,7 +44,7 @@ case:
     layout:
        x: 6
        y: 8
-       nth: 2
+       nth: 1
        WGRP: 1
        WGRP_NTASKS: 24
        WRTIOBUF: "32M"

--- a/workflow/cases/aerosol_free_forecast.yaml
+++ b/workflow/cases/aerosol_free_forecast.yaml
@@ -33,12 +33,6 @@ case:
     CASE: C384
     LEVS: 65
     DELTIM: 450
-    SEEDLET: 10
-#   CCPP_SUITE: FV3_GFS_v15p2_coupled
-    nst_anl: no
-    DO_SKEB: false
-    DO_SHUM: false
-    DO_SPPT: false
     layout:
        x: 6
        y: 8
@@ -46,10 +40,13 @@ case:
        WGRP: 1
        WGRP_NTASKS: 24
        WRTIOBUF: "32M"
-    cdmbgwd: "1.0,1.2"
+    CPL_ATMIC: FV3ICS
 
   chem_settings:
     MOD: gsdchem
+    ntdiag: 2
+    CFGDIR: /scratch1/NCEPDEV/nems/Raffaele.Montuoro/data/NASA/rc
+    INPDIR: /scratch1/NCEPDEV/nems/Raffaele.Montuoro/data/NASA/ExtData
 
   post:
     downset: 2

--- a/workflow/cases/aerosol_free_forecast.yaml
+++ b/workflow/cases/aerosol_free_forecast.yaml
@@ -1,0 +1,56 @@
+case:
+  places:
+    workflow_file: layout/free_forecast_gfs.yaml
+
+  settings: 
+    SDATE: 2013-04-01t00:00:00
+    EDATE: 2013-04-01t00:00:00
+
+    cplgocart: .true.
+    print_esmf: .true.
+    nems_temp: 'atm_aer'
+    nems_temp_cold: 'atm_aer'
+
+    run_gsi: No
+    ic_source: fv3_ic
+    mom6ic_prepared: .false.
+    chgres_and_convert_ics: Yes
+    IC_CDUMP: gfs
+
+    KEEPDATA: Yes
+
+  nsst:
+    NST_MODEL: 0
+
+  output_settings:
+    FHOUT_GFS: 6
+    FHMIN_GFS: 0
+    FHMAX_GFS: 48
+    FHMAX_HF_GFS: 0
+    FHOUT_HF_GFS: -1
+
+  fv3_gfs_settings:
+    CASE: C384
+    LEVS: 65
+    DELTIM: 450
+    SEEDLET: 10
+#   CCPP_SUITE: FV3_GFS_v15p2_coupled
+    nst_anl: no
+    DO_SKEB: false
+    DO_SHUM: false
+    DO_SPPT: false
+    layout:
+       x: 6
+       y: 8
+       nth: 2
+       WGRP: 1
+       WGRP_NTASKS: 24
+       WRTIOBUF: "32M"
+    cdmbgwd: "1.0,1.2"
+
+  chem_settings:
+    MOD: gsdchem
+
+  post:
+    downset: 2
+    GOESF: no

--- a/workflow/cases/aerosol_free_forecast.yaml
+++ b/workflow/cases/aerosol_free_forecast.yaml
@@ -40,13 +40,16 @@ case:
        WGRP: 1
        WGRP_NTASKS: 24
        WRTIOBUF: "32M"
-    CPL_ATMIC: FV3ICS
 
   chem_settings:
     MOD: gsdchem
     ntdiag: 2
+    # On Hera
     CFGDIR: /scratch1/NCEPDEV/nems/Raffaele.Montuoro/data/NASA/rc
     INPDIR: /scratch1/NCEPDEV/nems/Raffaele.Montuoro/data/NASA/ExtData
+    # On Orion
+    # CFGDIR: /work/noaa/stmp/rmontuor/nasa/data/rc
+    # INPDIR: /work/noaa/stmp/rmontuor/nasa/data/ExtData
 
   post:
     downset: 2

--- a/workflow/cases/aerosol_free_forecast.yaml
+++ b/workflow/cases/aerosol_free_forecast.yaml
@@ -5,6 +5,7 @@ case:
   settings: 
     SDATE: 2013-04-01t00:00:00
     EDATE: 2013-04-01t00:00:00
+    max_job_tries: 1
 
     cplgocart: .true.
     print_esmf: .true.
@@ -36,7 +37,7 @@ case:
     layout:
        x: 6
        y: 8
-       nth: 2
+       nth: 1
        WGRP: 1
        WGRP_NTASKS: 24
        WRTIOBUF: "32M"

--- a/workflow/config/base.yaml
+++ b/workflow/config/base.yaml
@@ -20,13 +20,25 @@ config_base:
     # Machine environment
     export machine="{doc.platform.name}"
 
+    export print_esmf="{doc.settings.print_esmf}"
+    export esmf_profile="{doc.settings.esmf_profile}"
+
+    # Coupling settings
     export cpl="{doc.settings.cpl}"
     export cplflx="{doc.settings.cplflx}"
+    export cplgocart="{doc.settings.cplgocart}"
     export cplice="{doc.settings.cplice}"
     export cplwav="{doc.settings.cplwav}"
     export cplwav2atm="{doc.settings.cplwav2atm}"
-    export print_esmf="{doc.settings.print_esmf}"
-    export esmf_profile="{doc.settings.esmf_profile}"
+
+    # Temporarily override settings for aerosol coupling
+    if [ $cplgocart = ".true." ]; then
+        export cplflx=".false."
+        export cplice=".false."
+        export cplocn=".false."
+        export cplwav=".false."
+        export cplwav2atm=".false."
+    fi
 
     if [[ $cplwav = ".true." ]]; then
        export DO_WAVE="YES"

--- a/workflow/config/base.yaml
+++ b/workflow/config/base.yaml
@@ -141,6 +141,8 @@ config_base:
     export ARCDIR="$NOSCRUB/archive/$PSLOT"
     export ICSDIR="{doc.places.ICSDIR}"
     export ATARDIR="{doc.archiving.ATARDIR}"
+    export OROFIX="{doc.places.OROFIX}"
+    export GRDFIX="{doc.places.GRDFIX}"
     
     # Commonly defined parameters in JJOBS
     export envir=${{envir:-"prod"}}

--- a/workflow/config/base.yaml
+++ b/workflow/config/base.yaml
@@ -141,8 +141,8 @@ config_base:
     export ARCDIR="$NOSCRUB/archive/$PSLOT"
     export ICSDIR="{doc.places.ICSDIR}"
     export ATARDIR="{doc.archiving.ATARDIR}"
-    export OROFIX="{doc.places.OROFIX}"
-    export GRDFIX="{doc.places.GRDFIX}"
+    export OROFIX="{doc.places.get('OROFIX','')}"
+    export GRDFIX="{doc.places.get('GRDFIX','')}"
     
     # Commonly defined parameters in JJOBS
     export envir=${{envir:-"prod"}}

--- a/workflow/config/fcst.yaml
+++ b/workflow/config/fcst.yaml
@@ -253,6 +253,8 @@ config_fcst:
     # Remember config.efcs will over-ride these values for ensemble forecasts
     # if these variables are re-defined there.
     # Otherwise, the ensemble forecast will inherit from config.fcst
+
+    # export KMP_INIT_AT_FORK=FALSE
     
     echo "END: config.fcst"
     

--- a/workflow/config/fcst.yaml
+++ b/workflow/config/fcst.yaml
@@ -230,6 +230,7 @@ config_fcst:
         export FIELD_TABLE="$HOMEgfs/parm/parm_fv3diag/field_table_aer"
         export CHM_CFGDIR="{doc.chem_settings.CFGDIR}"
         export CHM_INPDIR="{doc.chem_settings.INPDIR}"
+        export dnats="$(( $dnats + {doc.chem_settings.ntdiag} ))"
     elif [[ $cpl == .true. ]] ; then # coupled model
         export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_cpl"
     fi

--- a/workflow/config/fcst.yaml
+++ b/workflow/config/fcst.yaml
@@ -253,8 +253,6 @@ config_fcst:
     # Remember config.efcs will over-ride these values for ensemble forecasts
     # if these variables are re-defined there.
     # Otherwise, the ensemble forecast will inherit from config.fcst
-
-    # export KMP_INIT_AT_FORK=FALSE
     
     echo "END: config.fcst"
     

--- a/workflow/config/fcst.yaml
+++ b/workflow/config/fcst.yaml
@@ -228,6 +228,8 @@ config_fcst:
     if [ $cplgocart = .true. ]; then # temporary settings for aerosol coupling
         export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_aer"
         export FIELD_TABLE="$HOMEgfs/parm/parm_fv3diag/field_table_aer"
+        export CHM_CFGDIR="{doc.chem_settings.CFGDIR}"
+        export CHM_INPDIR="{doc.chem_settings.INPDIR}"
     elif [[ $cpl == .true. ]] ; then # coupled model
         export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_cpl"
     fi

--- a/workflow/config/fcst.yaml
+++ b/workflow/config/fcst.yaml
@@ -5,7 +5,7 @@
 config_fcst:
   filename: config.fcst
   FCSTEXEC: !FirstTrue
-    - when: !calc doc.settings.cplflx==".true."
+    - when: !calc ( doc.settings.cplflx==".true." or doc.settings.cplgocart==".true." )
       do: "ufs_model"
     - otherwise: "global_fv3gfs.x"
   more_exports_for_microphys: !FirstTrue
@@ -70,6 +70,7 @@ config_fcst:
     export OCN_model="{doc.ocn_settings.MOD}"
     export ICE_model="{doc.ice_settings.MOD}"
     export WAV_model="{doc.wave_settings.MOD}"
+    export CHM_model="{doc.chem_settings.MOD}"
 
     #######################################################################
     # COUPLING COMPONENTS
@@ -82,6 +83,7 @@ config_fcst:
     export OCNPETS="{doc.ocn_settings.OCNPETS}"
     export ICEPETS="{doc.ice_settings.ICEPETS}"
     export WAVPETS="{doc.wave_settings.WAVPETS}"
+    export CHMPETS="{resource_a[0].mpi_ranks}"
     #
     #######################################################################    
     # CICE parameters
@@ -220,9 +222,13 @@ config_fcst:
         export npe_remap={doc.partition_common.resources.fallback_run_gfsremap[0].mpi_ranks}
         export nth_remap={doc.partition_common.resources.fallback_run_gfsremap[0].OMP_NUM_THREADS}
 
+
     fi
 
-    if [[ $cpl == .true. ]] ; then # coupled model
+    if [ $cplgocart = .true. ]; then # temporary settings for aerosol coupling
+        export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_aer"
+        export FIELD_TABLE="$HOMEgfs/parm/parm_fv3diag/field_table_aer"
+    elif [[ $cpl == .true. ]] ; then # coupled model
         export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_cpl"
     fi
     

--- a/workflow/defaults/case.yaml
+++ b/workflow/defaults/case.yaml
@@ -3,6 +3,13 @@
 # of the case files, default files, platform file, and everywhere
 # else, and applies any validation from the schema/ directory.
 
+chem_settings: !Immediate
+  - !MergeMapping
+    - CDUMP: gfs
+      Template: *chem_settings_template
+    - !calc doc.chem_defaults
+    - !calc doc.case.get('chem_settings',{})
+
 ocn_settings: !Immediate
   - !MergeMapping
     - CDUMP: gfs

--- a/workflow/defaults/chem.yaml
+++ b/workflow/defaults/chem.yaml
@@ -1,0 +1,5 @@
+# default settings for chemistry model core
+
+chem_defaults: &chem_defaults
+  MOD: gsdchem
+  OCNPETS: 0

--- a/workflow/defaults/chem.yaml
+++ b/workflow/defaults/chem.yaml
@@ -3,3 +3,11 @@
 chem_defaults: &chem_defaults
   MOD: gsdchem
   ntdiag: 0
+  CFGDIR: !FirstTrue
+    - when: !calc (doc.settings.cplgocart != ".true.")
+      do: "not_set"
+    - otherwise:
+  INPDIR: !FirstTrue
+    - when: !calc (doc.settings.cplgocart != ".true.")
+      do: "not_set"
+    - otherwise:

--- a/workflow/defaults/chem.yaml
+++ b/workflow/defaults/chem.yaml
@@ -2,3 +2,4 @@
 
 chem_defaults: &chem_defaults
   MOD: gsdchem
+  ntdiag: 0

--- a/workflow/defaults/chem.yaml
+++ b/workflow/defaults/chem.yaml
@@ -2,4 +2,3 @@
 
 chem_defaults: &chem_defaults
   MOD: gsdchem
-  OCNPETS: 0

--- a/workflow/defaults/settings.yaml
+++ b/workflow/defaults/settings.yaml
@@ -55,6 +55,7 @@ default_settings: &default_settings
   cplwav: .false.
   cplwav2atm: .false.
   cplchem: .false.
+  cplgocart: .false.
   cpl: !FirstTrue
     - when: !calc doc.settings.cplflx==".true."
       do: .true.
@@ -63,6 +64,8 @@ default_settings: &default_settings
     - when: !calc doc.settings.cplwav==".true."
       do: .true.
     - when: !calc doc.settings.cplchem==".true."
+      do: .true.
+    - when: !calc doc.settings.cplgocart==".true."
       do: .true.
     - otherwise: .false.
 

--- a/workflow/schema/chem.yaml
+++ b/workflow/schema/chem.yaml
@@ -1,0 +1,9 @@
+# fv3_settings_template - sets the namelist values for the fv3
+# forecast.  See the physcs and model documentation for full
+# information on these variables.
+
+chem_settings_template: !Template &chem_settings_template
+  MOD:
+    type: string
+    allowed: [ gsdchem ]
+    description: "model selection for aerosols"

--- a/workflow/schema/chem.yaml
+++ b/workflow/schema/chem.yaml
@@ -7,3 +7,9 @@ chem_settings_template: !Template &chem_settings_template
     type: string
     allowed: [ gsdchem ]
     description: "model selection for aerosols"
+  CFGDIR:
+    type: string
+    description: "directory containing model resource files"
+  INPDIR:
+    type: string
+    description: "directory containing model input data"

--- a/workflow/schema/chem.yaml
+++ b/workflow/schema/chem.yaml
@@ -13,3 +13,6 @@ chem_settings_template: !Template &chem_settings_template
   INPDIR:
     type: string
     description: "directory containing model input data"
+  ntdiag:
+    type: int
+    description: "number of diagnostic tracers"

--- a/workflow/schema/places.yaml
+++ b/workflow/schema/places.yaml
@@ -53,3 +53,6 @@ places_schema: &places_schema !Template
     type: string
     allowed: [ opsgfs, pargfs ]
     description: initial conditions from opsgfs or pargfs
+
+  OROFIX: { type: string, optional: true }
+  GRDFIX: { type: string, optional: true }


### PR DESCRIPTION
This PR introduces preliminary changes to enable running the [FV3-GOCART](https://github.com/NOAA-EMC/FV3-GOCART) (UFS-Aerosols) app via the coupled global workflow on Hera and Orion. The app integrates a new UFS aerosols component (under development) directly coupled to the atmospheric model. 

Two test cases are also included as templates to help set up free coupled aerosols forecast runs.

This work supports the integration of NASA's 2nd-generation GOCART model component into the fully-coupled UFS Weather Model. See issue #304.