### PR TITLE
coupled-crow: catch copy errors and bail out if ICs do not exist

### DIFF
--- a/jobs/rocoto/coupled_ic.sh
+++ b/jobs/rocoto/coupled_ic.sh
@@ -53,18 +53,40 @@ fi
 
 # Setup ATM initial condition files
 cp -r $ORIGIN_ROOT/$CPL_ATMIC/$CDATE/$CDUMP/*  $ICSDIR/$CDATE/atmos/
+rc=$?
+if [[ $rc -ne 0 ]] ; then
+  echo "FATAL: Unable to copy $ORIGIN_ROOT/$CPL_ATMIC/$CDATE/$CDUMP/* to $ICSDIR/$CDATE/atmos/ (Error code $rc)"
+  exit $rc    
+fi
+
 
 # Setup Ocean IC files 
 cp -r $ORIGIN_ROOT/$CPL_OCNIC/$CDATE/ocn/$OCNRES/MOM*.nc  $ICSDIR/$CDATE/ocn/
+rc=$?
+if [[ $rc -ne 0 ]] ; then
+  echo "FATAL: Unable to copy $ORIGIN_ROOT/$CPL_OCNIC/$CDATE/ocn/$OCNRES/MOM*.nc to $ICSDIR/$CDATE/ocn/ (Error code $rc)"
+  exit $rc
+fi
 
 #Setup Ice IC files 
 cp $ORIGIN_ROOT/$CPL_ICEIC/$CDATE/ice/$ICERES/cice5_model_${ICERESdec}.res_$CDATE.nc $ICSDIR/$CDATE/ice/cice_model_${ICERESdec}.res_$CDATE.nc
+rc=$?
+if [[ $rc -ne 0 ]] ; then
+  echo "FATAL: Unable to copy $ORIGIN_ROOT/$CPL_ICEIC/$CDATE/ice/$ICERES/cice5_model_${ICERESdec}.res_$CDATE.nc to $ICSDIR/$CDATE/ice/cice_model_${ICERESdec}.res_$CDATE.nc (Error code $rc)"
+  exit $rc
+fi
 
 if [ $cplwav = ".true." ]; then
   [[ ! -d $ICSDIR/$CDATE/wav ]] && mkdir -p $ICSDIR/$CDATE/wav
   for grdID in $waveGRD
   do
     cp $ORIGIN_ROOT/$CPL_WAVIC/$CDATE/wav/$grdID/*restart.$grdID $ICSDIR/$CDATE/wav/
+    rc=$?
+    if [[ $rc -ne 0 ]] ; then
+      echo "FATAL: Unable to copy $ORIGIN_ROOT/$CPL_WAVIC/$CDATE/wav/$grdID/*restart.$grdID to $ICSDIR/$CDATE/wav/ (Error code $rc)" 
+      exit $rc
+    fi
+
   done
 fi
 

--- a/jobs/rocoto/coupled_ic.sh
+++ b/jobs/rocoto/coupled_ic.sh
@@ -85,7 +85,6 @@ if [ $cplwav = ".true." ]; then
     rc=$?
     if [[ $rc -ne 0 ]] ; then
       echo "FATAL: Unable to copy $ORIGIN_ROOT/$CPL_WAVIC/$CDATE/wav/$grdID/*restart.$grdID to $ICSDIR/$CDATE/wav/ (Error code $rc)" 
-      exit $rc
     fi
     ((err+=$rc))
   done

--- a/jobs/rocoto/coupled_ic.sh
+++ b/jobs/rocoto/coupled_ic.sh
@@ -19,6 +19,7 @@ set -x
 . $HOMEgfs/ush/load_fv3gfs_modules.sh
 status=$?
 [[ $status -ne 0 ]] && exit $status
+err=0
 
 export DATAROOT="$RUNDIR/$CDATE/$CDUMP"
 [[ ! -d $DATAROOT ]] && mkdir -p $DATAROOT
@@ -55,9 +56,9 @@ fi
 cp -r $ORIGIN_ROOT/$CPL_ATMIC/$CDATE/$CDUMP/*  $ICSDIR/$CDATE/atmos/
 rc=$?
 if [[ $rc -ne 0 ]] ; then
-  echo "FATAL: Unable to copy $ORIGIN_ROOT/$CPL_ATMIC/$CDATE/$CDUMP/* to $ICSDIR/$CDATE/atmos/ (Error code $rc)"
-  exit $rc    
+  echo "FATAL: Unable to copy $ORIGIN_ROOT/$CPL_ATMIC/$CDATE/$CDUMP/* to $ICSDIR/$CDATE/atmos/ (Error code $rc)" 
 fi
+((err+=$rc))
 
 
 # Setup Ocean IC files 
@@ -65,16 +66,16 @@ cp -r $ORIGIN_ROOT/$CPL_OCNIC/$CDATE/ocn/$OCNRES/MOM*.nc  $ICSDIR/$CDATE/ocn/
 rc=$?
 if [[ $rc -ne 0 ]] ; then
   echo "FATAL: Unable to copy $ORIGIN_ROOT/$CPL_OCNIC/$CDATE/ocn/$OCNRES/MOM*.nc to $ICSDIR/$CDATE/ocn/ (Error code $rc)"
-  exit $rc
 fi
+((err+=$rc))
 
 #Setup Ice IC files 
 cp $ORIGIN_ROOT/$CPL_ICEIC/$CDATE/ice/$ICERES/cice5_model_${ICERESdec}.res_$CDATE.nc $ICSDIR/$CDATE/ice/cice_model_${ICERESdec}.res_$CDATE.nc
 rc=$?
 if [[ $rc -ne 0 ]] ; then
   echo "FATAL: Unable to copy $ORIGIN_ROOT/$CPL_ICEIC/$CDATE/ice/$ICERES/cice5_model_${ICERESdec}.res_$CDATE.nc to $ICSDIR/$CDATE/ice/cice_model_${ICERESdec}.res_$CDATE.nc (Error code $rc)"
-  exit $rc
 fi
+((err+=$rc))
 
 if [ $cplwav = ".true." ]; then
   [[ ! -d $ICSDIR/$CDATE/wav ]] && mkdir -p $ICSDIR/$CDATE/wav
@@ -86,7 +87,7 @@ if [ $cplwav = ".true." ]; then
       echo "FATAL: Unable to copy $ORIGIN_ROOT/$CPL_WAVIC/$CDATE/wav/$grdID/*restart.$grdID to $ICSDIR/$CDATE/wav/ (Error code $rc)" 
       exit $rc
     fi
-
+    ((err+=$rc))
   done
 fi
 
@@ -97,6 +98,12 @@ COMOUT="$ROTDIR/$CDUMP.$PDY/$cyc/atmos"
 cd $COMOUT || exit 99
 rm -rf INPUT
 $NLN $OUTDIR .
+
+
+if  [[ $err -ne 0 ]] ; then 
+  echo "Fatal Error: ICs are not properly set-up" 
+  exit $err 
+fi 
 
 ##############################################################
 # Exit cleanly


### PR DESCRIPTION
In the script for copying in ICs, the script originally did not fail even though ICs did not exist on orion.  This update makes sure that the ic job fails instead of waiting for the forecast job to fail for ICs that do not exist. 