### PR TITLE
Update to tiled fix files, UGWD v1, NOAH-MP

### DIFF
--- a/sorc/build_ufs_coupled.sh
+++ b/sorc/build_ufs_coupled.sh
@@ -3,13 +3,13 @@ set -eux
 
 # Build S2S by default
 APP="S2SW"
-CCPP_SUITES="FV3_GFS_v16,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst"
+CCPP_SUITES="FV3_GFS_v16,FV3_GFS_v16_coupled,FV3_GFS_v16_couplednsst,FV3_GFS_v16_coupled_nsstNoahmpUGWPv1"
 
 while getopts "a" option; do
   case $option in
     a)
       APP="ATMAERO"
-      CCPP_SUITES="FV3_GFS_v16"
+      CCPP_SUITES="FV3_GFS_v16,FV3_GFS_v16_ugwpv1"
       shift
       ;;
     *)
@@ -21,11 +21,6 @@ done
 
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
-
-# Check final exec folder exists
-if [ ! -d "../exec" ]; then
-  mkdir ../exec
-fi
 
 # Set target platform
 case "${target}" in
@@ -39,6 +34,11 @@ MOD_PATH=$cwd/ufs_coupled.fd/modulefiles
 module purge
 
 cd ufs_coupled.fd/
+
+if [ -d build ]; then
+  rm -Rf build
+fi
+
 module use ${MOD_PATH}
 module load ufs_${target}
 CMAKE_FLAGS="-DAPP=${APP} -DCCPP_SUITES=${CCPP_SUITES}" ./build.sh

--- a/sorc/link_fv3gfs.sh
+++ b/sorc/link_fv3gfs.sh
@@ -44,23 +44,11 @@ pwd=$(pwd -P)
 if [ $machine = "cray" ]; then
     FIX_DIR="/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix"
 elif [ $machine = "dell" ]; then
-    if [ $model = "coupled" ]; then
-      FIX_DIR="/gpfs/dell2/emc/modeling/noscrub/Walter.Kolczynski/global-workflow/fix_UFSp6"
-    else 
-      FIX_DIR="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix"
-    fi 
+    FIX_DIR="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix_NEW"
 elif [ $machine = "hera" ]; then
-    if [ $model = "coupled" ]; then
-       FIX_DIR="/scratch2/NCEPDEV/climate/climpara/S2S/FIX/fix_UFSp6"
-    else
-       FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix"
-    fi
+    FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix_NEW"
 elif [ $machine = "orion" ]; then
-    if [ $model = "coupled" ]; then
-       FIX_DIR="/work/noaa/marine/jmeixner/tempFixICdir/fix_UFSp6"
-    else
-       FIX_DIR="/work/noaa/global/glopara/fix"
-    fi
+    FIX_DIR="/work/noaa/global/glopara/fix_NEW"
 elif [ $machine = "stampede" ]; then
     FIX_DIR="/work/07738/jkuang/stampede2/tempFixICdir/fix_UFSp6"
 fi
@@ -70,7 +58,7 @@ if [ ! -z $FIX_DIR ]; then
 fi
 cd ${pwd}/../fix                ||exit 8
 if [ $model = "coupled" ] ; then
-  for dir in fix_aer fix_am fix_chem fix_fv3_gmted2010 fix_gldas fix_lut fix_fv3_fracoro fix_orog fix_sfc_climo fix_verif fix_cice fix_mom6 fix_cpl fix_wave fix_reg2grb2 ; do
+  for dir in fix_aer fix_am fix_chem fix_fv3_gmted2010 fix_gldas fix_lut fix_fv3_fracoro fix_orog fix_sfc_climo fix_verif fix_cice fix_mom6 fix_cpl fix_wave fix_reg2grb2 fix_ugwd; do
     if [ -d $dir ]; then
       [[ $RUN_ENVIR = nco ]] && chmod -R 755 $dir
       rm -rf $dir

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -212,7 +212,13 @@ FV3_GFS_postdet(){
 		done
 	fi
 
+	export CCPP_SUITE=${CCPP_SUITE:-"FV3_GFS_v16"}
 	_suite_file=$HOMEgfs/sorc/ufs_coupled.fd/FV3/ccpp/suites/suite_${CCPP_SUITE}.xml
+
+	if [ ! -f ${_suite_file} ]; then
+		echo "FATAL: CCPP Suite file ${_suite_file} does not exist!"
+		exit 2
+	fi
 
 	# Scan suite file to determine whether it uses Noah-MP
 	if [ $(grep noahmpdrv ${_suite_file} | wc -l ) -gt 0 ]; then

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -198,21 +198,46 @@ FV3_GFS_postdet(){
 		$NLN ${src_grid_spec} $DATA/INPUT/${CASE}_mosaic.nc
 	fi
 
-	if [ -z ${OROFIX} ]; then
-		if [ $FRAC_GRID ]; then
-			FIXoro=${FIXoro:-$FIX_DIR/fix_fv3_fracoro}/${CASE}.mx${OCNRES}_frac/${CASE}.mx${OCNRES}_
-		else
-			FIXoro=$FIXfv3/$CASE/${CASE}_oro_data.
-		fi
+	if [ $FRAC_GRID = ".true." ]; then
+		OROFIX=${OROFIX:-"${FIX_DIR}/fix_fv3_fracoro/${CASE}.mx${OCNRES}_frac"}
+		FIX_SFC=${FIX_SFC:-"${OROFIX}/fix_sfc"}
+		for n in $(seq 1 $ntiles); do
+			$NLN ${OROFIX}/oro_${CASE}.mx${OCNRES}.tile${n}.nc $DATA/INPUT/oro_data.tile${n}.nc
+		done
 	else
-		FIXoro=${OROFIX}/oro_data.
+		OROFIX=${OROFIX:-"${FIXfv3}/${CASE}"}
+		FIX_SFC=${FIX_SFC:-"${FIXgrd}/fix_sfc"}
+		for n in $(seq 1 $ntiles); do
+			$NLN ${OROFIX}/${CASE}_oro_data.tile${n}.nc $DATA/INPUT/oro_data.tile${n}.nc
+		done
 	fi
-	for n in $(seq 1 $ntiles); do
-		$NLN ${FIXoro}tile${n}.nc $DATA/INPUT/oro_data.tile${n}.nc
-	done
+
+	_suite_file=$HOMEgfs/sorc/ufs_coupled.fd/FV3/ccpp/suites/suite_${CCPP_SUITE}.xml
+
+	# Scan suite file to determine whether it uses Noah-MP
+	if [ $(grep noahmpdrv ${_suite_file} | wc -l ) -gt 0 ]; then
+		lsm="2"
+	else
+		lsm="1"
+	fi
+
+	# Scan suite file to determine whether it uses UGWP v1
+	if [ $(grep -i ugwpv1_gsldrag ${_suite_file} | wc -l ) -gt 0 ]; then
+		gwd_opt="2"
+       	knob_ugwp_version="1"
+		OROFIX_ugwd=${OROFIX_ugwd:-"${FIX_DIR}/fix_ugwd"}
+		$NLN ${OROFIX_ugwd}/ugwp_limb_tau.nc $DATA/ugwp_limb_tau.nc
+		for n in $(seq 1 $ntiles); do
+			$NLN ${OROFIX_ugwd}/$CASE/${CASE}_oro_data_ls.tile${n}.nc $DATA/INPUT/oro_data_ls.tile${n}.nc
+			$NLN ${OROFIX_ugwd}/$CASE/${CASE}_oro_data_ss.tile${n}.nc $DATA/INPUT/oro_data_ss.tile${n}.nc
+		done
+	else
+		gwd_opt="1"
+       	knob_ugwp_version="0"
+       	launch_level=${launch_level:-$(echo "$LEVS/2.35" |bc)}
+	fi
 
 	# GFS standard input data
-
 	IALB=${IALB:-1}
 	IEMS=${IEMS:-1}
 	ISOL=${ISOL:-2}
@@ -295,30 +320,19 @@ FV3_GFS_postdet(){
 	FNTSFC=${FNTSFC:-"$FIX_AM/RTGSST.1982.2012.monthly.clim.grb"}
 	FNSNOC=${FNSNOC:-"$FIX_AM/global_snoclim.1.875.grb"}
 	FNZORC=${FNZORC:-"igbp"}
-	FNALBC2=${FNALBC2:-"$FIX_AM/global_albedo4.1x1.grb"}
+	FNALBC2=${FNALBC2:-"${FIX_SFC}/${CASE}.facsf.tileX.nc"}
 	FNAISC=${FNAISC:-"$FIX_AM/CFSR.SEAICE.1982.2012.monthly.clim.grb"}
-	FNTG3C=${FNTG3C:-"$FIX_AM/global_tg3clim.2.6x1.5.grb"}
-	FNVEGC=${FNVEGC:-"$FIX_AM/global_vegfrac.0.144.decpercent.grb"}
-	#if [ $cpl = ".true." ]; then
-	#        export FNMSKH=${FNMSKH:-"$FIX_AM/seaice_newland.grb"}
-	#else
-	export FNMSKH=${FNMSKH:-"$FIX_AM/global_slmask.t1534.3072.1536.grb"}
-	#fi
-	FNVMNC=${FNVMNC:-"$FIX_AM/global_shdmin.0.144x0.144.grb"}
-	FNVMXC=${FNVMXC:-"$FIX_AM/global_shdmax.0.144x0.144.grb"}
-	FNSLPC=${FNSLPC:-"$FIX_AM/global_slope.1x1.grb"}
-	FNALBC=${FNALBC:-"$FIX_AM/global_snowfree_albedo.bosu.t${JCAP}.${LONB}.${LATB}.rg.grb"}
-	FNVETC=${FNVETC:-"$FIX_AM/global_vegtype.igbp.t${JCAP}.${LONB}.${LATB}.rg.grb"}
-	FNSOTC=${FNSOTC:-"$FIX_AM/global_soiltype.statsgo.t${JCAP}.${LONB}.${LATB}.rg.grb"}
-	FNABSC=${FNABSC:-"$FIX_AM/global_mxsnoalb.uariz.t${JCAP}.${LONB}.${LATB}.rg.grb"}
+	FNTG3C=${FNTG3C:-"${FIX_SFC}/${CASE}.substrate_temperature.tileX.nc"}
+	FNVEGC=${FNVEGC:-"${FIX_SFC}/${CASE}.vegetation_greenness.tileX.nc"}
+	FNMSKH=${FNMSKH:-"$FIX_AM/global_slmask.t1534.3072.1536.grb"}
+	FNVMNC=${FNVMNC:-"${FIX_SFC}/${CASE}.vegetation_greenness.tileX.nc"}
+	FNVMXC=${FNVMXC:-"${FIX_SFC}/${CASE}.vegetation_greenness.tileX.nc"}
+	FNSLPC=${FNSLPC:-"${FIX_SFC}/${CASE}.slope_type.tileX.nc"}
+	FNALBC=${FNALBC:-"${FIX_SFC}/${CASE}.snowfree_albedo.tileX.nc"}
+	FNVETC=${FNVETC:-"${FIX_SFC}/${CASE}.vegetation_type.tileX.nc"}
+	FNSOTC=${FNSOTC:-"${FIX_SFC}/${CASE}.soil_type.tileX.nc"}
+	FNABSC=${FNABSC:-"${FIX_SFC}/${CASE}.maximum_snow_albedo.tileX.nc"}
 	FNSMCC=${FNSMCC:-"$FIX_AM/global_soilmgldas.statsgo.t${JCAP}.${LONB}.${LATB}.grb"}
-
-	# If the appropriate resolution fix file is not present, use the highest resolution available (T1534)
-	[[ ! -f $FNALBC ]] && FNALBC="$FIX_AM/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb"
-	[[ ! -f $FNVETC ]] && FNVETC="$FIX_AM/global_vegtype.igbp.t1534.3072.1536.rg.grb"
-	[[ ! -f $FNSOTC ]] && FNSOTC="$FIX_AM/global_soiltype.statsgo.t1534.3072.1536.rg.grb"
-	[[ ! -f $FNABSC ]] && FNABSC="$FIX_AM/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb"
-	[[ ! -f $FNSMCC ]] && FNSMCC="$FIX_AM/global_soilmgldas.statsgo.t1534.3072.1536.grb"
 
 	# NSST Options
 	# nstf_name contains the NSST related parameters

--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -48,7 +48,7 @@ cat > input.nml <<EOF
   blocksize = $blocksize
   chksum_debug = $chksum_debug
   dycore_only = $dycore_only
-  ccpp_suite = ${CCPP_SUITE:-"FV3_GFS_v15"}
+  ccpp_suite = $CCPP_SUITE
   fdiag = $FDIAG
   fhmax = $FHMAX
   fhout = $FHOUT

--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -156,21 +156,6 @@ cat > input.nml <<EOF
   $fv_core_nml
 /
 
-&cires_ugwp_nml
-       knob_ugwp_solver  = ${knob_ugwp_solver:-2}
-       knob_ugwp_source  = ${knob_ugwp_source:-1,1,0,0}
-       knob_ugwp_wvspec  = ${knob_ugwp_wvspec:-1,25,25,25}
-       knob_ugwp_azdir   = ${knob_ugwp_azdir:-2,4,4,4}
-       knob_ugwp_stoch   = ${knob_ugwp_stoch:-0,0,0,0}
-       knob_ugwp_effac   = ${knob_ugwp_effac:-1,1,1,1}
-       knob_ugwp_doaxyz  = ${knob_ugwp_doaxyz:-1}
-       knob_ugwp_doheat  = ${knob_ugwp_doheat:-1}
-       knob_ugwp_dokdis  = ${knob_ugwp_dokdis:-1}
-       knob_ugwp_ndx4lh  = ${knob_ugwp_ndx4lh:-1}
-       knob_ugwp_version = ${knob_ugwp_version:-0}
-       launch_level      = ${launch_level:-54}                   
-/
-
 &external_ic_nml
   filtered_terrain = $filtered_terrain
   levp = $LEVS
@@ -215,8 +200,8 @@ EOF
   min_lakeice  = ${min_lakeice:-"0.15"}
   min_seaice   = ${min_seaice:-"0.15"}
 EOF
- ;;
-  "FV3_GFS_v16_coupled" | "FV3_GFS_v16_couplednsst")
+ ;;  
+  FV3_GFS_v16_coupled*)
   cat >> input.nml << EOF
   iovr         = ${iovr:-"3"}
   ltaerosol    = ${ltaerosol:-".false."}
@@ -224,7 +209,6 @@ EOF
   ttendlim     = ${ttendlim:-"0.005"}
   oz_phys      = ${oz_phys:-".false."}
   oz_phys_2015 = ${oz_phys_2015:-".true."}
-  lsoil_lsm    = ${lsoil_lsm:-"4"}
   do_mynnedmf  = ${do_mynnedmf:-".false."}
   do_mynnsfclay = ${do_mynnsfclay:-".false."}
   icloud_bl    = ${icloud_bl:-"1"}
@@ -235,7 +219,7 @@ EOF
   min_seaice   = ${min_seaice:-"0.15"}
 EOF
   ;;
-  "FV3_GFS_v16")
+  FV3_GFS_v16*)
   cat >> input.nml << EOF
   iovr         = ${iovr:-"3"}
   ltaerosol    = ${ltaerosol:-".false."}
@@ -287,7 +271,7 @@ cat >> input.nml <<EOF
   ivegsrc      = ${ivegsrc:-"1"}
   isot         = ${isot:-"1"}
   lsoil        = ${lsoil:-"4"}
-  lsm          = ${lsm:-"1"}
+  lsm          = ${lsm:-"2"}
   iopt_dveg    = ${iopt_dveg:-"1"}
   iopt_crs     = ${iopt_crs:-"1"}
   iopt_btr     = ${iopt_btr:-"1"}
@@ -310,7 +294,7 @@ cat >> input.nml <<EOF
   cplwav       = ${cplwav:-".false."}              ! CROW configured
   ldiag_ugwp   = ${ldiag_ugwp:-".false."}
   do_ugwp      = ${do_ugwp:-".true."}
-  do_tofd      = ${do_tofd:-".true."}
+  do_tofd      = ${do_tofd:-".false."}
   do_sppt      = ${DO_SPPT:-".false."}
   do_shum      = ${DO_SHUM:-".false."}
   do_skeb      = ${DO_SKEB:-".false."}
@@ -336,12 +320,80 @@ if [ $DOIAU = "YES" ]; then
 EOF
 fi
 
-cat >> input.nml <<EOF
+case ${gwd_opt:-"2"} in
+  1)
+  cat >> input.nml << EOF
+  gwd_opt      = 1
+  do_ugwp      = .false.
+  do_ugwp_v0   = .false.
+  do_ugwp_v1   = .false.
+  do_tofd      = .true.
   $gfs_physics_nml
 /
-EOF
 
-echo "" >> input.nml
+&cires_ugwp_nml
+  knob_ugwp_version = ${knob_ugwp_version:-0}
+  knob_ugwp_solver  = ${knob_ugwp_solver:-2}
+  knob_ugwp_source  = ${knob_ugwp_source:-1,1,0,0}
+  knob_ugwp_wvspec  = ${knob_ugwp_wvspec:-1,25,25,25}
+  knob_ugwp_azdir   = ${knob_ugwp_azdir:-2,4,4,4}
+  knob_ugwp_stoch   = ${knob_ugwp_stoch:-0,0,0,0}
+  knob_ugwp_effac   = ${knob_ugwp_effac:-1,1,1,1}
+  knob_ugwp_doaxyz  = ${knob_ugwp_doaxyz:-1}
+  knob_ugwp_doheat  = ${knob_ugwp_doheat:-1}
+  knob_ugwp_dokdis  = ${knob_ugwp_dokdis:-1}
+  knob_ugwp_ndx4lh  = ${knob_ugwp_ndx4lh:-1}
+  launch_level      = ${launch_level:-54}
+  $cires_ugwp_nml
+/
+
+EOF
+    ;;
+  2)
+  cat >> input.nml << EOF
+  gwd_opt      = 2
+  do_ugwp      = .true.
+  do_ugwp_v0   = .false.
+  do_ugwp_v1   = .true.
+  do_tofd      = .false.
+  do_ugwp_v1_orog_only = .false.
+  do_gsl_drag_ls_bl    = ${do_gsl_drag_ls_bl:-".true."}
+  do_gsl_drag_ss       = ${do_gsl_drag_ss:-".true."}
+  do_gsl_drag_tofd     = ${do_gsl_drag_tofd:-".true."}
+  $gfs_physics_nml
+/
+
+&cires_ugwp_nml
+  knob_ugwp_version = ${knob_ugwp_version:-1}
+  knob_ugwp_solver  = ${knob_ugwp_solver:-2}
+  knob_ugwp_source  = ${knob_ugwp_source:-1,1,0,0}
+  knob_ugwp_wvspec  = ${knob_ugwp_wvspec:-1,25,25,25}
+  knob_ugwp_azdir   = ${knob_ugwp_azdir:-2,4,4,4}
+  knob_ugwp_stoch   = ${knob_ugwp_stoch:-0,0,0,0}
+  knob_ugwp_effac   = ${knob_ugwp_effac:-1,1,1,1}
+  knob_ugwp_doaxyz  = ${knob_ugwp_doaxyz:-1}
+  knob_ugwp_doheat  = ${knob_ugwp_doheat:-1}
+  knob_ugwp_dokdis  = ${knob_ugwp_dokdis:-2}
+  knob_ugwp_ndx4lh  = ${knob_ugwp_ndx4lh:-4}
+  knob_ugwp_palaunch = ${knob_ugwp_palaunch:-275.0e2}
+  knob_ugwp_nslope   = ${knob_ugwp_nslope:-1}
+  knob_ugwp_lzmax    = ${knob_ugwp_lzmax:-15.750e3}
+  knob_ugwp_lzmin    = ${knob_ugwp_lzmin:-0.75e3}
+  knob_ugwp_lzstar   = ${knob_ugwp_lzstar:-2.0e3}
+  knob_ugwp_taumin   = ${knob_ugwp_taumin:-0.25e-3}
+  knob_ugwp_tauamp   = ${knob_ugwp_tauamp:-3.0e-3}
+  knob_ugwp_lhmet    = ${knob_ugwp_lhmet:-200.0e3}
+  knob_ugwp_orosolv  = ${knob_ugwp_orosolv:-'pss-1986'}       
+  $cires_ugwp_nml
+/
+
+EOF
+    ;;
+  *)
+    echo "FATAL: Invalid gwd_opt specified: $gwd_opt"
+    exit 1
+    ;;
+esac
 
 cat >> input.nml <<EOF
 &gfdl_cloud_microphysics_nml

--- a/workflow/cases/aerosol_firex_forecast.yaml
+++ b/workflow/cases/aerosol_firex_forecast.yaml
@@ -48,7 +48,7 @@ case:
        WGRP_NTASKS: 24
        WRTIOBUF: "32M"
     CPL_ATMIC: FV3ICS
-    CCPP_SUITE: FV3_GFS_v16
+    CCPP_SUITE: FV3_GFS_v16_ugwpv1
     fscav_aero: [ '*:0.6', 'seas1:1.0', 'seas2:1.0', 'seas3:1.0', 'seas4:1.0', 'seas5:1.0' ]
 
   chem_settings:

--- a/workflow/cases/aerosol_free_forecast.yaml
+++ b/workflow/cases/aerosol_free_forecast.yaml
@@ -45,7 +45,7 @@ case:
        WGRP: 1
        WGRP_NTASKS: 24
        WRTIOBUF: "32M"
-    CCPP_SUITE: FV3_GFS_v16
+    CCPP_SUITE: FV3_GFS_v16_ugwpv1
     fscav_aero: [ '*:0.6', 'seas1:1.0', 'seas2:1.0', 'seas3:1.0', 'seas4:1.0', 'seas5:1.0' ]
 
   chem_settings:

--- a/workflow/cases/coupled_free_forecast.yaml
+++ b/workflow/cases/coupled_free_forecast.yaml
@@ -21,7 +21,11 @@ case:
     KEEPDATA: NO
 
   nsst:
-    NST_MODEL: 0
+    NST_MODEL: 2
+    NST_SPINUP: 1
+    NST_RESV: 0
+    ZSEA1: 0
+    ZSEA2: 0
 
   output_settings:
     OCN_INTERVAL: 24
@@ -38,7 +42,7 @@ case:
     min_lakeice: 0.15
     min_seaice: 1.0e-11
     SEEDLET: 10
-    CCPP_SUITE: FV3_GFS_v16_coupled
+    CCPP_SUITE: FV3_GFS_v16_coupled_nsstNoahmpUGWPv1
     CPL_ATMIC: CFSRfracL127
     nst_anl: yes
     psm_bc: 1

--- a/workflow/cases/coupled_free_forecast_wave.yaml
+++ b/workflow/cases/coupled_free_forecast_wave.yaml
@@ -43,7 +43,7 @@ case:
     min_lakeice: 0.15
     min_seaice: 1.0e-11
     SEEDLET: 10
-    CCPP_SUITE: FV3_GFS_v16_couplednsst
+    CCPP_SUITE: FV3_GFS_v16_coupled_nsstNoahmpUGWPv1
     CPL_ATMIC: CFSRfracL127
     nst_anl: yes
     psm_bc: 1

--- a/workflow/config/fcst.yaml
+++ b/workflow/config/fcst.yaml
@@ -130,10 +130,6 @@ config_fcst:
     # Options of stratosphere O3 physics reaction coefficients
     export new_o3forc="{tools.YES_NO(doc.fv3_gfs_settings.new_o3force)}"
 
-
-    export do_ugwp=".false."
-    export do_tofd=".true."
-
     # fv3_core_nml section
     export dnats={doc.fv3_gfs_settings.phy_dependent_var.dnats}
     export do_sat_adj="{tools.fort(doc.fv3_gfs_settings.phy_dependent_var.do_sat_adjust)}"


### PR DESCRIPTION
Updates model to use tiled fix files. Fix directory is updated to the
fix_NEW location.

Adds the ability to use UGWD v1. Since this capability is tied to the
CCPP suite used, the sutie definition file is grepped to determine whether
UGWD is active. Otherwise, gwd_opt 1 is used. Either way, the appropriate
namelist settings are added to input.nml. For v1, the necessary fix files
are also linked to the run directory. If additional options are supported
in the future, there will need to be more sophisicated parsing.

Adds the ability to use Noah-MP. Like UGWD, this is dictated by the CCPP
suite used, so the suite definition file is grepped to determine whether
to use Noah (lsm=1) or Noah-MP (lsm=2).

Additional CCPP suites are added to the build to allow for the new options.

The two non-fractional coupled cases are updated to use a CCPP suite using
both UGWD v1 and Noah-MP. The two aerosol cases are updated to a suite using
UGWD v1 (there does not appear to be an atm-only suite that has both).

There is also a minor change to the UFS build script to remove any existing
UFS build directory. This prevents problems when attempting to build a
different app after one has already been built.

Closes: #331, #346