### PR TITLE
Update feature/coupled-crow to latest ufs-weather-model 

### DIFF
--- a/parm/mom6/MOM_input_template_025
+++ b/parm/mom6/MOM_input_template_025
@@ -743,13 +743,6 @@ MIX_LEN_EXPONENT = 1.0          !   [nondim] default = 2.0
 USE_LA_LI2016 = MOM6_REPRO_LA   !   [nondim] default = False
                                 ! A logical to use the Li et al. 2016 (submitted) formula to determine the
                                 ! Langmuir number.
-LT_ENHANCE = 3                  !   [nondim] default = 0
-                                ! Integer for Langmuir number mode.
-                                !  *Requires USE_LA_LI2016 to be set to True.
-                                ! Options: 0 - No Langmuir
-                                !          1 - Van Roekel et al. 2014/Li et al., 2016
-                                !          2 - Multiplied w/ adjusted La.
-                                !          3 - Added w/ adjusted La.
 USE_WAVES = MOM6_USE_WAVES      !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 

--- a/parm/mom6/MOM_input_template_050
+++ b/parm/mom6/MOM_input_template_050
@@ -773,13 +773,6 @@ MIX_LEN_EXPONENT = 1.0          !   [nondim] default = 2.0
 USE_LA_LI2016 = MOM6_REPRO_LA   !   [nondim] default = False
                                 ! A logical to use the Li et al. 2016 (submitted) formula to determine the
                                 ! Langmuir number.
-LT_ENHANCE = 3                  !   [nondim] default = 0
-                                ! Integer for Langmuir number mode.
-                                !  *Requires USE_LA_LI2016 to be set to True.
-                                ! Options: 0 - No Langmuir
-                                !          1 - Van Roekel et al. 2014/Li et al., 2016
-                                !          2 - Multiplied w/ adjusted La.
-                                !          3 - Added w/ adjusted La.
 USE_WAVES = MOM6_USE_WAVES      !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 WAVE_METHOD = "SURFACE_BANDS"   ! default = "EMPTY"

--- a/parm/mom6/MOM_input_template_100
+++ b/parm/mom6/MOM_input_template_100
@@ -75,6 +75,31 @@ WRITE_GEOM = 2                  ! default = 1
 SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
+! === module MOM_oda_incupd ===
+ODA_INCUPD = MOM_IAU            ! [Boolean] default = False
+                                ! If true, oda incremental updates will be applied
+                                ! everywhere in the domain.
+ODA_INCUPD_FILE = "mom6_increment.nc" ! The name of the file with the T,S,h increments.
+
+ODA_TEMPINC_VAR = "pt_inc"      ! default = "ptemp_inc"
+                                ! The name of the potential temperature inc. variable in
+                                ! ODA_INCUPD_FILE.
+ODA_SALTINC_VAR = "s_inc"       ! default = "sal_inc"
+                                ! The name of the salinity inc. variable in
+                                ! ODA_INCUPD_FILE.
+ODA_THK_VAR = "h_fg"            ! default = "h"
+                                ! The name of the int. depth inc. variable in
+                                ! ODA_INCUPD_FILE.
+
+ODA_UINC_VAR = "u_inc"          ! default = "u_inc"
+                                ! The name of the zonal vel. inc. variable in
+                                ! ODA_INCUPD_UV_FILE.
+ODA_VINC_VAR = "v_inc"          ! default = "v_inc"
+                                ! The name of the meridional vel. inc. variable in
+                                ! ODA_INCUPD_UV_FILE.
+ODA_INCUPD_NHOURS = MOM_IAU_HRS ! default=3.0 
+                                ! Number of hours for full update (0=direct insertion).
+
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
                                 ! Use tripolar connectivity at the northern edge of the domain.  With
@@ -169,13 +194,6 @@ CHANNEL_CONFIG = "list"         ! default = "none"
                                 !       NetCDF file on the model grid.
 CHANNEL_LIST_FILE = "MOM_channels_SPEAR" ! default = "MOM_channel_list"
                                 ! The file from which the list of narrowed channels is read.
-GRID_ROTATION_ANGLE_BUGS = False !   [Boolean] default = False
-                                ! If true, use an older algorithm to calculate the sine and cosines needed
-                                ! rotate between grid-oriented directions and true north and east.  Differences
-                                ! arise at the tripolar fold.
-USE_TRIPOLAR_GEOLONB_BUG = False !   [Boolean] default = False
-                                ! If true, use older code that incorrectly sets the longitude in some points
-                                ! along the tripolar fold to be off by 360 degrees.
 
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -41,7 +41,7 @@ else
   if [[ ! -d ufs_coupled.fd ]] ; then
     git clone https://github.com/ufs-community/ufs-weather-model ufs_coupled.fd >> ${topdir}/checkout-ufs_coupled.log 2>&1
     cd ufs_coupled.fd
-    git checkout 9bbb6d466368d46797e2c72a9d08955fda39cf33 
+    git checkout b26a896f2c9bada438414a51218bc72236925b8c 
     git submodule update --init --recursive
     cd ${topdir} 
   else


### PR DESCRIPTION
This PR updates feature/coupled-crow to use the latest ufs-weather-model hash which is needed for running P7 as it has a fix for the memory issues that were preventing 35 day runs before. 