### PR TITLE
Create a case file to be used for prototype 7

### DIFF
--- a/workflow/cases/prototype7.yaml
+++ b/workflow/cases/prototype7.yaml
@@ -1,0 +1,81 @@
+case:
+  places:
+    workflow_file: layout/free_forecast_gfs.yaml
+
+  settings: 
+    SDATE: 2013-04-01t00:00:00
+    EDATE: 2013-04-01t00:00:00
+    STEP_GFS: !timedelta "24:00:00"
+    STEP_DA: !timedelta "00:00:00"
+
+    onestep: .true.
+    cplmode: nems_frac
+    FRAC_GRID: .true.
+    cplwav: .true.
+    cplwav2atm: .true.
+    cplflx: .true.
+    print_esmf: .false.
+    esmf_profile: .false.
+    nems_temp: 'cpld_wave'
+    mom6ic_prepared: .false.
+    inline_post: .true. 
+    KEEPDATA: NO
+
+  nsst:
+    NST_MODEL: 2
+    NST_SPINUP: 1
+    NST_RESV: 0
+    ZSEA1: 0
+    ZSEA2: 0
+
+  output_settings:
+    OCN_INTERVAL: 24
+    FHOUT_GFS: 6
+    FHMIN_GFS: 0
+    FHMAX_GFS: 840
+    FHMAX_HF_GFS: 0
+    FHOUT_HF_GFS: -1
+
+  fv3_gfs_settings:
+    CASE: C384
+    LEVS: 128
+    DELTIM: 225
+    min_lakeice: 0.15
+    min_seaice: 1.0e-11
+    SEEDLET: 10
+    CCPP_SUITE: FV3_GFS_v16_coupled_nsstNoahmpUGWPv1
+    CPL_ATMIC: GEFSwithNOAHMP
+    nst_anl: yes
+    psm_bc: 1
+    dddmp: 0.1
+    FSICL: 99999
+    DO_SKEB: false
+    DO_SHUM: false
+    DO_SPPT: false
+    k_split: 2
+    n_split: 6
+    layout:
+       x: 12
+       y: 16
+       nth: 2
+       WGRP: 1
+       WGRP_NTASKS: 88
+       WRTIOBUF: "32M"
+
+  ocn_settings:
+    OCNPETS: 220
+
+  ice_settings:
+    ICEPETS: 80
+
+  wave_settings: 
+    WAVPETS: 160
+    CPL_WAVIC: GEFSwave20210528
+    waveGRD: 'gwes_30m'
+    wavepostGRD: 'gwes_30m'
+    waveesmfGRD: ''
+    waveinterpGRD: ''    
+
+  post:
+    downset: 2
+    GOESF: no


### PR DESCRIPTION
This creates a case file to be used for prototype 7 based on coupled_free_forecast_wave.yaml but has the 35 day time limit and does not create the ESMF profile. 