### PR TITLE
Update namelist settings for prototype 7c

### DIFF
--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -223,8 +223,34 @@ FV3_GFS_postdet(){
 	# Scan suite file to determine whether it uses Noah-MP
 	if [ $(grep noahmpdrv ${_suite_file} | wc -l ) -gt 0 ]; then
 		lsm="2"
+		landice=".false."
+		iopt_dveg=${iopt_dveg:-"4"}
+		iopt_crs=${iopt_crs:-"2"}
+		iopt_btr=${iopt_btr:-"1"}
+		iopt_run=${iopt_run:-"1"}
+		iopt_sfc=${iopt_sfc:-"1"}
+		iopt_frz=${iopt_frz:-"1"}
+		iopt_inf=${iopt_inf:-"1"}
+		iopt_rad=${iopt_rad:-"3"}
+		iopt_alb=${iopt_alb:-"1"}
+		iopt_snf=${iopt_snf:-"4"}
+		iopt_tbot=${iopt_tbot:-"2"}
+		iopt_stc=${iopt_stc:-"3"}
 	else
 		lsm="1"
+		landice=".true."
+		iopt_dveg=${iopt_dveg:-"1"}
+		iopt_crs=${iopt_crs:-"1"}
+		iopt_btr=${iopt_btr:-"1"}
+		iopt_run=${iopt_run:-"1"}
+		iopt_sfc=${iopt_sfc:-"1"}
+		iopt_frz=${iopt_frz:-"1"}
+		iopt_inf=${iopt_inf:-"1"}
+		iopt_rad=${iopt_rad:-"1"}
+		iopt_alb=${iopt_alb:-"2"}
+		iopt_snf=${iopt_snf:-"4"}
+		iopt_tbot=${iopt_tbot:-"2"}
+		iopt_stc=${iopt_stc:-"1"}
 	fi
 
 	# Scan suite file to determine whether it uses UGWP v1

--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -95,11 +95,11 @@ cat > input.nml <<EOF
   ntiles = $ntiles
   npz = $npz
   dz_min =  ${dz_min:-"6"}    ! CROW configured
-  psm_bc = ${psm_bc:-"0"}    ! CROW configured
+  psm_bc = ${psm_bc:-"1"}    ! CROW configured
   grid_type = -1
   make_nh = $make_nh 
   fv_debug = ${fv_debug:-".false."}
-  range_warn = ${range_warn:-".false."}
+  range_warn = ${range_warn:-".true."}
   reset_eta = .false.
   n_sponge = ${n_sponge:-"10"}    ! CROW configured
   nudge_qv = ${nudge_qv:-".true."}
@@ -127,7 +127,7 @@ cat > input.nml <<EOF
   fv_sg_adj = ${fv_sg_adj:-"450"}
   d2_bg = 0.
   nord = ${nord:-3}		! CROW configured
-  dddmp = ${dddmp:-0.2}		! CROW configured
+  dddmp = ${dddmp:-0.1}		! CROW configured
   d4_bg = ${d4_bg:-0.15}	! CROW configured
   vtdm4 = $vtdm4
   delt_max = ${delt_max:-"0.002"}
@@ -264,9 +264,10 @@ cat >> input.nml <<EOF
   redrag       = ${redrag:-".true."}
   dspheat      = ${dspheat:-".true."}
   hybedmf      = ${hybedmf:-".false."}
-  satmedmf     = ${satmedmf-".true."}
-  isatmedmf    = ${isatmedmf-"1"}
-  lheatstrg    = ${lheatstrg-".false."}
+  satmedmf     = ${satmedmf:-".true."}
+  isatmedmf    = ${isatmedmf:-"1"}
+  lheatstrg    = ${lheatstrg:-".true."}
+  lseaspray    = ${lseaspray:-".true."}
   random_clds  = ${random_clds:-".true."} ! CROW configured
   trans_trac   = ${trans_trac:-".true."}
   cnvcld       = ${cnvcld:-".true."}
@@ -299,8 +300,6 @@ cat >> input.nml <<EOF
   effr_in      = ${effr_in:-".false."}
   cplwav       = ${cplwav:-".false."}              ! CROW configured
   ldiag_ugwp   = ${ldiag_ugwp:-".false."}
-  do_ugwp      = ${do_ugwp:-".true."}
-  do_tofd      = ${do_tofd:-".false."}
   do_sppt      = ${DO_SPPT:-".false."}
   do_shum      = ${DO_SHUM:-".false."}
   do_skeb      = ${DO_SKEB:-".false."}
@@ -374,7 +373,7 @@ EOF
   2)
   cat >> input.nml << EOF
   gwd_opt      = 2
-  do_ugwp      = .true.
+  do_ugwp      = .false.
   do_ugwp_v0   = .false.
   do_ugwp_v1   = .true.
   do_tofd      = .false.

--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -326,6 +326,22 @@ if [ $DOIAU = "YES" ]; then
 EOF
 fi
 
+if [ ${DO_CA:-"YES"} = "YES" ]; then
+  cat >> input.nml << EOF
+  do_ca      = .True.
+  ca_sgs     = ${ca_sgs:-".True."}
+  nca        = ${nca:-"1"}
+  scells     = ${scells:-"2600"}
+  tlives     = ${tlives:-"1800"}
+  nseed      = ${nseed:-"1"}
+  nfracseed  = ${nfracseed:-"0.5"}
+  rcell      = ${rcell:-"0.72"}
+  ca_trigger = ${ca_trigger:-".True."}
+  nspinup    = ${nspinup:-"1"}
+  iseed_ca   = ${iseed_ca:-"12345"}
+EOF
+fi
+
 case ${gwd_opt:-"2"} in
   1)
   cat >> input.nml << EOF
@@ -485,7 +501,7 @@ cat >> input.nml <<EOF
   FSMCL(2) = ${FSMCL2:-99999}
   FSMCL(3) = ${FSMCL3:-99999}
   FSMCL(4) = ${FSMCL4:-99999}
-  LANDICE  = ${landice:-".true."}
+  LANDICE  = ${landice:-".false."}
   FTSFS = ${FTSFS:-90}
   FAISL = ${FAISL:-99999}
   FAISS = ${FAISS:-99999}

--- a/workflow/cases/coupled_free_forecast.yaml
+++ b/workflow/cases/coupled_free_forecast.yaml
@@ -46,7 +46,7 @@ case:
     CPL_ATMIC: GEFSwithNOAHMP
     nst_anl: yes
     psm_bc: 1
-    dddmp: 0.2
+    dddmp: 0.1
     FSICL: 9999
     DO_SKEB: false
     DO_SHUM: false

--- a/workflow/cases/coupled_free_forecast_wave.yaml
+++ b/workflow/cases/coupled_free_forecast_wave.yaml
@@ -47,7 +47,7 @@ case:
     CPL_ATMIC: GEFSwithNOAHMP
     nst_anl: yes
     psm_bc: 1
-    dddmp: 0.2
+    dddmp: 0.1
     FSICL: 99999
     DO_SKEB: false
     DO_SHUM: false

--- a/workflow/config/fcst.yaml
+++ b/workflow/config/fcst.yaml
@@ -168,7 +168,7 @@ config_fcst:
     tbf=""
     if [ $satmedmf = ".true." ]; then tbf="_satmedmf" ; fi
 
-    export lheatstrg=.false.
+    export lheatstrg="{tools.fort(doc.fv3_gfs_settings.lheatstrg)}"
 
     export random_clds="{tools.fort(doc.fv3_gfs_settings.phy_dependent_var.random_clds)}"
     #export cnvcld="{tools.fort(doc.fv3_gfs_settings.cnvcld)}"

--- a/workflow/defaults/fv3_enkf.yaml
+++ b/workflow/defaults/fv3_enkf.yaml
@@ -19,7 +19,7 @@ fv3_enkf_defaults: &fv3_enkf_defaults
   MONO: "non-mono"
   MEMBER: -1
   d4_bg: 0.15
-  dddmp: 0.2
+  dddmp: 0.1
   ISEED: 0
   SET_STP_SEED: YES
 

--- a/workflow/defaults/fv3_enkf.yaml
+++ b/workflow/defaults/fv3_enkf.yaml
@@ -113,8 +113,8 @@ fv3_enkf_defaults: &fv3_enkf_defaults
   dspheat: YES
   shal_cnv: NO
   agrid_vel_rst: yes
-  IEMS: 1
-  IALB: 1
+  IEMS: 2
+  IALB: 2
   ISOL: 2
   IAER: 1011
   ICO2: 2

--- a/workflow/defaults/fv3_enkf.yaml
+++ b/workflow/defaults/fv3_enkf.yaml
@@ -20,6 +20,7 @@ fv3_enkf_defaults: &fv3_enkf_defaults
   MEMBER: -1
   d4_bg: 0.15
   dddmp: 0.1
+  lheatstrg: true
   ISEED: 0
   SET_STP_SEED: YES
 

--- a/workflow/defaults/fv3_gdas.yaml
+++ b/workflow/defaults/fv3_gdas.yaml
@@ -16,6 +16,7 @@ fv3_gdas_defaults: &fv3_gdas_defaults
   MEMBER: -1
   d4_bg: 0.15
   dddmp: 0.1
+  lheatstrg: true
   min_lakeice: 0.15
   min_seaice: 0.15
   ISEED: 0

--- a/workflow/defaults/fv3_gdas.yaml
+++ b/workflow/defaults/fv3_gdas.yaml
@@ -86,8 +86,8 @@ fv3_gdas_defaults: &fv3_gdas_defaults
   dspheat: YES
   shal_cnv: YES
   agrid_vel_rst: yes
-  IEMS: 1
-  IALB: 1
+  IEMS: 2
+  IALB: 2
   ISOL: 2
   IAER: 1011
   ICO2: 2

--- a/workflow/defaults/fv3_gdas.yaml
+++ b/workflow/defaults/fv3_gdas.yaml
@@ -15,7 +15,7 @@ fv3_gdas_defaults: &fv3_gdas_defaults
   MONO: "non-mono"
   MEMBER: -1
   d4_bg: 0.15
-  dddmp: 0.2
+  dddmp: 0.1
   min_lakeice: 0.15
   min_seaice: 0.15
   ISEED: 0

--- a/workflow/defaults/fv3_gfs.yaml
+++ b/workflow/defaults/fv3_gfs.yaml
@@ -17,6 +17,7 @@ fv3_gfs_defaults: &fv3_gfs_defaults
   MEMBER: -1
   d4_bg: 0.15
   dddmp: 0.1
+  lheatstrg: true
   min_lakeice: 0.15
   min_seaice: 0.15 
   ISEED: 0

--- a/workflow/defaults/fv3_gfs.yaml
+++ b/workflow/defaults/fv3_gfs.yaml
@@ -16,13 +16,13 @@ fv3_gfs_defaults: &fv3_gfs_defaults
   MONO: "non-mono"
   MEMBER: -1
   d4_bg: 0.15
-  dddmp: 0.2
+  dddmp: 0.1
   min_lakeice: 0.15
   min_seaice: 0.15 
   ISEED: 0
   SEEDLET: 1
   SET_STP_SEED: YES
-  psm_bc: 0
+  psm_bc: 1
   DO_SHUM: false
   DO_SKEB: false
   DO_SPPT: false

--- a/workflow/defaults/fv3_gfs.yaml
+++ b/workflow/defaults/fv3_gfs.yaml
@@ -92,8 +92,8 @@ fv3_gfs_defaults: &fv3_gfs_defaults
   dspheat: YES
   shal_cnv: YES
   agrid_vel_rst: yes
-  IEMS: 1
-  IALB: 1
+  IEMS: 2
+  IALB: 2
   ISOL: 2
   IAER: 1011
   ICO2: 2

--- a/workflow/schema/fv3.yaml
+++ b/workflow/schema/fv3.yaml
@@ -58,6 +58,7 @@ fv3_settings_template: !Template &fv3_settings_template
   warm_start:         { type: bool }
   read_increment:     { type: bool }
   restart_interval:   { type: string }
+  lheatstrg:          { type: bool }
 #  FIELD_TABLE:        { type: string }
 
   LEVS:


### PR DESCRIPTION
Several namelist settings are updated for prototype 7c.

A large number of the settings are tied to Noah-MP, so those settings
are now set alongside the lsm, but mostly accept overrides.

Another group of settings are related to cellular automata and are
only added to the namelist if a new setting, DO_CA, is set to YES.
The setting defaults to on (YES).

Two other settings, IALB and IEMS, are not confirmed to be tied to
other settings, so the defaults for these are just straightfowardly
changed to the new values.

Closes: #386