### PR TITLE
Fix ww3 pre-post modules

### DIFF
--- a/modulefiles/modulefile.ww3.hera
+++ b/modulefiles/modulefile.ww3.hera
@@ -13,18 +13,5 @@ module load jasper/2.0.25
 module load zlib/1.2.11
 module load png/1.6.35
 
-module load hdf5/1.10.6
-module load netcdf/4.7.4
-module load esmf/8_1_0_beta_snapshot_36
-
 module load bacio/2.4.1
-module load crtm/2.3.0
 module load g2/3.4.1
-module load g2tmpl/1.9.1
-module load ip/3.3.3
-module load nceppost/dceca26
-module load nemsio/2.5.2
-module load sp/2.3.3
-module load w3emc/2.7.3
-module load w3nco/2.4.1
-module load wgrib2/2.0.8

--- a/modulefiles/modulefile.ww3.orion
+++ b/modulefiles/modulefile.ww3.orion
@@ -14,18 +14,5 @@ module load jasper/2.0.25
 module load zlib/1.2.11
 module load png/1.6.35
 
-module load hdf5/1.10.6
-module load netcdf/4.7.4
-module load esmf/8_1_0_beta_snapshot_27
-
 module load bacio/2.4.1
-module load crtm/2.3.0
 module load g2/3.4.1
-module load g2tmpl/1.9.1
-module load ip/3.3.3
-module load nceppost/dceca26
-module load nemsio/2.5.2
-module load sp/2.3.3
-module load w3emc/2.7.3
-module load w3nco/2.4.1
-module load wgrib2/2.0.8

--- a/modulefiles/modulefile.ww3.wcoss_dell_p3
+++ b/modulefiles/modulefile.ww3.wcoss_dell_p3
@@ -9,18 +9,5 @@ module load jasper/2.0.25
 module load zlib/1.2.11
 module load png/1.6.35
 
-module load hdf5/1.10.6
-module load netcdf/4.7.4
-module load esmf/8_1_0_beta_snapshot_36
-
 module load bacio/2.4.1
-module load crtm/2.3.0
 module load g2/3.4.1
-module load g2tmpl/1.9.1
-module load ip/3.3.3
-module load nceppost/dceca26
-module load nemsio/2.5.2
-module load sp/2.3.3
-module load w3emc/2.7.3
-module load w3nco/2.4.1
-module load wgrib2/2.0.8


### PR DESCRIPTION
Fixes the build failure of ww3_grib in ww3prepost by eliminating unneeded modules from the modulefile. Also adds error checking to the ww3prepost build script.

Closes #339