### PR TITLE
Correct wrong settings for high-res warm-start free-forecast

### DIFF
--- a/jobs/rocoto/getic.sh
+++ b/jobs/rocoto/getic.sh
@@ -82,6 +82,7 @@ if [[ $gfs_ver = "v16" && $EXP_WARM_START = ".true." && $CASE = $OPS_RES ]]; the
 
   else # Opertional input - warm starts
 
+    cd $ROTDIR
     # Pull CDATE gfs restart tarball
     htar -xvf ${PRODHPSSDIR}/rh${yy}/${yy}${mm}/${yy}${mm}${dd}/com_gfs_prod_gfs.${yy}${mm}${dd}_${hh}.gfs_restart.tar
     # Pull GDATE gdas restart tarball

--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -112,13 +112,6 @@ export ARCDIR="$NOSCRUB/archive/$PSLOT"
 export ICSDIR="@ICSDIR@"
 export ATARDIR="/NCEPDEV/$HPSS_PROJECT/1year/$USER/$machine/scratch/$PSLOT"
 
-# Set operational version variables
-export OPS_RES="C768" # Do not change
-export gfs_ver="v16" # Do not change
-if [[ $gfs_ver = "v16" && $CASE = $OPS_RES ]]; then # Force EXP_WARM_START=true if v16 C768
-  export EXP_WARM_START=".true."
-fi
-
 # Commonly defined parameters in JJOBS
 export envir=${envir:-"prod"}
 export NET="gfs"
@@ -142,6 +135,9 @@ export SENDSDM=${SENDSDM:-"NO"}
 export SENDDBN_NTC=${SENDDBN_NTC:-"NO"}
 export SENDDBN=${SENDDBN:-"NO"}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
+
+# Set operational resolution
+export OPS_RES="C768" # Do not change
 
 # Resolution specific parameters
 export LEVS=128

--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -112,6 +112,13 @@ export ARCDIR="$NOSCRUB/archive/$PSLOT"
 export ICSDIR="@ICSDIR@"
 export ATARDIR="/NCEPDEV/$HPSS_PROJECT/1year/$USER/$machine/scratch/$PSLOT"
 
+# Set operational version variables
+export OPS_RES="C768" # Do not change
+export gfs_ver="v16" # Do not change
+if [[ $gfs_ver = "v16" && $CASE = $OPS_RES ]]; then # Force EXP_WARM_START=true if v16 C768
+  export EXP_WARM_START=".true."
+fi
+
 # Commonly defined parameters in JJOBS
 export envir=${envir:-"prod"}
 export NET="gfs"
@@ -140,7 +147,6 @@ export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 export LEVS=128
 export CASE="@CASECTL@"
 export CASE_ENKF="@CASEENS@"
-export OPS_RES="C768"
 
 # Run with CCPP physics
 export RUN_CCPP="YES"

--- a/parm/config/config.fv3
+++ b/parm/config/config.fv3
@@ -111,7 +111,7 @@ case $case_in in
         export layout_x_gfs=16
         export layout_y_gfs=12
         export npe_wav=140
-        export npe_wav_gfs=440
+        export npe_wav_gfs=140
         export nth_fv3=4
         export nth_fv3_gfs=4
         export cdmbgwd="4.0,0.15,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling

--- a/parm/config/config.fv3
+++ b/parm/config/config.fv3
@@ -109,15 +109,15 @@ case $case_in in
         export layout_x=8
         export layout_y=12
         export layout_x_gfs=16
-        export layout_y_gfs=16
+        export layout_y_gfs=12
         export npe_wav=140
         export npe_wav_gfs=440
         export nth_fv3=4
-        export nth_fv3_gfs=7
+        export nth_fv3_gfs=4
         export cdmbgwd="4.0,0.15,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=2
         export WRTTASK_PER_GROUP=$(echo "2*$npe_node_max" |bc)
-        export WRITE_GROUP_GFS=8
+        export WRITE_GROUP_GFS=4
         export WRTTASK_PER_GROUP_GFS=$(echo "2*$npe_node_max" |bc)
         export WRTIOBUF="32M"
         ;;

--- a/parm/config/config.getic
+++ b/parm/config/config.getic
@@ -12,10 +12,6 @@ export RETRO="NO" # YES = Pull v16 inputs from retrospective parallels; NO = use
 export gfs_ver="v16" # Default = v16
 export OPS_RES=${OPS_RES:-"C768"} # Operational resolution
 
-if [[ $gfs_ver = "v16" && $CASE = $OPS_RES ]]; then # Going to be using warm starts
-  export EXP_WARM_START=".true."
-fi
-
 export UFS_DIR=${HOMEgfs}/sorc/ufs_utils.fd
 export GDASINIT_DIR=${UFS_DIR}/util/gdas_init
 

--- a/parm/config/config.getic
+++ b/parm/config/config.getic
@@ -10,6 +10,11 @@ echo "BEGIN: config.getic"
 
 export RETRO="NO" # YES = Pull v16 inputs from retrospective parallels; NO = use operational inputs
 export gfs_ver="v16" # Default = v16
+export OPS_RES=${OPS_RES:-"C768"} # Operational resolution
+
+if [[ $gfs_ver = "v16" && $CASE = $OPS_RES ]]; then # Going to be using warm starts
+  export EXP_WARM_START=".true."
+fi
 
 export UFS_DIR=${HOMEgfs}/sorc/ufs_utils.fd
 export GDASINIT_DIR=${UFS_DIR}/util/gdas_init

--- a/ush/rocoto/setup_expt_fcstonly.py
+++ b/ush/rocoto/setup_expt_fcstonly.py
@@ -118,7 +118,7 @@ Create COMROT experiment directory structure'''
     parser.add_argument('--configdir', help='full path to directory containing the config files', type=str, required=False, default=None)
     parser.add_argument('--gfs_cyc', help='GFS cycles to run', type=int, choices=[0, 1, 2, 4], default=1, required=False)
     parser.add_argument('--partition', help='partition on machine', type=str, required=False, default=None)
-    parser.add_argument('--start', help='restart mode: warm or cold', type=str, choices=['warm', 'cold'], required=False, default='cold')
+    parser.add_argument('--start', help='restart mode: warm or cold', type=str, choices=['warm', 'cold'], required=False)
 
     args = parser.parse_args()
 
@@ -139,13 +139,14 @@ Create COMROT experiment directory structure'''
     start = args.start
 
     # Set restart setting in config.base
-    if start == 'cold':
+    if start is None:
+      if res == 768:
+        exp_warm_start = '.true.'
+      else:
+        exp_warm_start = '.false.'
+    elif start == 'cold':
       exp_warm_start = '.false.'
     elif start == 'warm':
-      exp_warm_start = '.true.'
-
-    # Check resolution for start setting - assume warm start if ops res
-    if res == 768:
       exp_warm_start = '.true.'
 
     # Set FDATE (first full cycle)

--- a/ush/rocoto/setup_expt_fcstonly.py
+++ b/ush/rocoto/setup_expt_fcstonly.py
@@ -144,6 +144,10 @@ Create COMROT experiment directory structure'''
     elif start == 'warm':
       exp_warm_start = '.true.'
 
+    # Check resolution for start setting - assume warm start if ops res
+    if res == 768:
+      exp_warm_start = '.true.'
+
     # Set FDATE (first full cycle)
     fdate = idate + timedelta(hours=6)
 


### PR DESCRIPTION
Changes in this PR:

- fix bug in getic when pulling warm starts off tape
- reduce C768 forecast resources to lower the node value below Hera limit of 210 nodes/job
- update setup_expt_fcstonly.py to better set EXP_WARM_START based on user inputs
- add OPS_RES variable to use for checks that need to know current ops resolution

Close #353 