### PR TITLE
Python3 upgrade, new UFS_UTILS, link script & module updates

### DIFF
--- a/modulefiles/module_base.wcoss2
+++ b/modulefiles/module_base.wcoss2
@@ -5,7 +5,7 @@ module load PrgEnv-intel/8.1.0
 module load craype/2.7.8
 module load intel/19.1.3.304
 module load cray-mpich/8.1.7
-module load cray-pals
+module load cray-pals/1.0.12
 module load esmf/8.1.0
 module load cfp/2.0.4
 setenv USE_CFP YES

--- a/modulefiles/module_base.wcoss2
+++ b/modulefiles/module_base.wcoss2
@@ -23,7 +23,7 @@ module load hdf5/1.10.6
 module load netcdf/4.7.4
 
 module load nco/4.7.9
-module load prod_util/2.0.8
+module load prod_util/2.0.9
 module load grib_util/1.2.3
 module load bufr_dump/2.0.0
 module load util_shared/1.4.0

--- a/sorc/build_ufs_utils.sh
+++ b/sorc/build_ufs_utils.sh
@@ -7,9 +7,9 @@ cwd=`pwd`
 if [ $target = wcoss_dell_p3 ]; then target=dell; fi
 if [ $target = wcoss_cray ]; then target=cray; fi
 
-cd ufs_utils.fd/sorc
+cd ufs_utils.fd
 
-./build_all_ufs_utils.sh
+./build_all.sh
 
 exit
 

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -58,9 +58,9 @@ fi
 echo ufs_utils checkout ...
 if [[ ! -d ufs_utils.fd ]] ; then
     rm -f ${topdir}/checkout-ufs_utils.log
-    git clone https://github.com/NOAA-EMC/UFS_UTILS.git ufs_utils.fd >> ${topdir}/checkout-ufs_utils.fd.log 2>&1
+    git clone https://github.com/GeorgeGayno-NOAA/UFS_UTILS.git ufs_utils.fd >> ${topdir}/checkout-ufs_utils.fd.log 2>&1
     cd ufs_utils.fd
-    git checkout ops-gfsv16.0.0
+    git checkout feature/wcoss2
     cd ${topdir}
 else
     echo 'Skip.  Directory ufs_utils.fd already exists.'

--- a/sorc/link_fv3gfs.sh
+++ b/sorc/link_fv3gfs.sh
@@ -51,7 +51,7 @@ for dir in fix_am fix_fv3_gmted2010 fix_gldas fix_orog fix_verif fix_wave_gfs ; 
 done
 
 if [ -d ${pwd}/ufs_utils.fd ]; then
-  cd ${pwd}/ufs_utils.fd/sorc
+  cd ${pwd}/ufs_utils.fd/fix
   ./link_fixdirs.sh $RUN_ENVIR $machine
 fi
 
@@ -79,8 +79,7 @@ cd ${pwd}/../ush                ||exit 8
         $LINK ../sorc/gfs_post.fd/ush/$file                  .
     done
     for file in emcsfc_ice_blend.sh  fv3gfs_driver_grid.sh  fv3gfs_make_orog.sh  global_cycle_driver.sh \
-        emcsfc_snow.sh  fv3gfs_filter_topo.sh  global_chgres_driver.sh  global_cycle.sh \
-        fv3gfs_chgres.sh  fv3gfs_make_grid.sh  global_chgres.sh  ; do
+        emcsfc_snow.sh  fv3gfs_filter_topo.sh  global_cycle.sh  fv3gfs_make_grid.sh  ; do
         $LINK ../sorc/ufs_utils.fd/ush/$file                  .
     done
     for file in gldas_archive.sh  gldas_forcing.sh gldas_get_data.sh  gldas_process_data.sh gldas_liscrd.sh  gldas_post.sh ; do
@@ -221,7 +220,7 @@ if [ -d ${pwd}/gfs_wafs.fd ]; then
 fi
 
 for ufs_utilsexe in \
-     emcsfc_ice_blend  emcsfc_snow2mdl  global_chgres  global_cycle ; do
+     emcsfc_ice_blend  emcsfc_snow2mdl  global_cycle ; do
     [[ -s $ufs_utilsexe ]] && rm -f $ufs_utilsexe
     $LINK ../sorc/ufs_utils.fd/exec/$ufs_utilsexe .
 done
@@ -295,28 +294,32 @@ cd ${pwd}/../sorc   ||   exit 8
     [[ -d recentersigp.fd ]] && rm -rf recentersigp.fd
     $SLINK gsi.fd/util/EnKF/gfs/src/recentersigp.fd                                        recentersigp.fd
 
+    [[ -d gfs_ncep_post.fd ]] && rm -rf gfs_ncep_post.fd
     $SLINK gfs_post.fd/sorc/ncep_post.fd                                                   gfs_ncep_post.fd
 
-    $SLINK ufs_utils.fd/sorc/fre-nctools.fd/tools/shave.fd                                 shave.fd
-    for prog in filter_topo fregrid make_hgrid make_solo_mosaic ; do
-        $SLINK ufs_utils.fd/sorc/fre-nctools.fd/tools/$prog                                ${prog}.fd                                
+    for prog in filter_topo shave; do
+        [[ -d ${prog}.fd ]] && rm -rf ${prog}.fd
+        $SLINK ufs_utils.fd/sorc/grid_tools.fd/${prog}.fd                                  ${prog}.fd
     done
-    for prog in  global_cycle.fd   nemsio_read.fd  nemsio_chgdate.fd \
-        emcsfc_ice_blend.fd  nst_tf_chg.fd \
-        emcsfc_snow2mdl.fd   global_chgres.fd  nemsio_get.fd    orog.fd ;do
-        $SLINK ufs_utils.fd/sorc/$prog                                                     $prog
+    for prog in fregrid make_hgrid make_solo_mosaic ; do
+        [[ -d ${prog} ]] && rm -rf ${prog}
+        $SLINK ufs_utils.fd/sorc/fre-nctools.fd/tools/${prog}                              ${prog}
     done
-
+    for prog in orog ; do
+        [[ -d ${prog}.fd ]] && rm -rf ${prog}.fd
+        $SLINK ufs_utils.fd/sorc/orog_mask_tools.fd/${prog}.fd                             ${prog}.fd
+    done
+    for prog in global_cycle emcsfc_ice_blend emcsfc_snow2mdl ; do
+        [[ -d ${prog}.fd ]] && rm -rf ${prog}.fd
+        $SLINK ufs_utils.fd/sorc/${prog}.fd                                                ${prog}.fd
+    done
 
     if [ -d ${pwd}/gfs_wafs.fd ]; then 
-        $SLINK gfs_wafs.fd/sorc/wafs_awc_wafavn.fd                                              wafs_awc_wafavn.fd
-        $SLINK gfs_wafs.fd/sorc/wafs_blending.fd                                                wafs_blending.fd
-        $SLINK gfs_wafs.fd/sorc/wafs_blending_0p25.fd                                           wafs_blending_0p25.fd
-        $SLINK gfs_wafs.fd/sorc/wafs_cnvgrib2.fd                                                wafs_cnvgrib2.fd
-        $SLINK gfs_wafs.fd/sorc/wafs_gcip.fd                                                    wafs_gcip.fd
-        $SLINK gfs_wafs.fd/sorc/wafs_grib2_0p25.fd                                              wafs_grib2_0p25.fd
-        $SLINK gfs_wafs.fd/sorc/wafs_makewafs.fd                                                wafs_makewafs.fd
-        $SLINK gfs_wafs.fd/sorc/wafs_setmissing.fd                                              wafs_setmissing.fd
+        for prog in wafs_awc_wafavn wafs_blending wafs_blending_0p25 wafs_cnvgrib2 \
+	    wafs_gcip wafs_grib2_0p25 wafs_makewafs wafs_setmissing ; do
+            [[ -d ${prog}.fd ]] && rm -rf ${prog}.fd
+            $SLINK gfs_wafs.fd/sorc/${prog}.fd						   ${prog}.fd
+	done
     fi
 
     for prog in gdas2gldas.fd  gldas2gdas.fd  gldas_forcing.fd  gldas_model.fd  gldas_post.fd  gldas_rst.fd ;do

--- a/ush/rocoto/rocoto.py
+++ b/ush/rocoto/rocoto.py
@@ -10,6 +10,8 @@
     AUTHOR:
         Rahul.Mahajan
         rahul.mahajan@noaa.gov
+        Brian Curtis (2021): Port to python 3.6.3+
+        brian.curtis@noaa.gov
 '''
 
 def create_metatask(task_dict, metatask_dict):
@@ -31,17 +33,17 @@ def create_metatask(task_dict, metatask_dict):
 
     strings = []
 
-    strings.append('<metatask name="%s">\n' % metataskname)
+    strings.append(f'<metatask name="{metataskname}">\n')
     strings.append('\n')
-    strings.append('\t<var name="%s">%s</var>\n' % (varname, str(varval)))
+    strings.append(f'\t<var name="{varname}">{str(varval)}</var>\n')
     if vardict is not None:
         for key in vardict.keys():
             value = str(vardict[key])
-            strings.append('\t<var name="%s">%s</var>\n' % (key, value))
+            strings.append(f'\t<var name="{key}">{value}</var>\n')
     strings.append('\n')
     tasklines = create_task(task_dict)
     for tl in tasklines:
-        strings.append('%s' % tl) if tl == '\n' else strings.append('\t%s' % tl)
+        strings.append(f'{tl}') if tl == '\n' else strings.append(f'\t{tl}')
     strings.append('\n')
     strings.append('</metatask>\n')
 
@@ -81,36 +83,35 @@ def create_task(task_dict):
 
     strings = []
 
-    strings.append('<task name="%s" cycledefs="%s" maxtries="%s"%s>\n' % \
-            (taskname, cycledef, str_maxtries, str_final))
+    strings.append(f'<task name="{taskname}" cycledefs="{cycledef}" maxtries="{str_maxtries}"{str_final}>\n')
     strings.append('\n')
-    strings.append('\t<command>%s</command>\n' % command)
+    strings.append(f'\t<command>{command}</command>\n')
     strings.append('\n')
-    strings.append('\t<jobname><cyclestr>%s</cyclestr></jobname>\n' % jobname)
-    strings.append('\t<account>%s</account>\n' % account)
-    strings.append('\t<queue>%s</queue>\n' % queue)
+    strings.append(f'\t<jobname><cyclestr>{jobname}</cyclestr></jobname>\n')
+    strings.append(f'\t<account>{account}</account>\n')
+    strings.append(f'\t<queue>{queue}</queue>\n')
     if partition is not None:
-        strings.append('\t<partition>%s</partition>\n' % partition)
+        strings.append(f'\t<partition>{partition}</partition>\n')
     if resources is not None:
-        strings.append('\t%s\n' % resources)
-    strings.append('\t<walltime>%s</walltime>\n' % walltime)
+        strings.append(f'\t{resources}\n')
+    strings.append(f'\t<walltime>{walltime}</walltime>\n')
     if memory is not None:
-        strings.append('\t<memory>%s</memory>\n' % memory)
+        strings.append(f'\t<memory>{memory}</memory>\n')
     if native is not None:
-        strings.append('\t<native>%s</native>\n' % native)
+        strings.append(f'\t<native>{native}</native>\n')
     strings.append('\n')
-    strings.append('\t<join><cyclestr>%s</cyclestr></join>\n' % log)
+    strings.append(f'\t<join><cyclestr>{log}</cyclestr></join>\n')
     strings.append('\n')
 
     if envar[0] is not None:
         for e in envar:
-            strings.append('\t%s\n' % e)
+            strings.append(f'\t{e}\n')
         strings.append('\n')
 
     if dependency is not None:
         strings.append('\t<dependency>\n')
         for d in dependency:
-            strings.append('\t\t%s\n' % d)
+            strings.append(f'\t\t{d}\n')
         strings.append('\t</dependency>\n')
         strings.append('\n')
 
@@ -149,11 +150,11 @@ def add_dependency(dep_dict):
 
     else:
 
-        msg = 'Unknown dependency type %s' % dep_dict['type']
+        msg = f'Unknown dependency type {dep_dict["type"]}'
         raise KeyError(msg)
 
     if dep_condition is not None:
-        string = '<%s>%s</%s>' % (dep_condition, string, dep_condition)
+        string = f'<{dep_condition}>{string}</{dep_condition}>'
 
     return string
 
@@ -172,13 +173,13 @@ def add_task_tag(dep_dict):
     dep_offset = dep_dict.get('offset', None)
 
     if dep_name is None:
-        msg = 'a %s name is necessary for %s dependency' % (dep_type, dep_type)
+        msg = f'a {dep_type} name is necessary for {dep_type} dependency'
         raise KeyError(msg)
 
     string = '<'
-    string += '%sdep %s="%s"' % (dep_type, dep_type, dep_name)
+    string += f'{dep_type}dep {dep_type}="{dep_name}"'
     if dep_offset is not None:
-        string += ' cycle_offset="%s"' % dep_offset
+        string += f' cycle_offset="{dep_offset}"'
     string += '/>'
 
     return string
@@ -197,7 +198,7 @@ def add_data_tag(dep_dict):
     dep_offset = dep_dict.get('offset', None)
 
     if dep_data is None:
-        msg = 'a data value is necessary for %s dependency' % dep_type
+        msg = f'a data value is necessary for {dep_type} dependency'
         raise KeyError(msg)
 
     if dep_offset is None:
@@ -208,11 +209,11 @@ def add_data_tag(dep_dict):
             offset_string_b = ''
             offset_string_e = ''
     else:
-        offset_string_b = '<cyclestr offset="%s">' % dep_offset
+        offset_string_b = f'<cyclestr offset="{dep_offset}">'
         offset_string_e = '</cyclestr>'
 
     string = '<datadep>'
-    string += '%s%s%s' % (offset_string_b, dep_data, offset_string_e)
+    string += f'{offset_string_b}{dep_data}{offset_string_e}'
     string += '</datadep>'
 
     return string
@@ -230,10 +231,10 @@ def add_cycle_tag(dep_dict):
     dep_offset = dep_dict.get('offset', None)
 
     if dep_offset is None:
-        msg = 'an offset value is necessary for %s dependency' % dep_type
+        msg = f'an offset value is necessary for {dep_type} dependency'
         raise KeyError(msg)
 
-    string = '<cycleexistdep cycle_offset="%s"/>' % dep_offset
+    string = f'<cycleexistdep cycle_offset="{dep_offset}"/>'
 
     return string
 
@@ -253,17 +254,17 @@ def add_streq_tag(dep_dict):
     fail = False
     msg = ''
     if dep_left is None:
-        msg += 'a left value is necessary for %s dependency' % dep_type
+        msg += f'a left value is necessary for {dep_type} dependency'
         fail = True
     if dep_right is None:
         if fail:
             msg += '\n'
-        msg += 'a right value is necessary for %s dependency' % dep_type
+        msg += f'a right value is necessary for {dep_type} dependency'
         fail = True
     if fail:
         raise KeyError(msg)
 
-    string = '<%s><left>%s</left><right>%s</right></%s>' % (dep_type, dep_left, dep_right, dep_type)
+    string = f'<{dep_type}><left>{dep_left}</left><right>{dep_right}</right></{dep_type}>'
 
     return string
 
@@ -305,18 +306,18 @@ def create_dependency(dep_condition=None, dep=None):
     strings = []
 
     if dep_condition is not None:
-        strings.append('<%s>' % dep_condition)
+        strings.append(f'<{dep_condition}>')
 
     if dep[0] is not None:
         for d in dep:
             if dep_condition is None:
-                strings.append('%s' % d)
+                strings.append(f'{d}')
             else:
                 for e in _traverse(d):
-                    strings.append('\t%s' % e)
+                    strings.append(f'\t{e}')
 
     if dep_condition is not None:
-        strings.append('</%s>' % dep_condition)
+        strings.append(f'</{dep_condition}>')
 
     return strings
 
@@ -335,8 +336,8 @@ def create_envar(name=None,value=None):
 
     string = ''
     string += '<envar>'
-    string += '<name>%s</name>' % name
-    string += '<value>%s</value>' % str(value)
+    string += f'<name>{name}</name>'
+    string += f'<value>{str(value)}</value>'
     string += '</envar>'
 
     return string

--- a/ush/rocoto/setup_expt.py
+++ b/ush/rocoto/setup_expt.py
@@ -28,9 +28,9 @@ def makedirs_if_missing(d):
 def create_EXPDIR():
 
     makedirs_if_missing(expdir)
-    configs = glob.glob('%s/config.*' % configdir)
+    configs = glob.glob(f'{configdir}/config.*')
     if len(configs) == 0:
-        msg = 'no config files found in %s' % configdir
+        msg = f'no config files found in {configdir}'
         raise IOError(msg)
     for config in configs:
         shutil.copy(config, expdir)
@@ -47,30 +47,30 @@ def create_COMROT():
     makedirs_if_missing(comrot)
 
     # Link ensemble member initial conditions
-    enkfdir = 'enkf%s.%s/%s' % (cdump, cymd, chh)
+    enkfdir = f'enkf{cdump}.{cymd}/{chh}'
     makedirs_if_missing(os.path.join(comrot, enkfdir))
     for i in range(1, nens + 1):
-        makedirs_if_missing(os.path.join(comrot, enkfdir, 'mem%03d' % i))
-        os.symlink(os.path.join(icsdir, idatestr, 'C%d' % resens, 'mem%03d' % i, 'INPUT'),
-                   os.path.join(comrot, enkfdir, 'mem%03d' % i, 'INPUT'))
+        makedirs_if_missing(os.path.join(comrot, enkfdir, f'mem{i:03d}'))
+        os.symlink(os.path.join(icsdir, idatestr, f'C{resens}', f'mem{i:03d}', 'INPUT'),
+                   os.path.join(comrot, enkfdir, f'mem{i:03d}', 'INPUT'))
 
     # Link deterministic initial conditions
-    detdir = '%s.%s/%s' % (cdump, cymd, chh)
+    detdir = f'{cdump}.{cymd}/{chh}'
     makedirs_if_missing(os.path.join(comrot, detdir))
-    os.symlink(os.path.join(icsdir, idatestr, 'C%d' % resdet, 'control', 'INPUT'),
+    os.symlink(os.path.join(icsdir, idatestr, f'C{resdet}', 'control', 'INPUT'),
                os.path.join(comrot, detdir, 'INPUT'))
 
     # Link bias correction and radiance diagnostics files
     for fname in ['abias', 'abias_pc', 'abias_air', 'radstat']:
-        os.symlink(os.path.join(icsdir, idatestr, '%s.t%sz.%s' % (cdump, chh, fname)),
-                   os.path.join(comrot, detdir, '%s.t%sz.%s' % (cdump, chh, fname)))
+        os.symlink(os.path.join(icsdir, idatestr, f'{cdump}.t{chh}z.{fname}'),
+                   os.path.join(comrot, detdir, f'{cdump}.t{chh}z.{fname}'))
 
     return
 
 
 def edit_baseconfig():
 
-    base_config = '%s/config.base' % expdir
+    base_config = f'{expdir}/config.base'
 
     here = os.path.dirname(__file__)
     top = os.path.abspath(os.path.join(
@@ -79,7 +79,7 @@ def edit_baseconfig():
     if os.path.exists(base_config):
         os.unlink(base_config)
 
-    print '\nSDATE = %s\nEDATE = %s' % (idate, edate)
+    print(f'\nSDATE = {idate}\nEDATE = {edate}')
     with open(base_config + '.emc.dyn', 'rt') as fi:
         with open(base_config, 'wt') as fo:
             for line in fi:
@@ -88,9 +88,9 @@ def edit_baseconfig():
                     .replace('@SDATE@', idate.strftime('%Y%m%d%H')) \
                     .replace('@FDATE@', fdate.strftime('%Y%m%d%H')) \
                     .replace('@EDATE@', edate.strftime('%Y%m%d%H')) \
-                    .replace('@CASEENS@', 'C%d' % resens) \
-                    .replace('@CASECTL@', 'C%d' % resdet) \
-                    .replace('@NMEM_ENKF@', '%d' % nens) \
+                    .replace('@CASEENS@', f'C{resens}') \
+                    .replace('@CASECTL@', f'C{resdet}') \
+                    .replace('@NMEM_ENKF@', f'{nens}') \
                     .replace('@HOMEgfs@', top) \
                     .replace('@BASE_GIT@', base_git) \
                     .replace('@DMPDIR@', dmpdir) \
@@ -105,10 +105,11 @@ def edit_baseconfig():
                     .replace('@QUEUE_SERVICE@', queue_service) \
                     .replace('@PARTITION_BATCH@', partition_batch) \
                     .replace('@EXP_WARM_START@', exp_warm_start) \
+                    .replace('@MODE@', 'cycled') \
                     .replace('@CHGRP_RSTPROD@', chgrp_rstprod) \
                     .replace('@CHGRP_CMD@', chgrp_cmd) \
                     .replace('@HPSSARCH@', hpssarch) \
-                    .replace('@gfs_cyc@', '%d' % gfs_cyc)
+                    .replace('@gfs_cyc@', f'{gfs_cyc}')
                 if expdir is not None:
                     line = line.replace('@EXPDIR@', os.path.dirname(expdir))
                 if comrot is not None:
@@ -117,11 +118,11 @@ def edit_baseconfig():
                     continue
                 fo.write(line)
 
-    print ''
-    print 'EDITED:  %s/config.base as per user input.' % expdir
-    print 'DEFAULT: %s/config.base.emc.dyn is for reference only.' % expdir
-    print 'Please verify and delete the default file before proceeding.'
-    print ''
+    print('')
+    print(f'EDITED:  {expdir}/config.base as per user input.')
+    print(f'DEFAULT: {expdir}/config.base.emc.dyn is for reference only.')
+    print('Please verify and delete the default file before proceeding.')
+    print('')
 
     return
 
@@ -223,7 +224,7 @@ link initial condition files from $ICSDIR to $COMROT'''
       base_svn = '/scratch1/NCEPDEV/global/glopara/svn'
       dmpdir = '/scratch1/NCEPDEV/global/glopara/dump'
       nwprod = '/scratch1/NCEPDEV/global/glopara/nwpara'
-      comroot = '/scratch1/NCEPDEV/global/glopara/com'
+      comroot = '/scratch1/NCEPDEV/rstprod/com'
       homedir = '/scratch1/NCEPDEV/global/$USER'
       stmp = '/scratch1/NCEPDEV/stmp2/$USER'
       ptmp = '/scratch1/NCEPDEV/stmp4/$USER'
@@ -238,7 +239,6 @@ link initial condition files from $ICSDIR to $COMROT'''
     elif machine == 'ORION':
       base_git = '/work/noaa/global/glopara/git'
       base_svn = '/work/noaa/global/glopara/svn'
-      #non-rstprod#dmpdir = '/work/noaa/global/glopara/dump'
       dmpdir = '/work/noaa/rstprod/dump'
       nwprod = '/work/noaa/global/glopara/nwpara'
       comroot = '/work/noaa/global/glopara/com'
@@ -255,7 +255,7 @@ link initial condition files from $ICSDIR to $COMROT'''
       hpssarch = 'NO'
 
     if args.icsdir is not None and not os.path.exists(icsdir):
-        msg = 'Initial conditions do not exist in %s' % icsdir
+        msg = f'Initial conditions do not exist in {icsdir}'
         raise IOError(msg)
 
     # COMROT directory
@@ -264,10 +264,10 @@ link initial condition files from $ICSDIR to $COMROT'''
     else:
        create_comrot = True
        if os.path.exists(comrot):
-           print
-           print 'COMROT already exists in %s' % comrot
-           print
-           overwrite_comrot = raw_input('Do you wish to over-write COMROT [y/N]: ')
+           print()
+           print(f'COMROT already exists in {comrot}')
+           print()
+           overwrite_comrot = input('Do you wish to over-write COMROT [y/N]: ')
            create_comrot = True if overwrite_comrot in ['y', 'yes', 'Y', 'YES'] else False
            if create_comrot:
               shutil.rmtree(comrot)
@@ -278,10 +278,10 @@ link initial condition files from $ICSDIR to $COMROT'''
     # EXP directory
     create_expdir = True
     if os.path.exists(expdir):
-        print
-        print 'EXPDIR already exists in %s' % expdir
-        print
-        overwrite_expdir = raw_input('Do you wish to over-write EXPDIR [y/N]: ')
+        print()
+        print(f'EXPDIR already exists in {expdir}')
+        print()
+        overwrite_expdir = input('Do you wish to over-write EXPDIR [y/N]: ')
         create_expdir = True if overwrite_expdir in ['y', 'yes', 'Y', 'YES'] else False
         if create_expdir:
             shutil.rmtree(expdir)

--- a/ush/rocoto/setup_expt_fcstonly.py
+++ b/ush/rocoto/setup_expt_fcstonly.py
@@ -28,9 +28,9 @@ def makedirs_if_missing(d):
 def create_EXPDIR():
 
     makedirs_if_missing(expdir)
-    configs = glob.glob('%s/config.*' % configdir)
+    configs = glob.glob(f'{configdir}/config.*')
     if len(configs) == 0:
-        msg = 'no config files found in %s' % configdir
+        msg = f'no config files found in {configdir}'
         raise IOError(msg)
     for config in configs:
         shutil.copy(config, expdir)
@@ -47,7 +47,7 @@ def create_COMROT():
 
 def edit_baseconfig():
 
-    base_config = '%s/config.base' % expdir
+    base_config = f'{expdir}/config.base'
 
     here = os.path.dirname(__file__)
     top = os.path.abspath(os.path.join(os.path.abspath(here), '../..'))
@@ -55,7 +55,7 @@ def edit_baseconfig():
     # make a copy of the default before editing
     shutil.copy(base_config, base_config + '.default')
 
-    print '\nSDATE = %s\nEDATE = %s' % (idate, edate)
+    print(f'\nSDATE = {idate}\nEDATE = {edate}')
     with open(base_config + '.default', 'rt') as fi:
         with open(base_config + '.new', 'wt') as fo:
             for line in fi:
@@ -64,7 +64,7 @@ def edit_baseconfig():
                     .replace('@SDATE@', idate.strftime('%Y%m%d%H')) \
                     .replace('@FDATE@', fdate.strftime('%Y%m%d%H')) \
                     .replace('@EDATE@', edate.strftime('%Y%m%d%H')) \
-                    .replace('@CASECTL@', 'C%d' % res) \
+                    .replace('@CASECTL@', f'C{res}') \
                     .replace('@HOMEgfs@', top) \
                     .replace('@BASE_GIT@', base_git) \
                     .replace('@DMPDIR@', dmpdir) \
@@ -79,10 +79,11 @@ def edit_baseconfig():
                     .replace('@QUEUE_SERVICE@', queue_service) \
                     .replace('@PARTITION_BATCH@', partition_batch) \
                     .replace('@EXP_WARM_START@', exp_warm_start) \
+                    .replace('@MODE@', 'free') \
                     .replace('@CHGRP_RSTPROD@', chgrp_rstprod) \
                     .replace('@CHGRP_CMD@', chgrp_cmd) \
                     .replace('@HPSSARCH@', hpssarch) \
-                    .replace('@gfs_cyc@', '%d' % gfs_cyc)
+                    .replace('@gfs_cyc@', f'{gfs_cyc}')
                 if expdir is not None:
                     line = line.replace('@EXPDIR@', os.path.dirname(expdir))
                 if comrot is not None:
@@ -92,11 +93,11 @@ def edit_baseconfig():
     os.unlink(base_config)
     os.rename(base_config + '.new', base_config)
 
-    print ''
-    print 'EDITED:  %s/config.base as per user input.' % expdir
-    print 'DEFAULT: %s/config.base.default is for reference only.' % expdir
-    print 'Please verify and delete the default file before proceeding.'
-    print ''
+    print('')
+    print(f'EDITED:  {expdir}/config.base as per user input.')
+    print(f'DEFAULT: {expdir}/config.base.default is for reference only.')
+    print('Please verify and delete the default file before proceeding.')
+    print('')
 
     return
 
@@ -117,7 +118,7 @@ Create COMROT experiment directory structure'''
     parser.add_argument('--configdir', help='full path to directory containing the config files', type=str, required=False, default=None)
     parser.add_argument('--gfs_cyc', help='GFS cycles to run', type=int, choices=[0, 1, 2, 4], default=1, required=False)
     parser.add_argument('--partition', help='partition on machine', type=str, required=False, default=None)
-    parser.add_argument('--start', help='restart mode: warm or cold', type=str, choices=['warm', 'cold'], required=False, default='cold')
+    parser.add_argument('--start', help='restart mode: warm or cold', type=str, choices=['warm', 'cold'], required=False)
 
     args = parser.parse_args()
 
@@ -138,7 +139,12 @@ Create COMROT experiment directory structure'''
     start = args.start
 
     # Set restart setting in config.base
-    if start == 'cold':
+    if start is None:
+      if res == 768:
+        exp_warm_start = '.true.'
+      else:
+        exp_warm_start = '.false.'
+    elif start == 'cold':
       exp_warm_start = '.false.'
     elif start == 'warm':
       exp_warm_start = '.true.'
@@ -189,7 +195,7 @@ Create COMROT experiment directory structure'''
       base_svn = '/scratch1/NCEPDEV/global/glopara/svn'
       dmpdir = '/scratch1/NCEPDEV/global/glopara/dump'
       nwprod = '/scratch1/NCEPDEV/global/glopara/nwpara'
-      comroot = '/scratch1/NCEPDEV/global/glopara/com'
+      comroot = '/scratch1/NCEPDEV/rstprod/com'
       homedir = '/scratch1/NCEPDEV/global/$USER'
       stmp = '/scratch1/NCEPDEV/stmp2/$USER'
       ptmp = '/scratch1/NCEPDEV/stmp4/$USER'
@@ -201,10 +207,26 @@ Create COMROT experiment directory structure'''
       chgrp_rstprod = 'YES'
       chgrp_cmd = 'chgrp rstprod'
       hpssarch = 'YES'
+    elif machine == 'JET':
+      base_git = '/lfs4/HFIP/hfv3gfs/glopara/git'
+      base_svn = '/dev/null/global/save/glopara/svn/'
+      dmpdir = '/lfs4/HFIP/hfv3gfs/glopara/dump'
+      nwprod = '/lfs4/HFIP/hfv3gfs/glopara/nwpara'
+      comroot = '/lfs4/HFIP/hfv3gfs/glopara/com'
+      homedir = '/lfs4/HFIP/hfv3gfs/$USER'
+      stmp = '/lfs4/HFIP/hfv3gfs/${USER}/stmp'
+      ptmp = '/lfs4/HFIP/hfv3gfs/${USER}/ptmp'
+      noscrub = '$HOMEDIR'
+      account = 'hfv3gfs'
+      queue = 'batch'
+      queue_service = 'service'
+      partition_batch = 'xjet'
+      chgrp_rstprod = 'YES'
+      chgrp_cmd = 'chgrp rstprod'
+      hpssarch = 'YES'
     elif machine == 'ORION':
       base_git = '/work/noaa/global/glopara/git'
       base_svn = '/work/noaa/global/glopara/svn'
-      #non-rstprod#dmpdir = '/work/noaa/global/glopara/dump'
       dmpdir = '/work/noaa/rstprod/dump'
       nwprod = '/work/noaa/global/glopara/nwpara'
       comroot = '/work/noaa/global/glopara/com'
@@ -223,10 +245,10 @@ Create COMROT experiment directory structure'''
     # COMROT directory
     create_comrot = True
     if os.path.exists(comrot):
-        print
-        print 'COMROT already exists in %s' % comrot
-        print
-        overwrite_comrot = raw_input('Do you wish to over-write COMROT [y/N]: ')
+        print()
+        print(f'COMROT already exists in {comrot}')
+        print()
+        overwrite_comrot = input('Do you wish to over-write COMROT [y/N]: ')
         create_comrot = True if overwrite_comrot in ['y', 'yes', 'Y', 'YES'] else False
         if create_comrot:
             shutil.rmtree(comrot)
@@ -237,10 +259,10 @@ Create COMROT experiment directory structure'''
     # EXP directory
     create_expdir = True
     if os.path.exists(expdir):
-        print
-        print 'EXPDIR already exists in %s' % expdir
-        print
-        overwrite_expdir = raw_input('Do you wish to over-write EXPDIR [y/N]: ')
+        print()
+        print(f'EXPDIR already exists in {expdir}')
+        print()
+        overwrite_expdir = input('Do you wish to over-write EXPDIR [y/N]: ')
         create_expdir = True if overwrite_expdir in ['y', 'yes', 'Y', 'YES'] else False
         if create_expdir:
             shutil.rmtree(expdir)

--- a/ush/rocoto/setup_workflow.py
+++ b/ush/rocoto/setup_workflow.py
@@ -37,9 +37,9 @@ def main():
     _base = wfu.config_parser([wfu.find_config('config.base', configs)])
 
     if not os.path.samefile(args.expdir, _base['EXPDIR']):
-        print 'MISMATCH in experiment directories!'
-        print 'config.base: EXPDIR = %s' % repr(_base['EXPDIR'])
-        print 'input arg:     --expdir = %s' % repr(args.expdir)
+        print('MISMATCH in experiment directories!')
+        print(f'config.base: EXPDIR = {repr(_base["EXPDIR"])}')
+        print(f'input arg:     --expdir = {repr(args.expdir)}')
         sys.exit(1)
 
     gfs_steps = ['prep', 'anal', 'analdiag', 'analcalc', 'gldas', 'fcst', 'postsnd', 'post', 'vrfy', 'arch']
@@ -110,10 +110,10 @@ def get_gfs_cyc_dates(base):
     sdate_gfs = sdate + timedelta(hours=hrinc)
     edate_gfs = edate - timedelta(hours=hrdet)
     if sdate_gfs > edate:
-        print 'W A R N I N G!'
-        print 'Starting date for GFS cycles is after Ending date of experiment'
-        print 'SDATE = %s,     EDATE = %s' % (sdate.strftime('%Y%m%d%H'), edate.strftime('%Y%m%d%H'))
-        print 'SDATE_GFS = %s, EDATE_GFS = %s' % (sdate_gfs.strftime('%Y%m%d%H'), edate_gfs.strftime('%Y%m%d%H'))
+        print('W A R N I N G!')
+        print('Starting date for GFS cycles is after Ending date of experiment')
+        print(f'SDATE = {sdate.strftime("%Y%m%d%H")},     EDATE = {edate.strftime("%Y%m%d%H")}')
+        print(f'SDATE_GFS = {sdate_gfs.strftime("%Y%m%d%H")}, EDATE_GFS = {edate_gfs.strftime("%Y%m%d%H")}')
         gfs_cyc = 0
 
     base_out['gfs_cyc'] = gfs_cyc
@@ -123,7 +123,7 @@ def get_gfs_cyc_dates(base):
 
     fhmax_gfs = {}
     for hh in ['00', '06', '12', '18']:
-        fhmax_gfs[hh] = base.get('FHMAX_GFS_%s' % hh, 'FHMAX_GFS_00')
+        fhmax_gfs[hh] = base.get(f'FHMAX_GFS_{hh}', 'FHMAX_GFS_00')
     base_out['FHMAX_GFS'] = fhmax_gfs
 
     return base_out
@@ -148,7 +148,7 @@ def get_preamble():
     strings.append('\t\trahul.mahajan@noaa.gov\n')
     strings.append('\n')
     strings.append('\tNOTES:\n')
-    strings.append('\t\tThis workflow was automatically generated at %s\n' % datetime.now())
+    strings.append(f'\t\tThis workflow was automatically generated at {datetime.now()}\n')
     strings.append('\t-->\n')
 
     return ''.join(strings)
@@ -161,44 +161,45 @@ def get_definitions(base):
 
     machine = base.get('machine', wfu.detectMachine())
     scheduler = wfu.get_scheduler(machine)
+    hpssarch = base.get('HPSSARCH', 'NO').upper()
 
     strings = []
 
     strings.append('\n')
     strings.append('\t<!-- Experiment parameters such as name, starting, ending dates -->\n')
-    strings.append('\t<!ENTITY PSLOT "%s">\n' % base['PSLOT'])
-    strings.append('\t<!ENTITY SDATE "%s">\n' % base['SDATE'].strftime('%Y%m%d%H%M'))
-    strings.append('\t<!ENTITY EDATE "%s">\n' % base['EDATE'].strftime('%Y%m%d%H%M'))
+    strings.append(f'''\t<!ENTITY PSLOT "{base['PSLOT']}">\n''')
+    strings.append(f'''\t<!ENTITY SDATE "{base['SDATE'].strftime('%Y%m%d%H%M')}">\n''')
+    strings.append(f'''\t<!ENTITY EDATE "{base['EDATE'].strftime('%Y%m%d%H%M')}">\n''')
 
     if base['gfs_cyc'] != 0:
         strings.append(get_gfs_dates(base))
         strings.append('\n')
 
     strings.append('\t<!-- Run Envrionment -->\n')
-    strings.append('\t<!ENTITY RUN_ENVIR "%s">\n' % base['RUN_ENVIR'])
+    strings.append(f'''\t<!ENTITY RUN_ENVIR "{base['RUN_ENVIR']}">\n''')
     strings.append('\n')
     strings.append('\t<!-- Experiment and Rotation directory -->\n')
-    strings.append('\t<!ENTITY EXPDIR "%s">\n' % base['EXPDIR'])
-    strings.append('\t<!ENTITY ROTDIR "%s">\n' % base['ROTDIR'])
+    strings.append(f'''\t<!ENTITY EXPDIR "{base['EXPDIR']}">\n''')
+    strings.append(f'''\t<!ENTITY ROTDIR "{base['ROTDIR']}">\n''')
     strings.append('\n')
     strings.append('\t<!-- Directories for driving the workflow -->\n')
-    strings.append('\t<!ENTITY HOMEgfs  "%s">\n' % base['HOMEgfs'])
-    strings.append('\t<!ENTITY JOBS_DIR "%s">\n' % base['BASE_JOB'])
-    strings.append('\t<!ENTITY DMPDIR   "%s">\n' % base['DMPDIR'])
+    strings.append(f'''\t<!ENTITY HOMEgfs  "{base['HOMEgfs']}">\n''')
+    strings.append(f'''\t<!ENTITY JOBS_DIR "{base['BASE_JOB']}">\n''')
+    strings.append(f'''\t<!ENTITY DMPDIR   "{base['DMPDIR']}">\n''')
     strings.append('\n')
     strings.append('\t<!-- Machine related entities -->\n')
-    strings.append('\t<!ENTITY ACCOUNT    "%s">\n' % base['ACCOUNT'])
+    strings.append(f'''\t<!ENTITY ACCOUNT    "{base['ACCOUNT']}">\n''')
 
-    strings.append('\t<!ENTITY QUEUE      "%s">\n' % base['QUEUE'])
-    strings.append('\t<!ENTITY QUEUE_SERVICE "%s">\n' % base['QUEUE_SERVICE'])
+    strings.append(f'''\t<!ENTITY QUEUE      "{base['QUEUE']}">\n''')
+    strings.append(f'''\t<!ENTITY QUEUE_SERVICE "{base['QUEUE_SERVICE']}">\n''')
     if scheduler in ['slurm'] and machine in ['ORION']:
-        strings.append('\t<!ENTITY PARTITION_BATCH "%s">\n' % base['PARTITION_BATCH'])
+        strings.append(f'''\t<!ENTITY PARTITION_BATCH "{base['PARTITION_BATCH']}">\n''')
     if scheduler in ['slurm']:
-        strings.append('\t<!ENTITY PARTITION_SERVICE "%s">\n' % base['QUEUE_SERVICE'])
-    strings.append('\t<!ENTITY SCHEDULER  "%s">\n' % scheduler)
+        strings.append(f'''\t<!ENTITY PARTITION_SERVICE "{base['QUEUE_SERVICE']}">\n''')
+    strings.append(f'\t<!ENTITY SCHEDULER  "{scheduler}">\n')
     strings.append('\n')
     strings.append('\t<!-- Toggle HPSS archiving -->\n')
-    strings.append('\t<!ENTITY ARCHIVE_TO_HPSS "YES">\n')
+    strings.append(f'''\t<!ENTITY ARCHIVE_TO_HPSS "{base['HPSSARCH']}">\n''')
     strings.append('\n')
     strings.append('\t<!-- ROCOTO parameters that control workflow -->\n')
     strings.append('\t<!ENTITY CYCLETHROTTLE "3">\n')
@@ -218,9 +219,9 @@ def get_gfs_dates(base):
 
     strings.append('\n')
     strings.append('\t<!-- Starting and ending dates for GFS cycle -->\n')
-    strings.append('\t<!ENTITY SDATE_GFS    "%s">\n' % base['SDATE_GFS'].strftime('%Y%m%d%H%M'))
-    strings.append('\t<!ENTITY EDATE_GFS    "%s">\n' % base['EDATE_GFS'].strftime('%Y%m%d%H%M'))
-    strings.append('\t<!ENTITY INTERVAL_GFS "%s">\n' % base['INTERVAL_GFS'])
+    strings.append(f'''\t<!ENTITY SDATE_GFS    "{base['SDATE_GFS'].strftime('%Y%m%d%H%M')}">\n''')
+    strings.append(f'''\t<!ENTITY EDATE_GFS    "{base['EDATE_GFS'].strftime('%Y%m%d%H%M')}">\n''')
+    strings.append(f'''\t<!ENTITY INTERVAL_GFS "{base['INTERVAL_GFS']}">\n''')
 
     return ''.join(strings)
 
@@ -251,11 +252,13 @@ def get_gdasgfs_resources(dict_configs, cdump='gdas'):
     if cdump in ['gdas'] and do_gldas in ['Y', 'YES']:
         tasks += ['gldas']
     if cdump in ['gdas'] and do_wave in ['Y', 'YES'] and do_wave_cdump in ['GDAS', 'BOTH']:
+        #tasks += ['waveinit', 'waveprep', 'wavepostsbs', 'wavepostbndpnt', 'wavepostpnt', 'wavestat']
         tasks += ['waveinit', 'waveprep', 'wavepostsbs', 'wavepostbndpnt', 'wavepostbndpntbll', 'wavepostpnt']
 
     tasks += ['fcst', 'post', 'vrfy', 'arch']
 
     if cdump in ['gfs'] and do_wave in ['Y', 'YES'] and do_wave_cdump in ['GFS', 'BOTH']:
+        #tasks += ['waveinit', 'waveprep', 'wavepostsbs', 'wavepostbndpnt', 'wavepostpnt', 'wavestat']
         tasks += ['waveinit', 'waveprep', 'wavepostsbs', 'wavepostbndpnt', 'wavepostbndpntbll', 'wavepostpnt']
     if cdump in ['gfs'] and do_bufrsnd in ['Y', 'YES']:
         tasks += ['postsnd']
@@ -271,7 +274,7 @@ def get_gdasgfs_resources(dict_configs, cdump='gdas'):
         tasks += ['metp']
     if cdump in ['gfs'] and do_wave in ['Y', 'YES'] and do_awips in ['Y', 'YES']:
         tasks += ['waveawipsbulls', 'waveawipsgridded']
- 
+
     dict_resources = OrderedDict()
 
     for task in tasks:
@@ -279,21 +282,21 @@ def get_gdasgfs_resources(dict_configs, cdump='gdas'):
         cfg = dict_configs[task]
 
         wtimestr, resstr, queuestr, memstr, natstr = wfu.get_resources(machine, cfg, task, reservation, cdump=cdump)
-        taskstr = '%s_%s' % (task.upper(), cdump.upper())
+        taskstr = f'{task.upper()}_{cdump.upper()}'
 
         strings = []
-        strings.append('\t<!ENTITY QUEUE_%s     "%s">\n' % (taskstr, queuestr))
+        strings.append(f'\t<!ENTITY QUEUE_{taskstr}     "{queuestr}">\n')
         if scheduler in ['slurm'] and machine in ['ORION'] and task not in ['arch']:
-            strings.append('\t<!ENTITY PARTITION_%s "&PARTITION_BATCH;">\n' % taskstr )
+            strings.append(f'\t<!ENTITY PARTITION_{taskstr} "&PARTITION_BATCH;">\n')
         if scheduler in ['slurm'] and task in ['arch']:
-            strings.append('\t<!ENTITY PARTITION_%s "&PARTITION_SERVICE;">\n' % taskstr )
-        strings.append('\t<!ENTITY WALLTIME_%s  "%s">\n' % (taskstr, wtimestr))
-        strings.append('\t<!ENTITY RESOURCES_%s "%s">\n' % (taskstr, resstr))
+            strings.append(f'\t<!ENTITY PARTITION_{taskstr} "&PARTITION_SERVICE;">\n')
+        strings.append(f'\t<!ENTITY WALLTIME_{taskstr}  "{wtimestr}">\n')
+        strings.append(f'\t<!ENTITY RESOURCES_{taskstr} "{resstr}">\n')
         if len(memstr) != 0:
-            strings.append('\t<!ENTITY MEMORY_%s    "%s">\n' % (taskstr, memstr))
-        strings.append('\t<!ENTITY NATIVE_%s    "%s">\n' % (taskstr, natstr))
+            strings.append(f'\t<!ENTITY MEMORY_{taskstr}    "{memstr}">\n')
+        strings.append(f'\t<!ENTITY NATIVE_{taskstr}    "{natstr}">\n')
 
-        dict_resources['%s%s' % (cdump, task)] = ''.join(strings)
+        dict_resources[f'{cdump}{task}'] = ''.join(strings)
 
     return dict_resources
 
@@ -332,18 +335,18 @@ def get_hyb_resources(dict_configs):
 
             wtimestr, resstr, queuestr, memstr, natstr = wfu.get_resources(machine, cfg, task, reservation, cdump=cdump)
 
-            taskstr = '%s_%s' % (task.upper(), cdump.upper())
+            taskstr = f'{task.upper()}_{cdump.upper()}'
 
             strings = []
 
-            strings.append('\t<!ENTITY QUEUE_%s     "%s">\n' % (taskstr, queuestr))
-            strings.append('\t<!ENTITY WALLTIME_%s  "%s">\n' % (taskstr, wtimestr))
-            strings.append('\t<!ENTITY RESOURCES_%s "%s">\n' % (taskstr, resstr))
+            strings.append(f'\t<!ENTITY QUEUE_{taskstr}     "{queuestr}">\n')
+            strings.append(f'\t<!ENTITY WALLTIME_{taskstr}  "{wtimestr}">\n')
+            strings.append(f'\t<!ENTITY RESOURCES_{taskstr} "{resstr}">\n')
             if len(memstr) != 0:
-                strings.append('\t<!ENTITY MEMORY_%s    "%s">\n' % (taskstr, memstr))
-            strings.append('\t<!ENTITY NATIVE_%s    "%s">\n' % (taskstr, natstr))
+                strings.appendf(f'\t<!ENTITY MEMORY_{taskstr}    "{memstr}">\n')
+            strings.append(f'\t<!ENTITY NATIVE_{taskstr}    "{natstr}">\n')
 
-            dict_resources['%s%s' % (cdump, task)] = ''.join(strings)
+            dict_resources[f'{cdump}{task}'] = ''.join(strings)
 
 
     # These tasks are always run as part of the GDAS cycle
@@ -355,21 +358,21 @@ def get_hyb_resources(dict_configs):
 
         wtimestr, resstr, queuestr, memstr, natstr = wfu.get_resources(machine, cfg, task, reservation, cdump=cdump)
 
-        taskstr = '%s_%s' % (task.upper(), cdump.upper())
+        taskstr = f'{task.upper()}_{cdump.upper()}'
 
         strings = []
-        strings.append('\t<!ENTITY QUEUE_%s     "%s">\n' % (taskstr, queuestr))
+        strings.append(f'\t<!ENTITY QUEUE_{taskstr}     "{queuestr}">\n')
         if scheduler in ['slurm'] and machine in ['ORION'] and task not in ['earc']:
-            strings.append('\t<!ENTITY PARTITION_%s "&PARTITION_BATCH;">\n' % taskstr )
+            strings.append(f'\t<!ENTITY PARTITION_{taskstr} "&PARTITION_BATCH;">\n')
         if scheduler in ['slurm'] and task in ['earc']:
-            strings.append('\t<!ENTITY PARTITION_%s "&PARTITION_SERVICE;">\n' % taskstr )
-        strings.append('\t<!ENTITY WALLTIME_%s  "%s">\n' % (taskstr, wtimestr))
-        strings.append('\t<!ENTITY RESOURCES_%s "%s">\n' % (taskstr, resstr))
+            strings.append(f'\t<!ENTITY PARTITION_{taskstr} "&PARTITION_SERVICE;">\n')
+        strings.append(f'\t<!ENTITY WALLTIME_{taskstr}  "{wtimestr}">\n')
+        strings.append(f'\t<!ENTITY RESOURCES_{taskstr} "{resstr}">\n')
         if len(memstr) != 0:
-            strings.append('\t<!ENTITY MEMORY_%s    "%s">\n' % (taskstr, memstr))
-        strings.append('\t<!ENTITY NATIVE_%s    "%s">\n' % (taskstr, natstr))
+            strings.append(f'\t<!ENTITY MEMORY_{taskstr}    "{memstr}">\n')
+        strings.append(f'\t<!ENTITY NATIVE_{taskstr}    "{natstr}">\n')
 
-        dict_resources['%s%s' % (cdump, task)] = ''.join(strings)
+        dict_resources[f'{cdump}{task}'] = ''.join(strings)
 
     return dict_resources
 
@@ -386,7 +389,7 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
     envars.append(rocoto.create_envar(name='HOMEgfs', value='&HOMEgfs;'))
     envars.append(rocoto.create_envar(name='EXPDIR', value='&EXPDIR;'))
     envars.append(rocoto.create_envar(name='CDATE', value='<cyclestr>@Y@m@d@H</cyclestr>'))
-    envars.append(rocoto.create_envar(name='CDUMP', value='%s' % cdump))
+    envars.append(rocoto.create_envar(name='CDUMP', value=f'{cdump}'))
     envars.append(rocoto.create_envar(name='PDY', value='<cyclestr>@Y@m@d</cyclestr>'))
     envars.append(rocoto.create_envar(name='cyc', value='<cyclestr>@H</cyclestr>'))
 
@@ -410,12 +413,12 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
 
     # prep
     deps = []
-    dep_dict = {'type': 'metatask', 'name': '%spost' % 'gdas', 'offset': '-06:00:00'}
+    dep_dict = {'type': 'metatask', 'name': f'{"gdas"}post', 'offset': '-06:00:00'}
     deps.append(rocoto.add_dependency(dep_dict))
-    data = '&ROTDIR;/gdas.@Y@m@d/@H/atmos/gdas.t@Hz.atmf009%s' % (gridsuffix)
+    data = f'&ROTDIR;/gdas.@Y@m@d/@H/atmos/gdas.t@Hz.atmf009{gridsuffix}'
     dep_dict = {'type': 'data', 'data': data, 'offset': '-06:00:00'}
     deps.append(rocoto.add_dependency(dep_dict))
-    data = '&DMPDIR;/%s%s.@Y@m@d/@H/%s.t@Hz.updated.status.tm00.bufr_d' % (cdump, dumpsuffix, cdump)
+    data = f'&DMPDIR;/{cdump}{dumpsuffix}.@Y@m@d/@H/{cdump}.t@Hz.updated.status.tm00.bufr_d'
     dep_dict = {'type': 'data', 'data': data}
     deps.append(rocoto.add_dependency(dep_dict))
     dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
@@ -431,7 +434,7 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
     else:
         task = wfu.create_wf_task('prep', cdump=cdump, envar=envars, dependency=dependencies)
 
-    dict_tasks['%sprep' % cdump] = task
+    dict_tasks[f'{cdump}prep'] = task
 
     # wave tasks in gdas or gfs or both
     if do_wave_cdump in ['BOTH']:
@@ -444,61 +447,61 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
     # waveinit
     if do_wave in ['Y', 'YES'] and cdump in cdumps:
         deps = []
-        dep_dict = {'type': 'task', 'name': '%sprep' % cdump}
+        dep_dict = {'type': 'task', 'name': '{cdump}prep'}
         deps.append(rocoto.add_dependency(dep_dict))
         dep_dict = {'type': 'cycleexist', 'condition': 'not', 'offset': '-06:00:00'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='or', dep=deps)
         task = wfu.create_wf_task('waveinit', cdump=cdump, envar=envars, dependency=dependencies)
-        dict_tasks['%swaveinit' % cdump] = task
+        dict_tasks['{cdump}waveinit'] = task
 
     # waveprep
     if do_wave in ['Y', 'YES'] and cdump in cdumps:
         deps = []
-        dep_dict = {'type': 'task', 'name': '%swaveinit' % cdump}
+        dep_dict = {'type': 'task', 'name': '{cdump}waveinit'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('waveprep', cdump=cdump, envar=envars, dependency=dependencies)
-        dict_tasks['%swaveprep' % cdump] = task
+        dict_tasks['{cdump}waveprep'] = task
 
     # anal
     deps = []
-    dep_dict = {'type': 'task', 'name': '%sprep' % cdump}
+    dep_dict = {'type': 'task', 'name': f'{cdump}prep'}
     deps.append(rocoto.add_dependency(dep_dict))
     if dohybvar in ['y', 'Y', 'yes', 'YES']:
-        dep_dict = {'type': 'metatask', 'name': '%sepmn' % 'gdas', 'offset': '-06:00:00'}
+        dep_dict = {'type': 'metatask', 'name': f'{"gdas"}epmn', 'offset': '-06:00:00'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
     else:
         dependencies = rocoto.create_dependency(dep=deps)
     task = wfu.create_wf_task('anal', cdump=cdump, envar=envars, dependency=dependencies)
 
-    dict_tasks['%sanal' % cdump] = task
+    dict_tasks[f'{cdump}anal'] = task
 
     # analcalc
     deps1 = []
-    data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.loginc.txt' % (cdump, cdump)
+    data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.loginc.txt'
     dep_dict = {'type': 'data', 'data': data}
     deps1.append(rocoto.add_dependency(dep_dict))
-    dep_dict = {'type': 'task', 'name': '%sanal' % cdump}
+    dep_dict = {'type': 'task', 'name': f'{cdump}anal'}
     deps.append(rocoto.add_dependency(dep_dict))
     if dohybvar in ['y', 'Y', 'yes', 'YES'] and cdump == 'gdas':
-        dep_dict = {'type': 'task', 'name': '%sechgres' % 'gdas', 'offset': '-06:00:00'}
+        dep_dict = {'type': 'task', 'name': f'{"gdas"}echgres', 'offset': '-06:00:00'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
     else:
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
     task = wfu.create_wf_task('analcalc', cdump=cdump, envar=envars, dependency=dependencies)
 
-    dict_tasks['%sanalcalc' % cdump] = task
+    dict_tasks[f'{cdump}analcalc'] = task
 
     # analdiag
     if cdump in ['gdas']:
         deps1 = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.loginc.txt' % (cdump, cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.loginc.txt'
         dep_dict = {'type': 'data', 'data': data}
         deps1.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'task', 'name': '%sanal' % cdump}
+        dep_dict = {'type': 'task', 'name': f'{cdump}anal'}
         deps1.append(rocoto.add_dependency(dep_dict))
         dependencies1 = rocoto.create_dependency(dep_condition='or', dep=deps1)
 
@@ -510,15 +513,15 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
 
         task = wfu.create_wf_task('analdiag', cdump=cdump, envar=envars, dependency=dependencies2)
 
-        dict_tasks['%sanaldiag' % cdump] = task
+        dict_tasks[f'{cdump}analdiag'] = task
 
     # gldas
     if cdump in ['gdas'] and do_gldas in ['Y', 'YES']:
         deps1 = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.loginc.txt' % (cdump, cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.loginc.txt'
         dep_dict = {'type': 'data', 'data': data}
         deps1.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'task', 'name': '%sanal' % cdump}
+        dep_dict = {'type': 'task', 'name': f'{cdump}anal'}
         deps1.append(rocoto.add_dependency(dep_dict))
         dependencies1 = rocoto.create_dependency(dep_condition='or', dep=deps1)
 
@@ -529,45 +532,45 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
         dependencies2 = rocoto.create_dependency(dep_condition='and', dep=deps2)
 
         task = wfu.create_wf_task('gldas', cdump=cdump, envar=envars, dependency=dependencies2)
-        dict_tasks['%sgldas' % cdump] = task
+        dict_tasks[f'{cdump}gldas'] = task
 
     # fcst
     deps1 = []
-    #data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.loginc.txt' % (cdump, cdump)
+    #data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.loginc.txt'
     #dep_dict = {'type': 'data', 'data': data}
     #deps1.append(rocoto.add_dependency(dep_dict))
     if cdump in ['gdas']:
         dep_dict = {'type': 'cycleexist', 'condition': 'not', 'offset': '-06:00:00'}
         deps1.append(rocoto.add_dependency(dep_dict))
         if do_gldas in ['Y', 'YES']:
-            dep_dict = {'type': 'task', 'name': '%sgldas' % cdump}
+            dep_dict = {'type': 'task', 'name': f'{cdump}gldas'}
             deps1.append(rocoto.add_dependency(dep_dict))
         else:
-            dep_dict = {'type': 'task', 'name': '%sanalcalc' % cdump}
+            dep_dict = {'type': 'task', 'name': f'{cdump}analcalc'}
             deps1.append(rocoto.add_dependency(dep_dict))
     elif cdump in ['gfs']:
-        dep_dict = {'type': 'task', 'name': '%sanal' % cdump}
+        dep_dict = {'type': 'task', 'name': f'{cdump}anal'}
         deps1.append(rocoto.add_dependency(dep_dict))
     dependencies1 = rocoto.create_dependency(dep_condition='or', dep=deps1)
 
     if do_wave in ['Y', 'YES'] and cdump in cdumps:
         deps2 = []
         deps2 = dependencies1
-        dep_dict = {'type': 'task', 'name': '%swaveprep' % cdump}
+        dep_dict = {'type': 'task', 'name': f'{cdump}waveprep'}
         deps2.append(rocoto.add_dependency(dep_dict))
         dependencies2 = rocoto.create_dependency(dep_condition='and', dep=deps2)
         task = wfu.create_wf_task('fcst', cdump=cdump, envar=envars, dependency=dependencies2)
     else:
         task = wfu.create_wf_task('fcst', cdump=cdump, envar=envars, dependency=dependencies1)
 
-    dict_tasks['%sfcst' % cdump] = task
+    dict_tasks[f'{cdump}fcst'] = task
 
     # post
     deps = []
-    data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.log#dep#.txt' % (cdump, cdump)
+    data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.log#dep#.txt'
     dep_dict = {'type': 'data', 'data': data}
     deps.append(rocoto.add_dependency(dep_dict))
-    dep_dict = {'type': 'task', 'name': '%sfcst' % cdump}
+    dep_dict = {'type': 'task', 'name': f'{cdump}fcst'}
     deps.append(rocoto.add_dependency(dep_dict))
     dependencies = rocoto.create_dependency(dep_condition='or', dep=deps)
     fhrgrp = rocoto.create_envar(name='FHRGRP', value='#grp#')
@@ -580,92 +583,92 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
     task = wfu.create_wf_task('post', cdump=cdump, envar=postenvars, dependency=dependencies,
                               metatask='post', varname=varname1, varval=varval1, vardict=vardict)
 
-    dict_tasks['%spost' % cdump] = task
+    dict_tasks[f'{cdump}post'] = task
 
     # wavepostsbs
     if do_wave in ['Y', 'YES'] and cdump in cdumps:
         deps = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/wave/rundata/%swave.out_grd.gnh_10m.@Y@m@d.@H0000' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/wave/rundata/{cdump}wave.out_grd.gnh_10m.@Y@m@d.@H0000'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/wave/rundata/%swave.out_grd.aoc_9km.@Y@m@d.@H0000' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/wave/rundata/{cdump}wave.out_grd.aoc_9km.@Y@m@d.@H0000'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/wave/rundata/%swave.out_grd.gsh_15m.@Y@m@d.@H0000' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/wave/rundata/{cdump}wave.out_grd.gsh_15m.@Y@m@d.@H0000'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         task = wfu.create_wf_task('wavepostsbs', cdump=cdump, envar=envars, dependency=dependencies)
-        dict_tasks['%swavepostsbs' % cdump] = task
+        dict_tasks[f'{cdump}wavepostsbs'] = task
 
     # wavepostbndpnt
     if do_wave in ['Y', 'YES'] and cdump in ['gfs']:
         deps = []
-        dep_dict = {'type':'task', 'name':'%sfcst' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('wavepostbndpnt', cdump=cdump, envar=envars, dependency=dependencies)
-        dict_tasks['%swavepostbndpnt' % cdump] = task
+        dict_tasks[f'{cdump}wavepostbndpnt'] = task
 
     # wavepostbndpntbll
     if do_wave in ['Y', 'YES'] and cdump in ['gfs']:
         deps = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.logf180.txt' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.logf180.txt'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type':'task', 'name':'%swavepostbndpnt' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}wavepostbndpnt'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         task = wfu.create_wf_task('wavepostbndpntbll', cdump=cdump, envar=envars, dependency=dependencies)
-        dict_tasks['%swavepostbndpntbll' % cdump] = task
+        dict_tasks[f'{cdump}wavepostbndpntbll'] = task
 
     # wavepostpnt
     if do_wave in ['Y', 'YES'] and cdump in ['gdas']:
         deps = []
-        dep_dict = {'type':'task', 'name':'%sfcst' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('wavepostpnt', cdump=cdump, envar=envars, dependency=dependencies)
-        dict_tasks['%swavepostpnt' % cdump] = task
+        dict_tasks[f'{cdump}wavepostpnt'] = task
 
     if do_wave in ['Y', 'YES'] and cdump in ['gfs']:
         deps = []
-        dep_dict = {'type':'task', 'name':'%sfcst' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type':'task', 'name':'%swavepostbndpntbll' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}wavepostbndpntbll'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         task = wfu.create_wf_task('wavepostpnt', cdump=cdump, envar=envars, dependency=dependencies)
-        dict_tasks['%swavepostpnt' % cdump] = task
+        dict_tasks[f'{cdump}wavepostpnt'] = task
 
     # wavegempak
     if do_wave in ['Y', 'YES'] and do_gempak in ['Y', 'YES'] and cdump in ['gfs']:
         deps = []
-        dep_dict = {'type':'task', 'name':'%swavepostsbs' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}wavepostsbs'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('wavegempak', cdump=cdump, envar=envars, dependency=dependencies)
-        dict_tasks['%swavegempak' % cdump] = task
+        dict_tasks[f'{cdump}wavegempak'] = task
 
     # waveawipsgridded
     if do_wave in ['Y', 'YES'] and do_awips in ['Y', 'YES'] and cdump in ['gfs']:
         deps = []
-        dep_dict = {'type':'task', 'name':'%swavepostsbs' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}wavepostsbs'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('waveawipsgridded', cdump=cdump, envar=envars, dependency=dependencies)
-        dict_tasks['%swaveawipsgridded' % cdump] = task
+        dict_tasks[f'{cdump}waveawipsgridded'] = task
 
     # waveawipsbulls
     if do_wave in ['Y', 'YES'] and do_awips in ['Y', 'YES'] and cdump in ['gfs']:
         deps = []
-        dep_dict = {'type':'task', 'name':'%swavepostsbs' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}wavepostsbs'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type':'task', 'name':'%swavepostpnt' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}wavepostpnt'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         task = wfu.create_wf_task('waveawipsbulls', cdump=cdump, envar=envars, dependency=dependencies)
-        dict_tasks['%swaveawipsbulls' % cdump] = task
+        dict_tasks[f'{cdump}waveawipsbulls'] = task
 
     # wavestat
     #if do_wave in ['Y', 'YES'] and cdump in cdumps:
@@ -678,43 +681,44 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
 
     # vrfy
     deps = []
-    dep_dict = {'type': 'metatask', 'name': '%spost' % cdump}
+    dep_dict = {'type': 'metatask', 'name': f'{cdump}post'}
     deps.append(rocoto.add_dependency(dep_dict))
     dependencies = rocoto.create_dependency(dep=deps)
     task = wfu.create_wf_task('vrfy', cdump=cdump, envar=envars, dependency=dependencies)
 
-    dict_tasks['%svrfy' % cdump] = task
+    dict_tasks[f'{cdump}vrfy'] = task
 
     # metp
     if cdump in ['gfs'] and do_metp in ['Y', 'YES']:
         deps = []
-        dep_dict = {'type':'metatask', 'name':'%spost' % cdump}
+        dep_dict = {'type':'metatask', 'name':f'{cdump}post'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type':'task', 'name':'%sarch' % cdump, 'offset':'-&INTERVAL_GFS;'}
+        dep_dict = {'type':'task', 'name':f'{cdump}arch', 'offset':'-&INTERVAL_GFS;'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
+        sdate_gfs = rocoto.create_envar(name='SDATE_GFS', value='&SDATE_GFS;')
         metpcase = rocoto.create_envar(name='METPCASE', value='#metpcase#')
-        metpenvars = envars + [metpcase]
+        metpenvars = envars + [sdate_gfs] + [metpcase]
         varname1 = 'metpcase'
         varval1 = 'g2g1 g2o1 pcp1'
         task = wfu.create_wf_task('metp', cdump=cdump, envar=metpenvars, dependency=dependencies,
                                    metatask='metp', varname=varname1, varval=varval1)
-        dict_tasks['%smetp' % cdump] = task
+        dict_tasks[f'{cdump}metp'] = task
 
     #postsnd
     if cdump in ['gfs'] and do_bufrsnd in ['Y', 'YES']:
         deps = []
-        dep_dict = {'type': 'task', 'name': '%sfcst' % cdump}
+        dep_dict = {'type': 'task', 'name': f'{cdump}fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('postsnd', cdump=cdump, envar=envars, dependency=dependencies)
 
-        dict_tasks['%spostsnd' % cdump] = task
+        dict_tasks[f'{cdump}postsnd'] = task
 
     # awips
     if cdump in ['gfs'] and do_awips in ['Y', 'YES']:
         deps = []
-        dep_dict = {'type': 'metatask', 'name': '%spost' % cdump}
+        dep_dict = {'type': 'metatask', 'name': f'{cdump}post'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         fhrgrp = rocoto.create_envar(name='FHRGRP', value='#grp#')
@@ -727,208 +731,206 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
         task = wfu.create_wf_task('awips', cdump=cdump, envar=awipsenvars, dependency=dependencies,
                                   metatask='awips', varname=varname1, varval=varval1, vardict=vardict)
 
-        dict_tasks['%sawips' % cdump] = task
+        dict_tasks[f'{cdump}awips'] = task
 
     # gempak
     if cdump in ['gfs'] and do_gempak in ['Y', 'YES']:
         deps = []
-        dep_dict = {'type': 'metatask', 'name': '%spost' % cdump}
+        dep_dict = {'type': 'metatask', 'name': f'{cdump}post'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('gempak', cdump=cdump, envar=envars, dependency=dependencies)
 
-        dict_tasks['%sgempak' % cdump] = task
+        dict_tasks[f'{cdump}gempak'] = task
 
     # wafs
     if cdump in ['gfs'] and do_wafs in ['Y', 'YES']:
         deps = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if006' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if006'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if012' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if012'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if015' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if015'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if018' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if018'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if021' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if021'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if024' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if024'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if027' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if027'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if030' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if030'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if033' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if033'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if036' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if036'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         task = wfu.create_wf_task('wafs', cdump=cdump, envar=envars, dependency=dependencies)
 
-        dict_tasks['%swafs' % cdump] = task
+        dict_tasks[f'{cdump}wafs'] = task
 
     # wafsgcip
     if cdump in ['gfs'] and do_wafs in ['Y', 'YES']:
         deps = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if006' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if006'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if012' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if012'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if015' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if015'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if018' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if018'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if021' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if021'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if024' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if024'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if027' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if027'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if030' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if030'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if033' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if033'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if036' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if036'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         task = wfu.create_wf_task('wafsgcip', cdump=cdump, envar=envars, dependency=dependencies)
 
-        dict_tasks['%swafsgcip' % cdump] = task
+        dict_tasks[f'{cdump}wafsgcip'] = task
 
     # wafsgrib2
     if cdump in ['gfs'] and do_wafs in ['Y', 'YES']:
         deps = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if006' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if006'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if012' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if012'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if015' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if015'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if018' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if018'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if021' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if021'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if024' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if024'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if027' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if027'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if030' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if030'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if033' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if033'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if036' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if036'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         task = wfu.create_wf_task('wafsgrib2', cdump=cdump, envar=envars, dependency=dependencies)
 
-        dict_tasks['%swafsgrib2' % cdump] = task
+        dict_tasks[f'{cdump}wafsgrib2'] = task
 
     # wafsgrib20p25
     if cdump in ['gfs'] and do_wafs in ['Y', 'YES']:
         deps = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if006' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if006'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if012' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if012'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if015' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if015'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if018' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if018'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if021' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if021'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if024' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if024'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if027' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if027'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if030' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if030'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if033' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if033'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if036' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if036'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         task = wfu.create_wf_task('wafsgrib20p25', cdump=cdump, envar=envars, dependency=dependencies)
 
-        dict_tasks['%swafsgrib20p25' % cdump] = task
+        dict_tasks[f'{cdump}wafsgrib20p25'] = task
 
     # wafsblending
     if cdump in ['gfs'] and do_wafs in ['Y', 'YES']:
         deps = []
-        dep_dict = {'type': 'task', 'name': '%swafsgrib2' % cdump}
+        dep_dict = {'type': 'task', 'name': f'{cdump}wafsgrib2'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('wafsblending', cdump=cdump, envar=envars, dependency=dependencies)
 
-        dict_tasks['%swafsblending' % cdump] = task
+        dict_tasks[f'{cdump}wafsblending'] = task
 
     # wafsblending0p25
     if cdump in ['gfs'] and do_wafs in ['Y', 'YES']:
         deps = []
-        dep_dict = {'type': 'task', 'name': '%swafsgrib20p25' % cdump}
+        dep_dict = {'type': 'task', 'name': f'{cdump}wafsgrib20p25'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('wafsblending0p25', cdump=cdump, envar=envars, dependency=dependencies)
 
-        dict_tasks['%swafsblending0p25' % cdump] = task
+        dict_tasks[f'{cdump}wafsblending0p25'] = task
 
     # arch
     deps = []
-    dep_dict = {'type': 'task', 'name': '%svrfy' % cdump}
-    deps.append(rocoto.add_dependency(dep_dict))
-    dep_dict = {'type': 'streq', 'left': '&ARCHIVE_TO_HPSS;', 'right': 'YES'}
+    dep_dict = {'type': 'task', 'name': f'{cdump}vrfy'}
     deps.append(rocoto.add_dependency(dep_dict))
     if do_wave in ['Y', 'YES']:
-      dep_dict = {'type': 'task', 'name': '%swavepostsbs' % cdump}
+      dep_dict = {'type': 'task', 'name': f'{cdump}wavepostsbs'}
       deps.append(rocoto.add_dependency(dep_dict))
-      dep_dict = {'type': 'task', 'name': '%swavepostpnt' % cdump}
+      dep_dict = {'type': 'task', 'name': f'{cdump}wavepostpnt'}
       deps.append(rocoto.add_dependency(dep_dict))
       if cdump in ['gfs']:
-        dep_dict = {'type': 'task', 'name': '%swavepostbndpnt' % cdump}
+        dep_dict = {'type': 'task', 'name': f'{cdump}wavepostbndpnt'}
         deps.append(rocoto.add_dependency(dep_dict))
     dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
     task = wfu.create_wf_task('arch', cdump=cdump, envar=envars, dependency=dependencies)
 
-    dict_tasks['%sarch' % cdump] = task
+    dict_tasks[f'{cdump}arch'] = task
 
     return dict_tasks
 
@@ -947,17 +949,17 @@ def get_hyb_tasks(dict_configs, cycledef='enkf'):
     eobs = dict_configs['eobs']
     nens_eomg = eobs['NMEM_EOMGGRP']
     neomg_grps = nens / nens_eomg
-    EOMGGROUPS = ' '.join(['%02d' % x for x in range(1, neomg_grps + 1)])
+    EOMGGROUPS = ' '.join([f'{x:02d}' for x in range(1, int(neomg_grps) + 1)])
 
     efcs = dict_configs['efcs']
     nens_efcs = efcs['NMEM_EFCSGRP']
     nefcs_grps = nens / nens_efcs
-    EFCSGROUPS = ' '.join(['%02d' % x for x in range(1, nefcs_grps + 1)])
+    EFCSGROUPS = ' '.join([f'{x:02d}' for x in range(1, int(nefcs_grps) + 1)])
 
     earc = dict_configs['earc']
     nens_earc = earc['NMEM_EARCGRP']
     nearc_grps = nens / nens_earc
-    EARCGROUPS = ' '.join(['%02d' % x for x in range(0, nearc_grps + 1)])
+    EARCGROUPS = ' '.join([f'{x:02d}' for x in range(0, int(nearc_grps) + 1)])
 
     envars = []
     if wfu.get_scheduler(wfu.detectMachine()) in ['slurm']:
@@ -966,7 +968,7 @@ def get_hyb_tasks(dict_configs, cycledef='enkf'):
     envars.append(rocoto.create_envar(name='HOMEgfs', value='&HOMEgfs;'))
     envars.append(rocoto.create_envar(name='EXPDIR', value='&EXPDIR;'))
     envars.append(rocoto.create_envar(name='CDATE', value='<cyclestr>@Y@m@d@H</cyclestr>'))
-    #envars.append(rocoto.create_envar(name='CDUMP', value='%s' % cdump))
+    #envars.append(rocoto.create_envar(name='CDUMP', value=f'{cdump}'))
     envars.append(rocoto.create_envar(name='PDY', value='<cyclestr>@Y@m@d</cyclestr>'))
     envars.append(rocoto.create_envar(name='cyc', value='<cyclestr>@H</cyclestr>'))
 
@@ -983,72 +985,72 @@ def get_hyb_tasks(dict_configs, cycledef='enkf'):
 
     for cdump in cdumps:
 
-        envar_cdump = rocoto.create_envar(name='CDUMP', value='%s' % cdump)
+        envar_cdump = rocoto.create_envar(name='CDUMP', value=f'{cdump}')
         envars1 = envars + [envar_cdump]
 
         # eobs
         deps = []
-        dep_dict = {'type': 'task', 'name': '%sprep' % cdump}
+        dep_dict = {'type': 'task', 'name': f'{cdump}prep'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'metatask', 'name': '%sepmn' % 'gdas', 'offset': '-06:00:00'}
+        dep_dict = {'type': 'metatask', 'name': f'{"gdas"}epmn', 'offset': '-06:00:00'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         task = wfu.create_wf_task('eobs', cdump=cdump, envar=envars1, dependency=dependencies, cycledef=cycledef)
 
-        dict_tasks['%seobs' % cdump] = task
+        dict_tasks[f'{cdump}eobs'] = task
 
         # eomn, eomg
         if lobsdiag_forenkf in ['.F.', '.FALSE.']:
             deps = []
-            dep_dict = {'type': 'task', 'name': '%seobs' % cdump}
+            dep_dict = {'type': 'task', 'name': f'{cdump}eobs'}
             deps.append(rocoto.add_dependency(dep_dict))
             dependencies = rocoto.create_dependency(dep=deps)
             eomgenvars= envars1 + [ensgrp]
             task = wfu.create_wf_task('eomg', cdump=cdump, envar=eomgenvars, dependency=dependencies,
                                       metatask='eomn', varname='grp', varval=EOMGGROUPS, cycledef=cycledef)
 
-            dict_tasks['%seomn' % cdump] = task
+            dict_tasks[f'{cdump}eomn'] = task
 
         # ediag
         else:
             deps = []
-            dep_dict = {'type': 'task', 'name': '%seobs' % cdump}
+            dep_dict = {'type': 'task', 'name': f'{cdump}eobs'}
             deps.append(rocoto.add_dependency(dep_dict))
             dependencies = rocoto.create_dependency(dep=deps)
             task = wfu.create_wf_task('ediag', cdump=cdump, envar=envars1, dependency=dependencies, cycledef=cycledef)
 
-            dict_tasks['%sediag' % cdump] = task
+            dict_tasks[f'{cdump}ediag'] = task
 
         # eupd
         deps = []
         if lobsdiag_forenkf in ['.F.', '.FALSE.']:
-            dep_dict = {'type': 'metatask', 'name': '%seomn' % cdump}
+            dep_dict = {'type': 'metatask', 'name': f'{cdump}eomn'}
         else:
-            dep_dict = {'type': 'task', 'name': '%sediag' % cdump}
+            dep_dict = {'type': 'task', 'name': f'{cdump}ediag'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('eupd', cdump=cdump, envar=envars1, dependency=dependencies, cycledef=cycledef)
 
-        dict_tasks['%seupd' % cdump] = task
+        dict_tasks[f'{cdump}eupd'] = task
 
     # All hybrid tasks beyond this point are always executed in the GDAS cycle
     cdump = 'gdas'
-    envar_cdump = rocoto.create_envar(name='CDUMP', value='%s' % cdump)
+    envar_cdump = rocoto.create_envar(name='CDUMP', value=f'{cdump}')
     envars1 = envars + [envar_cdump]
     cdump_eupd = 'gfs' if eupd_cyc in ['GFS'] else 'gdas'
 
     # ecmn, ecen
     deps1 = []
-    data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.loganl.txt' % (cdump, cdump)
+    data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.loganl.txt'
     dep_dict = {'type': 'data', 'data': data}
     deps1.append(rocoto.add_dependency(dep_dict))
-    dep_dict = {'type': 'task', 'name': '%sanalcalc' % cdump}
+    dep_dict = {'type': 'task', 'name': f'{cdump}analcalc'}
     deps1.append(rocoto.add_dependency(dep_dict))
     dependencies1 = rocoto.create_dependency(dep_condition='or', dep=deps1)
 
     deps2 = []
-    deps2 = dependencies1    
-    dep_dict = {'type': 'task', 'name': '%seupd' % cdump_eupd}
+    deps2 = dependencies1
+    dep_dict = {'type': 'task', 'name': f'{cdump_eupd}eupd'}
     deps2.append(rocoto.add_dependency(dep_dict))
     dependencies2 = rocoto.create_dependency(dep_condition='and', dep=deps2)
 
@@ -1061,34 +1063,34 @@ def get_hyb_tasks(dict_configs, cycledef='enkf'):
     task = wfu.create_wf_task('ecen', cdump=cdump, envar=ecenenvars, dependency=dependencies2,
                               metatask='ecmn', varname=varname1, varval=varval1, vardict=vardict)
 
-    dict_tasks['%secmn' % cdump] = task
+    dict_tasks[f'{cdump}ecmn'] = task
 
     # esfc
     deps1 = []
-    data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.loganl.txt' % (cdump, cdump)
+    data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.loganl.txt'
     dep_dict = {'type': 'data', 'data': data}
     deps1.append(rocoto.add_dependency(dep_dict))
-    dep_dict = {'type': 'task', 'name': '%sanalcalc' % cdump}
+    dep_dict = {'type': 'task', 'name': f'{cdump}analcalc'}
     deps1.append(rocoto.add_dependency(dep_dict))
     dependencies1 = rocoto.create_dependency(dep_condition='or', dep=deps1)
 
     deps2 = []
     deps2 = dependencies1
-    dep_dict = {'type': 'task', 'name': '%seupd' % cdump_eupd}
+    dep_dict = {'type': 'task', 'name': f'{cdump_eupd}eupd'}
     deps2.append(rocoto.add_dependency(dep_dict))
     dependencies2 = rocoto.create_dependency(dep_condition='and', dep=deps2)
     task = wfu.create_wf_task('esfc', cdump=cdump, envar=envars1, dependency=dependencies2, cycledef=cycledef)
 
-    dict_tasks['%sesfc' % cdump] = task
+    dict_tasks[f'{cdump}esfc'] = task
 
     # efmn, efcs
     deps1 = []
-    dep_dict = {'type': 'metatask', 'name': '%secmn' % cdump}
+    dep_dict = {'type': 'metatask', 'name': f'{cdump}ecmn'}
     deps1.append(rocoto.add_dependency(dep_dict))
-    dep_dict = {'type': 'task', 'name': '%sesfc' % cdump}
+    dep_dict = {'type': 'task', 'name': f'{cdump}esfc'}
     deps1.append(rocoto.add_dependency(dep_dict))
     dependencies1 = rocoto.create_dependency(dep_condition='and', dep=deps1)
-  
+
     deps2 = []
     deps2 = dependencies1
     dep_dict = {'type': 'cycleexist', 'condition': 'not', 'offset': '-06:00:00'}
@@ -1099,22 +1101,22 @@ def get_hyb_tasks(dict_configs, cycledef='enkf'):
     task = wfu.create_wf_task('efcs', cdump=cdump, envar=efcsenvars, dependency=dependencies2,
                               metatask='efmn', varname='grp', varval=EFCSGROUPS, cycledef=cycledef)
 
-    dict_tasks['%sefmn' % cdump] = task
+    dict_tasks[f'{cdump}efmn'] = task
 
     # echgres
     deps1 = []
-    dep_dict = {'type': 'task', 'name': '%sfcst' % cdump}
+    dep_dict = {'type': 'task', 'name': f'{cdump}fcst'}
     deps1.append(rocoto.add_dependency(dep_dict))
-    dep_dict = {'type': 'metatask', 'name': '%sefmn' % cdump}
+    dep_dict = {'type': 'metatask', 'name': f'{cdump}efmn'}
     deps1.append(rocoto.add_dependency(dep_dict))
     dependencies1 = rocoto.create_dependency(dep_condition='and', dep=deps1)
     task = wfu.create_wf_task('echgres', cdump=cdump, envar=envars1, dependency=dependencies1, cycledef=cycledef)
 
-    dict_tasks['%sechgres' % cdump] = task
+    dict_tasks[f'{cdump}echgres'] = task
 
     # epmn, epos
     deps = []
-    dep_dict = {'type': 'metatask', 'name': '%sefmn' % cdump}
+    dep_dict = {'type': 'metatask', 'name': f'{cdump}efmn'}
     deps.append(rocoto.add_dependency(dep_dict))
     dependencies = rocoto.create_dependency(dep=deps)
     fhrgrp = rocoto.create_envar(name='FHRGRP', value='#grp#')
@@ -1126,18 +1128,18 @@ def get_hyb_tasks(dict_configs, cycledef='enkf'):
     task = wfu.create_wf_task('epos', cdump=cdump, envar=eposenvars, dependency=dependencies,
                               metatask='epmn', varname=varname1, varval=varval1, vardict=vardict)
 
-    dict_tasks['%sepmn' % cdump] = task
+    dict_tasks[f'{cdump}epmn'] = task
 
     # eamn, earc
     deps = []
-    dep_dict = {'type': 'metatask', 'name': '%sepmn' % cdump}
+    dep_dict = {'type': 'metatask', 'name': f'{cdump}epmn'}
     deps.append(rocoto.add_dependency(dep_dict))
     dependencies = rocoto.create_dependency(dep=deps)
     earcenvars = envars1 + [ensgrp]
     task = wfu.create_wf_task('earc', cdump=cdump, envar=earcenvars, dependency=dependencies,
                               metatask='eamn', varname='grp', varval=EARCGROUPS, cycledef=cycledef)
 
-    dict_tasks['%seamn' % cdump] = task
+    dict_tasks[f'{cdump}eamn'] = task
 
     return  dict_tasks
 
@@ -1194,16 +1196,16 @@ def get_postgroups(post, cdump='gdas'):
         fhmax_hf = post['FHMAX_HF_GFS']
         fhout_hf = post['FHOUT_HF_GFS']
         fhrs_hf = range(fhmin, fhmax_hf+fhout_hf, fhout_hf)
-        fhrs = fhrs_hf + range(fhrs_hf[-1]+fhout, fhmax+fhout, fhout)
+        fhrs = list(fhrs_hf) + list(range(fhrs_hf[-1]+fhout, fhmax+fhout, fhout))
 
     npostgrp = post['NPOSTGRP']
     ngrps = npostgrp if len(fhrs) > npostgrp else len(fhrs)
 
-    fhrs = ['f%03d' % f for f in fhrs]
+    fhrs = [f'f{f:03d}' for f in fhrs]
     fhrs = np.array_split(fhrs, ngrps)
     fhrs = [f.tolist() for f in fhrs]
 
-    fhrgrp = ' '.join(['%03d' % x for x in range(0, ngrps+1)])
+    fhrgrp = ' '.join([f'{x:03d}' for x in range(0, ngrps+1)])
     fhrdep = ' '.join(['anl'] + [f[-1] for f in fhrs])
     fhrlst = ' '.join(['anl'] + ['_'.join(f) for f in fhrs])
 
@@ -1233,11 +1235,11 @@ def get_awipsgroups(awips, cdump='gdas'):
     nawipsgrp = awips['NAWIPSGRP']
     ngrps = nawipsgrp if len(fhrs) > nawipsgrp else len(fhrs)
 
-    fhrs = ['f%03d' % f for f in fhrs]
+    fhrs = [f'f{f:03d}' for f in fhrs]
     fhrs = np.array_split(fhrs, ngrps)
     fhrs = [f.tolist() for f in fhrs]
 
-    fhrgrp = ' '.join(['%03d' % x for x in range(0, ngrps)])
+    fhrgrp = ' '.join([f'{x:03d}' for x in range(0, ngrps)])
     fhrdep = ' '.join([f[-1] for f in fhrs])
     fhrlst = ' '.join(['_'.join(f) for f in fhrs])
 
@@ -1247,13 +1249,13 @@ def get_ecengroups(dict_configs, ecen, cdump='gdas'):
 
     base = dict_configs['base']
 
-    if base.get('DOIAU_ENKF', 'NO') == 'YES' : 
+    if base.get('DOIAU_ENKF', 'NO') == 'YES' :
         fhrs = list(base.get('IAUFHRS','6').split(','))
-        ifhrs = ['f00%01s' % f for f in fhrs]
+        ifhrs = [f'f00{ff}' for ff in fhrs]
         ifhrs0 = ifhrs[0]
         nfhrs = len(fhrs)
 
-        ifhrs = ['f00%01s' % f for f in fhrs]
+        ifhrs = [f'f00{ff}' for ff in fhrs]
         ifhrs0 = ifhrs[0]
         nfhrs = len(fhrs)
 
@@ -1262,7 +1264,7 @@ def get_ecengroups(dict_configs, ecen, cdump='gdas'):
 
         ifhrs = np.array_split(ifhrs, ngrps)
 
-        fhrgrp = ' '.join(['%03d' % x for x in range(0, ngrps)])
+        fhrgrp = ' '.join([f'{x:03d}' for x in range(0, ngrps)])
         fhrdep = ' '.join([f[-1] for f in ifhrs])
         fhrlst = ' '.join(['_'.join(f) for f in ifhrs])
 
@@ -1283,11 +1285,11 @@ def get_eposgroups(epos, cdump='gdas'):
     neposgrp = epos['NEPOSGRP']
     ngrps = neposgrp if len(fhrs) > neposgrp else len(fhrs)
 
-    fhrs = ['f%03d' % f for f in fhrs]
+    fhrs = [f'f{f:03d}' for f in fhrs]
     fhrs = np.array_split(fhrs, ngrps)
     fhrs = [f.tolist() for f in fhrs]
 
-    fhrgrp = ' '.join(['%03d' % x for x in range(0, ngrps)])
+    fhrgrp = ' '.join([f'{x:03d}' for x in range(0, ngrps)])
     fhrdep = ' '.join([f[-1] for f in fhrs])
     fhrlst = ' '.join(['_'.join(f) for f in fhrs])
 
@@ -1310,7 +1312,8 @@ def create_xml(dict_configs):
         create the workflow XML
     '''
 
-    from  __builtin__ import any as b_any
+    from builtins import any as b_any
+    #from  __builtin__ import any as b_any
 
     base = dict_configs['base']
     dohybvar = base.get('DOHYBVAR', 'NO').upper()
@@ -1344,9 +1347,9 @@ def create_xml(dict_configs):
                      'gdasepos':'gdasepmn',
                      'gdasearc':'gdaseamn',
                      'gdasechgres':'gdasechgres'}
-        for each_task, each_resource_string in dict_hyb_resources.iteritems():
-            #print each_task,hyp_tasks[each_task]
-            #print dict_hyb_tasks[hyp_tasks[each_task]]
+        for each_task, each_resource_string in dict_hyb_resources.items():
+            #print(each_task,hyp_tasks[each_task])
+            #print(dict_hyb_tasks[hyp_tasks[each_task]])
             if 'MEMORY' not in each_resource_string:
                 if each_task in dict_hyb_tasks:
                     temp_task_string = []
@@ -1366,7 +1369,7 @@ def create_xml(dict_configs):
     dict_gfs_tasks = get_gdasgfs_tasks(dict_configs, cdump='gfs')
 
     # Removes <memory>&MEMORY_JOB_DUMP</memory> post mortem from gdas tasks
-    for each_task, each_resource_string in dict_gdas_resources.iteritems():
+    for each_task, each_resource_string in dict_gdas_resources.items():
         if each_task not in dict_gdas_tasks:
             continue
         if 'MEMORY' not in each_resource_string:
@@ -1377,7 +1380,7 @@ def create_xml(dict_configs):
             dict_gdas_tasks[each_task] = ''.join(temp_task_string)
 
     # Removes <memory>&MEMORY_JOB_DUMP</memory> post mortem from gfs tasks
-    for each_task, each_resource_string in dict_gfs_resources.iteritems():
+    for each_task, each_resource_string in dict_gfs_resources.items():
         if each_task not in dict_gfs_tasks:
             continue
         if 'MEMORY' not in each_resource_string:
@@ -1422,7 +1425,7 @@ def create_xml(dict_configs):
     xmlfile.append(workflow_footer)
 
     # Write the XML file
-    fh = open('%s/%s.xml' % (base['EXPDIR'], base['PSLOT']), 'w')
+    fh = open(f'{base["EXPDIR"]}/{base["PSLOT"]}.xml', 'w')
     fh.write(''.join(xmlfile))
     fh.close()
 

--- a/ush/rocoto/setup_workflow_fcstonly.py
+++ b/ush/rocoto/setup_workflow_fcstonly.py
@@ -27,8 +27,7 @@ from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import rocoto
 import workflow_utils as wfu
 
-#taskplan = ['getic', 'fv3ic', 'waveinit', 'waveprep', 'fcst', 'post', 'wavepostsbs', 'wavegempak', 'waveawipsbulls', 'waveawipsgridded', 'wavepost', 'wavestat', 'wafs', 'wafsgrib2', 'wafsblending', 'wafsgcip', 'wafsgrib20p25', 'wafsblending0p25', 'vrfy', 'metp', 'arch']
-taskplan = ['getic', 'fv3ic', 'waveinit', 'waveprep', 'fcst', 'post', 'wavepostsbs', 'wavepostbndpnt', 'wavepostbndpntbll', 'wavepostpnt', 'wavegempak', 'waveawipsbulls', 'waveawipsgridded', 'wafs', 'wafsgrib2', 'wafsblending', 'wafsgcip', 'wafsgrib20p25', 'wafsblending0p25', 'vrfy', 'metp', 'arch']
+taskplan = ['getic', 'init', 'waveinit', 'waveprep', 'fcst', 'post', 'wavepostsbs', 'wavepostbndpnt', 'wavepostbndpntbll', 'wavepostpnt', 'wavegempak', 'waveawipsbulls', 'waveawipsgridded', 'wafs', 'wafsgrib2', 'wafsblending', 'wafsgcip', 'wafsgrib20p25', 'wafsblending0p25', 'postsnd', 'gempak', 'awips', 'vrfy', 'metp', 'arch']
 
 def main():
     parser = ArgumentParser(description='Setup XML workflow and CRONTAB for a forecast only experiment.', formatter_class=ArgumentDefaultsHelpFormatter)
@@ -42,9 +41,9 @@ def main():
     _base = wfu.config_parser([wfu.find_config('config.base', configs)])
 
     if not os.path.samefile(args.expdir,_base['EXPDIR']):
-        print 'MISMATCH in experiment directories!'
-        print 'config.base: EXPDIR = %s' % repr(_base['EXPDIR'])
-        print 'input arg:     --expdir = %s' % repr(args.expdir)
+        print('MISMATCH in experiment directories!')
+        print(f'''config.base: EXPDIR = {repr(_base['EXPDIR'])}''')
+        print(f'input arg:     --expdir = {repr(args.expdir)}')
         sys.exit(1)
 
     dict_configs = wfu.source_configs(configs, taskplan)
@@ -79,7 +78,7 @@ def get_preamble():
     strings.append('\t\trahul.mahajan@noaa.gov\n')
     strings.append('\n')
     strings.append('\tNOTES:\n')
-    strings.append('\t\tThis workflow was automatically generated at %s\n' % datetime.now())
+    strings.append(f'\t\tThis workflow was automatically generated at {datetime.now()}\n')
     strings.append('\t-->\n')
 
     return ''.join(strings)
@@ -92,47 +91,48 @@ def get_definitions(base):
 
     machine = base.get('machine', wfu.detectMachine())
     scheduler = wfu.get_scheduler(machine)
+    hpssarch = base.get('HPSSARCH', 'NO').upper()
 
     strings = []
 
     strings.append('\n')
     strings.append('\t<!-- Experiment parameters such as name, cycle, resolution -->\n')
-    strings.append('\t<!ENTITY PSLOT    "%s">\n' % base['PSLOT'])
-    strings.append('\t<!ENTITY CDUMP    "%s">\n' % base['CDUMP'])
-    strings.append('\t<!ENTITY CASE     "%s">\n' % base['CASE'])
+    strings.append(f'''\t<!ENTITY PSLOT    "{base['PSLOT']}">\n''')
+    strings.append(f'''\t<!ENTITY CDUMP    "{base['CDUMP']}">\n''')
+    strings.append(f'''\t<!ENTITY CASE     "{base['CASE']}">\n''')
     strings.append('\n')
     strings.append('\t<!-- Experiment parameters such as starting, ending dates -->\n')
-    strings.append('\t<!ENTITY SDATE    "%s">\n' % base['SDATE'].strftime('%Y%m%d%H%M'))
-    strings.append('\t<!ENTITY EDATE    "%s">\n' % base['EDATE'].strftime('%Y%m%d%H%M'))
+    strings.append(f'''\t<!ENTITY SDATE    "{base['SDATE'].strftime('%Y%m%d%H%M')}">\n''')
+    strings.append(f'''\t<!ENTITY EDATE    "{base['EDATE'].strftime('%Y%m%d%H%M')}">\n''')
     if base['INTERVAL'] is None:
-        print 'cycle INTERVAL cannot be None'
+        print('cycle INTERVAL cannot be None')
         sys.exit(1)
-    strings.append('\t<!ENTITY INTERVAL "%s">\n' % base['INTERVAL'])
+    strings.append(f'''\t<!ENTITY INTERVAL "{base['INTERVAL']}">\n''')
     strings.append('\n')
     strings.append('\t<!-- Run Envrionment -->\n')
-    strings.append('\t<!ENTITY RUN_ENVIR "%s">\n' % base['RUN_ENVIR'])
+    strings.append(f'''\t<!ENTITY RUN_ENVIR "{base['RUN_ENVIR']}">\n''')
     strings.append('\n')
     strings.append('\t<!-- Experiment related directories -->\n')
-    strings.append('\t<!ENTITY EXPDIR "%s">\n' % base['EXPDIR'])
-    strings.append('\t<!ENTITY ROTDIR "%s">\n' % base['ROTDIR'])
-    strings.append('\t<!ENTITY ICSDIR "%s">\n' % base['ICSDIR'])
+    strings.append(f'''\t<!ENTITY EXPDIR "{base['EXPDIR']}">\n''')
+    strings.append(f'''\t<!ENTITY ROTDIR "{base['ROTDIR']}">\n''')
+    strings.append(f'''\t<!ENTITY ICSDIR "{base['ICSDIR']}">\n''')
     strings.append('\n')
     strings.append('\t<!-- Directories for driving the workflow -->\n')
-    strings.append('\t<!ENTITY HOMEgfs  "%s">\n' % base['HOMEgfs'])
-    strings.append('\t<!ENTITY JOBS_DIR "%s">\n' % base['BASE_JOB'])
+    strings.append(f'''\t<!ENTITY HOMEgfs  "{base['HOMEgfs']}">\n''')
+    strings.append(f'''\t<!ENTITY JOBS_DIR "{base['BASE_JOB']}">\n''')
     strings.append('\n')
     strings.append('\t<!-- Machine related entities -->\n')
-    strings.append('\t<!ENTITY ACCOUNT    "%s">\n' % base['ACCOUNT'])
-    strings.append('\t<!ENTITY QUEUE      "%s">\n' % base['QUEUE'])
-    strings.append('\t<!ENTITY QUEUE_SERVICE "%s">\n' % base['QUEUE_SERVICE'])
-    if scheduler in ['slurm'] and machine in ['ORION']:
-       strings.append('\t<!ENTITY PARTITION_BATCH "%s">\n' % base['PARTITION_BATCH'])
+    strings.append(f'''\t<!ENTITY ACCOUNT    "{base['ACCOUNT']}">\n''')
+    strings.append(f'''\t<!ENTITY QUEUE      "{base['QUEUE']}">\n''')
+    strings.append(f'''\t<!ENTITY QUEUE_SERVICE "{base['QUEUE_SERVICE']}">\n''')
+    if scheduler in ['slurm'] and machine in ['ORION','JET']:
+       strings.append(f'''\t<!ENTITY PARTITION_BATCH "{base['PARTITION_BATCH']}">\n''')
     if scheduler in ['slurm']:
-       strings.append('\t<!ENTITY PARTITION_SERVICE "%s">\n' % base['QUEUE_SERVICE'])
-    strings.append('\t<!ENTITY SCHEDULER  "%s">\n' % scheduler)
+       strings.append(f'''\t<!ENTITY PARTITION_SERVICE "{base['QUEUE_SERVICE']}">\n''')
+    strings.append(f'\t<!ENTITY SCHEDULER  "{scheduler}">\n')
     strings.append('\n')
     strings.append('\t<!-- Toggle HPSS archiving -->\n')
-    strings.append('\t<!ENTITY ARCHIVE_TO_HPSS "YES">\n')
+    strings.append(f'''\t<!ENTITY ARCHIVE_TO_HPSS "{base['HPSSARCH']}">\n''')
     strings.append('\n')
     strings.append('\t<!-- ROCOTO parameters that control workflow -->\n')
     strings.append('\t<!ENTITY CYCLETHROTTLE "2">\n')
@@ -159,6 +159,7 @@ def get_resources(dict_configs, cdump='gdas'):
     scheduler = wfu.get_scheduler(machine)
 
     do_wave = base.get('DO_WAVE', 'NO').upper()
+    do_bufrsnd = base.get('DO_BUFRSND', 'NO').upper()
     do_gempak = base.get('DO_GEMPAK', 'NO').upper()
     do_awips = base.get('DO_AWIPS', 'NO').upper()
     do_metp = base.get('DO_METP', 'NO').upper()
@@ -169,18 +170,18 @@ def get_resources(dict_configs, cdump='gdas'):
 
         wtimestr, resstr, queuestr, memstr, natstr = wfu.get_resources(machine, cfg, task, reservation, cdump=cdump)
 
-        taskstr = '%s_%s' % (task.upper(), cdump.upper())
+        taskstr = f'{task.upper()}_{cdump.upper()}'
 
-        strings.append('\t<!ENTITY QUEUE_%s     "%s">\n' % (taskstr, queuestr))
-        if scheduler in ['slurm'] and machine in ['ORION'] and task not in ['getic', 'arch']:
-            strings.append('\t<!ENTITY PARTITION_%s "&PARTITION_BATCH;">\n' % taskstr )
+        strings.append(f'\t<!ENTITY QUEUE_{taskstr}     "{queuestr}">\n')
+        if scheduler in ['slurm'] and machine in ['ORION', 'JET'] and task not in ['getic', 'arch']:
+            strings.append(f'\t<!ENTITY PARTITION_{taskstr} "&PARTITION_BATCH;">\n')
         if scheduler in ['slurm'] and task in ['getic', 'arch']:
-            strings.append('\t<!ENTITY PARTITION_%s "&PARTITION_SERVICE;">\n' % taskstr )
-        strings.append('\t<!ENTITY WALLTIME_%s  "%s">\n' % (taskstr, wtimestr))
-        strings.append('\t<!ENTITY RESOURCES_%s "%s">\n' % (taskstr, resstr))
+            strings.append(f'\t<!ENTITY PARTITION_{taskstr} "&PARTITION_SERVICE;">\n')
+        strings.append(f'\t<!ENTITY WALLTIME_{taskstr}  "{wtimestr}">\n')
+        strings.append(f'\t<!ENTITY RESOURCES_{taskstr} "{resstr}">\n')
         if len(memstr) != 0:
-            strings.append('\t<!ENTITY MEMORY_%s    "%s">\n' % (taskstr, memstr))
-        strings.append('\t<!ENTITY NATIVE_%s    "%s">\n' % (taskstr, natstr))
+            strings.append(f'\t<!ENTITY MEMORY_{taskstr}    "{memstr}">\n')
+        strings.append(f'\t<!ENTITY NATIVE_{taskstr}    "{natstr}">\n')
 
         strings.append('\n')
 
@@ -197,23 +198,23 @@ def get_postgroups(post, cdump='gdas'):
 
     # Get a list of all forecast hours
     if cdump in ['gdas']:
-        fhrs = range(fhmin, fhmax+fhout, fhout)
+        fhrs = list(range(fhmin, fhmax+fhout, fhout))
     elif cdump in ['gfs']:
         fhmax = np.max([post['FHMAX_GFS_00'],post['FHMAX_GFS_06'],post['FHMAX_GFS_12'],post['FHMAX_GFS_18']])
         fhout = post['FHOUT_GFS']
         fhmax_hf = post['FHMAX_HF_GFS']
         fhout_hf = post['FHOUT_HF_GFS']
-        fhrs_hf = range(fhmin, fhmax_hf+fhout_hf, fhout_hf)
-        fhrs = fhrs_hf + range(fhrs_hf[-1]+fhout, fhmax+fhout, fhout)
+        fhrs_hf = list(range(fhmin, fhmax_hf+fhout_hf, fhout_hf))
+        fhrs = fhrs_hf + list(range(fhrs_hf[-1]+fhout, fhmax+fhout, fhout))
 
     npostgrp = post['NPOSTGRP']
     ngrps = npostgrp if len(fhrs) > npostgrp else len(fhrs)
 
-    fhrs = ['f%03d' % f for f in fhrs]
+    fhrs = [f'f{f:03d}' for f in fhrs]
     fhrs = np.array_split(fhrs, ngrps)
     fhrs = [f.tolist() for f in fhrs]
 
-    fhrgrp = ' '.join(['%03d' % x for x in range(1, ngrps+1)])
+    fhrgrp = ' '.join([f'{x:03d}' for x in range(1, ngrps+1)])
     fhrdep = ' '.join([f[-1] for f in fhrs])
     fhrlst = ' '.join(['_'.join(f) for f in fhrs])
 
@@ -235,104 +236,116 @@ def get_workflow(dict_configs, cdump='gdas'):
     envars.append(rocoto.create_envar(name='cyc', value='<cyclestr>@H</cyclestr>'))
 
     base = dict_configs['base']
+    machine = base.get('machine', wfu.detectMachine())
+    hpssarch = base.get('HPSSARCH', 'NO').upper()
     do_wave = base.get('DO_WAVE', 'NO').upper()
+    do_wave_cdump = base.get('WAVE_CDUMP', 'BOTH').upper()
+    do_bufrsnd = base.get('DO_BUFRSND', 'NO').upper()
     do_gempak = base.get('DO_GEMPAK', 'NO').upper()
     do_awips = base.get('DO_AWIPS', 'NO').upper()
     do_wafs = base.get('WAFSF', 'NO').upper()
+    do_vrfy = base.get('DO_VRFY', 'YES').upper()
     do_metp = base.get('DO_METP', 'NO').upper()
 
     tasks = []
 
-    # getics
-    deps = []
-    data = '&ICSDIR;/@Y@m@d@H/&CDUMP;/&CDUMP;.@Y@m@d/@H/siganl.&CDUMP;.@Y@m@d@H'
-    dep_dict = {'type':'data', 'data':data}
-    deps.append(rocoto.add_dependency(dep_dict))
-    data = '&ICSDIR;/@Y@m@d@H/&CDUMP;/&CDUMP;.@Y@m@d/@H/&CDUMP;.t@Hz.sanl'
-    dep_dict = {'type':'data', 'data':data}
-    deps.append(rocoto.add_dependency(dep_dict))
-    data = '&ICSDIR;/@Y@m@d@H/&CDUMP;/&CDUMP;.@Y@m@d/@H/gfnanl.&CDUMP;.@Y@m@d@H'
-    dep_dict = {'type':'data', 'data':data}
-    deps.append(rocoto.add_dependency(dep_dict))
-    data = '&ICSDIR;/@Y@m@d@H/&CDUMP;/&CDUMP;.@Y@m@d/@H/&CDUMP;.t@Hz.atmanl.nemsio'
-    dep_dict = {'type':'data', 'data':data}
-    deps.append(rocoto.add_dependency(dep_dict))
-    deps = rocoto.create_dependency(dep_condition='or', dep=deps)
-    dependencies = rocoto.create_dependency(dep_condition='not', dep=deps)
-    task = wfu.create_wf_task('getic', cdump=cdump, envar=envars, dependency=dependencies)
-    tasks.append(task)
-    tasks.append('\n')
+    # getic
+    if hpssarch in ['YES']:
+      deps = []
+      data = '&ROTDIR;/&CDUMP;.@Y@m@d/@H/atmos/INPUT/sfc_data.tile6.nc'
+      dep_dict = {'type':'data', 'data':data}
+      deps.append(rocoto.add_dependency(dep_dict))
+      data = '&ROTDIR;/&CDUMP;.@Y@m@d/@H/atmos/RESTART/@Y@m@d.@H0000.sfcanl_data.tile6.nc'
+      dep_dict = {'type':'data', 'data':data}
+      deps.append(rocoto.add_dependency(dep_dict))
+      dependencies = rocoto.create_dependency(dep_condition='nor', dep=deps)
 
-    # chgres fv3ic
+      task = wfu.create_wf_task('getic', cdump=cdump, envar=envars, dependency=dependencies)
+      tasks.append(task)
+      tasks.append('\n')
+
+    # init
     deps = []
-    data = '&ICSDIR;/@Y@m@d@H/&CDUMP;/&CDUMP;.@Y@m@d/@H/siganl.&CDUMP;.@Y@m@d@H'
+    data = '&ROTDIR;/&CDUMP;.@Y@m@d/@H/gfs.t@Hz.sanl'
     dep_dict = {'type':'data', 'data':data}
     deps.append(rocoto.add_dependency(dep_dict))
-    data = '&ICSDIR;/@Y@m@d@H/&CDUMP;/&CDUMP;.@Y@m@d/@H/&CDUMP;.t@Hz.sanl'
+    data = '&ROTDIR;/&CDUMP;.@Y@m@d/@H/gfs.t@Hz.atmanl.nemsio'
     dep_dict = {'type':'data', 'data':data}
     deps.append(rocoto.add_dependency(dep_dict))
-    data = '&ICSDIR;/@Y@m@d@H/&CDUMP;/&CDUMP;.@Y@m@d/@H/gfnanl.&CDUMP;.@Y@m@d@H'
+    data = '&ROTDIR;/&CDUMP;.@Y@m@d/@H/gfs.t@Hz.atmanl.nc'
     dep_dict = {'type':'data', 'data':data}
     deps.append(rocoto.add_dependency(dep_dict))
-    data = '&ICSDIR;/@Y@m@d@H/&CDUMP;/&CDUMP;.@Y@m@d/@H/&CDUMP;.t@Hz.atmanl.nemsio'
+    data = '&ROTDIR;/&CDUMP;.@Y@m@d/@H/atmos/gfs.t@Hz.atmanl.nc'
+    dep_dict = {'type':'data', 'data':data}
+    deps.append(rocoto.add_dependency(dep_dict))
+    data = '&ROTDIR;/&CDUMP;.@Y@m@d/@H/atmos/RESTART/@Y@m@d.@H0000.sfcanl_data.tile6.nc'
     dep_dict = {'type':'data', 'data':data}
     deps.append(rocoto.add_dependency(dep_dict))
     dependencies = rocoto.create_dependency(dep_condition='or', dep=deps)
 
-    deps = []
-    data = '&ICSDIR;/@Y@m@d@H/&CDUMP;/&CASE;/INPUT/gfs_data.tile6.nc'
-    dep_dict = {'type':'data', 'data':data}
-    deps.append(rocoto.add_dependency(dep_dict))
-    data = '&ICSDIR;/@Y@m@d@H/&CDUMP;/&CASE;/INPUT/sfc_data.tile6.nc'
-    dep_dict = {'type':'data', 'data':data}
-    deps.append(rocoto.add_dependency(dep_dict))
-    deps = rocoto.create_dependency(dep_condition='and', dep=deps)
-    dependencies2 = rocoto.create_dependency(dep_condition='not', dep=deps)
+    if hpssarch in ['YES']:
+      deps = []
+      dep_dict = {'type': 'task', 'name': f'{cdump}getic'}
+      deps.append(rocoto.add_dependency(dep_dict))
+      dependencies2 = rocoto.create_dependency(dep=deps)
 
     deps = []
     deps.append(dependencies)
-    deps.append(dependencies2)
-    dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
+    if hpssarch in ['YES']:
+      deps.append(dependencies2)
+      dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
-    task = wfu.create_wf_task('fv3ic', cdump=cdump, envar=envars, dependency=dependencies)
+    task = wfu.create_wf_task('init', cdump=cdump, envar=envars, dependency=dependencies)
     tasks.append(task)
     tasks.append('\n')
 
     # waveinit
-    if do_wave in ['Y', 'YES']:
+    if do_wave in ['Y', 'YES'] and do_wave_cdump in ['GFS', 'BOTH']:
         task = wfu.create_wf_task('waveinit', cdump=cdump, envar=envars)
         tasks.append(task)
         tasks.append('\n')
 
     # waveprep
-    if do_wave in ['Y', 'YES']:
+    if do_wave in ['Y', 'YES'] and do_wave_cdump in ['GFS', 'BOTH']:
         deps = []
-        dep_dict = {'type': 'task', 'name': '%swaveinit' % cdump}
+        dep_dict = {'type': 'task', 'name': f'{cdump}waveinit'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dependencies = rocoto.create_dependency(dep=deps)
+        dep_dict = {'type': 'task', 'name': f'{cdump}init'}
+        deps.append(rocoto.add_dependency(dep_dict))
+        dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         task = wfu.create_wf_task('waveprep', cdump=cdump, envar=envars, dependency=dependencies)
         tasks.append(task)
         tasks.append('\n')
 
     # fcst
     deps = []
-    data = '&ICSDIR;/@Y@m@d@H/&CDUMP;/&CASE;/INPUT/gfs_data.tile6.nc'
+    data = '&ROTDIR;/&CDUMP;.@Y@m@d/@H/atmos/INPUT/sfc_data.tile6.nc'
     dep_dict = {'type':'data', 'data':data}
     deps.append(rocoto.add_dependency(dep_dict))
-    data = '&ICSDIR;/@Y@m@d@H/&CDUMP;/&CASE;/INPUT/sfc_data.tile6.nc'
+    data = '&ROTDIR;/&CDUMP;.@Y@m@d/@H/atmos/RESTART/@Y@m@d.@H0000.sfcanl_data.tile6.nc'
     dep_dict = {'type':'data', 'data':data}
     deps.append(rocoto.add_dependency(dep_dict))
-    if do_wave in ['Y', 'YES']:
-        dep_dict = {'type': 'task', 'name': '%swaveprep' % cdump}
+    dependencies = rocoto.create_dependency(dep_condition='or', dep=deps)
+
+    if do_wave in ['Y', 'YES'] and do_wave_cdump in ['GFS', 'BOTH']:
+        deps = []
+        dep_dict = {'type': 'task', 'name': f'{cdump}waveprep'}
         deps.append(rocoto.add_dependency(dep_dict))
+        dependencies2 = rocoto.create_dependency(dep_condition='and', dep=deps)
+
+    deps = []
+    deps.append(dependencies)
+    if do_wave in ['Y', 'YES'] and do_wave_cdump in ['GFS', 'BOTH']:
+        deps.append(dependencies2)
     dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
+
     task = wfu.create_wf_task('fcst', cdump=cdump, envar=envars, dependency=dependencies)
     tasks.append(task)
     tasks.append('\n')
 
     # post
     deps = []
-    data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.log#dep#.txt' % (cdump, cdump)
+    data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.log#dep#.txt'
     dep_dict = {'type': 'data', 'data': data}
     deps.append(rocoto.add_dependency(dep_dict))
     dependencies = rocoto.create_dependency(dep=deps)
@@ -349,15 +362,15 @@ def get_workflow(dict_configs, cdump='gdas'):
     tasks.append('\n')
 
     # wavepostsbs
-    if do_wave in ['Y', 'YES']:
+    if do_wave in ['Y', 'YES'] and do_wave_cdump in ['GFS', 'BOTH']:
         deps = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/wave/rundata/%swave.out_grd.gnh_10m.@Y@m@d.@H0000' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/wave/rundata/{cdump}wave.out_grd.gnh_10m.@Y@m@d.@H0000'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/wave/rundata/%swave.out_grd.aoc_9km.@Y@m@d.@H0000' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/wave/rundata/{cdump}wave.out_grd.aoc_9km.@Y@m@d.@H0000'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/wave/rundata/%swave.out_grd.gsh_15m.@Y@m@d.@H0000' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/wave/rundata/{cdump}wave.out_grd.gsh_15m.@Y@m@d.@H0000'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
@@ -368,8 +381,7 @@ def get_workflow(dict_configs, cdump='gdas'):
     # wavepostbndpnt
     if do_wave in ['Y', 'YES']:
         deps = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.logf180.txt' % (cdump,cdump)
-        dep_dict = {'type': 'data', 'data': data}
+        dep_dict = {'type':'task', 'name':f'{cdump}fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('wavepostbndpnt', cdump=cdump, envar=envars, dependency=dependencies)
@@ -379,7 +391,7 @@ def get_workflow(dict_configs, cdump='gdas'):
     # wavepostbndpntbll
     if do_wave in ['Y', 'YES']:
         deps = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.logf180.txt' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.logf180.txt'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
@@ -390,29 +402,19 @@ def get_workflow(dict_configs, cdump='gdas'):
     # wavepostpnt
     if do_wave in ['Y', 'YES']:
         deps = []
-        dep_dict = {'type':'task', 'name':'%sfcst' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type':'task', 'name':'%swavepostbndpntbll' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}wavepostbndpntbll'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         task = wfu.create_wf_task('wavepostpnt', cdump=cdump, envar=envars, dependency=dependencies)
         tasks.append(task)
         tasks.append('\n')
 
-    # wavestat
-    #if do_wave in ['Y', 'YES']:
-    #    deps = []
-    #    dep_dict = {'type':'task', 'name':'%swavepost' % cdump}
-    #    deps.append(rocoto.add_dependency(dep_dict))
-    #    dependencies = rocoto.create_dependency(dep=deps)
-    #    task = wfu.create_wf_task('wavestat', cdump=cdump, envar=envars, dependency=dependencies)
-    #    tasks.append(task)
-    #    tasks.append('\n')
-
     # wavegempak
     if do_wave in ['Y', 'YES'] and do_gempak in ['Y', 'YES']:
         deps = []
-        dep_dict = {'type':'task', 'name':'%swavepostsbs' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}wavepostsbs'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('wavegempak', cdump=cdump, envar=envars, dependency=dependencies)
@@ -422,9 +424,9 @@ def get_workflow(dict_configs, cdump='gdas'):
     # waveawipsbulls
     if do_wave in ['Y', 'YES'] and do_awips in ['Y', 'YES']:
         deps = []
-        dep_dict = {'type':'task', 'name':'%swavepostsbs' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}wavepostsbs'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type':'task', 'name':'%swavepostpnt' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}wavepostpnt'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         task = wfu.create_wf_task('waveawipsbulls', cdump=cdump, envar=envars, dependency=dependencies)
@@ -434,7 +436,7 @@ def get_workflow(dict_configs, cdump='gdas'):
     # waveawipsgridded
     if do_wave in ['Y', 'YES'] and do_awips in ['Y', 'YES']:
         deps = []
-        dep_dict = {'type':'task', 'name':'%swavepostsbs' % cdump}
+        dep_dict = {'type':'task', 'name':f'{cdump}wavepostsbs'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('waveawipsgridded', cdump=cdump, envar=envars, dependency=dependencies)
@@ -444,34 +446,34 @@ def get_workflow(dict_configs, cdump='gdas'):
     # wafs
     if do_wafs in ['Y', 'YES']:
         deps = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if006' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if006'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if012' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if012'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if015' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if015'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if018' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if018'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if021' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if021'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if024' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if024'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if027' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if027'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if030' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if030'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if033' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if033'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if036' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if036'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
@@ -482,34 +484,34 @@ def get_workflow(dict_configs, cdump='gdas'):
     # wafsgcip
     if do_wafs in ['Y', 'YES']:
         deps = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if006' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if006'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if012' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if012'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if015' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if015'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if018' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if018'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if021' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if021'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if024' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if024'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if027' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if027'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if030' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if030'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if033' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if033'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if036' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if036'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
@@ -520,34 +522,34 @@ def get_workflow(dict_configs, cdump='gdas'):
     # wafsgrib2
     if do_wafs in ['Y', 'YES']:
         deps = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if006' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if006'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if012' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if012'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if015' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if015'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if018' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if018'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if021' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if021'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if024' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if024'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if027' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if027'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if030' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if030'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if033' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if033'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if036' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if036'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
@@ -558,34 +560,34 @@ def get_workflow(dict_configs, cdump='gdas'):
     # wafsgrib20p25
     if do_wafs in ['Y', 'YES']:
         deps = []
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if006' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if006'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if012' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if012'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if015' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if015'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if018' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if018'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if021' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if021'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if024' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if024'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if027' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if027'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if030' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if030'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if033' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if033'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
-        data = '&ROTDIR;/%s.@Y@m@d/@H/atmos/%s.t@Hz.wafs.grb2if036' % (cdump,cdump)
+        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.wafs.grb2if036'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
@@ -596,7 +598,7 @@ def get_workflow(dict_configs, cdump='gdas'):
     # wafsblending
     if do_wafs in ['Y', 'YES']:
         deps = []
-        dep_dict = {'type': 'task', 'name': '%swafsgrib2' % cdump}
+        dep_dict = {'type': 'task', 'name': f'{cdump}wafsgrib2'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('wafsblending', cdump=cdump, envar=envars, dependency=dependencies)
@@ -606,32 +608,72 @@ def get_workflow(dict_configs, cdump='gdas'):
     # wafsblending0p25
     if do_wafs in ['Y', 'YES']:
         deps = []
-        dep_dict = {'type': 'task', 'name': '%swafsgrib20p25' % cdump}
+        dep_dict = {'type': 'task', 'name': f'{cdump}wafsgrib20p25'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('wafsblending0p25', cdump=cdump, envar=envars, dependency=dependencies)
         tasks.append(task)
         tasks.append('\n')
 
+    #postsnd
+    if do_bufrsnd in ['Y', 'YES']:
+        deps = []
+        dep_dict = {'type': 'task', 'name': f'{cdump}fcst'}
+        deps.append(rocoto.add_dependency(dep_dict))
+        dependencies = rocoto.create_dependency(dep=deps)
+        task = wfu.create_wf_task('postsnd', cdump=cdump, envar=envars, dependency=dependencies)
+        tasks.append(task)
+        tasks.append('\n')
+
+    # awips
+    if do_awips in ['Y', 'YES']:
+        deps = []
+        dep_dict = {'type': 'metatask', 'name': f'{cdump}post'}
+        deps.append(rocoto.add_dependency(dep_dict))
+        dependencies = rocoto.create_dependency(dep=deps)
+        fhrgrp = rocoto.create_envar(name='FHRGRP', value='#grp#')
+        fhrlst = rocoto.create_envar(name='FHRLST', value='#lst#')
+        ROTDIR = rocoto.create_envar(name='ROTDIR', value='&ROTDIR;')
+        awipsenvars = envars + [fhrgrp] + [fhrlst] + [ROTDIR]
+        varname1, varname2, varname3 = 'grp', 'dep', 'lst'
+        varval1, varval2, varval3 = get_awipsgroups(dict_configs['awips'], cdump=cdump)
+        vardict = {varname2: varval2, varname3: varval3}
+        task = wfu.create_wf_task('awips', cdump=cdump, envar=awipsenvars, dependency=dependencies,
+                                  metatask='awips', varname=varname1, varval=varval1, vardict=vardict)
+        tasks.append(task)
+        tasks.append('\n')
+
+    # gempak
+    if do_gempak in ['Y', 'YES']:
+        deps = []
+        dep_dict = {'type': 'metatask', 'name': f'{cdump}post'}
+        deps.append(rocoto.add_dependency(dep_dict))
+        dependencies = rocoto.create_dependency(dep=deps)
+        task = wfu.create_wf_task('gempak', cdump=cdump, envar=envars, dependency=dependencies)
+        tasks.append(task)
+        tasks.append('\n')
+
     # vrfy
-    deps = []
-    dep_dict = {'type':'metatask', 'name':'%spost' % cdump}
-    deps.append(rocoto.add_dependency(dep_dict))
-    dependencies = rocoto.create_dependency(dep=deps)
-    task = wfu.create_wf_task('vrfy', cdump=cdump, envar=envars, dependency=dependencies)
-    tasks.append(task)
-    tasks.append('\n')
+    if do_vrfy in ['Y', 'YES']:
+        deps = []
+        dep_dict = {'type':'metatask', 'name':f'{cdump}post'}
+        deps.append(rocoto.add_dependency(dep_dict))
+        dependencies = rocoto.create_dependency(dep=deps)
+        task = wfu.create_wf_task('vrfy', cdump=cdump, envar=envars, dependency=dependencies)
+        tasks.append(task)
+        tasks.append('\n')
 
     # metp
     if do_metp in ['Y', 'YES']:
         deps = []
-        dep_dict = {'type':'metatask', 'name':'%spost' % cdump}
+        dep_dict = {'type':'metatask', 'name':f'{cdump}post'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type':'task', 'name':'%sarch' % cdump, 'offset':'-&INTERVAL;'}
+        dep_dict = {'type':'task', 'name':f'{cdump}arch', 'offset':'-&INTERVAL;'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
+        sdate_gfs = rocoto.create_envar(name='SDATE_GFS', value='&SDATE;')
         metpcase = rocoto.create_envar(name='METPCASE', value='#metpcase#')
-        metpenvars = envars + [metpcase]
+        metpenvars = envars + [sdate_gfs] + [metpcase]
         varname1 = 'metpcase'
         varval1 = 'g2g1 g2o1 pcp1'
         task = wfu.create_wf_task('metp', cdump=cdump, envar=metpenvars, dependency=dependencies,
@@ -641,12 +683,20 @@ def get_workflow(dict_configs, cdump='gdas'):
 
     # arch
     deps = []
-    dep_dict = {'type':'metatask', 'name':'%spost' % cdump}
+    dep_dict = {'type':'metatask', 'name':f'{cdump}post'}
     deps.append(rocoto.add_dependency(dep_dict))
-    dep_dict = {'type':'task', 'name':'%svrfy' % cdump}
+    if do_vrfy in ['Y', 'YES']:
+        dep_dict = {'type':'task', 'name':f'{cdump}vrfy'}
+        deps.append(rocoto.add_dependency(dep_dict))
+    dep_dict = {'type':'streq', 'left':'&ARCHIVE_TO_HPSS;', 'right':f'{hpssarch}'}
     deps.append(rocoto.add_dependency(dep_dict))
-    dep_dict = {'type':'streq', 'left':'&ARCHIVE_TO_HPSS;', 'right':'YES'}
-    deps.append(rocoto.add_dependency(dep_dict))
+    if do_wave in ['Y', 'YES']:
+      dep_dict = {'type': 'task', 'name': f'{cdump}wavepostsbs'}
+      deps.append(rocoto.add_dependency(dep_dict))
+      dep_dict = {'type': 'task', 'name': f'{cdump}wavepostpnt'}
+      deps.append(rocoto.add_dependency(dep_dict))
+      dep_dict = {'type': 'task', 'name': f'{cdump}wavepostbndpnt'}
+      deps.append(rocoto.add_dependency(dep_dict))
     dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
     task = wfu.create_wf_task('arch', cdump=cdump, envar=envars, dependency=dependencies, final=True)
     tasks.append(task)
@@ -670,7 +720,7 @@ def get_workflow_body(dict_configs, cdump='gdas'):
     strings.append('\t<log verbosity="10"><cyclestr>&EXPDIR;/logs/@Y@m@d@H.log</cyclestr></log>\n')
     strings.append('\n')
     strings.append('\t<!-- Define the cycles -->\n')
-    strings.append('\t<cycledef group="%s">&SDATE; &EDATE; &INTERVAL;</cycledef>\n' % cdump)
+    strings.append(f'\t<cycledef group="{cdump}">&SDATE; &EDATE; &INTERVAL;</cycledef>\n')
     strings.append('\n')
     strings.append(get_workflow(dict_configs, cdump=cdump))
     strings.append('\n')
@@ -709,7 +759,7 @@ def create_xml(dict_configs):
     workflow = temp_workflow
 
     # Start writing the XML file
-    fh = open('%s/%s.xml' % (base['EXPDIR'], base['PSLOT']), 'w')
+    fh = open(f'{base["EXPDIR"]}/{base["PSLOT"]}.xml', 'w')
 
     fh.write(preamble)
     fh.write(definitions)

--- a/ush/rocoto/workflow_utils.py
+++ b/ush/rocoto/workflow_utils.py
@@ -16,6 +16,7 @@ import rocoto
 
 DATE_ENV_VARS=['CDATE','SDATE','EDATE']
 SCHEDULER_MAP={'HERA':'slurm',
+               'JET':'slurm',
                'ORION':'slurm',
                'WCOSS':'lsf',
                'WCOSS_DELL_P3':'lsf',
@@ -34,13 +35,14 @@ class ShellScriptException(Exception):
 
 def get_shell_env(scripts):
     vars=dict()
-    runme=''.join([ 'source %s ; '%(s,) for s in scripts ])
-    magic='--- ENVIRONMENT BEGIN %d ---'%random.randint(0,64**5)
-    runme+='/bin/echo -n "%s" ; /usr/bin/env -0'%(magic,)
-    with open('/dev/null','wb+') as null:
+    runme=''.join([ f'source {s} ; ' for s in scripts ])
+    magic=f'--- ENVIRONMENT BEGIN {random.randint(0,64**5)} ---'
+    runme+=f'/bin/echo -n "{(magic,)}" ; /usr/bin/env -0'
+    with open('/dev/null','w') as null:
         env=subprocess.Popen(runme,shell=True,stdin=null.fileno(),
                        stdout=subprocess.PIPE)
         (out,err)=env.communicate()
+    out = out.decode()
     begin=out.find(magic)
     if begin<0:
         raise ShellScriptException(scripts,'Cannot find magic string; '
@@ -70,7 +72,7 @@ def get_configs(expdir):
         return a list of configs minus the ones ending with ".default"
     """
     result=list()
-    for config in glob.glob('%s/config.*' % expdir):
+    for config in glob.glob(f'{expdir}/config.*'):
         if not config.endswith('.default'):
             result.append(config)
     return result
@@ -81,8 +83,7 @@ def find_config(config_name, configs):
         if config_name == os.path.basename(config):
             return config
 
-    raise UnknownConfigError("%s does not exist (known: %s), ABORT!" % (
-        config_name,repr(config_name)))
+    raise UnknownConfigError(f'{config_name} does not exist (known: {repr(config_name)}), ABORT!')
 
 def source_configs(configs, tasks):
     '''
@@ -113,9 +114,9 @@ def source_configs(configs, tasks):
             files.append(find_config('config.fcst', configs))
             files.append(find_config('config.efcs', configs))
         else:
-            files.append(find_config('config.%s' % task, configs))
+            files.append(find_config(f'config.{task}', configs))
 
-        print 'sourcing config.%s' % task
+        print(f'sourcing config.{task}')
         dict_configs[task] = config_parser(files)
 
     return dict_configs
@@ -130,10 +131,10 @@ def config_parser(files):
             in the script.
     :rtype: dict
     """
-    if isinstance(files,basestring):
+    if isinstance(files,(str, bytes)):
         files=[files]
     varbles=dict()
-    for key,value in get_script_env(files).iteritems():
+    for key,value in get_script_env(files).items():
         if key in DATE_ENV_VARS: # likely a date, convert to datetime
             varbles[key] = datetime.strptime(value,'%Y%m%d%H')
         elif '.' in value: # Likely a number and that too a float
@@ -145,7 +146,7 @@ def config_parser(files):
 
 def detectMachine():
 
-    machines = ['HERA', 'ORION' 'WCOSS_C', 'WCOSS_DELL_P3']
+    machines = ['HERA', 'ORION', 'WCOSS_C', 'WCOSS_DELL_P3', 'JET']
 
     if os.path.exists('/scratch1/NCEPDEV'):
         return 'HERA'
@@ -155,55 +156,57 @@ def detectMachine():
         return 'WCOSS_C'
     elif os.path.exists('/gpfs/dell2'):
         return 'WCOSS_DELL_P3'
+    elif os.path.exists('/lfs4/HFIP'):
+        return 'JET'
     else:
-        print 'workflow is currently only supported on: %s' % ' '.join(machines)
+        print(f'workflow is currently only supported on: {machines}')
         raise NotImplementedError('Cannot auto-detect platform, ABORT!')
 
 def get_scheduler(machine):
     try:
         return SCHEDULER_MAP[machine]
     except KeyError:
-        raise UnknownMachineError('Unknown machine: %s, ABORT!' % machine)
+        raise UnknownMachineError(f'Unknown machine: {machine}, ABORT!')
 
 def create_wf_task(task, cdump='gdas', cycledef=None, envar=None, dependency=None, \
                    metatask=None, varname=None, varval=None, vardict=None, \
                    final=False):
 
     if metatask is None:
-        taskstr = '%s' % task
+        taskstr = f'{task}'
     else:
-        taskstr = '%s#%s#' % (task, varname)
-        metataskstr = '%s%s' % (cdump, metatask)
+        taskstr = f'{task}#{varname}#'
+        metataskstr = f'{cdump}{metatask}'
         metatask_dict = {'metataskname': metataskstr, \
-                         'varname': '%s' % varname, \
-                         'varval': '%s' % varval, \
+                         'varname': f'{varname}', \
+                         'varval': f'{varval}', \
                          'vardict': vardict}
 
-    taskstr = '%s%s' % (cdump, taskstr)
+    taskstr = f'{cdump}{taskstr}'
     cycledefstr = cdump if cycledef is None else cycledef
 
-    task_dict = {'taskname': '%s' % taskstr, \
-                 'cycledef': '%s' % cycledefstr, \
+    task_dict = {'taskname': f'{taskstr}', \
+                 'cycledef': f'{cycledefstr}', \
                  'maxtries': '&MAXTRIES;', \
-                 'command': '&JOBS_DIR;/%s.sh' % task, \
-                 'jobname': '&PSLOT;_%s_@H' % taskstr, \
+                 'command': f'&JOBS_DIR;/{task}.sh', \
+                 'jobname': f'&PSLOT;_{taskstr}_@H', \
                  'account': '&ACCOUNT;', \
-                 'queue': '&QUEUE_%s_%s;' % (task.upper(), cdump.upper()), \
-                 'walltime': '&WALLTIME_%s_%s;' % (task.upper(), cdump.upper()), \
-                 'native': '&NATIVE_%s_%s;' % (task.upper(), cdump.upper()), \
-                 'memory': '&MEMORY_%s_%s;' % (task.upper(), cdump.upper()), \
-                 'resources': '&RESOURCES_%s_%s;' % (task.upper(), cdump.upper()), \
-                 'log': '&ROTDIR;/logs/@Y@m@d@H/%s.log' % taskstr, \
+                 'queue': f'&QUEUE_{task.upper()}_{cdump.upper()};', \
+                 'walltime': f'&WALLTIME_{task.upper()}_{cdump.upper()};', \
+                 'native': f'&NATIVE_{task.upper()}_{cdump.upper()};', \
+                 'memory': f'&MEMORY_{task.upper()}_{cdump.upper()};', \
+                 'resources': f'&RESOURCES_{task.upper()}_{cdump.upper()};', \
+                 'log': f'&ROTDIR;/logs/@Y@m@d@H/{taskstr}.log', \
                  'envar': envar, \
                  'dependency': dependency, \
                  'final': final}
 
     # Add PARTITION_BATCH to all non-service jobs on Orion (SLURM)
-    if get_scheduler(detectMachine()) in ['slurm'] and detectMachine() in ['ORION']:
+    if get_scheduler(detectMachine()) in ['slurm'] and detectMachine() in ['ORION','JET']:
         task_dict['partition'] = '&PARTITION_BATCH;'
     # Add PARTITION_SERVICE to all service jobs (SLURM)
     if get_scheduler(detectMachine()) in ['slurm'] and task in ['getic','arch','earc']:
-        task_dict['partition'] = '&PARTITION_%s_%s;' % (task.upper(),cdump.upper())
+        task_dict['partition'] = f'&PARTITION_{task.upper()}_{cdump.upper()};'
 
     if metatask is None:
         task = rocoto.create_task(task_dict)
@@ -220,7 +223,7 @@ def create_firstcyc_task(cdump='gdas'):
     '''
 
     task = 'firstcyc'
-    taskstr = '%s' % task
+    taskstr = f'{task}'
 
     deps = []
     data = '&EXPDIR;/logs/@Y@m@d@H.log'
@@ -230,18 +233,18 @@ def create_firstcyc_task(cdump='gdas'):
     deps.append(rocoto.add_dependency(dep_dict))
     dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
-    task_dict = {'taskname': '%s' % taskstr, \
+    task_dict = {'taskname': f'{taskstr}' , \
                  'cycledef': 'first', \
                  'maxtries': '&MAXTRIES;', \
                  'final' : True, \
                  'command': 'sleep 1', \
-                 'jobname': '&PSLOT;_%s_@H' % taskstr, \
+                 'jobname': f'&PSLOT;_{taskstr}_@H', \
                  'account': '&ACCOUNT;', \
                  'queue': '&QUEUE_SERVICE;', \
-                 'walltime': '&WALLTIME_ARCH_%s;' % cdump.upper(), \
-                 'native': '&NATIVE_ARCH_%s;' % cdump.upper(), \
-                 'resources': '&RESOURCES_ARCH_%s;' % cdump.upper(), \
-                 'log': '&ROTDIR;/logs/@Y@m@d@H/%s.log' % taskstr, \
+                 'walltime': f'&WALLTIME_ARCH_{cdump.upper()};', \
+                 'native': f'&NATIVE_ARCH_{cdump.upper()};', \
+                 'resources': f'&RESOURCES_ARCH_{cdump.upper()};', \
+                 'log': f'&ROTDIR;/logs/@Y@m@d@H/{taskstr}.log', \
                  'dependency': dependencies}
 
     if get_scheduler(detectMachine()) in ['slurm']:
@@ -275,27 +278,33 @@ def get_resources(machine, cfg, task, reservation, cdump='gdas'):
 
     scheduler = get_scheduler(machine)
 
-    if cdump in ['gfs'] and 'wtime_%s_gfs' % task in cfg.keys():
-        wtimestr = cfg['wtime_%s_gfs' % task]
+    if cdump in ['gfs'] and f'wtime_{task}_gfs' in cfg.keys():
+        wtimestr = cfg[f'wtime_{task}_gfs']
     else:
-        wtimestr = cfg['wtime_%s' % task]
+        wtimestr = cfg[f'wtime_{task}']
 
     ltask = 'eobs' if task in ['eomg'] else task
 
-    memory = cfg.get('memory_%s' % ltask, None)
+    memory = cfg.get(f'memory_{ltask}', None)
 
-    if cdump in ['gfs'] and 'npe_%s_gfs' % task in cfg.keys():
-        tasks = cfg['npe_%s_gfs' % ltask]
+    if cdump in ['gfs'] and f'npe_{task}_gfs' in cfg.keys():
+        tasks = cfg[f'npe_{ltask}_gfs']
     else:
-        tasks = cfg['npe_%s' % ltask]
+        try:
+            tasks = cfg[f'npe_{ltask}']
+        except KeyError:
+            tasks = cfg["',)npe_waveawipsgridded"]
 
-    if cdump in ['gfs'] and 'npe_node_%s_gfs' % task in cfg.keys():
-        ppn = cfg['npe_node_%s_gfs' % ltask]
+    if cdump in ['gfs'] and f'npe_node_{task}_gfs' in cfg.keys():
+        ppn = cfg[f'npe_node_{ltask}_gfs']
     else:
-        ppn = cfg['npe_node_%s' % ltask]
+        ppn = cfg[f'npe_node_{ltask}']
 
-    if machine in [ 'WCOSS_DELL_P3', 'HERA', 'ORION']:
-        threads = cfg['nth_%s' % ltask]
+    if machine in [ 'WCOSS_DELL_P3', 'HERA', 'ORION', 'JET' ]:
+        try:
+            threads = cfg[f'nth_{ltask}']
+        except KeyError:
+            threads = cfg["',)nth_epos"]
 
     nodes = np.int(np.ceil(np.float(tasks) / np.float(ppn)))
 
@@ -305,28 +314,28 @@ def get_resources(machine, cfg, task, reservation, cdump='gdas'):
     if scheduler in ['slurm']:
         natstr = '--export=NONE'
 
-    if machine in ['HERA', 'ORION', 'WCOSS_C', 'WCOSS_DELL_P3']:
+    if machine in ['HERA', 'JET', 'ORION', 'WCOSS_C', 'WCOSS_DELL_P3']:
 
-        if machine in ['HERA', 'ORION']:
-            resstr = '<nodes>%d:ppn=%d:tpp=%d</nodes>' % (nodes, ppn, threads)
+        if machine in ['HERA', 'JET', 'ORION']:
+            resstr = f'<nodes>{nodes}:ppn={ppn}:tpp={threads}</nodes>'
         else:
-            resstr = '<nodes>%d:ppn=%d</nodes>' % (nodes, ppn)
+            resstr = f'<nodes>{nodes}:ppn={ppn}</nodes>'
 
         if machine in ['WCOSS_C'] and task in ['arch', 'earc', 'getic']:
             resstr += '<shared></shared>'
 
         if machine in ['WCOSS_DELL_P3']:
             if not reservation in ['NONE']:
-               natstr = "-U %s -R 'affinity[core(%d)]'" % (reservation, threads)
+               natstr = f"-U {reservation} -R 'affinity[core({threads})]'"
             else:
-               natstr = "-R 'affinity[core(%d)]'" % (threads)
+               natstr = f"-R 'affinity[core({threads})]'"
 
             if task in ['arch', 'earc', 'getic']:
                   natstr = "-R 'affinity[core(1)]'"
 
 
     elif machine in ['WCOSS']:
-        resstr = '<cores>%d</cores>' % tasks
+        resstr = f'<cores>{tasks}</cores>'
 
     if task in ['arch', 'earc', 'getic']:
         queuestr = '&QUEUE;' if scheduler in ['slurm'] else '&QUEUE_SERVICE;'
@@ -344,7 +353,7 @@ def create_crontab(base, cronint=5):
     # No point creating a crontab if rocotorun is not available.
     rocotoruncmd = find_executable('rocotorun')
     if rocotoruncmd is None:
-        print 'Failed to find rocotorun, crontab will not be created'
+        print('Failed to find rocotorun, crontab will not be created')
         return
 
 # Leaving the code for a wrapper around crontab file if needed again later
@@ -373,13 +382,13 @@ def create_crontab(base, cronint=5):
 #
 #    else:
 
-    rocotorunstr = '%s -d %s/%s.db -w %s/%s.xml' % (rocotoruncmd, base['EXPDIR'], base['PSLOT'], base['EXPDIR'], base['PSLOT'])
-    cronintstr = '*/%d * * * *' % cronint
+    rocotorunstr = f'''{rocotoruncmd} -d {base['EXPDIR']}/{base['PSLOT']}.db -w {base['EXPDIR']}/{base['PSLOT']}.xml'''
+    cronintstr = f'*/{cronint} * * * *'
 
     # On WCOSS, rocoto module needs to be loaded everytime cron runs
     if base['machine'] in ['WCOSS']:
         rocotoloadstr = '. /usrx/local/Modules/default/init/sh; module use -a /usrx/local/emc_rocoto/modulefiles; module load rocoto/1.3.0rc2)'
-        rocotorunstr = '(%s %s)' % (rocotoloadstr, rocotorunstr)
+        rocotorunstr = f'({rocotoloadstr} {rocotorunstr})'
 
     try:
         REPLYTO = os.environ['REPLYTO']
@@ -389,13 +398,13 @@ def create_crontab(base, cronint=5):
     strings = []
 
     strings.append('\n')
-    strings.append('#################### %s ####################\n' % base['PSLOT'])
-    strings.append('MAILTO="%s"\n' % REPLYTO)
-    strings.append('%s %s\n' % (cronintstr, rocotorunstr))
+    strings.append(f'''#################### {base['PSLOT']} ####################\n''')
+    strings.append(f'MAILTO="{REPLYTO}"\n')
+    strings.append(f'{cronintstr} {rocotorunstr}\n')
     strings.append('#################################################################\n')
     strings.append('\n')
 
-    fh = open(os.path.join(base['EXPDIR'], '%s.crontab' % base['PSLOT']), 'w')
+    fh = open(os.path.join(base['EXPDIR'], f'''{base['PSLOT']}.crontab'''), 'w')
     fh.write(''.join(strings))
     fh.close()
 


### PR DESCRIPTION
Several updates for WCOSS2 port of operations branch:
- updates to use test version of UFS_UTILS (checkout, build, and link scripts)
- cleanup and fix some symlink creation in link_fv3gfs.sh that was going awry
- module_base.wcoss2 updates to add module version to cray-pals module load and update prod_util module to 2.0.9 (2.0.8 had bug)
- bring in rocoto setup scripts from develop branch to update from python2 to python3; no task changes in this update, although Jet free-forecast support comes in with the python upgrade; working on adding WCOSS2 support now

Refs: #399