### PR TITLE
Update repository name for EMC_post component to UPP in develop branch

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -21,11 +21,11 @@ repo_url = https://github.com/NOAA-EMC/GLDAS.git
 protocol = git
 required = True
 
-[EMC_post]
+[UPP]
 #No externals setting = .gitmodules will be invoked for CMakeModules and comupp/src/lib/crtm2 submodules
 hash = ff42e0227d6100285d4179a2572b700fd5a959cb
 local_path = sorc/gfs_post.fd
-repo_url = https://github.com/NOAA-EMC/EMC_post.git
+repo_url = https://github.com/NOAA-EMC/UPP.git
 protocol = git
 required = True
 

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -69,10 +69,10 @@ else
     echo 'Skip.  Directory ufs_utils.fd already exists.'
 fi
 
-echo EMC_post checkout ...
+echo UPP checkout ...
 if [[ ! -d gfs_post.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_post.log
-    git clone https://github.com/NOAA-EMC/EMC_post.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
+    git clone https://github.com/NOAA-EMC/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
     cd gfs_post.fd
     git checkout ff42e0227d6100285d4179a2572b700fd5a959cb
     git submodule update --init CMakeModules


### PR DESCRIPTION
The "EMC_post" repository was renamed to "UPP" on September 6th 2021. Have updated repository url in checkout script and Externals.cfg. Tested updated checkout on Hera and then tested build and run to confirm functionality.

Refs: #433