### PR TITLE
GFSv16.1.2 - Update EMC_post tag to upp_gfsv16_release.v1.1.4 and GSI tag to gfsda.v16.1.1a

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -22,7 +22,7 @@ protocol = git
 required = True
 
 [EMC_post]
-tag = upp_gfsv16_release.v1.1.3
+tag = upp_gfsv16_release.v1.1.4
 local_path = sorc/gfs_post.fd
 repo_url = https://github.com/NOAA-EMC/EMC_post.git
 protocol = git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.1.0
+tag = gfsda.v16.1.1a
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -38,7 +38,7 @@ if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
     git clone --recursive https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
-    git checkout gfsda.v16.1.0
+    git checkout gfsda.v16.1.1a
     git submodule update
     cd ${topdir}
 else

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -72,7 +72,7 @@ if [[ ! -d gfs_post.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_post.log
     git clone https://github.com/NOAA-EMC/EMC_post.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
     cd gfs_post.fd
-    git checkout upp_gfsv16_release.v1.1.3
+    git checkout upp_gfsv16_release.v1.1.4
     ################################################################################
     # checkout_gtg
     ## yes: The gtg code at NCAR private repository is available for ops. GFS only.


### PR DESCRIPTION
New tag for GSI to disable cris assimilation (ops hotfix) and two updates in new upp_gfsv16_release.v1.1.4 tag:

1. Triggering postanl job change for reliability from @lgannoaa
2. Fix for wafs processing failure from @YaliMao-NOAA

New tags increments operational GFS version to v16.1.2.

From June 18th RFC memo:

> RFC 8313 - Upgrade the GFS to v16.1.2, which includes the following two fixes:
> * an updated UPP GTG subroutine to increase
>   * wind threshold to 500 m/s,
>   * height threshold to 1.0E7 m, and
>   * temperature threshold to 3000 K.
> Also instead of aborting, only send out “out of bound” warning messages when thresholds are exceeded.
> * an updated GFS post processing script so that the GFS post-processing job will not crash and the generation of GFS pgb files will continue even if the WAFS fails.
>
> These changes address recent failures of the GFS WAFS post-processing job which produce turbulence products, which then caused the generation of GFS pgb files and downstream products to come to a halt. To be implemented on June 22 at 1430Z.

Refs: #330
Close #330 