### PR TITLE
Fix module base for Hera

### DIFF
--- a/modulefiles/module_base.hera
+++ b/modulefiles/module_base.hera
@@ -14,7 +14,7 @@ module load hpc-impi/2018.0.4
 module load g2/3.4.1
 module load g2tmpl/1.9.1
 module load grib_util/1.2.2
-module load crtm 2.3.0
+module load crtm/2.3.0
 module load prod_util/1.2.2
 module load grib_util/1.2.2
 module load ip/3.3.3


### PR DESCRIPTION
There was a missing slash in the module load for crtm in the module_base file for Hera.