### PR TITLE
Fix NST_SPINUP being ignored by CROW

### DIFF
--- a/workflow/config/nsst.yaml
+++ b/workflow/config/nsst.yaml
@@ -6,12 +6,12 @@ config_nsst:
   filename: config.nsst
   nst_spinup_logic: !FirstTrue
     - when: !calc doc.nsst.get("NST_SPINUP","")
-      do: !expand "export NST_SPINUP=$NST_SPINUP"
+      do: !expand "export NST_SPINUP={doc.nsst.NST_SPINUP}"
     - otherwise: |
         export NST_SPINUP=0
         #if [[ "$CDATE" = $SDATE ]]; then
         #    export NST_SPINUP=1
-        #fi      
+        #fi
   content: !expand |
     #!/bin/ksh -x
     


### PR DESCRIPTION
The NSST config file was setting NST_SPINUP to use an environment variable rather than using the value set by the yaml, so values set in the case file were ignored.

Refs: #337