### PR TITLE
Fix cycle date for wave bulletins

### DIFF
--- a/ush/wave_outp_spec.sh
+++ b/ush/wave_outp_spec.sh
@@ -160,7 +160,7 @@
   if [ "$specdir" = "bull" ]
   then
     tstart="`echo $ymdh | cut -c1-8` `echo $ymdh | cut -c9-10`0000"
-    truntime="`echo $CDATE | cut -c1-8` `echo $YMDH | cut -c9-10`0000"
+    truntime="`echo $CDATE | cut -c1-8` `echo $CDATE | cut -c9-10`0000"
     sed -e "s/TIME/$tstart/g" \
       -e "s/DT/$dtspec/g" \
       -e "s/POINT/$point/g" \


### PR DESCRIPTION
This fixed the wave bulletins so that they will have the correct cycle date. 

This was pulled into operations by Jen and started running with on 20210324 for the 12z cycle. 