### PR TITLE
Update EMC_verif-global tag to verif_global_v2.5.2

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -21,11 +21,11 @@ repo_url = https://github.com/NOAA-EMC/GLDAS.git
 protocol = git
 required = True
 
-[EMC_post]
+[UPP]
 #No externals setting = .gitmodules will be invoked for CMakeModules and comupp/src/lib/crtm2 submodules
 hash = ff42e0227d6100285d4179a2572b700fd5a959cb
 local_path = sorc/gfs_post.fd
-repo_url = https://github.com/NOAA-EMC/EMC_post.git
+repo_url = https://github.com/NOAA-EMC/UPP.git
 protocol = git
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -37,7 +37,7 @@ protocol = git
 required = True
 
 [EMC_verif-global]
-tag = verif_global_v2.0.2
+tag = verif_global_v2.5.2
 local_path = sorc/verif-global.fd
 repo_url = https://github.com/NOAA-EMC/EMC_verif-global.git
 protocol = git

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -69,10 +69,10 @@ else
     echo 'Skip.  Directory ufs_utils.fd already exists.'
 fi
 
-echo EMC_post checkout ...
+echo UPP checkout ...
 if [[ ! -d gfs_post.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_post.log
-    git clone https://github.com/NOAA-EMC/EMC_post.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
+    git clone https://github.com/NOAA-EMC/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
     cd gfs_post.fd
     git checkout ff42e0227d6100285d4179a2572b700fd5a959cb
     git submodule update --init CMakeModules

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -113,7 +113,7 @@ if [[ ! -d verif-global.fd ]] ; then
     rm -f ${topdir}/checkout-verif-global.log
     git clone --recursive https://github.com/NOAA-EMC/EMC_verif-global.git verif-global.fd >> ${topdir}/checkout-verif-global.log 2>&1
     cd verif-global.fd
-    git checkout verif_global_v2.2.1
+    git checkout verif_global_v2.5.2
     cd ${topdir}
 else
     echo 'Skip. Directory verif-global.fd already exist.'


### PR DESCRIPTION
New EMC_verif-global tag provides the following updates since the verif_global_v2.2.1 tag:
- Added capability to produce a scorecard (no need to use METviewer AWS to produce scorecards)
- Added capability to produce fit-to-obs plots
- Added support for Jet
- Updated DA ensemble plots graphics to support when models ensemble mean and spread output is on different grids
- Hot fix for new METviewer AWS host name
- Hot fix for reorganizing precipitation verification input files

Close: #438