### PR TITLE
Update default IC location for prototype 7c

### DIFF
--- a/workflow/cases/coupled_free_forecast.yaml
+++ b/workflow/cases/coupled_free_forecast.yaml
@@ -43,7 +43,7 @@ case:
     min_seaice: 1.0e-11
     SEEDLET: 10
     CCPP_SUITE: FV3_GFS_v16_coupled_nsstNoahmpUGWPv1
-    CPL_ATMIC: CFSRfracL127
+    CPL_ATMIC: GEFSwithNOAHMP
     nst_anl: yes
     psm_bc: 1
     dddmp: 0.2

--- a/workflow/cases/coupled_free_forecast_wave.yaml
+++ b/workflow/cases/coupled_free_forecast_wave.yaml
@@ -44,7 +44,7 @@ case:
     min_seaice: 1.0e-11
     SEEDLET: 10
     CCPP_SUITE: FV3_GFS_v16_coupled_nsstNoahmpUGWPv1
-    CPL_ATMIC: CFSRfracL127
+    CPL_ATMIC: GEFSwithNOAHMP
     nst_anl: yes
     psm_bc: 1
     dddmp: 0.2
@@ -70,7 +70,7 @@ case:
 
   wave_settings: 
     WAVPETS: 160
-    CPL_WAVIC: GEFSwave20210623
+    CPL_WAVIC: GEFSwave20210528
     waveGRD: 'gwes_30m'
     wavepostGRD: 'gwes_30m'
     waveesmfGRD: ''

--- a/workflow/platforms/orion.yaml
+++ b/workflow/platforms/orion.yaml
@@ -37,7 +37,7 @@ platform: !Platform
 
 
   #BASE_CPLIC - is the base directory of ICs for coupled s2s runs
-  BASE_CPLIC: "/work/noaa/marine/Partha.Bhattacharjee/IC_Dir"
+  BASE_CPLIC: "/work/noaa/global/wkolczyn/noscrub/global-workflow/IC"
   #ncks - NCO netcdf operator used in ocean post 
   ncks: "/apps/intel-2020/nco-4.8.1/bin/ncks"
 

--- a/workflow/schema/wave.yaml
+++ b/workflow/schema/wave.yaml
@@ -9,4 +9,3 @@ wave_settings_template: !Template &wave_settings_template
     description: "model selection for wave"
   CPL_WAVIC:
     type: string
-    allowed: [ 'CFSR', 'CFSRwave20200925', 'GEFSwave20210623' ]


### PR DESCRIPTION
Update the default IC locations to those for prototype 7c.

The list of valid CPL_WAVIC values is removed so any value can be
used if necessary without having to update the list.

The IC location on Orion is updated to Walter's directory. This
change should've been made previously.

Refs: #382