### PR TITLE
GFSv16.1.2.1 - Update obsproc package versions for TAC2BUFR implementation

### DIFF
--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -67,8 +67,8 @@ export REALTIME="YES"
 export FIXgsi="$HOMEgfs/fix/fix_gsi"
 export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
 export HOMEpost="$HOMEgfs"
-export HOMEobsproc_prep="$BASE_GIT/obsproc/gfsv16b/obsproc_prep.iss70457.netcdfhistory"
-export HOMEobsproc_network="$BASE_GIT/obsproc/gfsv16b/obsproc_global_RB-3.4.0"
+export HOMEobsproc_prep="$BASE_GIT/obsproc/obsproc_prep.v5.5.0"
+export HOMEobsproc_network="$BASE_GIT/obsproc/obsproc_global.v3.4.2"
 export HOMEobsproc_global=$HOMEobsproc_network
 export BASE_VERIF="$BASE_GIT/verif/global/tags/vsdb"
 

--- a/parm/config/config.base.nco.static
+++ b/parm/config/config.base.nco.static
@@ -64,8 +64,8 @@ export REALTIME="YES"
 export FIXgsi="$HOMEgfs/fix/fix_gsi"
 export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
 export HOMEpost="$HOMEgfs"
-export HOMEobsproc_prep="$NWPROD/obsproc_prep.v5.4.0"
-export HOMEobsproc_network="$NWPROD/obsproc_global.v3.4.1"
+export HOMEobsproc_prep="$NWPROD/obsproc_prep.v5.5.0"
+export HOMEobsproc_network="$NWPROD/obsproc_global.v3.4.2"
 export HOMEobsproc_global=$HOMEobsproc_network
 export BASE_VERIF="$BASE_GIT/verif/global/tags/vsdb"
 


### PR DESCRIPTION
New obsproc package versions:
- obsproc_prep.v5.5.0
- obsproc_global.v3.4.2

Installed new packages on WCOSS-Dell, Hera, Jet, and Orion.

Tested against operations on WCOSS-Dell and reproduced the 2021081812 cycle.

```
RFC 8521 - On WCOSS, implement obsprocv16. This upgrade primarily addresses the ability to encode 
BUFR format ships and C-MAN platform data into all obsproc supported networks’ dump and prepbufr files. 
Networks include: gdas, gfs, rap, rtma, urma, nam, cdas, dump_monitor. 
For full details, see SCN: https://www.weather.gov/media/notification/pdf2/scn21-72_bufr_format_ships_c-man_data.pdf
```
Implemented August 18th ~06z.

Refs: #341