### PR TITLE
Update vrfy/metp jobs to use jobid in their DATAROOT folders

### DIFF
--- a/jobs/rocoto/metp.sh
+++ b/jobs/rocoto/metp.sh
@@ -44,8 +44,10 @@ status=$?
 export COMPONENT=${COMPONENT:-atmos}
 export VDATE="$(echo $($NDATE -${VRFYBACK_HRS} $CDATE) | cut -c1-8)"
 
+export pid=${pid:-$$}
+export jobid=${job}.${pid}
 export COMIN="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT"
-export DATAROOT="$RUNDIR/$CDATE/$CDUMP/vrfy"
+export DATAROOT="$RUNDIR/$CDATE/$CDUMP/metp.${jobid}"
 [[ -d $DATAROOT ]] && rm -rf $DATAROOT
 mkdir -p $DATAROOT
 

--- a/jobs/rocoto/vrfy.sh
+++ b/jobs/rocoto/vrfy.sh
@@ -43,8 +43,10 @@ export COMPONENT=${COMPONENT:-atmos}
 export CDATEm1=$($NDATE -24 $CDATE)
 export PDYm1=$(echo $CDATEm1 | cut -c1-8)
 
+export pid=${pid:-$$}
+export jobid=${job}.${pid}
 export COMIN="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT"
-export DATAROOT="$RUNDIR/$CDATE/$CDUMP/vrfy"
+export DATAROOT="$RUNDIR/$CDATE/$CDUMP/vrfy.${jobid}"
 [[ -d $DATAROOT ]] && rm -rf $DATAROOT
 mkdir -p $DATAROOT
 

--- a/parm/config/config.post
+++ b/parm/config/config.post
@@ -41,6 +41,6 @@ else
 fi
 
 export GRIBVERSION='grib2'
-export SENDCOM=${SENDCOM:-"YES"}
+export SENDCOM="YES"
 
 echo "END: config.post"


### PR DESCRIPTION
This PR updates how the vrfy and metp* jobs set/use their $DATAROOT rundir folders:

- add pid and jobid variable settings to metp.sh and vrfy.sh (as other jobs do)
- update DATAROOT setting for both jobs to use jobid variable in folder name
- this update stops the vrfy and metp* jobs from all using a generic "vrfy" subfolder under $DATA for $DATAROOT
- the metp* jobs now also use distinct DATAROOTs to avoid race conditions between them
- further DATA/DATAROOT work will happen in issue #413
- tested successfully on WCOSS-Dell with vrfy/metp jobs running in parallel

Refs #401
Close #401 