### PR TITLE
Update to UFS as of 2021 Oct 07

### DIFF
--- a/modulefiles/module_base.hera
+++ b/modulefiles/module_base.hera
@@ -26,8 +26,8 @@ module load png/1.6.35
 module load hdf5/1.10.6
 module load netcdf/4.7.4
 module load pio/2.5.2
-module load esmf/8_1_1
-module load fms/2020.04.03
+module load esmf/8_2_0_beta_snapshot_14
+module load fms/2021.03
 
 module load bacio/2.4.1
 module load g2/3.4.1

--- a/modulefiles/module_base.jet
+++ b/modulefiles/module_base.jet
@@ -19,6 +19,7 @@ module load prod_util/1.2.2
 module load grib_util/1.2.2
 module load g2tmpl/1.10.0 
 module load crtm/2.3.0
-module load esmf/8_1_1
+module load esmf/8_2_0_beta_snapshot_14
+module load fms/2021.03
 module load netcdf/4.7.4
 module load rocoto

--- a/modulefiles/module_base.orion
+++ b/modulefiles/module_base.orion
@@ -25,8 +25,8 @@ module load png/1.6.35
 module load hdf5/1.10.6
 module load netcdf/4.7.4
 module load pio/2.5.2
-module load esmf/8_1_1
-module load fms/2020.04.03
+module load esmf/8_2_0_beta_snapshot_14
+module load fms/2021.03
 
 module load bacio/2.4.1
 module load g2/3.4.1

--- a/modulefiles/module_base.wcoss_dell_p3
+++ b/modulefiles/module_base.wcoss_dell_p3
@@ -33,8 +33,8 @@ module load png/1.6.35
 module load hdf5/1.10.6
 module load netcdf/4.7.4
 module load pio/2.5.2
-module load esmf/8_1_1
-module load fms/2020.04.03
+module load esmf/8_2_0_beta_snapshot_14
+module load fms/2021.03
 
 module load bacio/2.4.1
 module load g2/3.4.1

--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -189,7 +189,6 @@ export FHMAX_GFS=$(eval echo \${FHMAX_GFS_$cyc})
 export FHOUT_GFS=3
 export FHMAX_HF_GFS=0
 export FHOUT_HF_GFS=1
-export FHRLST="[0, 6, 12, 18, 24, 30, 36, 42, 48]"
 export STEP_GFS="24"
 export ILPOST=1           # gempak output frequency up to F120
 

--- a/parm/config/config.fcst
+++ b/parm/config/config.fcst
@@ -114,11 +114,11 @@ tbf=""
 if [ $satmedmf = ".true." ]; then tbf="_satmedmf" ; fi
 
 # Radiation options 
-export IAER=1011    ;#spectral band mapping method for aerosol optical properties
-export iovr_lw=3    ;#de-correlation length cloud overlap method (Barker, 2008) 
-export iovr_sw=3    ;#de-correlation length cloud overlap method (Barker, 2008) 
-export iovr=3       ;#de-correlation length cloud overlap method (Barker, 2008) 
-export icliq_sw=2   ;#cloud optical coeffs from AER's newer version v3.9-v4.0 for hu and stamnes
+export IAER=1011    ; #spectral band mapping method for aerosol optical properties
+export iovr_lw=3    ; #de-correlation length cloud overlap method (Barker, 2008) 
+export iovr_sw=3    ; #de-correlation length cloud overlap method (Barker, 2008) 
+export iovr=3       ; #de-correlation length cloud overlap method (Barker, 2008) 
+export icliq_sw=2   ; #cloud optical coeffs from AER's newer version v3.9-v4.0 for hu and stamnes
 export isubc_sw=2
 export isubc_lw=2
 
@@ -176,7 +176,10 @@ fi
 export DO_SPPT=${DO_SPPT:-"NO"}
 export DO_SKEB=${DO_SKEB:-"NO"}
 export DO_SHUM=${DO_SHUM:-"NO"}
+export DO_LAND_PERT=${DO_LAND_PERT:-"NO"}
 export DO_CA=${DO_CA:-"NO"}
+export DO_OCN_SPPT=${DO_OCN_SPPT:-"NO"}
+export DO_OCN_PERT_EPBL=${DO_OCN_PERT_EPBL:-"NO"}
 
 #coupling settings
 export FRAC_GRID=".true."

--- a/parm/mom6/MOM_input_template_025
+++ b/parm/mom6/MOM_input_template_025
@@ -11,10 +11,10 @@
 TRIPOLAR_N = True               !   [Boolean] default = False
                                 ! Use tripolar connectivity at the northern edge of the domain.  With
                                 ! TRIPOLAR_N, NIGLOBAL must be even.
-NIGLOBAL = NX_GLB               !
+NIGLOBAL = @[NX_GLB]            !
                                 ! The total number of thickness grid points in the x-direction in the physical
                                 ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
-NJGLOBAL = NY_GLB               !
+NJGLOBAL = @[NY_GLB]            !
                                 ! The total number of thickness grid points in the y-direction in the physical
                                 ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NIHALO = 4                      ! default = 4
@@ -40,16 +40,16 @@ THICKNESSDIFFUSE = True         !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
                                 ! If true, do thickness diffusion before dynamics. This is only used if
                                 ! THICKNESSDIFFUSE is true.
-DT = DT_DYNAM_MOM6              !   [s]
+DT = @[DT_DYNAM_MOM6]           !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DT_THERM = DT_THERM_MOM6        !   [s] default = 900.0
+DT_THERM = @[DT_THERM_MOM6]     !   [s] default = 1800.0
                                 ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-THERMO_SPANS_COUPLING = MOM6_THERMO_SPAN    !   [Boolean] default = False
+THERMO_SPANS_COUPLING = @[MOM6_THERMO_SPAN]    !   [Boolean] default = False
                                 ! If true, the MOM will take thermodynamic and tracer timesteps that can be
                                 ! longer than the coupling timestep. The actual thermodynamic timestep that is
                                 ! used in this case is the largest integer multiple of the coupling timestep
@@ -58,6 +58,7 @@ HFREEZE = 20.0                  !   [m] default = -1.0
                                 ! If HFREEZE > 0, melt potential will be computed. The actual depth
                                 ! over which melt potential is computed will be min(HFREEZE, OBLD)
                                 ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default)
+                                ! melt potential will not be computed.
 USE_PSURF_IN_EOS = False        !   [Boolean] default = False
                                 ! If true, always include the surface pressure contributions in equation of
                                 ! state calculations.
@@ -97,7 +98,7 @@ WRITE_GEOM = 2                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
-SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
+SAVE_INITIAL_CONDS = True      !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_hor_index ===
@@ -118,6 +119,13 @@ GRID_CONFIG = "mosaic"          !
                                 !     mercator - use a Mercator spherical grid.
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
+GRID_ROTATION_ANGLE_BUGS = False  ! [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and
+                                ! cosines needed rotate between grid-oriented directions and
+                                ! true north and east.  Differences arise at the tripolar fold
+USE_TRIPOLAR_GEOLONB_BUG = False !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -148,7 +156,7 @@ TOPO_FILE = "ocean_topog.nc"    ! default = "topog.nc"
                                 ! The file from which the bathymetry is read.
 TOPO_EDITS_FILE = "All_edits.nc" ! default = ""
                                 ! The file from which to read a list of i,j,z topography overrides.
-ALLOW_LANDMASK_CHANGES = MOM6_ALLOW_LANDMASK_CHANGES   ! default = "False"
+ALLOW_LANDMASK_CHANGES = @[MOM6_ALLOW_LANDMASK_CHANGES]   ! default = "False"
                                 ! If true, allow topography overrides to change ocean points to land
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
@@ -157,13 +165,6 @@ MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
                                 ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
                                 ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
                                 ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
-GRID_ROTATION_ANGLE_BUGS = False  ! [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold
-USE_TRIPOLAR_GEOLONB_BUG = False  ! [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees
 
 ! === module MOM_open_boundary ===
 ! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
@@ -324,6 +325,7 @@ Z_INIT_FILE_PTEMP_VAR = "temp"  ! default = "ptemp"
 Z_INIT_FILE_SALT_VAR = "salt"   ! default = "salt"
                                 ! The name of the salinity variable in
                                 ! SALT_Z_INIT_FILE.
+
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
@@ -670,7 +672,6 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 VERTEX_SHEAR = False             !   [Boolean] default = False
                                 ! If true, do the calculations of the shear-driven mixing
                                 ! at the cell vertices (i.e., the vorticity points).
-
 KAPPA_SHEAR_ITER_BUG = True     !   [Boolean] default = True
                                 ! If true, use an older, dimensionally inconsistent estimate of the derivative
                                 ! of diffusivity with energy in the Newton's method iteration.  The bug causes
@@ -695,7 +696,7 @@ PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
 VAR_PEN_SW = True               !   [Boolean] default = False
                                 ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
                                 ! the e-folding depth of incoming short wave radiation.
-CHL_FILE = "seawifs-clim-1997-2010.1440x1080.v20180328.nc" !
+CHL_FILE = @[CHLCLIM]           !
                                 ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
                                 ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "chlor_a"         ! default = "CHL_A"
@@ -740,12 +741,11 @@ MIX_LEN_EXPONENT = 1.0          !   [nondim] default = 2.0
                                 ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
                                 ! which determines the shape of the mixing length. This is only used if
                                 ! USE_MLD_ITERATION is True.
-USE_LA_LI2016 = MOM6_REPRO_LA   !   [nondim] default = False
+USE_LA_LI2016 = @[MOM6_USE_LI2016] !   [nondim] default = False
                                 ! A logical to use the Li et al. 2016 (submitted) formula to determine the
                                 ! Langmuir number.
-USE_WAVES = MOM6_USE_WAVES      !   [Boolean] default = False
+USE_WAVES = @[MOM6_USE_WAVES]   !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
-
 WAVE_METHOD = "SURFACE_BANDS"   ! default = "EMPTY"
                                 ! Choice of wave method, valid options include:
                                 !  TEST_PROFILE  - Prescribed from surface Stokes drift
@@ -756,19 +756,17 @@ WAVE_METHOD = "SURFACE_BANDS"   ! default = "EMPTY"
                                 !                  wave spectrum with prescribed values.
                                 !  LF17          - Infers Stokes drift profile from wind
                                 !                  speed following Li and Fox-Kemper 2017.
-
 SURFBAND_SOURCE = "COUPLER"     ! default = "EMPTY"
                                 ! Choice of SURFACE_BANDS data mode, valid options include:
                                 !  DATAOVERRIDE  - Read from NetCDF using FMS DataOverride.
                                 !  COUPLER       - Look for variables from coupler pass
                                 !  INPUT         - Testing with fixed values.
-
 STK_BAND_COUPLER = 3            ! default = 1
                                 ! STK_BAND_COUPLER is the number of Stokes drift bands in the coupler. This has
                                 ! to be consistent with the number of Stokes drift bands in WW3, or the model
                                 ! will fail.
-
 SURFBAND_WAVENUMBERS = 0.04, 0.11, 0.3305 !   [rad/m] default = 0.12566
+                                ! Central wavenumbers for surface Stokes drift bands.
 EPBL_LANGMUIR_SCHEME = "ADDITIVE" ! default = "NONE"
                                 ! EPBL_LANGMUIR_SCHEME selects the method for including Langmuir turbulence.
                                 ! Valid values are:
@@ -826,12 +824,14 @@ ENERGYSAVEDAYS = 1.00           !   [days] default = 1.0
                                 ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
+
+! === module MOM_surface_forcing ===
 OCEAN_SURFACE_STAGGER = "A"     ! default = "C"
                                 ! A case-insensitive character string to indicate the
                                 ! staggering of the surface velocity field that is
                                 ! returned to the coupler.  Valid values include
                                 ! 'A', 'B', or 'C'.
-! === module MOM_surface_forcing ===
+
 MAX_P_SURF = 0.0                !   [Pa] default = -1.0
                                 ! The maximum surface pressure that can be exerted by the atmosphere and
                                 ! floating sea-ice or ice shelves. This is needed because the FMS coupling
@@ -855,9 +855,14 @@ USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
 SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
                                 ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
                                 ! rigidity
-LIQUID_RUNOFF_FROM_DATA = MOM6_RIVER_RUNOFF  !   [Boolean] default = False
+LIQUID_RUNOFF_FROM_DATA = @[MOM6_RIVER_RUNOFF]  !   [Boolean] default = False
                                 ! If true, allows liquid river runoff to be specified via
                                 ! the data_table using the component name 'OCN'.
+! === module ocean_stochastics ===
+DO_SPPT   = @[DO_OCN_SPPT]      ! [Boolean] default = False
+                                ! If true perturb the diabatic tendencies in MOM_diabadic_driver 
+PERT_EPBL = @[PERT_EPBL]        ! [Boolean] default = False 
+                                ! If true perturb the KE dissipation and destruction in MOM_energetic_PBL
 ! === module MOM_restart ===
 RESTART_CHECKSUMS_REQUIRED = False
 ! === module MOM_file_parser ===

--- a/parm/mom6/MOM_input_template_050
+++ b/parm/mom6/MOM_input_template_050
@@ -11,10 +11,10 @@
 TRIPOLAR_N = True               !   [Boolean] default = False
                                 ! Use tripolar connectivity at the northern edge of the domain.  With
                                 ! TRIPOLAR_N, NIGLOBAL must be even.
-NIGLOBAL = NX_GLB               !
+NIGLOBAL = @[NX_GLB]            !
                                 ! The total number of thickness grid points in the x-direction in the physical
                                 ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
-NJGLOBAL = NY_GLB               !
+NJGLOBAL = @[NY_GLB]            !
                                 ! The total number of thickness grid points in the y-direction in the physical
                                 ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NIHALO = 4                      ! default = 4
@@ -40,16 +40,16 @@ THICKNESSDIFFUSE = True         !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
                                 ! If true, do thickness diffusion before dynamics. This is only used if
                                 ! THICKNESSDIFFUSE is true.
-DT = DT_DYNAM_MOM6              !   [s]
+DT = @[DT_DYNAM_MOM6]           !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DT_THERM = DT_THERM_MOM6        !   [s] default = 1800.0
+DT_THERM = @[DT_THERM_MOM6]     !   [s] default = 1800.0
                                 ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-THERMO_SPANS_COUPLING = MOM6_THERMO_SPAN    !   [Boolean] default = False
+THERMO_SPANS_COUPLING = @[MOM6_THERMO_SPAN]    !   [Boolean] default = False
                                 ! If true, the MOM will take thermodynamic and tracer timesteps that can be
                                 ! longer than the coupling timestep. The actual thermodynamic timestep that is
                                 ! used in this case is the largest integer multiple of the coupling timestep
@@ -98,7 +98,7 @@ WRITE_GEOM = 2                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
-SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
+SAVE_INITIAL_CONDS = True      !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_hor_index ===
@@ -119,6 +119,13 @@ GRID_CONFIG = "mosaic"          !
                                 !     mercator - use a Mercator spherical grid.
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
+GRID_ROTATION_ANGLE_BUGS = False  ! [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and
+                                ! cosines needed rotate between grid-oriented directions and
+                                ! true north and east.  Differences arise at the tripolar fold
+USE_TRIPOLAR_GEOLONB_BUG = False !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -147,7 +154,7 @@ TOPO_CONFIG = "file"            !
                                 !     USER - call a user modified routine.
 TOPO_FILE = "ocean_topog.nc"    ! default = "topog.nc"
                                 ! The file from which the bathymetry is read.
-ALLOW_LANDMASK_CHANGES = MOM6_ALLOW_LANDMASK_CHANGES   ! default = "False"
+ALLOW_LANDMASK_CHANGES = @[MOM6_ALLOW_LANDMASK_CHANGES]   ! default = "False"
                                 ! If true, allow topography overrides to change ocean points to land
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
@@ -156,14 +163,7 @@ MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
                                 ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
                                 ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
                                 ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
-GRID_ROTATION_ANGLE_BUGS = False  ! [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold
 
-USE_TRIPOLAR_GEOLONB_BUG = False !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude in some points
-                                ! along the tripolar fold to be off by 360 degrees.
 ! === module MOM_open_boundary ===
 ! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
 ! if any.
@@ -183,9 +183,6 @@ CHANNEL_CONFIG = "list"         ! default = "none"
                                 !       NetCDF file on the model grid.
 CHANNEL_LIST_FILE = "MOM_channels_global_025" ! default = "MOM_channel_list"
                                 ! The file from which the list of narrowed channels is read.
-PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file, otherwise a single
-                                ! restart file is generated
 
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
@@ -200,6 +197,9 @@ DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
+PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_flow_control ===
 USE_IDEAL_AGE_TRACER = False    !   [Boolean] default = False
@@ -726,7 +726,8 @@ PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
 VAR_PEN_SW = True               !   [Boolean] default = False
                                 ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
                                 ! the e-folding depth of incoming short wave radiation.
-CHL_FILE = CHLCLIM              ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+CHL_FILE = @[CHLCLIM]           !
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
                                 ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "chlor_a"         ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
@@ -770,10 +771,10 @@ MIX_LEN_EXPONENT = 1.0          !   [nondim] default = 2.0
                                 ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
                                 ! which determines the shape of the mixing length. This is only used if
                                 ! USE_MLD_ITERATION is True.
-USE_LA_LI2016 = MOM6_REPRO_LA   !   [nondim] default = False
+USE_LA_LI2016 = @[MOM6_USE_LI2016] !   [nondim] default = False
                                 ! A logical to use the Li et al. 2016 (submitted) formula to determine the
                                 ! Langmuir number.
-USE_WAVES = MOM6_USE_WAVES      !   [Boolean] default = False
+USE_WAVES = @[MOM6_USE_WAVES]   !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 WAVE_METHOD = "SURFACE_BANDS"   ! default = "EMPTY"
                                 ! Choice of wave method, valid options include:
@@ -825,7 +826,7 @@ VAR_PEN_SW = True               !   [Boolean] default = False
                                 ! If true, use one of the CHL_A schemes specified by
                                 ! OPACITY_SCHEME to determine the e-folding depth of
                                 ! incoming short wave radiation.
-CHL_FILE = CHLCLIM              ! CHL_FILE is the file containing chl_a concentrations in
+CHL_FILE = @[CHLCLIM]           ! CHL_FILE is the file containing chl_a concentrations in
                                 ! the variable CHL_A. It is used when VAR_PEN_SW and
                                 ! CHL_FROM_FILE are true.
 CHL_VARNAME = "chlor_a"         ! default = "CHL_A"
@@ -858,11 +859,7 @@ USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 
 ! === module ocean_model_init ===
-OCEAN_SURFACE_STAGGER = "A"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+
 RESTART_CHECKSUMS_REQUIRED = False
 ! === module MOM_lateral_boundary_diffusion ===
 ! This module implements lateral diffusion of tracers near boundaries
@@ -883,6 +880,12 @@ ENERGYSAVEDAYS_GEOMETRIC = 0.25 !   [days] default = 0.0
 ! === module ocean_model_init ===
 
 ! === module MOM_surface_forcing ===
+OCEAN_SURFACE_STAGGER = "A"     ! default = "C"
+                                ! A case-insensitive character string to indicate the
+                                ! staggering of the surface velocity field that is
+                                ! returned to the coupler.  Valid values include
+                                ! 'A', 'B', or 'C'.
+
 MAX_P_SURF = 0.0                !   [Pa] default = -1.0
                                 ! The maximum surface pressure that can be exerted by the atmosphere and
                                 ! floating sea-ice or ice shelves. This is needed because the FMS coupling
@@ -906,9 +909,14 @@ USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
 SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
                                 ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
                                 ! rigidity
-LIQUID_RUNOFF_FROM_DATA = MOM6_RIVER_RUNOFF  !   [Boolean] default = False
+LIQUID_RUNOFF_FROM_DATA = @[MOM6_RIVER_RUNOFF]  !   [Boolean] default = False
                                 ! If true, allows liquid river runoff to be specified via
                                 ! the data_table using the component name 'OCN'.
+! === module ocean_stochastics ===
+DO_SPPT   = @[DO_OCN_SPPT]      ! [Boolean] default = False
+                                ! If true perturb the diabatic tendencies in MOM_diabadic_driver 
+PERT_EPBL = @[PERT_EPBL]        ! [Boolean] default = False 
+                                ! If true perturb the KE dissipation and destruction in MOM_energetic_PBL
 ! === module MOM_restart ===
 
 ! === module MOM_file_parser ===

--- a/parm/mom6/MOM_input_template_100
+++ b/parm/mom6/MOM_input_template_100
@@ -12,16 +12,16 @@ THICKNESSDIFFUSE = True         !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
                                 ! If true, do thickness diffusion before dynamics. This is only used if
                                 ! THICKNESSDIFFUSE is true.
-DT = DT_DYNAM_MOM6              !   [s]
+DT = @[DT_DYNAM_MOM6]           !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DT_THERM = DT_THERM_MOM6        !   [s] default = 1800.0
+DT_THERM = @[DT_THERM_MOM6]     !   [s] default = 1800.0
                                 ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-THERMO_SPANS_COUPLING = MOM6_THERMO_SPAN    !   [Boolean] default = False
+THERMO_SPANS_COUPLING = @[MOM6_THERMO_SPAN]    !   [Boolean] default = False
                                 ! If true, the MOM will take thermodynamic and tracer timesteps that can be
                                 ! longer than the coupling timestep. The actual thermodynamic timestep that is
                                 ! used in this case is the largest integer multiple of the coupling timestep
@@ -72,11 +72,11 @@ WRITE_GEOM = 2                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
-SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
+SAVE_INITIAL_CONDS = True      !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_oda_incupd ===
-ODA_INCUPD = MOM_IAU            ! [Boolean] default = False
+ODA_INCUPD = @[MOM_IAU]         ! [Boolean] default = False
                                 ! If true, oda incremental updates will be applied
                                 ! everywhere in the domain.
 ODA_INCUPD_FILE = "mom6_increment.nc" ! The name of the file with the T,S,h increments.
@@ -97,17 +97,17 @@ ODA_UINC_VAR = "u_inc"          ! default = "u_inc"
 ODA_VINC_VAR = "v_inc"          ! default = "v_inc"
                                 ! The name of the meridional vel. inc. variable in
                                 ! ODA_INCUPD_UV_FILE.
-ODA_INCUPD_NHOURS = MOM_IAU_HRS ! default=3.0 
+ODA_INCUPD_NHOURS = @[MOM_IAU_HRS] ! default=3.0
                                 ! Number of hours for full update (0=direct insertion).
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
                                 ! Use tripolar connectivity at the northern edge of the domain.  With
                                 ! TRIPOLAR_N, NIGLOBAL must be even.
-NIGLOBAL = NX_GLB               !
+NIGLOBAL = @[NX_GLB]            !
                                 ! The total number of thickness grid points in the x-direction in the physical
                                 ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
-NJGLOBAL = NY_GLB               !
+NJGLOBAL = @[NY_GLB]            !
                                 ! The total number of thickness grid points in the y-direction in the physical
                                 ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
@@ -165,7 +165,7 @@ TOPO_CONFIG = "file"            !
                                 !     USER - call a user modified routine.
 TOPO_EDITS_FILE = "topo_edits_011818.nc" ! default = ""
                                 ! The file from which to read a list of i,j,z topography overrides.
-ALLOW_LANDMASK_CHANGES = MOM6_ALLOW_LANDMASK_CHANGES   ! default = "False"
+ALLOW_LANDMASK_CHANGES = @[MOM6_ALLOW_LANDMASK_CHANGES]   ! default = "False"
                                 ! If true, allow topography overrides to change ocean points to land
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
@@ -694,7 +694,7 @@ PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
 VAR_PEN_SW = True               !   [Boolean] default = False
                                 ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
                                 ! the e-folding depth of incoming short wave radiation.
-CHL_FILE = CHLCLIM              !
+CHL_FILE = @[CHLCLIM]           !
                                 ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
                                 ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 
@@ -737,10 +737,10 @@ MIX_LEN_EXPONENT = 1.0          !   [nondim] default = 2.0
                                 ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
                                 ! which determines the shape of the mixing length. This is only used if
                                 ! USE_MLD_ITERATION is True.
-USE_LA_LI2016 = MOM6_REPRO_LA   !   [nondim] default = False
+USE_LA_LI2016 = @[MOM6_USE_LI2016] !   [nondim] default = False
                                 ! A logical to use the Li et al. 2016 (submitted) formula to determine the
                                 ! Langmuir number.
-USE_WAVES = MOM6_USE_WAVES      !   [Boolean] default = False
+USE_WAVES = @[MOM6_USE_WAVES]   !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 WAVE_METHOD = "SURFACE_BANDS"   ! default = "EMPTY"
                                 ! Choice of wave method, valid options include:
@@ -851,6 +851,11 @@ GUST_CONST = 0.02               !   [Pa] default = 0.0
 FIX_USTAR_GUSTLESS_BUG = False  !   [Boolean] default = True
                                 ! If true correct a bug in the time-averaging of the gustless wind friction
                                 ! velocity
+! === module ocean_stochastics ===
+DO_SPPT   = @[DO_OCN_SPPT]      ! [Boolean] default = False
+                                ! If true perturb the diabatic tendencies in MOM_diabadic_driver 
+PERT_EPBL = @[PERT_EPBL]        ! [Boolean] default = False 
+                                ! If true perturb the KE dissipation and destruction in MOM_energetic_PBL
 
 ! === module MOM_restart ===
 

--- a/parm/parm_fv3diag/data_table
+++ b/parm/parm_fv3diag/data_table
@@ -1,1 +1,1 @@
-"OCN", "runoff", "runoff", "./INPUT/FRUNOFF", "none" ,  1.0
+"OCN", "runoff", "runoff", "./INPUT/@[FRUNOFF]", "none" ,  1.0

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -31,7 +31,7 @@ echo ufs-weather-model checkout ...
 if [[ ! -d ufs_model.fd ]] ; then
     git clone https://github.com/ufs-community/ufs-weather-model ufs_model.fd >> ${logdir}/checkout-ufs_model.log 2>&1
     cd ufs_model.fd
-    git checkout ${ufs_model_hash:-b26a896f2c9bada438414a51218bc72236925b8c}
+    git checkout ${ufs_model_hash:-c1d619}
     git submodule update --init --recursive
     cd ${topdir}
 else

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -856,6 +856,7 @@ CICE_postdet() {
   year=$(echo $CDATE|cut -c 1-4)
   month=$(echo $CDATE|cut -c 5-6)
   day=$(echo $CDATE|cut -c 7-8)
+  sec=$(echo $CDATE|cut -c 9-10)  
   stepsperhr=$((3600/$ICETIM))
   nhours=$($NHOUR $CDATE ${year}010100)
   steps=$((nhours*stepsperhr))

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -496,6 +496,7 @@ EOF
     ISEED_SHUM=$((CDATE*1000 + MEMBER*10 + 2))
     ISEED_SPPT=$((CDATE*1000 + MEMBER*10 + 3))
     ISEED_CA=$(( (CDATE*1000 + MEMBER*10 + 4) % 2147483647 ))
+    ISEED_LNDP=$(( (CDATE*1000 + MEMBER*10 + 5) % 2147483647 ))
   else
     ISEED=${ISEED:-0}
   fi
@@ -507,6 +508,15 @@ EOF
   fi
   if [ $DO_SHUM = "YES" ]; then
     do_shum=".true."
+  fi
+  if [ $DO_LAND_PERT = "YES" ]; then
+    lndp_type=${lndp_type:-2}
+    LNDP_TAU=${LNDP_TAU:-21600}
+    LNDP_SCALE=${LNDP_SCALE:-500000}
+    ISEED_LNDP=${ISEED_LNDP:-$ISEED}
+    lndp_var_list=${lndp_var_list:-"'smc', 'vgf',"}
+    lndp_prt_list=${lndp_prt_list:-"0.2,0.1"}
+    n_var_lndp=$(echo "$lndp_var_list" | wc -w)
   fi
   JCAP_STP=${JCAP_STP:-$JCAP_CASE}
   LONB_STP=${LONB_STP:-$LONB_CASE}
@@ -529,7 +539,7 @@ EOF
 
   if [ $QUILTING = ".true." -a $OUTPUT_GRID = "gaussian_grid" ]; then
     fhr=$FHMIN
-    while [ $fhr -le $FHMAX ]; do
+    for fhr in $OUTPUT_FH; do
       FH3=$(printf %03i $fhr)
       FH2=$(printf %02i $fhr)
       atmi=atmf${FH3}.$affix
@@ -549,11 +559,6 @@ EOF
         eval $NLN $pgbo $pgbi
         eval $NLN $flxo $flxi
       fi
-      FHINC=$FHOUT
-      if [ $FHMAX_HF -gt 0 -a $FHOUT_HF -gt 0 -a $fhr -lt $FHMAX_HF ]; then
-        FHINC=$FHOUT_HF
-      fi
-      fhr=$((fhr+FHINC))
     done
   else
     for n in $(seq 1 $ntiles); do
@@ -761,6 +766,15 @@ MOM6_postdet() {
   fi
 
   echo "SUB ${FUNCNAME[0]}: MOM6 input data linked/copied"
+
+  if [ $DO_OCN_SPPT = "YES" -o $DO_OCN_PERT_EPBL = "YES" ]; then
+    if [ ${SET_STP_SEED:-"YES"} = "YES" ]; then
+      ISEED_OCNSPPT=$(( (CDATE*1000 + MEMBER*10 + 6) % 2147483647 ))
+      ISEED_EPBL=$(( (CDATE*1000 + MEMBER*10 + 7) % 2147483647 ))
+    else
+      ISEED=${ISEED:-0}
+    fi
+  fi
 }
 
 MOM6_nml() {
@@ -794,7 +808,7 @@ MOM6_out() {
     if [ $FHRGRP -eq 0 ]; then
       fhrlst="anl"
     else
-      fhrlst=$(echo $FHRLST | sed -e 's/_/ /g; s/\[/ /g; s/\]/ /g; s/f/ /g; s/,/ /g')
+      fhrlst=$OUTPUT_HF
     fi
 
     # copy ocn files

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -54,6 +54,19 @@ FV3_GFS_predet(){
   restart_interval=${restart_interval:-0}
   rst_invt1=`echo $restart_interval |cut -d " " -f 1`
 
+  # Convert output settings into an explicit list
+  OUTPUT_FH=""
+  FHMIN_LF=$FHMIN
+  if (( FHOUT_HF > 0 && FHMAX_HF > 0 )); then
+    for (( fh = FHMIN; fh < FHMAX_HF; fh = fh + FHOUT_HF )); do
+      OUTPUT_FH="$OUTPUT_FH $fh"
+    done
+    FHMIN_LF=$FHMAX_HF
+  fi
+  for (( fh = FHMIN_LF; fh <= FHMAX; fh = fh + FHOUT )); do
+    OUTPUT_FH="$OUTPUT_FH $fh"
+  done
+
   PDY=$(echo $CDATE | cut -c1-8)
   cyc=$(echo $CDATE | cut -c9-10)
 

--- a/ush/parsing_model_configure_FV3.sh
+++ b/ush/parsing_model_configure_FV3.sh
@@ -53,10 +53,7 @@ ideflate:                ${ideflate:-1}
 nbits:                   ${nbits:-14}
 imo:                     $LONB_IMO
 jmo:                     $LATB_JMO
-
-nfhout:                  $FHOUT
-nfhmax_hf:               $FHMAX_HF
-nfhout_hf:               $FHOUT_HF
+output_fh:               $OUTPUT_FH
 nsout:                   $NSOUT
 iau_offset:              ${IAU_OFFSET:-0}
 EOF

--- a/ush/parsing_namelists_CICE.sh
+++ b/ush/parsing_namelists_CICE.sh
@@ -105,7 +105,7 @@ cat > ice_in <<eof
    kdyn            = 1
    ndte            = 120
    revised_evp     = .false.
-   kevp_kernel     = 0
+   evp_algorithm   = 'standard_2d'
    brlx            = 300.0
    arlx            = 300.0
    ssh_stress      = 'coupled'
@@ -148,6 +148,10 @@ cat > ice_in <<eof
    rfracmin        = 0.15
    rfracmax        = 1.
    pndaspect       = 0.8
+/
+
+&snow_nml
+   snwredist       = 'none'
 /
 
 &forcing_nml

--- a/ush/parsing_namelists_CICE.sh
+++ b/ush/parsing_namelists_CICE.sh
@@ -16,6 +16,7 @@ cat > ice_in <<eof
    year_init      = $year
    month_init     = $month
    day_init       = $day
+   sec_init       = $sec
    dt             = $ICETIM
    npt            = $npt
    ndtd           = 1

--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -178,6 +178,8 @@ cat >> input.nml << EOF
   fhzero       = $FHZER
   h2o_phys     = ${h2o_phys:-".true."}
   ldiag3d      = ${ldiag3d:-".false."}
+  qdiag3d      = ${qdiag3d:-".false."}
+  print_diff_pgr = ${print_diff_pgr:-".false."}
   fhcyc        = $FHCYC
   use_ufo      = ${use_ufo:-".true."}
   pre_rad      = ${pre_rad:-".false."}
@@ -283,6 +285,7 @@ cat >> input.nml <<EOF
   cnvcld       = ${cnvcld:-".true."}
   imfshalcnv   = ${imfshalcnv:-"2"}
   imfdeepcnv   = ${imfdeepcnv:-"2"}
+  ras          = ${ras:-".false."}
   cdmbgwd      = ${cdmbgwd:-"3.5,0.25"}
   prslrd0      = ${prslrd0:-"0."}
   ivegsrc      = ${ivegsrc:-"1"}
@@ -346,6 +349,7 @@ fi
 if [ ${DO_CA:-"NO"} = "YES" ]; then
   cat >> input.nml << EOF
   do_ca      = .True.
+  ca_global  = ${ca_global:-".False."}
   ca_sgs     = ${ca_sgs:-".True."}
   nca        = ${nca:-"1"}
   scells     = ${scells:-"2600"}
@@ -356,6 +360,13 @@ if [ ${DO_CA:-"NO"} = "YES" ]; then
   ca_trigger = ${ca_trigger:-".True."}
   nspinup    = ${nspinup:-"1"}
   iseed_ca   = ${ISEED_CA:-"12345"}
+EOF
+fi
+
+if [ ${DO_LAND_PERT:-"NO"} = "YES" ]; then
+  cat >> input.nml << EOF
+  lndp_type = ${lndp_type:-2}
+  n_var_lndp = ${n_var_lndp:-0}
 EOF
 fi
 
@@ -544,7 +555,7 @@ EOF
 # Add namelist for stochastic physics options
 echo "" >> input.nml
 #if [ $MEMBER -gt 0 ]; then
-if [ $DO_SPPT = "YES" -o $DO_SHUM = "YES" -o $DO_SKEB = "YES" ]; then
+if [ $DO_SPPT = "YES" -o $DO_SHUM = "YES" -o $DO_SKEB = "YES" -o $DO_LAND_PERT = "YES" ]; then
 
     cat >> input.nml << EOF
 &nam_stochy
@@ -588,12 +599,19 @@ EOF
 /
 EOF
 
-
+  if [ $DO_LAND_PERT = "YES" ]; then
     cat >> input.nml << EOF
 &nam_sfcperts
+  lndp_type = ${lndp_type}
+  LNDP_TAU = ${LNDP_TAU}
+  LNDP_SCALE = ${LNDP_SCALE}
+  ISEED_LNDP = ${ISEED_LNDP:-$ISEED}
+  lndp_var_list = ${lndp_var_list}
+  lndp_prt_list = ${lndp_prt_list}
   $nam_sfcperts_nml
 /
 EOF
+  fi
 
 else
 


### PR DESCRIPTION
This update adds several new stochastic physics possibilities, with
associated switched added. There are also some other new namelist
settings.

MOM input template files have been updated to use the @[ ] notation
following same changes in UFS, with corresponding changes to the
replacement code. The new template files were copied from UFS, except
saving of initial conditions is turned on.

Due to changes in how the output cadence is defined in the namelist,
an explicit list of forecast hours is generated in the pre-det script.
To avoid duplication, this list is used later to create the symlinks
for the output files.