### PR TITLE
Set seed for Cellular Automata

### DIFF
--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -487,6 +487,8 @@ FV3_GFS_postdet(){
 		ISEED_SKEB=$((CDATE*1000 + MEMBER*10 + 1))
 		ISEED_SHUM=$((CDATE*1000 + MEMBER*10 + 2))
 		ISEED_SPPT=$((CDATE*1000 + MEMBER*10 + 3))
+		# CA Seed is only 32-bit
+		ISEED_CA=$(( (CDATE*1000 + MEMBER*10 + 4) % 2147483647 ))
 	else
 		ISEED=${ISEED:-0}
 	fi

--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -337,7 +337,7 @@ if [ ${DO_CA:-"YES"} = "YES" ]; then
   rcell      = ${rcell:-"0.72"}
   ca_trigger = ${ca_trigger:-".True."}
   nspinup    = ${nspinup:-"1"}
-  iseed_ca   = ${iseed_ca:-"12345"}
+  iseed_ca   = ${ISEED_CA:-"12345"}
 EOF
 fi
 


### PR DESCRIPTION
The seed for the CA is now set in the same manner as the stochastic
physics components. Because the CA seed is only 32-bit (in contrast
to the 64-bit seed used for SP), a modulus is taken to ensure the
number stays in-bounds.

Refs: #386