### PR TITLE
Update obsproc package versions for TAC2BUFR implementation

### DIFF
--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -72,8 +72,8 @@ export MODE="@MODE@" # cycled/free
 export FIXgsi="$HOMEgfs/fix/fix_gsi"
 export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
 export HOMEpost="$HOMEgfs"
-export HOMEobsproc_prep="$BASE_GIT/obsproc/obsproc_prep_RB-5.4.0_hpc-stack"
-export HOMEobsproc_network="$BASE_GIT/obsproc/obsproc_global_RB-3.4.0_hpc-stack"
+export HOMEobsproc_prep="$BASE_GIT/obsproc/obsproc_prep.v5.5.0"
+export HOMEobsproc_network="$BASE_GIT/obsproc/obsproc_global.v3.4.2"
 export HOMEobsproc_global=$HOMEobsproc_network
 export BASE_VERIF="$BASE_GIT/verif/global/tags/vsdb"
 

--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -72,8 +72,8 @@ export MODE="@MODE@" # cycled/free
 export FIXgsi="$HOMEgfs/fix/fix_gsi"
 export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
 export HOMEpost="$HOMEgfs"
-export HOMEobsproc_prep="$BASE_GIT/obsproc/obsproc_prep.v5.5.0"
-export HOMEobsproc_network="$BASE_GIT/obsproc/obsproc_global.v3.4.2"
+export HOMEobsproc_prep="$BASE_GIT/obsproc/obsproc_prep.v5.5.0_hpc-stack"
+export HOMEobsproc_network="$BASE_GIT/obsproc/obsproc_global.v3.4.2_hpc-stack"
 export HOMEobsproc_global=$HOMEobsproc_network
 export BASE_VERIF="$BASE_GIT/verif/global/tags/vsdb"
 

--- a/parm/config/config.base.nco.static
+++ b/parm/config/config.base.nco.static
@@ -65,8 +65,8 @@ export REALTIME="YES"
 export FIXgsi="$HOMEgfs/fix/fix_gsi"
 export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
 export HOMEpost="$HOMEgfs"
-export HOMEobsproc_prep="$NWPROD/obsproc_prep.v5.4.0"
-export HOMEobsproc_network="$NWPROD/obsproc_global.v3.4.1"
+export HOMEobsproc_prep="$NWPROD/obsproc_prep.v5.5.0"
+export HOMEobsproc_network="$NWPROD/obsproc_global.v3.4.2"
 export HOMEobsproc_global=$HOMEobsproc_network
 export BASE_VERIF="$BASE_GIT/verif/global/tags/vsdb"
 


### PR DESCRIPTION
This PR updates the obsproc_prep and obsproc_global packages in the develop branch to match the new versions in operations as of August 18th 2021. See issue #341 for more details. Companion PR into operations branch: #422 

New obsproc package versions:
- obsproc_prep.v5.5.0
- obsproc_global.v3.4.2

Installed new packages on WCOSS-Dell, Hera, Jet, and Orion. Tested on WCOSS-Dell and Orion.

Refs: #341
Close #341 