### PR TITLE
Add rstprod support to Orion

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -113,7 +113,7 @@ if [[ ! -d verif-global.fd ]] ; then
     rm -f ${topdir}/checkout-verif-global.log
     git clone --recursive https://github.com/NOAA-EMC/EMC_verif-global.git verif-global.fd >> ${topdir}/checkout-verif-global.log 2>&1
     cd verif-global.fd
-    git checkout verif_global_v2.0.2
+    git checkout verif_global_v2.2.1
     cd ${topdir}
 else
     echo 'Skip. Directory verif-global.fd already exist.'

--- a/ush/rocoto/setup_expt.py
+++ b/ush/rocoto/setup_expt.py
@@ -239,7 +239,7 @@ link initial condition files from $ICSDIR to $COMROT'''
     elif machine == 'ORION':
       base_git = '/work/noaa/global/glopara/git'
       base_svn = '/work/noaa/global/glopara/svn'
-      dmpdir = '/work/noaa/global/glopara/dump'
+      dmpdir = '/work/noaa/rstprod/dump'
       nwprod = '/work/noaa/global/glopara/nwpara'
       comroot = '/work/noaa/global/glopara/com'
       homedir = '/work/noaa/global/$USER'

--- a/ush/rocoto/setup_expt.py
+++ b/ush/rocoto/setup_expt.py
@@ -250,8 +250,8 @@ link initial condition files from $ICSDIR to $COMROT'''
       queue = 'batch'
       queue_service = 'service'
       partition_batch = 'orion'
-      chgrp_rstprod = 'NO'
-      chgrp_cmd = 'ls'
+      chgrp_rstprod = 'YES'
+      chgrp_cmd = 'chgrp rstprod'
       hpssarch = 'NO'
 
     if args.icsdir is not None and not os.path.exists(icsdir):

--- a/ush/rocoto/setup_expt_fcstonly.py
+++ b/ush/rocoto/setup_expt_fcstonly.py
@@ -238,8 +238,8 @@ Create COMROT experiment directory structure'''
       queue = 'batch'
       queue_service = 'service'
       partition_batch = 'orion'
-      chgrp_rstprod = 'NO'          # No rstprod on Orion
-      chgrp_cmd = 'ls'
+      chgrp_rstprod = 'YES'
+      chgrp_cmd = 'chgrp rstprod'
       hpssarch = 'NO'
 
     # COMROT directory

--- a/ush/rocoto/setup_expt_fcstonly.py
+++ b/ush/rocoto/setup_expt_fcstonly.py
@@ -227,7 +227,7 @@ Create COMROT experiment directory structure'''
     elif machine == 'ORION':
       base_git = '/work/noaa/global/glopara/git'
       base_svn = '/work/noaa/global/glopara/svn'
-      dmpdir = '/work/noaa/global/glopara/dump'
+      dmpdir = '/work/noaa/rstprod/dump'
       nwprod = '/work/noaa/global/glopara/nwpara'
       comroot = '/work/noaa/global/glopara/com'
       homedir = '/work/noaa/global/$USER'


### PR DESCRIPTION
This PR updates Orion settings to use rstprod by default now that the restricted data policy is in place. The following changes are incoming:

* new EMC_verif-global tag (to add rstprod support on Orion): `verif_global_v2.2.1`
* change DMPDIR path to point to rstprod-supported GDA on Orion: `/work/noaa/rstprod/dump`
* set `CHGRP_RSTPROD='YES'` by default on Orion
* set `CHGRP_CMD='chgrp rstprod'` so files can be assigned rstprod group permissions where needed

Tested PR branch on WCOSS-Dell and Orion. @malloryprow has confirmed the metp jobs worked as intended on WCOSS-Dell using new EMC_verif-global tag. Will seek similar confirmation when Orion test completes.

Close #347 