### PR TITLE
Updates for cycling w/o IAU

### DIFF
--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -196,6 +196,7 @@ export QUILTING=".true."
 export OUTPUT_GRID="gaussian_grid"
 export OUTPUT_FILE="netcdf"
 export WRITE_DOPOST=".true."
+export WRITE_NSFLIP=".true."
 
 # suffix options depending on file format
 if [ $OUTPUT_FILE = "netcdf" ]; then

--- a/parm/config/config.base.nco.static
+++ b/parm/config/config.base.nco.static
@@ -173,6 +173,7 @@ export QUILTING=".true."
 export OUTPUT_GRID="gaussian_grid"
 export OUTPUT_FILE="netcdf"
 export WRITE_DOPOST=".true."
+export WRITE_NSFLIP=".true."
 
 # suffix options depending on file format
 if [ $OUTPUT_FILE = "netcdf" ]; then

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -169,9 +169,6 @@ FV3_GFS_predet(){
   JCAP_CASE=$((2*res-2))
   LONB_CASE=$((4*res))
   LATB_CASE=$((2*res))
-  if [ $LATB_CASE -eq 192 ]; then
-    LATB_CASE=190 # berror file is at this resolution
-  fi
 
   JCAP=${JCAP:-$JCAP_CASE}
   LONB=${LONB:-$LONB_CASE}

--- a/ush/parsing_model_configure_FV3.sh
+++ b/ush/parsing_model_configure_FV3.sh
@@ -39,6 +39,7 @@ write_groups:            ${WRITE_GROUP:-1}
 write_tasks_per_group:   ${WRTTASK_PER_GROUP:-24}
 output_history:          ${OUTPUT_HISTORY:-".true."}
 write_dopost:            ${WRITE_DOPOST:-".false."}
+write_nsflip:            ${WRITE_NSFLIP:-".false."}
 num_files:               ${NUM_FILES:-2}
 filename_base:           'atm' 'sfc'
 output_grid:             $OUTPUT_GRID


### PR DESCRIPTION
Tested feature/coupled_sprint on WCOSS-Dell atmos-only with IAU turned off. Successfully cycled 5.5 cycles at C192C96L127 with IAU off:

Mars: /gpfs/dell2/emc/modeling/save/Kate.Friedman/expdir/fcscycnoiau

Issue with IAU has been resolved in https://github.com/ufs-community/ufs-weather-model/pull/782. Will test with IAU on when feature/coupled_sprint reaches the associated ufs-weather-model hash (https://github.com/ufs-community/ufs-weather-model/commit/29fa4534b7da362c29be71efe2d1904c77f8470e).

Thankfully only minimal updates were needed so far to cycle feature/coupled_sprint with recent forecast updates:

1) had to add new `WRITE_NSFLIP` variable and set it to `.true.` (default is `.false.`)to get latitudes written out in GFSv16 order
2) had to remove a LATB_CASE=192 check in ush/forecast_predet.sh to stop wrong berror file being used at runtime for that resolution

Ref: #427 