### PR TITLE
bug fix for wave post point 

### DIFF
--- a/scripts/exgfs_wave_post_pnt.sh
+++ b/scripts/exgfs_wave_post_pnt.sh
@@ -306,10 +306,10 @@
     mv buoy_log.tmp buoy_log.dat
 
     grep -F -f ibp_tags buoy_lst.loc >  buoy_tmp1.loc
-    sed    '$d' buoy_tmp1.loc > buoy_tmp2.loc
-    buoys=`awk '{ print $1 }' buoy_tmp2.loc`
-    Nb=`wc buoy_tmp2.loc | awk '{ print $1 }'`
-    rm -f buoy_tmp1.loc buoy_tmp2.loc
+    #sed    '$d' buoy_tmp1.loc > buoy_tmp2.loc
+    buoys=`awk '{ print $1 }' buoy_tmp1.loc`
+    Nb=`wc buoy_tmp1.loc | awk '{ print $1 }'`
+    rm -f buoy_tmp1.loc 
 
     if [ -s buoy_log.dat ]
     then


### PR DESCRIPTION
This bug was found while testing the RW-points for NHC issue.  The commented out line of code removes the last buoy from the buoy list and it should be included. 


I have run a test of the point post jobs using the para run data and the only effect is that the last point is actually included as it should be. 

This should be included with the 16.1 (assuming waves continues as part of this). 

FYI @CatherineThomas-NOAA @RussTreadon-NOAA @KateFriedman-NOAA   I have given this to Jen, this was the bug I mentioned that I found in the email thread yesterday. 