### PR TITLE
Update workflow_utils build modules and remove ncio module hack

### DIFF
--- a/modulefiles/workflow_utils.hera
+++ b/modulefiles/workflow_utils.hera
@@ -20,7 +20,9 @@ module load sp/2.3.3
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
-#module load ncio/1.0.0
+module load ncio/1.0.0
+module load landsfcutil/2.4.1
+module load wgrib2/2.0.8
 module load sigio/2.3.2
 module load g2/3.4.1
 module load bufr/11.4.0

--- a/modulefiles/workflow_utils.hera
+++ b/modulefiles/workflow_utils.hera
@@ -12,6 +12,8 @@ module load hpc-impi/2018.0.4
 module load jasper/2.0.25
 module load zlib/1.2.11
 module load png/1.6.35
+module load hdf5/1.10.6
+module load netcdf/4.7.4
 
 module load bacio/2.4.1
 module load w3nco/2.4.1
@@ -20,8 +22,6 @@ module load sp/2.3.3
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
-module load hdf5/1.10.6
-module load netcdf/4.7.4
 module load ncio/1.0.0
 module load sigio/2.3.2
 module load g2/3.4.1

--- a/modulefiles/workflow_utils.hera
+++ b/modulefiles/workflow_utils.hera
@@ -20,12 +20,9 @@ module load sp/2.3.3
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
+module load hdf5/1.10.6
+module load netcdf/4.7.4
 module load ncio/1.0.0
-module load landsfcutil/2.4.1
-module load wgrib2/2.0.8
 module load sigio/2.3.2
 module load g2/3.4.1
 module load bufr/11.4.0
-
-module load hdf5/1.10.6
-module load netcdf/4.7.4

--- a/modulefiles/workflow_utils.jet
+++ b/modulefiles/workflow_utils.jet
@@ -24,12 +24,9 @@ module load sp/2.3.3
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
+module load hdf5/1.10.6
+module load netcdf/4.7.4
 module load ncio/1.0.0
-module load landsfcutil/2.4.1
-module load wgrib2/2.0.8
 module load sigio/2.3.2
 module load g2/3.4.1
 module load bufr/11.4.0
-
-module load hdf5/1.10.6
-module load netcdf/4.7.4

--- a/modulefiles/workflow_utils.jet
+++ b/modulefiles/workflow_utils.jet
@@ -16,6 +16,8 @@ module load hpc-impi/2018.4.274
 module load jasper/2.0.25
 module load zlib/1.2.11
 module load png/1.6.35
+module load hdf5/1.10.6
+module load netcdf/4.7.4
 
 module load bacio/2.4.1
 module load w3nco/2.4.1
@@ -24,8 +26,6 @@ module load sp/2.3.3
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
-module load hdf5/1.10.6
-module load netcdf/4.7.4
 module load ncio/1.0.0
 module load sigio/2.3.2
 module load g2/3.4.1

--- a/modulefiles/workflow_utils.jet
+++ b/modulefiles/workflow_utils.jet
@@ -24,6 +24,9 @@ module load sp/2.3.3
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
+module load ncio/1.0.0
+module load landsfcutil/2.4.1
+module load wgrib2/2.0.8
 module load sigio/2.3.2
 module load g2/3.4.1
 module load bufr/11.4.0

--- a/modulefiles/workflow_utils.orion
+++ b/modulefiles/workflow_utils.orion
@@ -20,7 +20,9 @@ module load sp/2.3.3
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
-#module load ncio/1.0.0
+module load ncio/1.0.0
+module load landsfcutil/2.4.1
+module load wgrib2/2.0.8
 module load sigio/2.3.2
 module load g2/3.4.1
 module load bufr/11.4.0

--- a/modulefiles/workflow_utils.orion
+++ b/modulefiles/workflow_utils.orion
@@ -20,12 +20,9 @@ module load sp/2.3.3
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
+module load hdf5/1.10.6
+module load netcdf/4.7.4
 module load ncio/1.0.0
-module load landsfcutil/2.4.1
-module load wgrib2/2.0.8
 module load sigio/2.3.2
 module load g2/3.4.1
 module load bufr/11.4.0
-
-module load hdf5/1.10.6
-module load netcdf/4.7.4

--- a/modulefiles/workflow_utils.orion
+++ b/modulefiles/workflow_utils.orion
@@ -12,6 +12,8 @@ module load hpc-impi/2018.4
 module load jasper/2.0.25
 module load zlib/1.2.11
 module load png/1.6.35
+module load hdf5/1.10.6
+module load netcdf/4.7.4
 
 module load bacio/2.4.1
 module load w3nco/2.4.1
@@ -20,8 +22,6 @@ module load sp/2.3.3
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
-module load hdf5/1.10.6
-module load netcdf/4.7.4
 module load ncio/1.0.0
 module load sigio/2.3.2
 module load g2/3.4.1

--- a/modulefiles/workflow_utils.wcoss_dell_p3
+++ b/modulefiles/workflow_utils.wcoss_dell_p3
@@ -20,7 +20,9 @@ module load sp/2.3.3
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
-#module load ncio/1.0.0
+module load ncio/1.0.0
+module load landsfcutil/2.4.1
+module load wgrib2/2.0.8
 module load sigio/2.3.2
 module load g2/3.4.1
 module load bufr/11.4.0

--- a/modulefiles/workflow_utils.wcoss_dell_p3
+++ b/modulefiles/workflow_utils.wcoss_dell_p3
@@ -20,12 +20,9 @@ module load sp/2.3.3
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
+module load hdf5/1.10.6
+module load netcdf/4.7.4
 module load ncio/1.0.0
-module load landsfcutil/2.4.1
-module load wgrib2/2.0.8
 module load sigio/2.3.2
 module load g2/3.4.1
 module load bufr/11.4.0
-
-module load hdf5/1.10.6
-module load netcdf/4.7.4

--- a/modulefiles/workflow_utils.wcoss_dell_p3
+++ b/modulefiles/workflow_utils.wcoss_dell_p3
@@ -12,6 +12,8 @@ module load hpc-impi/18.0.1
 module load jasper/2.0.25
 module load zlib/1.2.11
 module load png/1.6.35
+module load hdf5/1.10.6
+module load netcdf/4.7.4
 
 module load bacio/2.4.1
 module load w3nco/2.4.1
@@ -20,8 +22,6 @@ module load sp/2.3.3
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load nemsiogfs/2.5.3
-module load hdf5/1.10.6
-module load netcdf/4.7.4
 module load ncio/1.0.0
 module load sigio/2.3.2
 module load g2/3.4.1

--- a/sorc/build_workflow_utils.sh
+++ b/sorc/build_workflow_utils.sh
@@ -16,24 +16,6 @@ if [[ -f $modulefile ]]; then
 fi
 # End adaptation
 
-# Begin hack
-# In place until nceplibs-ncio is in hpc-stack and available as a module
-# After nceplibs-ncio is in hpc-stack, add the following line to
-# ${UTILS_DIR}/../modulefiles/workflow_utils.<platform>
-# "module load ncio/<ncio-version>"
-# and remove this hack
-
-[[ -d nceplibs-ncio ]] && rm -rf nceplibs-ncio
-git clone -b develop https://github.com/noaa-emc/nceplibs-ncio
-cd nceplibs-ncio
-mkdir -p build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=../install ..
-make -j ${BUILD_JOBS:-4} VERBOSE=${BUILD_VERBOSE:-}
-make install
-cd ../..
-export ncio_ROOT=$PWD/nceplibs-ncio/install
-# End hack
-
 BUILD_DIR=${BUILD_DIR:-${UTILS_DIR}/build}
 [[ -d $BUILD_DIR ]] && rm -rf $BUILD_DIR
 mkdir -p ${BUILD_DIR}


### PR DESCRIPTION
This PR removes the ncio module hack in the workflow_utils build and updates the workflow_utils build modules on all supported platforms to add the ncio module available via hpc-stack.

Close #407 