### PR TITLE
UFS_UTILS tag update - gdas_init support on Jet and HPSS path update for GFSv16 real-time parallel

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ protocol = git
 required = True
 
 [UFS_UTILS]
-tag = ufs_utils_1_4_0
+tag = ufs_utils_1_6_0
 local_path = sorc/ufs_utils.fd
 repo_url = https://github.com/NOAA-EMC/UFS_UTILS.git
 protocol = git

--- a/parm/config/config.getic
+++ b/parm/config/config.getic
@@ -26,10 +26,14 @@ if [ ${RETRO:-"NO"} = "YES" ]; then # Retrospective parallel input
     HPSSDIR=/NCEPDEV/emc-global/5year/emc.glopara/WCOSS_D/gfsv16/v16retro1e
   elif [[ "$CDATE" -lt "2019101706" ]]; then
     HPSSDIR=/NCEPDEV/emc-global/5year/emc.glopara/WCOSS_D/gfsv16/v16retro2e
-  elif [[ "$CDATE" -lt "2020122206" ]]; then
+  elif [[ "$CDATE" -lt "2020122200" ]]; then
     HPSSDIR=/NCEPDEV/emc-global/5year/emc.glopara/WCOSS_D/gfsv16/v16rt2
+  elif [[ "$CDATE" -le "2021032506" ]]; then
+    HPSSDIR=/NCEPDEV/emc-global/5year/emc.glopara/WCOSS_D/gfsv16/v16rt2n
   else
-    HPSSDIR=/NCEPDEV/emc-global/5year/emc.gloparadev/WCOSS_D/gfsv16/v16rt2n
+    set +x
+    echo NO DATA FOR $CDATE
+    exit 3
   fi
 elif [ ${RETRO:-"NO"} = "NO" ]; then # Operational input
   # No ENKF data prior to 2012/05/21/00z

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -63,7 +63,7 @@ if [[ ! -d ufs_utils.fd ]] ; then
     rm -f ${topdir}/checkout-ufs_utils.log
     git clone --recursive https://github.com/NOAA-EMC/UFS_UTILS.git ufs_utils.fd >> ${topdir}/checkout-ufs_utils.fd.log 2>&1
     cd ufs_utils.fd
-    git checkout ufs_utils_1_4_0
+    git checkout ufs_utils_1_6_0
     cd ${topdir}
 else
     echo 'Skip.  Directory ufs_utils.fd already exists.'


### PR DESCRIPTION
This PR updates the UFS_UTILS version to the new ufs_utils_1_6_0 tag. This tag provides the following:

* gdas_init offline support on Jet
* HPSS path update for the GFSv16 pre-implementation real-time parallels
  * moved from emc.gloparadev to emc.glopara space
  * changed v16rt2 CDATE check from 2020122206 to 2020122200
  * add CDATE window for v16rt2n
* HPSS path and v16rt2/v16rt2n CDATEs also updated in config.getic

Close #400