### PR TITLE
GFSv16.1.3 - Update GSI tag to gfsda.v16.1.3 (turn off IASI early)

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.1.1a
+tag = gfsda.v16.1.3
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -38,7 +38,7 @@ if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
     git clone --recursive https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
-    git checkout gfsda.v16.1.1a
+    git checkout gfsda.v16.1.3
     git submodule update
     cd ${topdir}
 else


### PR DESCRIPTION
Emergency change occurred in operations during 2021092206 gdas cycle to turn off the IASI from Metop-a earlier than planned. GSI global_satinfo.txt was updated to turn off IASI.

From SDM log on 20210921: 

```
1ap. 1900Z - IDSB Chief Carissa requested an ARFC for the SPA Team. The metopA "IASI" instrument is failing, so they
need to make a modification to dump jobs so models do not assimilate the degraded data. They would like to make
the change at 12Z tomorrow. NCO Deputy Director and SDM approved. (MBG)
```

Test of `release/gfs.v16.1.3` branch on WCOSS-Dell against ops reproduced 2021092300 output.

Close: #446