### PR TITLE
Update repository name for EMC_post component to UPP in operations branch

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -21,10 +21,10 @@ repo_url = https://github.com/NOAA-EMC/GLDAS.git
 protocol = git
 required = True
 
-[EMC_post]
+[UPP]
 tag = upp_gfsv16_release.v1.1.4
 local_path = sorc/gfs_post.fd
-repo_url = https://github.com/NOAA-EMC/EMC_post.git
+repo_url = https://github.com/NOAA-EMC/UPP.git
 protocol = git
 required = True
 

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -5,7 +5,7 @@ while getopts "o" option;
 do
  case $option in
   o)
-   echo "Received -o flag for optional checkout of GTG, will check out GTG with EMC_post"
+   echo "Received -o flag for optional checkout of GTG, will check out GTG with UPP"
    checkout_gtg="YES"
    ;;
   :)
@@ -67,10 +67,10 @@ else
     echo 'Skip.  Directory ufs_utils.fd already exists.'
 fi
 
-echo EMC_post checkout ...
+echo UPP checkout ...
 if [[ ! -d gfs_post.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_post.log
-    git clone https://github.com/NOAA-EMC/EMC_post.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
+    git clone https://github.com/NOAA-EMC/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
     cd gfs_post.fd
     git checkout upp_gfsv16_release.v1.1.4
     ################################################################################


### PR DESCRIPTION
The "EMC_post" repository was renamed to "UPP" on September 6th 2021. Have updated repository url in checkout script and Externals.cfg. Tested checkout, build, and execs on Hera.

Refs: #433