### PR TITLE
GFSv16.1.4 - Operational Assimilation of Commercial GPS-RO in DO-3

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.1.1a
+tag = gfsda.v16.1.3
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.1.3
+tag = gfsda.v16.1.4
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git

--- a/docs/Release_Notes.gfs.v16.1.3.txt
+++ b/docs/Release_Notes.gfs.v16.1.3.txt
@@ -1,0 +1,155 @@
+GFS V16.1.3 RELEASE NOTES
+
+
+PRELUDE
+ 
+  NOAA awarded Delivery Order 3 (DO-3) of its commercial radio occultation
+  (RO) data purchase to Spire Global on August 12, 2021.  This purchase 
+  covers 3000 occultations per day over a six month period with the data 
+  flow starting on September 16, 2021.  On the same date, the GeoOptics 
+  data from Delivery Order 2 (DO-2) will be discontinued.
+
+  GNSSRO bending angle observations from GeoOptics and Spire were initially 
+  evaluated as part of Delivery Order 1 (DO-1), covering a 30-day period 
+  starting on December 15, 2020.  The data from both vendors were found to 
+  be of similar quality to other operationally assimilated RO data.  Low 
+  resolution experiments informed the configuration of the quality control 
+  and observation errors for the following DO-2, which was awarded to 
+  GeoOptics only, covering an average of 1300 occultations per day over a 
+  six month period starting on March 17, 2021.  These data began to be 
+  assimilated operationally with the implementation of GFSv16.1.1 on 
+  May 22, 2021 after two months of parallel testing at full resolution.
+
+  Following the v16.1.1 implementation, the observation errors for 
+  commercial RO were tuned to better utilize the new data.  Additionally, 
+  two fixes related to the handling of super-refractivity in the RO bending 
+  angle observation operator were added.  These fixes resolve minimization 
+  issues that were related to the increased vertical resolution in v16. 
+  Therefore, the stricter gross check quality control measures originally 
+  put in place to mitigate minimization problems will now be relaxed.  
+
+  This implementation plans to:
+    * Turn off the active assimilation of GeoOptics data
+    * Turn on the active assimilation of Spire data
+    * Adjust the observation errors for the Spire data
+    * Address two issues within the RO bending angle observation operator
+    * Relax the strict gross check added because of those issues.
+
+  These changes only affect two files within the GSI tag of the global workflow.
+
+
+IMPLEMENTATION INSTRUCTIONS
+
+  The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com 
+  are used to manage the GFS.v16.1.3 code. The SPA(s) handling the GFS.v16.1.3 
+  implementation need to have permissions to clone VLab gerrit repositories and 
+  the private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are 
+  publicly readable and do not require access permissions.  Please follow the 
+  following steps to install the package on WCOSS-Dell:
+
+  1) cd $NWROOTp3
+
+  2) mkdir gfs.v16.1.3
+
+  3) cd gfs.v16.1.3
+
+  4) git clone -b EMC-v16.1.3  https://github.com/NOAA-EMC/global-workflow.git .
+
+  5) cd sorc
+
+  6) ./checkout.sh -o
+     * This script extracts the following GFS components:
+         MODEL     tag GFS.v16.0.16                  Jun.Wang@noaa.gov
+         GSI       tag gfsda.v16.1.3                 Russ.Treadon@noaa.gov
+         GLDAS     tag gldas_gfsv16_release.v1.12.0  Helin.Wei@noaa.gov
+         UFS_UTILS tag ops-gfsv16.0.0                George.Gayno@noaa.gov
+         POST      tag upp_gfsv16_release.v1.1.4     Wen.Meng@noaa.gov
+         WAFS      tag gfs_wafs.v6.0.22              Yali.Mao@noaa.gov
+
+  7) ./build_all.sh
+     * This script compiles all GFS components. Runtime output from the build for 
+       each package is written to log files in directory logs. To build an 
+       individual program, for instance, gsi, use build_gsi.sh.
+
+  8) ./link_fv3gfs.sh nco dell	
+
+
+SORC CHANGES
+
+* sorc/
+  * checkout.sh will checkout the following changed model tags:
+    * GSI; tag gfsda.v16.1.3 
+      * src/gsi/setupbend.f90:  Add two fixes for handling of 
+        super-refractivity layer, change the observation errors
+        of the commercial data, relax stricter gross check back to 
+        original values 
+
+
+FIX CHANGES
+
+* fix/fix_gsi:
+  * global_convinfo.txt: Discontinue assimilating GeoOptics and 
+    begin assimilating Spire, relax stricter gross check back to
+    original values.
+  * gfsv16_historical/: Add fix files for retrospective parallels.
+    Does not impact operations.
+
+
+PARM/CONFIG CHANGES
+
+* parm/config/config.anal:  Add historical fix file entries.  Does
+  not impact operations.
+
+
+JOBS CHANGES
+
+* No change from GFS v16.1.2
+
+
+SCRIPT CHANGES
+
+* No change from GFS v16.1.2
+
+
+CHANGES TO RESOURCES AND FILE SIZES
+
+  There should be no change in analysis runtime nor cnvstat file size
+  greater than the normal cycle to cycle variation.
+
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+
+* Which production jobs should be tested as part of this implementation?
+  * The entire GFS v16.1.3 package needs to be installed and tested. 
+
+* Does this change require a 30-day evaluation?
+  * No.
+
+
+DISSEMINATION INFORMATION
+
+* Where should this output be sent?
+  * No change from GFS v16.1.2
+
+* Who are the users?
+  * No change from GFS v16.1.2
+
+* Which output files should be transferred from PROD WCOSS to DEV WCOSS?
+  * No change from GFS v16.1.2
+
+* Directory changes
+  * No change from GFS v16.1.2
+
+* File changes
+  * No change from GFS v16.1.2
+
+
+HPSS ARCHIVE
+
+* No change from GFS v16.1.2
+
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+
+* No change from GFS v16.1.2
+

--- a/docs/Release_Notes.gfs.v16.1.4.txt
+++ b/docs/Release_Notes.gfs.v16.1.4.txt
@@ -37,6 +37,9 @@ PRELUDE
 
   These changes only affect two files within the GSI tag of the global workflow.
 
+  In addition, a small bug fix is required to correct the ingest of new BUFR
+  observations from ships that was previously causing erroneous observations
+  to be assimilated.  This alters one additional file in the GSI tag.
 
 IMPLEMENTATION INSTRUCTIONS
 
@@ -83,6 +86,8 @@ SORC CHANGES
         super-refractivity layer, change the observation errors
         of the commercial data, relax stricter gross check back to 
         original values 
+      * src/read_nsstbufr.f90: Changes to handle NC001013, NC001101
+        and NC001113 marine bufr subsets.
 
 
 FIX CHANGES

--- a/docs/Release_Notes.gfs.v16.1.4.txt
+++ b/docs/Release_Notes.gfs.v16.1.4.txt
@@ -1,4 +1,4 @@
-GFS V16.1.3 RELEASE NOTES
+GFS V16.1.4 RELEASE NOTES
 
 
 PRELUDE
@@ -41,7 +41,7 @@ PRELUDE
 IMPLEMENTATION INSTRUCTIONS
 
   The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com 
-  are used to manage the GFS.v16.1.3 code. The SPA(s) handling the GFS.v16.1.3 
+  are used to manage the GFS.v16.1.4 code. The SPA(s) handling the GFS.v16.1.4 
   implementation need to have permissions to clone VLab gerrit repositories and 
   the private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are 
   publicly readable and do not require access permissions.  Please follow the 
@@ -49,18 +49,18 @@ IMPLEMENTATION INSTRUCTIONS
 
   1) cd $NWROOTp3
 
-  2) mkdir gfs.v16.1.3
+  2) mkdir gfs.v16.1.4
 
-  3) cd gfs.v16.1.3
+  3) cd gfs.v16.1.4
 
-  4) git clone -b EMC-v16.1.3  https://github.com/NOAA-EMC/global-workflow.git .
+  4) git clone -b EMC-v16.1.4  https://github.com/NOAA-EMC/global-workflow.git .
 
   5) cd sorc
 
   6) ./checkout.sh -o
      * This script extracts the following GFS components:
          MODEL     tag GFS.v16.0.16                  Jun.Wang@noaa.gov
-         GSI       tag gfsda.v16.1.3                 Russ.Treadon@noaa.gov
+         GSI       tag gfsda.v16.1.4                 Russ.Treadon@noaa.gov
          GLDAS     tag gldas_gfsv16_release.v1.12.0  Helin.Wei@noaa.gov
          UFS_UTILS tag ops-gfsv16.0.0                George.Gayno@noaa.gov
          POST      tag upp_gfsv16_release.v1.1.4     Wen.Meng@noaa.gov
@@ -78,7 +78,7 @@ SORC CHANGES
 
 * sorc/
   * checkout.sh will checkout the following changed model tags:
-    * GSI; tag gfsda.v16.1.3 
+    * GSI; tag gfsda.v16.1.4
       * src/gsi/setupbend.f90:  Add two fixes for handling of 
         super-refractivity layer, change the observation errors
         of the commercial data, relax stricter gross check back to 
@@ -103,12 +103,12 @@ PARM/CONFIG CHANGES
 
 JOBS CHANGES
 
-* No change from GFS v16.1.2
+* No change from GFS v16.1.3
 
 
 SCRIPT CHANGES
 
-* No change from GFS v16.1.2
+* No change from GFS v16.1.3
 
 
 CHANGES TO RESOURCES AND FILE SIZES
@@ -120,7 +120,7 @@ CHANGES TO RESOURCES AND FILE SIZES
 PRE-IMPLEMENTATION TESTING REQUIREMENTS
 
 * Which production jobs should be tested as part of this implementation?
-  * The entire GFS v16.1.3 package needs to be installed and tested. 
+  * The entire GFS v16.1.4 package needs to be installed and tested. 
 
 * Does this change require a 30-day evaluation?
   * No.
@@ -129,27 +129,27 @@ PRE-IMPLEMENTATION TESTING REQUIREMENTS
 DISSEMINATION INFORMATION
 
 * Where should this output be sent?
-  * No change from GFS v16.1.2
+  * No change from GFS v16.1.3
 
 * Who are the users?
-  * No change from GFS v16.1.2
+  * No change from GFS v16.1.3
 
 * Which output files should be transferred from PROD WCOSS to DEV WCOSS?
-  * No change from GFS v16.1.2
+  * No change from GFS v16.1.3
 
 * Directory changes
-  * No change from GFS v16.1.2
+  * No change from GFS v16.1.3
 
 * File changes
-  * No change from GFS v16.1.2
+  * No change from GFS v16.1.3
 
 
 HPSS ARCHIVE
 
-* No change from GFS v16.1.2
+* No change from GFS v16.1.3
 
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 
-* No change from GFS v16.1.2
+* No change from GFS v16.1.3
 

--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -95,7 +95,30 @@ if [[ $RUN_ENVIR == "emc" ]]; then
 #   Assimilate 135 (T) & 235 (uv) Canadian AMDAR observations
     if [[ "$CDATE" -ge "2020040718" && "$CDATE" -lt "2020052612" ]]; then
 	export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020040718
+	export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2020040718
     fi
+
+#   Assimilate COSMIC-2
+    if [[ "$CDATE" -ge "2020052612" && "$CDATE" -lt "2020082412" ]]; then
+        export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020052612
+	export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2020040718
+    fi
+
+#   Assimilate HDOB
+    if [[ "$CDATE" -ge "2020082412" && "$CDATE" -lt "2020091612" ]]; then
+        export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020082412
+    fi
+
+#   Assimilate Metop-C GNSSRO
+    if [[ "$CDATE" -ge "2020091612" && "$CDATE" -lt "2021031712" ]]; then
+        export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020091612
+    fi
+
+#   Assimilate DO-2 GeoOptics
+    if [[ "$CDATE" -ge "2021031712" && "$CDATE" -lt "2021091612" ]]; then
+        export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021031712
+    fi
+
 
 #   NOTE:
 #   As of 2020052612, gfsv16_historical/global_convinfo.txt.2020052612 is

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -38,7 +38,7 @@ if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
     git clone --recursive https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
-    git checkout gfsda.v16.1.3
+    git checkout gfsda.v16.1.4
     git submodule update
     cd ${topdir}
 else

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -38,7 +38,7 @@ if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
     git clone --recursive https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
-    git checkout gfsda.v16.1.1a
+    git checkout gfsda.v16.1.3
     git submodule update
     cd ${topdir}
 else


### PR DESCRIPTION
RFC 8702 - On WCOSS, implement GFS v16.1.4. This update includes turning on the active assimilation of Spire gpsro (GPS radio occultation) data and turning off the active assimilation of GeoOptics gpsro data. In addition, this update will fix a bug in the GFS/GSI where large errors are seen in SSTs. 

Implemented September 27 at 1430Z. (12z GFS cycle).

Close #420 