### PR TITLE
Add ocean model resolution case block in config.efcs

### DIFF
--- a/parm/config/config.efcs
+++ b/parm/config/config.efcs
@@ -84,4 +84,14 @@ fi
 # wave model
 export cplwav=.false.
 
+# ocean model resolution
+case "$CASE_ENKF" in
+    "C48") export OCNRES=100;;
+    "C96") export OCNRES=100;;
+    "C192") export OCNRES=050;;
+    "C384") export OCNRES=025;;
+    "C768") export OCNRES=025;;
+    *) export OCNRES=025;;
+esac
+
 echo "END: config.efcs"


### PR DESCRIPTION
- duplicate case block from config.fcst for setting OCNRES based on model resolution
- change CASE to CASE_ENKF to use EnKF resolution for efcs jobs

Refs: #427