### PR TITLE
Update of non-aerosol components in prep for mini-P7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Currently this is set up for benchmark runs which have ICs which are already gen
 
 Prototype 5: global-workflow hash 005468b9299ea6fc9afdbeace33c336c6797833a
 Prototype 6: global-workflow hash 8a7694a2ab7ac95cd5530c0b14f7971602504cf9
+Prototype 7.0: global-workflow hash ac39d00a07ab716aa53236bb3017c95c86929bfe 
 
 ## Managing Default / Adding new configuration variables
 

--- a/modulefiles/module_base.hera
+++ b/modulefiles/module_base.hera
@@ -1,48 +1,51 @@
 #%Module######################################################################
 ##
-##      S2S prerequisites
+##      FV3GFS prerequisites
 ##
 
-# Modules availble through hpc-stack
 module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack
-
 module load hpc/1.1.0
 module load hpc-intel/18.0.5.274
 module load hpc-impi/2018.0.4
-# use shared memory and OpenFabrics Alliance (OFA) fabric with Intel MPI to circumvent RDMA-related bug in DAPL.
-setenv I_MPI_FABRICS shm:ofa
 
-# Non-MPI
-module load g2/3.4.2
-module load g2tmpl/1.10.0
-module load grib_util/1.2.2
-module load crtm/2.3.0
+module load hpss/hpss
+module load nco/4.9.1
+module load gempak/7.4.2
+
+#Load from hpc-stack
 module load prod_util/1.2.2
 module load grib_util/1.2.2
-module load ip/3.3.3
 
-module load sp/2.3.3
-module load w3nco/2.4.1
-module load bacio/2.4.1
-module load landsfcutil/2.4.1
+module load crtm/2.3.0
+setenv CRTM_FIX /scratch2/NCEPDEV/nwprod/NCEPLIBS/fix/crtm_v2.3.0
+
 module load jasper/2.0.25
 module load zlib/1.2.11
 module load png/1.6.35
 
-# MPI
-module load netcdf/4.7.4
 module load hdf5/1.10.6
-module load esmf/8_1_1
-module load w3emc/2.7.3
-module load wgrib2/2.0.8
-setenv "WGRIB2" "wgrib2"
+module load netcdf/4.7.4
+module load pio/2.5.2
+module load esmf/8_2_0_beta_snapshot_14
+module load fms/2021.03
 
-# Modules not under hpc-stack
-module load hpss/hpss
-module load nco/4.9.1
-module load gempak/7.4.2
-module load ncl/6.5.0
-module load cdo/1.9.5
-module load intelpython/3.6.8
-# netCDF4 is not in the python installation on Hera
-append-path "PYTHONPATH" "/scratch2/NCEPDEV/ensemble/save/Walter.Kolczynski/python_packages"
+module load bacio/2.4.1
+module load g2/3.4.1
+module load g2tmpl/1.9.1
+module load ip/3.3.3
+module load nemsio/2.5.2
+module load sp/2.3.3
+module load w3emc/2.7.3
+module load w3nco/2.4.1
+module load upp/10.0.8
+
+module load wgrib2/2.0.8
+setenv WGRIB2 wgrib2
+
+# python
+module use -a /contrib/anaconda/modulefiles
+module load anaconda/2.3.0
+
+# waveprep
+module load cdo/1.9.5 
+

--- a/modulefiles/module_base.hera
+++ b/modulefiles/module_base.hera
@@ -30,14 +30,14 @@ module load esmf/8_2_0_beta_snapshot_14
 module load fms/2021.03
 
 module load bacio/2.4.1
-module load g2/3.4.1
-module load g2tmpl/1.9.1
+module load g2/3.4.2
+module load g2tmpl/1.10.0
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load sp/2.3.3
-module load w3emc/2.7.3
+module load w3emc/2.9.1
 module load w3nco/2.4.1
-module load upp/10.0.8
+module load upp/10.0.9
 
 module load wgrib2/2.0.8
 setenv WGRIB2 wgrib2

--- a/modulefiles/module_base.orion
+++ b/modulefiles/module_base.orion
@@ -1,55 +1,52 @@
 #%Module######################################################################
 ##
-##    NEMS FV3 Prerequisites: Orion/Intel
-
+##      FV3GFS prerequisites
 ##
-## load contrib environment
-## load slurm utils (arbitrary.pl  layout.pl)
-##
-module load contrib noaatools
 
-module load nco/4.9.3
-module load gempak/7.5.1
-module load ncl/6.6.2
-module load cdo/1.9.8
-
-# Remaining modules availble through hpc-stack
 module use /apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack
 module load hpc/1.1.0
 module load hpc-intel/2018.4
 module load hpc-impi/2018.4
 
-# Non-MPI
-module load g2/3.4.2
-module load g2tmpl/1.10.0
+#module load hpss/hpss
+module load nco/4.8.1
+module load gempak/7.5.1
+
 module load grib_util/1.2.2
-module load crtm 2.3.0
 module load prod_util/1.2.2
-module load grib_util/1.2.2
-module load ip/3.3.3
-module load sp/2.3.3
-module load w3nco/2.4.1
-module load bacio/2.4.1
-module load landsfcutil/2.4.1
+
+module load crtm/2.3.0
+setenv CRTM_FIX /apps/contrib/NCEPLIBS/orion/fix/crtm_v2.3.0
+
 module load jasper/2.0.25
 module load zlib/1.2.11
 module load png/1.6.35
 
-# MPI
-module load netcdf/4.7.4
 module load hdf5/1.10.6
-module load esmf/8_1_1
+module load netcdf/4.7.4
+module load pio/2.5.2
+module load esmf/8_2_0_beta_snapshot_14
+module load fms/2021.03
+
+module load bacio/2.4.1
+module load g2/3.4.1
+module load g2tmpl/1.9.1
+module load ip/3.3.3
+module load nemsio/2.5.2
+module load sp/2.3.3
 module load w3emc/2.7.3
-module load wgrib2/2.0.8
+module load w3nco/2.4.1
+module load upp/10.0.8
+
+module load wgrib/2.0.8
 setenv WGRIB2 wgrib2
 
+module load contrib
+module load rocoto/1.3.3
 module load slurm/19.05.3-2
 
-##
-### load cmake
-###
-module load cmake/3.15.4
-setenv CMAKE_C_COMPILER mpiicc
-setenv CMAKE_CXX_COMPILER mpiicpc
-setenv CMAKE_Fortran_COMPILER mpiifort
-setenv CMAKE_Platform orion.intel
+# Python
+module load python/3.7.5
+
+# waveprep
+module load cdo/1.9.5

--- a/modulefiles/module_base.orion
+++ b/modulefiles/module_base.orion
@@ -29,14 +29,14 @@ module load esmf/8_2_0_beta_snapshot_14
 module load fms/2021.03
 
 module load bacio/2.4.1
-module load g2/3.4.1
-module load g2tmpl/1.9.1
+module load g2/3.4.2
+module load g2tmpl/1.10.0
 module load ip/3.3.3
 module load nemsio/2.5.2
 module load sp/2.3.3
 module load w3emc/2.7.3
 module load w3nco/2.4.1
-module load upp/10.0.8
+module load upp/10.0.9
 
 module load wgrib/2.0.8
 setenv WGRIB2 wgrib2

--- a/modulefiles/module_base.wcoss_dell_p3
+++ b/modulefiles/module_base.wcoss_dell_p3
@@ -1,46 +1,56 @@
 #%Module######################################################################
+##
+##      FV3GFS prerequisites
 
-# Remaining modules availble through hpc-stack
+# From default environment
+
 module use /usrx/local/nceplibs/dev/hpc-stack/libs/hpc-stack/modulefiles/stack
 module load hpc/1.1.0
 module load hpc-ips/18.0.1.163
 module load hpc-impi/18.0.1
 
-# Not hpc-stack, but must come after impi load
+module load lsf/10.1       
+module load EnvVars/1.0.3
+module load HPSS/5.0.2.5
+
+module load prod_util/1.2.2
+module load prod_envir/1.1.0
+module load grib_util/1.2.2
+module load util_shared/1.3.0
+
+module load crtm/2.3.0
+setenv CRTM_FIX /gpfs/dell1/nco/ops/nwprod/lib/crtm/v2.3.0/fix
+
+module load NCO/4.7.0   
 module load CFP/2.0.2
 setenv USE_CFP YES
+module load pm5
 
-# Non-MPI
-module load g2/3.4.2
-module load g2tmpl/1.10.0
-module load grib_util/1.2.2
-module load crtm 2.3.0
-module load prod_util/1.2.2
-module load ip/3.3.3
-module load sp/2.3.3
-module load w3nco/2.4.1
-module load bacio/2.4.1
-module load landsfcutil/2.4.1
 module load jasper/2.0.25
 module load zlib/1.2.11
 module load png/1.6.35
 
-# MPI
-module load netcdf/4.7.4
 module load hdf5/1.10.6
-module load esmf/8_1_1
+module load netcdf/4.7.4
+module load pio/2.5.2
+module load esmf/8_2_0_beta_snapshot_14
+module load fms/2021.03
+
+module load bacio/2.4.1
+module load g2/3.4.1
+module load g2tmpl/1.9.1
+module load ip/3.3.3
+module load nemsio/2.5.2
+module load sp/2.3.3
 module load w3emc/2.7.3
+module load w3nco/2.4.1
+module load upp/10.0.8
+
 module load wgrib2/2.0.8
 setenv WGRIB2 wgrib2
 
-# Modules not under hpc-stack
-module load HPSS/5.0.2.5
-module load NCO/4.7.0
+module use -a /gpfs/dell1/nco/ops/nwprod/modulefiles/
 module load gempak/7.3.3
-module load NCL/6.4.0
-module load cdo/1.9.8
-module load g2tmpl/1.6.0
-module load util_shared/1.3.0
 
 # Load for WAFS
 module load bufr_dumplist/2.0.0
@@ -49,9 +59,5 @@ module load dumpjb/5.1.0
 # python
 module load python/3.6.3
 
-# WCOSS-specific
-module load lsf/10.1
-module load EnvVars/1.0.3
-module load prod_envir/1.1.0
-module load pm5/1.0
-
+# waveprep
+module load cdo/1.9.8

--- a/parm/mom6/MOM_input_template_025
+++ b/parm/mom6/MOM_input_template_025
@@ -11,10 +11,10 @@
 TRIPOLAR_N = True               !   [Boolean] default = False
                                 ! Use tripolar connectivity at the northern edge of the domain.  With
                                 ! TRIPOLAR_N, NIGLOBAL must be even.
-NIGLOBAL = NX_GLB               !
+NIGLOBAL = @[NX_GLB]            !
                                 ! The total number of thickness grid points in the x-direction in the physical
                                 ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
-NJGLOBAL = NY_GLB               !
+NJGLOBAL = @[NY_GLB]            !
                                 ! The total number of thickness grid points in the y-direction in the physical
                                 ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NIHALO = 4                      ! default = 4
@@ -40,16 +40,16 @@ THICKNESSDIFFUSE = True         !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
                                 ! If true, do thickness diffusion before dynamics. This is only used if
                                 ! THICKNESSDIFFUSE is true.
-DT = DT_DYNAM_MOM6              !   [s]
+DT = @[DT_DYNAM_MOM6]           !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DT_THERM = DT_THERM_MOM6        !   [s] default = 900.0
+DT_THERM = @[DT_THERM_MOM6]     !   [s] default = 1800.0
                                 ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-THERMO_SPANS_COUPLING = MOM6_THERMO_SPAN    !   [Boolean] default = False
+THERMO_SPANS_COUPLING = @[MOM6_THERMO_SPAN]    !   [Boolean] default = False
                                 ! If true, the MOM will take thermodynamic and tracer timesteps that can be
                                 ! longer than the coupling timestep. The actual thermodynamic timestep that is
                                 ! used in this case is the largest integer multiple of the coupling timestep
@@ -58,6 +58,7 @@ HFREEZE = 20.0                  !   [m] default = -1.0
                                 ! If HFREEZE > 0, melt potential will be computed. The actual depth
                                 ! over which melt potential is computed will be min(HFREEZE, OBLD)
                                 ! where OBLD is the boundary layer depth. If HFREEZE <= 0 (default)
+                                ! melt potential will not be computed.
 USE_PSURF_IN_EOS = False        !   [Boolean] default = False
                                 ! If true, always include the surface pressure contributions in equation of
                                 ! state calculations.
@@ -97,7 +98,7 @@ WRITE_GEOM = 2                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
-SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
+SAVE_INITIAL_CONDS = True      !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_hor_index ===
@@ -118,6 +119,13 @@ GRID_CONFIG = "mosaic"          !
                                 !     mercator - use a Mercator spherical grid.
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
+GRID_ROTATION_ANGLE_BUGS = False  ! [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and
+                                ! cosines needed rotate between grid-oriented directions and
+                                ! true north and east.  Differences arise at the tripolar fold
+USE_TRIPOLAR_GEOLONB_BUG = False !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -148,7 +156,7 @@ TOPO_FILE = "ocean_topog.nc"    ! default = "topog.nc"
                                 ! The file from which the bathymetry is read.
 TOPO_EDITS_FILE = "All_edits.nc" ! default = ""
                                 ! The file from which to read a list of i,j,z topography overrides.
-ALLOW_LANDMASK_CHANGES = MOM6_ALLOW_LANDMASK_CHANGES   ! default = "False"
+ALLOW_LANDMASK_CHANGES = @[MOM6_ALLOW_LANDMASK_CHANGES]   ! default = "False"
                                 ! If true, allow topography overrides to change ocean points to land
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
@@ -157,13 +165,6 @@ MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
                                 ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
                                 ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
                                 ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
-GRID_ROTATION_ANGLE_BUGS = False  ! [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold
-USE_TRIPOLAR_GEOLONB_BUG = False  ! [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude
-                                ! in some points along the tripolar fold to be off by 360 degrees
 
 ! === module MOM_open_boundary ===
 ! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
@@ -324,6 +325,7 @@ Z_INIT_FILE_PTEMP_VAR = "temp"  ! default = "ptemp"
 Z_INIT_FILE_SALT_VAR = "salt"   ! default = "salt"
                                 ! The name of the salinity variable in
                                 ! SALT_Z_INIT_FILE.
+
 Z_INIT_ALE_REMAPPING = True     !   [Boolean] default = False
                                 ! If True, then remap straight to model coordinate from file.
 Z_INIT_REMAP_OLD_ALG = True     !   [Boolean] default = True
@@ -670,7 +672,6 @@ MAX_RINO_IT = 25                !   [nondim] default = 50
 VERTEX_SHEAR = False             !   [Boolean] default = False
                                 ! If true, do the calculations of the shear-driven mixing
                                 ! at the cell vertices (i.e., the vorticity points).
-
 KAPPA_SHEAR_ITER_BUG = True     !   [Boolean] default = True
                                 ! If true, use an older, dimensionally inconsistent estimate of the derivative
                                 ! of diffusivity with energy in the Newton's method iteration.  The bug causes
@@ -695,7 +696,7 @@ PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
 VAR_PEN_SW = True               !   [Boolean] default = False
                                 ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
                                 ! the e-folding depth of incoming short wave radiation.
-CHL_FILE = "seawifs-clim-1997-2010.1440x1080.v20180328.nc" !
+CHL_FILE = @[CHLCLIM]           !
                                 ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
                                 ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "chlor_a"         ! default = "CHL_A"
@@ -740,12 +741,11 @@ MIX_LEN_EXPONENT = 1.0          !   [nondim] default = 2.0
                                 ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
                                 ! which determines the shape of the mixing length. This is only used if
                                 ! USE_MLD_ITERATION is True.
-USE_LA_LI2016 = MOM6_REPRO_LA   !   [nondim] default = False
+USE_LA_LI2016 = @[MOM6_USE_LI2016] !   [nondim] default = False
                                 ! A logical to use the Li et al. 2016 (submitted) formula to determine the
                                 ! Langmuir number.
-USE_WAVES = MOM6_USE_WAVES      !   [Boolean] default = False
+USE_WAVES = @[MOM6_USE_WAVES]   !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
-
 WAVE_METHOD = "SURFACE_BANDS"   ! default = "EMPTY"
                                 ! Choice of wave method, valid options include:
                                 !  TEST_PROFILE  - Prescribed from surface Stokes drift
@@ -756,19 +756,17 @@ WAVE_METHOD = "SURFACE_BANDS"   ! default = "EMPTY"
                                 !                  wave spectrum with prescribed values.
                                 !  LF17          - Infers Stokes drift profile from wind
                                 !                  speed following Li and Fox-Kemper 2017.
-
 SURFBAND_SOURCE = "COUPLER"     ! default = "EMPTY"
                                 ! Choice of SURFACE_BANDS data mode, valid options include:
                                 !  DATAOVERRIDE  - Read from NetCDF using FMS DataOverride.
                                 !  COUPLER       - Look for variables from coupler pass
                                 !  INPUT         - Testing with fixed values.
-
 STK_BAND_COUPLER = 3            ! default = 1
                                 ! STK_BAND_COUPLER is the number of Stokes drift bands in the coupler. This has
                                 ! to be consistent with the number of Stokes drift bands in WW3, or the model
                                 ! will fail.
-
 SURFBAND_WAVENUMBERS = 0.04, 0.11, 0.3305 !   [rad/m] default = 0.12566
+                                ! Central wavenumbers for surface Stokes drift bands.
 EPBL_LANGMUIR_SCHEME = "ADDITIVE" ! default = "NONE"
                                 ! EPBL_LANGMUIR_SCHEME selects the method for including Langmuir turbulence.
                                 ! Valid values are:
@@ -826,12 +824,14 @@ ENERGYSAVEDAYS = 1.00           !   [days] default = 1.0
                                 ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
+
+! === module MOM_surface_forcing ===
 OCEAN_SURFACE_STAGGER = "A"     ! default = "C"
                                 ! A case-insensitive character string to indicate the
                                 ! staggering of the surface velocity field that is
                                 ! returned to the coupler.  Valid values include
                                 ! 'A', 'B', or 'C'.
-! === module MOM_surface_forcing ===
+
 MAX_P_SURF = 0.0                !   [Pa] default = -1.0
                                 ! The maximum surface pressure that can be exerted by the atmosphere and
                                 ! floating sea-ice or ice shelves. This is needed because the FMS coupling
@@ -855,9 +855,14 @@ USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
 SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
                                 ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
                                 ! rigidity
-LIQUID_RUNOFF_FROM_DATA = MOM6_RIVER_RUNOFF  !   [Boolean] default = False
+LIQUID_RUNOFF_FROM_DATA = @[MOM6_RIVER_RUNOFF]  !   [Boolean] default = False
                                 ! If true, allows liquid river runoff to be specified via
                                 ! the data_table using the component name 'OCN'.
+! === module ocean_stochastics ===
+DO_SPPT   = @[DO_OCN_SPPT]      ! [Boolean] default = False
+                                ! If true perturb the diabatic tendencies in MOM_diabadic_driver 
+PERT_EPBL = @[PERT_EPBL]        ! [Boolean] default = False 
+                                ! If true perturb the KE dissipation and destruction in MOM_energetic_PBL
 ! === module MOM_restart ===
 RESTART_CHECKSUMS_REQUIRED = False
 ! === module MOM_file_parser ===

--- a/parm/mom6/MOM_input_template_050
+++ b/parm/mom6/MOM_input_template_050
@@ -11,10 +11,10 @@
 TRIPOLAR_N = True               !   [Boolean] default = False
                                 ! Use tripolar connectivity at the northern edge of the domain.  With
                                 ! TRIPOLAR_N, NIGLOBAL must be even.
-NIGLOBAL = NX_GLB               !
+NIGLOBAL = @[NX_GLB]            !
                                 ! The total number of thickness grid points in the x-direction in the physical
                                 ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
-NJGLOBAL = NY_GLB               !
+NJGLOBAL = @[NY_GLB]            !
                                 ! The total number of thickness grid points in the y-direction in the physical
                                 ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 NIHALO = 4                      ! default = 4
@@ -40,16 +40,16 @@ THICKNESSDIFFUSE = True         !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
                                 ! If true, do thickness diffusion before dynamics. This is only used if
                                 ! THICKNESSDIFFUSE is true.
-DT = DT_DYNAM_MOM6              !   [s]
+DT = @[DT_DYNAM_MOM6]           !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DT_THERM = DT_THERM_MOM6        !   [s] default = 1800.0
+DT_THERM = @[DT_THERM_MOM6]     !   [s] default = 1800.0
                                 ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-THERMO_SPANS_COUPLING = MOM6_THERMO_SPAN    !   [Boolean] default = False
+THERMO_SPANS_COUPLING = @[MOM6_THERMO_SPAN]    !   [Boolean] default = False
                                 ! If true, the MOM will take thermodynamic and tracer timesteps that can be
                                 ! longer than the coupling timestep. The actual thermodynamic timestep that is
                                 ! used in this case is the largest integer multiple of the coupling timestep
@@ -98,7 +98,7 @@ WRITE_GEOM = 2                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
-SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
+SAVE_INITIAL_CONDS = True      !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_hor_index ===
@@ -119,6 +119,13 @@ GRID_CONFIG = "mosaic"          !
                                 !     mercator - use a Mercator spherical grid.
 GRID_FILE = "ocean_hgrid.nc"    !
                                 ! Name of the file from which to read horizontal grid data.
+GRID_ROTATION_ANGLE_BUGS = False  ! [Boolean] default = True
+                                ! If true, use an older algorithm to calculate the sine and
+                                ! cosines needed rotate between grid-oriented directions and
+                                ! true north and east.  Differences arise at the tripolar fold
+USE_TRIPOLAR_GEOLONB_BUG = False !   [Boolean] default = True
+                                ! If true, use older code that incorrectly sets the longitude in some points
+                                ! along the tripolar fold to be off by 360 degrees.
 TOPO_CONFIG = "file"            !
                                 ! This specifies how bathymetry is specified:
                                 !     file - read bathymetric information from the file
@@ -147,7 +154,7 @@ TOPO_CONFIG = "file"            !
                                 !     USER - call a user modified routine.
 TOPO_FILE = "ocean_topog.nc"    ! default = "topog.nc"
                                 ! The file from which the bathymetry is read.
-ALLOW_LANDMASK_CHANGES = MOM6_ALLOW_LANDMASK_CHANGES   ! default = "False"
+ALLOW_LANDMASK_CHANGES = @[MOM6_ALLOW_LANDMASK_CHANGES]   ! default = "False"
                                 ! If true, allow topography overrides to change ocean points to land
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
@@ -156,14 +163,7 @@ MINIMUM_DEPTH = 9.5             !   [m] default = 0.0
                                 ! assumed to be land and all fluxes are masked out. If MASKING_DEPTH is
                                 ! specified, then all depths shallower than MINIMUM_DEPTH but deeper than
                                 ! MASKING_DEPTH are rounded to MINIMUM_DEPTH.
-GRID_ROTATION_ANGLE_BUGS = False  ! [Boolean] default = True
-                                ! If true, use an older algorithm to calculate the sine and
-                                ! cosines needed rotate between grid-oriented directions and
-                                ! true north and east.  Differences arise at the tripolar fold
 
-USE_TRIPOLAR_GEOLONB_BUG = False !   [Boolean] default = True
-                                ! If true, use older code that incorrectly sets the longitude in some points
-                                ! along the tripolar fold to be off by 360 degrees.
 ! === module MOM_open_boundary ===
 ! Controls where open boundaries are located, what kind of boundary condition to impose, and what data to apply,
 ! if any.
@@ -183,9 +183,6 @@ CHANNEL_CONFIG = "list"         ! default = "none"
                                 !       NetCDF file on the model grid.
 CHANNEL_LIST_FILE = "MOM_channels_global_025" ! default = "MOM_channel_list"
                                 ! The file from which the list of narrowed channels is read.
-PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
-                                ! If true, each processor writes its own restart file, otherwise a single
-                                ! restart file is generated
 
 ! === module MOM_verticalGrid ===
 ! Parameters providing information about the vertical grid.
@@ -200,6 +197,9 @@ DTFREEZE_DP = -7.75E-08         !   [deg C Pa-1] default = 0.0
                                 ! temperature with pressure.
 
 ! === module MOM_restart ===
+PARALLEL_RESTARTFILES = True    !   [Boolean] default = False
+                                ! If true, each processor writes its own restart file, otherwise a single
+                                ! restart file is generated
 
 ! === module MOM_tracer_flow_control ===
 USE_IDEAL_AGE_TRACER = False    !   [Boolean] default = False
@@ -726,7 +726,8 @@ PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
 VAR_PEN_SW = True               !   [Boolean] default = False
                                 ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
                                 ! the e-folding depth of incoming short wave radiation.
-CHL_FILE = CHLCLIM              ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
+CHL_FILE = @[CHLCLIM]           !
+                                ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
                                 ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 CHL_VARNAME = "chlor_a"         ! default = "CHL_A"
                                 ! Name of CHL_A variable in CHL_FILE.
@@ -770,10 +771,10 @@ MIX_LEN_EXPONENT = 1.0          !   [nondim] default = 2.0
                                 ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
                                 ! which determines the shape of the mixing length. This is only used if
                                 ! USE_MLD_ITERATION is True.
-USE_LA_LI2016 = MOM6_REPRO_LA   !   [nondim] default = False
+USE_LA_LI2016 = @[MOM6_USE_LI2016] !   [nondim] default = False
                                 ! A logical to use the Li et al. 2016 (submitted) formula to determine the
                                 ! Langmuir number.
-USE_WAVES = MOM6_USE_WAVES      !   [Boolean] default = False
+USE_WAVES = @[MOM6_USE_WAVES]   !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 WAVE_METHOD = "SURFACE_BANDS"   ! default = "EMPTY"
                                 ! Choice of wave method, valid options include:
@@ -825,7 +826,7 @@ VAR_PEN_SW = True               !   [Boolean] default = False
                                 ! If true, use one of the CHL_A schemes specified by
                                 ! OPACITY_SCHEME to determine the e-folding depth of
                                 ! incoming short wave radiation.
-CHL_FILE = CHLCLIM              ! CHL_FILE is the file containing chl_a concentrations in
+CHL_FILE = @[CHLCLIM]           ! CHL_FILE is the file containing chl_a concentrations in
                                 ! the variable CHL_A. It is used when VAR_PEN_SW and
                                 ! CHL_FROM_FILE are true.
 CHL_VARNAME = "chlor_a"         ! default = "CHL_A"
@@ -858,11 +859,7 @@ USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 
 ! === module ocean_model_init ===
-OCEAN_SURFACE_STAGGER = "A"     ! default = "C"
-                                ! A case-insensitive character string to indicate the
-                                ! staggering of the surface velocity field that is
-                                ! returned to the coupler.  Valid values include
-                                ! 'A', 'B', or 'C'.
+
 RESTART_CHECKSUMS_REQUIRED = False
 ! === module MOM_lateral_boundary_diffusion ===
 ! This module implements lateral diffusion of tracers near boundaries
@@ -883,6 +880,12 @@ ENERGYSAVEDAYS_GEOMETRIC = 0.25 !   [days] default = 0.0
 ! === module ocean_model_init ===
 
 ! === module MOM_surface_forcing ===
+OCEAN_SURFACE_STAGGER = "A"     ! default = "C"
+                                ! A case-insensitive character string to indicate the
+                                ! staggering of the surface velocity field that is
+                                ! returned to the coupler.  Valid values include
+                                ! 'A', 'B', or 'C'.
+
 MAX_P_SURF = 0.0                !   [Pa] default = -1.0
                                 ! The maximum surface pressure that can be exerted by the atmosphere and
                                 ! floating sea-ice or ice shelves. This is needed because the FMS coupling
@@ -906,9 +909,14 @@ USE_RIGID_SEA_ICE = True        !   [Boolean] default = False
 SEA_ICE_RIGID_MASS = 100.0      !   [kg m-2] default = 1000.0
                                 ! The mass of sea-ice per unit area at which the sea-ice starts to exhibit
                                 ! rigidity
-LIQUID_RUNOFF_FROM_DATA = MOM6_RIVER_RUNOFF  !   [Boolean] default = False
+LIQUID_RUNOFF_FROM_DATA = @[MOM6_RIVER_RUNOFF]  !   [Boolean] default = False
                                 ! If true, allows liquid river runoff to be specified via
                                 ! the data_table using the component name 'OCN'.
+! === module ocean_stochastics ===
+DO_SPPT   = @[DO_OCN_SPPT]      ! [Boolean] default = False
+                                ! If true perturb the diabatic tendencies in MOM_diabadic_driver 
+PERT_EPBL = @[PERT_EPBL]        ! [Boolean] default = False 
+                                ! If true perturb the KE dissipation and destruction in MOM_energetic_PBL
 ! === module MOM_restart ===
 
 ! === module MOM_file_parser ===

--- a/parm/mom6/MOM_input_template_100
+++ b/parm/mom6/MOM_input_template_100
@@ -12,16 +12,16 @@ THICKNESSDIFFUSE = True         !   [Boolean] default = False
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
                                 ! If true, do thickness diffusion before dynamics. This is only used if
                                 ! THICKNESSDIFFUSE is true.
-DT = DT_DYNAM_MOM6              !   [s]
+DT = @[DT_DYNAM_MOM6]           !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-DT_THERM = DT_THERM_MOM6        !   [s] default = 1800.0
+DT_THERM = @[DT_THERM_MOM6]     !   [s] default = 1800.0
                                 ! The thermodynamic and tracer advection time step. Ideally DT_THERM should be
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-THERMO_SPANS_COUPLING = MOM6_THERMO_SPAN    !   [Boolean] default = False
+THERMO_SPANS_COUPLING = @[MOM6_THERMO_SPAN]    !   [Boolean] default = False
                                 ! If true, the MOM will take thermodynamic and tracer timesteps that can be
                                 ! longer than the coupling timestep. The actual thermodynamic timestep that is
                                 ! used in this case is the largest integer multiple of the coupling timestep
@@ -72,11 +72,11 @@ WRITE_GEOM = 2                  ! default = 1
                                 ! If =0, never write the geometry and vertical grid files. If =1, write the
                                 ! geometry and vertical grid files only for a new simulation. If =2, always
                                 ! write the geometry and vertical grid files. Other values are invalid.
-SAVE_INITIAL_CONDS = True       !   [Boolean] default = False
+SAVE_INITIAL_CONDS = True      !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_oda_incupd ===
-ODA_INCUPD = MOM_IAU            ! [Boolean] default = False
+ODA_INCUPD = @[MOM_IAU]         ! [Boolean] default = False
                                 ! If true, oda incremental updates will be applied
                                 ! everywhere in the domain.
 ODA_INCUPD_FILE = "mom6_increment.nc" ! The name of the file with the T,S,h increments.
@@ -97,17 +97,17 @@ ODA_UINC_VAR = "u_inc"          ! default = "u_inc"
 ODA_VINC_VAR = "v_inc"          ! default = "v_inc"
                                 ! The name of the meridional vel. inc. variable in
                                 ! ODA_INCUPD_UV_FILE.
-ODA_INCUPD_NHOURS = MOM_IAU_HRS ! default=3.0 
+ODA_INCUPD_NHOURS = @[MOM_IAU_HRS] ! default=3.0
                                 ! Number of hours for full update (0=direct insertion).
 
 ! === module MOM_domains ===
 TRIPOLAR_N = True               !   [Boolean] default = False
                                 ! Use tripolar connectivity at the northern edge of the domain.  With
                                 ! TRIPOLAR_N, NIGLOBAL must be even.
-NIGLOBAL = NX_GLB               !
+NIGLOBAL = @[NX_GLB]            !
                                 ! The total number of thickness grid points in the x-direction in the physical
                                 ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
-NJGLOBAL = NY_GLB               !
+NJGLOBAL = @[NY_GLB]            !
                                 ! The total number of thickness grid points in the y-direction in the physical
                                 ! domain. With STATIC_MEMORY_ this is set in MOM_memory.h at compile time.
 
@@ -165,7 +165,7 @@ TOPO_CONFIG = "file"            !
                                 !     USER - call a user modified routine.
 TOPO_EDITS_FILE = "topo_edits_011818.nc" ! default = ""
                                 ! The file from which to read a list of i,j,z topography overrides.
-ALLOW_LANDMASK_CHANGES = MOM6_ALLOW_LANDMASK_CHANGES   ! default = "False"
+ALLOW_LANDMASK_CHANGES = @[MOM6_ALLOW_LANDMASK_CHANGES]   ! default = "False"
                                 ! If true, allow topography overrides to change ocean points to land
 MAXIMUM_DEPTH = 6500.0          !   [m]
                                 ! The maximum depth of the ocean.
@@ -694,7 +694,7 @@ PRESSURE_DEPENDENT_FRAZIL = False !   [Boolean] default = False
 VAR_PEN_SW = True               !   [Boolean] default = False
                                 ! If true, use one of the CHL_A schemes specified by OPACITY_SCHEME to determine
                                 ! the e-folding depth of incoming short wave radiation.
-CHL_FILE = CHLCLIM              !
+CHL_FILE = @[CHLCLIM]           !
                                 ! CHL_FILE is the file containing chl_a concentrations in the variable CHL_A. It
                                 ! is used when VAR_PEN_SW and CHL_FROM_FILE are true.
 
@@ -737,10 +737,10 @@ MIX_LEN_EXPONENT = 1.0          !   [nondim] default = 2.0
                                 ! The exponent applied to the ratio of the distance to the MLD and the MLD depth
                                 ! which determines the shape of the mixing length. This is only used if
                                 ! USE_MLD_ITERATION is True.
-USE_LA_LI2016 = MOM6_REPRO_LA   !   [nondim] default = False
+USE_LA_LI2016 = @[MOM6_USE_LI2016] !   [nondim] default = False
                                 ! A logical to use the Li et al. 2016 (submitted) formula to determine the
                                 ! Langmuir number.
-USE_WAVES = MOM6_USE_WAVES      !   [Boolean] default = False
+USE_WAVES = @[MOM6_USE_WAVES]   !   [Boolean] default = False
                                 ! If true, enables surface wave modules.
 WAVE_METHOD = "SURFACE_BANDS"   ! default = "EMPTY"
                                 ! Choice of wave method, valid options include:
@@ -851,6 +851,11 @@ GUST_CONST = 0.02               !   [Pa] default = 0.0
 FIX_USTAR_GUSTLESS_BUG = False  !   [Boolean] default = True
                                 ! If true correct a bug in the time-averaging of the gustless wind friction
                                 ! velocity
+! === module ocean_stochastics ===
+DO_SPPT   = @[DO_OCN_SPPT]      ! [Boolean] default = False
+                                ! If true perturb the diabatic tendencies in MOM_diabadic_driver 
+PERT_EPBL = @[PERT_EPBL]        ! [Boolean] default = False 
+                                ! If true perturb the KE dissipation and destruction in MOM_energetic_PBL
 
 ! === module MOM_restart ===
 

--- a/parm/parm_fv3diag/data_table
+++ b/parm/parm_fv3diag/data_table
@@ -1,1 +1,1 @@
-"OCN", "runoff", "runoff", "./INPUT/FRUNOFF", "none" ,  1.0
+"OCN", "runoff", "runoff", "./INPUT/@[FRUNOFF]", "none" ,  1.0

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -41,7 +41,7 @@ else
   if [[ ! -d ufs_coupled.fd ]] ; then
     git clone https://github.com/ufs-community/ufs-weather-model ufs_coupled.fd >> ${topdir}/checkout-ufs_coupled.log 2>&1
     cd ufs_coupled.fd
-    git checkout b26a896f2c9bada438414a51218bc72236925b8c 
+    git checkout c1d6d19d615363d8443ddc15c2a7a9c3dc7bc5f9 
     git submodule update --init --recursive
     cd ${topdir} 
   else

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -790,7 +790,7 @@ CICE_postdet() {
 	year=$(echo $CDATE|cut -c 1-4)
 	month=$(echo $CDATE|cut -c 5-6)
 	day=$(echo $CDATE|cut -c 7-8)
-
+        sec=$(echo $CDATE|cut -c 9-10)
 	stepsperhr=$((3600/$ICETIM))
 	nhours=$($NHOUR $CDATE ${year}010100)
 	steps=$((nhours*stepsperhr))

--- a/ush/parsing_namelists_CICE.sh
+++ b/ush/parsing_namelists_CICE.sh
@@ -4,22 +4,23 @@ CICE_namelists(){
 
 if [ $warm_start = ".true." ]; then
   cmeps_run_type='continue'
-else 
+else
   cmeps_run_type='initial'
 fi
 
 
-cat > ice_in <<eof  
+cat > ice_in <<eof
 &setup_nml
    days_per_year  = 365
    use_leap_years = .true.
    year_init      = $year
    month_init     = $month
    day_init       = $day
+   sec_init       = $sec
    dt             = $ICETIM
    npt            = $npt
    ndtd           = 1
-   runtype        = '$cmeps_run_type' 
+   runtype        = '$cmeps_run_type'
    runid          = 'cpcice'
    ice_ic         = '$iceic'
    restart        = .true.
@@ -34,7 +35,7 @@ cat > ice_in <<eof
    pointer_file   = './ice.restart_file'
    dumpfreq       = '$dumpfreq'
    dumpfreq_n     =  $dumpfreq_n
-   dump_last      = .false.  
+   dump_last      = .false.
    bfbflag        = 'off'
    diagfreq       = 6
    diag_type      = 'file'
@@ -105,7 +106,7 @@ cat > ice_in <<eof
    kdyn            = 1
    ndte            = 120
    revised_evp     = .false.
-   kevp_kernel     = 0
+   evp_algorithm   = 'standard_2d'
    brlx            = 300.0
    arlx            = 300.0
    ssh_stress      = 'coupled'
@@ -128,7 +129,7 @@ cat > ice_in <<eof
    albicev         = 0.78
    albicei         = 0.36
    albsnowv        = 0.98
-   albsnowi        = 0.70 
+   albsnowi        = 0.70
    ahmax           = 0.3
    R_ice           = 0.
    R_pnd           = 0.
@@ -148,6 +149,10 @@ cat > ice_in <<eof
    rfracmin        = 0.15
    rfracmax        = 1.
    pndaspect       = 0.8
+/
+
+&snow_nml
+   snwredist       = 'none'
 /
 
 &forcing_nml
@@ -205,32 +210,32 @@ cat > ice_in <<eof
    f_VGRDb         = .false.
    f_VGRDa         = .true.
    f_bounds        = .false.
-   f_aice          = 'mdhxx' 
+   f_aice          = 'mdhxx'
    f_hi            = 'mdhxx'
-   f_hs            = 'mdhxx' 
-   f_Tsfc          = 'mdhxx' 
-   f_sice          = 'mdhxx' 
-   f_uvel          = 'mdhxx' 
+   f_hs            = 'mdhxx'
+   f_Tsfc          = 'mdhxx'
+   f_sice          = 'mdhxx'
+   f_uvel          = 'mdhxx'
    f_vvel          = 'mdhxx'
    f_uatm          = 'mdhxx'
    f_vatm          = 'mdhxx'
-   f_fswdn         = 'mdhxx' 
+   f_fswdn         = 'mdhxx'
    f_flwdn         = 'mdhxx'
    f_snowfrac      = 'x'
-   f_snow          = 'mdhxx' 
-   f_snow_ai       = 'x' 
-   f_rain          = 'mdhxx' 
-   f_rain_ai       = 'x' 
-   f_sst           = 'mdhxx' 
-   f_sss           = 'mdhxx' 
-   f_uocn          = 'mdhxx' 
-   f_vocn          = 'mdhxx' 
+   f_snow          = 'mdhxx'
+   f_snow_ai       = 'x'
+   f_rain          = 'mdhxx'
+   f_rain_ai       = 'x'
+   f_sst           = 'mdhxx'
+   f_sss           = 'mdhxx'
+   f_uocn          = 'mdhxx'
+   f_vocn          = 'mdhxx'
    f_frzmlt        = 'mdhxx'
    f_fswfac        = 'mdhxx'
    f_fswint_ai     = 'x'
-   f_fswabs        = 'mdhxx' 
-   f_fswabs_ai     = 'x' 
-   f_albsni        = 'mdhxx' 
+   f_fswabs        = 'mdhxx'
+   f_fswabs_ai     = 'x'
+   f_albsni        = 'mdhxx'
    f_alvdr         = 'mdhxx'
    f_alidr         = 'mdhxx'
    f_alvdf         = 'mdhxx'
@@ -243,22 +248,22 @@ cat > ice_in <<eof
    f_albsno        = 'x'
    f_albpnd        = 'x'
    f_coszen        = 'x'
-   f_flat          = 'mdhxx' 
-   f_flat_ai       = 'x' 
-   f_fsens         = 'mdhxx' 
-   f_fsens_ai      = 'x' 
+   f_flat          = 'mdhxx'
+   f_flat_ai       = 'x'
+   f_fsens         = 'mdhxx'
+   f_fsens_ai      = 'x'
    f_fswup         = 'x'
-   f_flwup         = 'mdhxx' 
-   f_flwup_ai      = 'x' 
-   f_evap          = 'mdhxx' 
-   f_evap_ai       = 'x' 
-   f_Tair          = 'mdhxx' 
-   f_Tref          = 'mdhxx' 
+   f_flwup         = 'mdhxx'
+   f_flwup_ai      = 'x'
+   f_evap          = 'mdhxx'
+   f_evap_ai       = 'x'
+   f_Tair          = 'mdhxx'
+   f_Tref          = 'mdhxx'
    f_Qref          = 'mdhxx'
-   f_congel        = 'mdhxx' 
-   f_frazil        = 'mdhxx' 
-   f_snoice        = 'mdhxx' 
-   f_dsnow         = 'mdhxx' 
+   f_congel        = 'mdhxx'
+   f_frazil        = 'mdhxx'
+   f_snoice        = 'mdhxx'
+   f_dsnow         = 'mdhxx'
    f_melts         = 'mdhxx'
    f_meltt         = 'mdhxx'
    f_meltb         = 'mdhxx'
@@ -268,31 +273,31 @@ cat > ice_in <<eof
    f_fsalt         = 'mdhxx'
    f_fsalt_ai      = 'x'
    f_fbot          = 'mdhxx'
-   f_fhocn         = 'mdhxx' 
-   f_fhocn_ai      = 'x' 
-   f_fswthru       = 'x' 
-   f_fswthru_ai    = 'x' 
+   f_fhocn         = 'mdhxx'
+   f_fhocn_ai      = 'x'
+   f_fswthru       = 'x'
+   f_fswthru_ai    = 'x'
    f_fsurf_ai      = 'x'
    f_fcondtop_ai   = 'x'
-   f_fmeltt_ai     = 'x' 
+   f_fmeltt_ai     = 'x'
    f_strairx       = 'mdhxx'
    f_strairy       = 'mdhxx'
-   f_strtltx       = 'x' 
-   f_strtlty       = 'x' 
-   f_strcorx       = 'x' 
-   f_strcory       = 'x' 
-   f_strocnx       = 'mdhxx' 
-   f_strocny       = 'mdhxx' 
-   f_strintx       = 'x' 
+   f_strtltx       = 'x'
+   f_strtlty       = 'x'
+   f_strcorx       = 'x'
+   f_strcory       = 'x'
+   f_strocnx       = 'mdhxx'
+   f_strocny       = 'mdhxx'
+   f_strintx       = 'x'
    f_strinty       = 'x'
    f_taubx         = 'x'
    f_tauby         = 'x'
    f_strength      = 'x'
    f_divu          = 'mdhxx'
    f_shear         = 'mdhxx'
-   f_sig1          = 'x' 
+   f_sig1          = 'x'
    f_sig2          = 'x'
-   f_sigP          = 'x' 
+   f_sigP          = 'x'
    f_dvidtt        = 'mdhxx'
    f_dvidtd        = 'mdhxx'
    f_daidtt        = 'mdhxx'
@@ -368,4 +373,4 @@ cat > ice_in <<eof
 /
 eof
 
-} 
+}

--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-##### 
+#####
 ## "parsing_namelist_FV3.sh"
 ## This script writes namelist for FV3 model
 ##
@@ -12,7 +12,7 @@ FV3_namelists(){
 
 # copy over the tables
 DIAG_TABLE=${DIAG_TABLE:-$PARM_FV3DIAG/diag_table}
-DIAG_TABLE_AOD=${DIAG_TABLE_AOD:-$PARM_FV3DIAG/diag_table_aod}
+DIAG_TABLE_APPEND=${DIAG_TABLE_APPEND:-$PARM_FV3DIAG/diag_table_aod}
 DATA_TABLE=${DATA_TABLE:-$PARM_FV3DIAG/data_table}
 FIELD_TABLE=${FIELD_TABLE:-$PARM_FV3DIAG/field_table}
 
@@ -33,7 +33,7 @@ fi
 
 # Append AOD diag table for MERRA2
 if [ $IAER = "1011" ]; then
-  cat $DIAG_TABLE_AOD >> diag_table
+  cat $DIAG_TABLE_APPEND >> diag_table
 fi
 
 $NCP $DATA_TABLE  data_table
@@ -89,20 +89,28 @@ cat > input.nml <<EOF
   npy = $npy
   ntiles = $ntiles
   npz = $npz
-  dz_min =  ${dz_min:-"6"}    
-  psm_bc = ${psm_bc:-"1"}    
+EOF
+
+if [ $cpl = .true. ]; then
+  cat >> input.nml << EOF
+  dz_min =  ${dz_min:-"6"}    ! no longer in develop branch
+  psm_bc = ${psm_bc:-"0"}    ! no longer in develop branch
+EOF
+fi
+
+cat >> input.nml << EOF
   grid_type = -1
-  make_nh = $make_nh 
+  make_nh = $make_nh
   fv_debug = ${fv_debug:-".false."}
   range_warn = ${range_warn:-".true."}
   reset_eta = .false.
-  n_sponge = ${n_sponge:-"10"}    
+  n_sponge = ${n_sponge:-"10"}
   nudge_qv = ${nudge_qv:-".true."}
   nudge_dz = ${nudge_dz:-".false."}
   tau = ${tau:-10.}
   rf_cutoff = ${rf_cutoff:-"7.5e2"}
-  d2_bg_k1 = ${d2_bg_k1:-"0.15"}    
-  d2_bg_k2 = ${d2_bg_k2:-"0.02"}    
+  d2_bg_k1 = ${d2_bg_k1:-"0.15"}
+  d2_bg_k2 = ${d2_bg_k2:-"0.02"}
   kord_tm = ${kord_tm:-"-9"}
   kord_mt = ${kord_mt:-"9"}
   kord_wz = ${kord_wz:-"9"}
@@ -115,15 +123,15 @@ cat > input.nml <<EOF
   p_fac = 0.1
   k_split = $k_split
   n_split = $n_split
-  nwat = ${nwat:-2}		
+  nwat = ${nwat:-2}
   na_init = $na_init
   d_ext = 0.
-  dnats = ${dnats:-0}		
+  dnats = ${dnats:-0}
   fv_sg_adj = ${fv_sg_adj:-"450"}
   d2_bg = 0.
-  nord = ${nord:-3}		
-  dddmp = ${dddmp:-0.1}		
-  d4_bg = ${d4_bg:-0.15}	
+  nord = ${nord:-3}
+  dddmp = ${dddmp:-0.1}
+  d4_bg = ${d4_bg:-0.15}
   vtdm4 = $vtdm4
   delt_max = ${delt_max:-"0.002"}
   ke_bg = 0.
@@ -135,15 +143,15 @@ cat > input.nml <<EOF
   mountain = $mountain
   ncep_ic = $ncep_ic
   d_con = $d_con
-  hord_mt = $hord_mt		
-  hord_vt = $hord_xx		
-  hord_tm = $hord_xx		
-  hord_dp = -$hord_xx		
-  hord_tr = ${hord_tr:-"8"}	
+  hord_mt = $hord_mt
+  hord_vt = $hord_xx
+  hord_tm = $hord_xx
+  hord_dp = -$hord_xx
+  hord_tr = ${hord_tr:-"8"}
   adjust_dry_mass = ${adjust_dry_mass:-".true."}
   dry_mass=${dry_mass:-98320.0}
   consv_te = $consv_te
-  do_sat_adj = ${do_sat_adj:-".false."}	
+  do_sat_adj = ${do_sat_adj:-".false."}
   consv_am = .false.
   fill = .true.
   dwind_2d = .false.
@@ -168,12 +176,14 @@ cat > input.nml <<EOF
 
 &gfs_physics_nml
   fhzero       = $FHZER
-  h2o_phys     = ${h2o_phys:-".true."}	
+  h2o_phys     = ${h2o_phys:-".true."}
   ldiag3d      = ${ldiag3d:-".false."}
-  fhcyc        = $FHCYC			
+  qdiag3d      = ${qdiag3d:-".false."}
+  print_diff_pgr = ${print_diff_pgr:-".false."}
+  fhcyc        = $FHCYC
   use_ufo      = ${use_ufo:-".true."}
   pre_rad      = ${pre_rad:-".false."}
-  imp_physics  = ${imp_physics:-"99"}	
+  imp_physics  = ${imp_physics:-"99"}
 EOF
 
 case "${CCPP_SUITE:-}" in
@@ -186,22 +196,22 @@ EOF
   "FV3_GSD_v0")
   cat >> input.nml << EOF
   iovr         = ${iovr:-"3"}
-  ltaerosol    = ${ltaerosol:-".F."}    
-  lradar       = ${lradar:-".F."}	
-  ttendlim     = ${ttendlim:-0.005}	
+  ltaerosol    = ${ltaerosol:-".F."}
+  lradar       = ${lradar:-".F."}
+  ttendlim     = ${ttendlim:-0.005}
   oz_phys      = ${oz_phys:-".false."}
   oz_phys_2015 = ${oz_phys_2015:-".true."}
   lsoil_lsm    = ${lsoil_lsm:-"4"}
   do_mynnedmf  = ${do_mynnedmf:-".false."}
   do_mynnsfclay = ${do_mynnsfclay:-".false."}
-  icloud_bl    = ${icloud_bl:-"1"}	
-  bl_mynn_edmf = ${bl_mynn_edmf:-"1"}	
-  bl_mynn_tkeadvect=${bl_mynn_tkeadvect:-".true."}	
-  bl_mynn_edmf_mom=${bl_mynn_edmf_mom:-"1"}	
+  icloud_bl    = ${icloud_bl:-"1"}
+  bl_mynn_edmf = ${bl_mynn_edmf:-"1"}
+  bl_mynn_tkeadvect=${bl_mynn_tkeadvect:-".true."}
+  bl_mynn_edmf_mom=${bl_mynn_edmf_mom:-"1"}
   min_lakeice  = ${min_lakeice:-"0.15"}
   min_seaice   = ${min_seaice:-"0.15"}
 EOF
- ;;  
+  ;;
   FV3_GFS_v16_coupled*)
   cat >> input.nml << EOF
   iovr         = ${iovr:-"3"}
@@ -224,10 +234,17 @@ EOF
   cat >> input.nml << EOF
   iovr         = ${iovr:-"3"}
   ltaerosol    = ${ltaerosol:-".false."}
+  lradar       = ${lradar:-".false."}
+  ttendlim     = ${ttendlim:-"0.005"}
   oz_phys      = ${oz_phys:-".false."}
   oz_phys_2015 = ${oz_phys_2015:-".true."}
-  lsoil        = ${lsoil:-"4"}
+  lsoil_lsm    = ${lsoil_lsm:-"4"}
+  do_mynnedmf  = ${do_mynnedmf:-".false."}
+  do_mynnsfclay = ${do_mynnsfclay:-".false."}
   icloud_bl    = ${icloud_bl:-"1"}
+  bl_mynn_edmf = ${bl_mynn_edmf:-"1"}
+  bl_mynn_tkeadvect = ${bl_mynn_tkeadvect:-".true."}
+  bl_mynn_edmf_mom = ${bl_mynn_edmf_mom:-"1"}
   min_lakeice  = ${min_lakeice:-"0.15"}
   min_seaice   = ${min_seaice:-"0.15"}
 EOF
@@ -243,32 +260,33 @@ cat >> input.nml <<EOF
   pdfcld       = ${pdfcld:-".false."}
   fhswr        = ${FHSWR:-"3600."}
   fhlwr        = ${FHLWR:-"3600."}
-  ialb         = ${IALB:-"1"}           
-  iems         = ${IEMS:-"1"}           
-  iaer         = $IAER			
-  icliq_sw     = ${icliq_sw:-"2"}	
-  ico2         = $ICO2			
-  isubc_sw     = ${isubc_sw:-"2"}	
-  isubc_lw     = ${isubc_lw:-"2"}	
-  isol         = ${ISOL:-"2"}		
+  ialb         = ${IALB:-"1"}
+  iems         = ${IEMS:-"1"}
+  iaer         = $IAER
+  icliq_sw     = ${icliq_sw:-"2"}
+  ico2         = $ICO2
+  isubc_sw     = ${isubc_sw:-"2"}
+  isubc_lw     = ${isubc_lw:-"2"}
+  isol         = ${ISOL:-"2"}
   lwhtr        = ${lwhtr:-".true."}
   swhtr        = ${swhtr:-".true."}
   cnvgwd       = ${cnvgwd:-".true."}
   shal_cnv     = ${shal_cnv:-".true."}
-  cal_pre      = ${cal_pre:-".true."}	
+  cal_pre      = ${cal_pre:-".true."}
   redrag       = ${redrag:-".true."}
   dspheat      = ${dspheat:-".true."}
   hybedmf      = ${hybedmf:-".false."}
-  satmedmf     = ${satmedmf:-".true."}
-  isatmedmf    = ${isatmedmf:-"1"}
-  lheatstrg    = ${lheatstrg:-".true."}
+  satmedmf     = ${satmedmf-".true."}
+  isatmedmf    = ${isatmedmf-"1"}
+  lheatstrg    = ${lheatstrg-".true."}
   lseaspray    = ${lseaspray:-".true."}
-  random_clds  = ${random_clds:-".true."} 
+  random_clds  = ${random_clds:-".true."}
   trans_trac   = ${trans_trac:-".true."}
   cnvcld       = ${cnvcld:-".true."}
   imfshalcnv   = ${imfshalcnv:-"2"}
   imfdeepcnv   = ${imfdeepcnv:-"2"}
-  cdmbgwd      = ${cdmbgwd:-"3.5,0.25"}   
+  ras          = ${ras:-".false."}
+  cdmbgwd      = ${cdmbgwd:-"3.5,0.25"}
   prslrd0      = ${prslrd0:-"0."}
   ivegsrc      = ${ivegsrc:-"1"}
   isot         = ${isot:-"1"}
@@ -288,25 +306,33 @@ cat >> input.nml <<EOF
   iopt_stc     = ${iopt_stc:-"1"}
   debug        = ${gfs_phys_debug:-".false."}
   nstf_name    = $nstf_name
-  nst_anl      = $nst_anl            
+  nst_anl      = $nst_anl
   psautco      = ${psautco:-"0.0008,0.0005"}
   prautco      = ${prautco:-"0.00015,0.00015"}
   lgfdlmprad   = ${lgfdlmprad:-".false."}
   effr_in      = ${effr_in:-".false."}
-  cplwav       = ${cplwav:-".false."}              
+  cplwav       = ${cplwav:-".false."}
   ldiag_ugwp   = ${ldiag_ugwp:-".false."}
-  do_sppt      = ${DO_SPPT:-".false."}
-  do_shum      = ${DO_SHUM:-".false."}
-  do_skeb      = ${DO_SKEB:-".false."}
-  frac_grid    = ${FRAC_GRID:-".false."}
-  fscav_aero   = ${fscav_aero:-'*:0.0'}
 EOF
 
 if [ $cpl = .true. ]; then
   cat >> input.nml << EOF
-  cplchm       = ${cplchem:-".false."}
+  fscav_aero = ${fscav_aero:-'*:0.0'}
+EOF
+fi
+
+cat >> input.nml <<EOF
+  do_sppt      = ${do_sppt:-".false."}
+  do_shum      = ${do_shum:-".false."}
+  do_skeb      = ${do_skeb:-".false."}
+EOF
+
+if [ $cpl = .true. ]; then
+  cat >> input.nml << EOF
+  frac_grid    = ${FRAC_GRID:-".true."}
+  cplchm = ${cplchem:-".false."}
   cplflx       = $cplflx
-  cplwav2atm   = ${cplwav2atm}          
+  cplwav2atm   = ${cplwav2atm}
 EOF
 fi
 
@@ -320,9 +346,10 @@ if [ $DOIAU = "YES" ]; then
 EOF
 fi
 
-if [ ${DO_CA:-"YES"} = "YES" ]; then
+if [ ${DO_CA:-"NO"} = "YES" ]; then
   cat >> input.nml << EOF
   do_ca      = .True.
+  ca_global  = ${ca_global:-".False."}
   ca_sgs     = ${ca_sgs:-".True."}
   nca        = ${nca:-"1"}
   scells     = ${scells:-"2600"}
@@ -336,9 +363,16 @@ if [ ${DO_CA:-"YES"} = "YES" ]; then
 EOF
 fi
 
+if [ ${DO_LAND_PERT:-"NO"} = "YES" ]; then
+  cat >> input.nml << EOF
+  lndp_type = ${lndp_type:-2}
+  n_var_lndp = ${n_var_lndp:-0}
+EOF
+fi
+
 case ${gwd_opt:-"2"} in
   1)
-  cat >> input.nml << EOF
+  cat >> input.nml <<EOF
   gwd_opt      = 1
   do_ugwp      = .false.
   do_ugwp_v0   = .false.
@@ -346,7 +380,6 @@ case ${gwd_opt:-"2"} in
   do_tofd      = .true.
   $gfs_physics_nml
 /
-
 &cires_ugwp_nml
   knob_ugwp_version = ${knob_ugwp_version:-0}
   knob_ugwp_solver  = ${knob_ugwp_solver:-2}
@@ -364,7 +397,7 @@ case ${gwd_opt:-"2"} in
 /
 
 EOF
-    ;;
+  ;;
   2)
   cat >> input.nml << EOF
   gwd_opt      = 2
@@ -378,7 +411,6 @@ EOF
   do_gsl_drag_tofd     = ${do_gsl_drag_tofd:-".true."}
   $gfs_physics_nml
 /
-
 &cires_ugwp_nml
   knob_ugwp_version = ${knob_ugwp_version:-1}
   knob_ugwp_solver  = ${knob_ugwp_solver:-2}
@@ -399,17 +431,18 @@ EOF
   knob_ugwp_taumin   = ${knob_ugwp_taumin:-0.25e-3}
   knob_ugwp_tauamp   = ${knob_ugwp_tauamp:-3.0e-3}
   knob_ugwp_lhmet    = ${knob_ugwp_lhmet:-200.0e3}
-  knob_ugwp_orosolv  = ${knob_ugwp_orosolv:-'pss-1986'}       
+  knob_ugwp_orosolv  = ${knob_ugwp_orosolv:-'pss-1986'}
   $cires_ugwp_nml
 /
-
 EOF
-    ;;
+  ;;
   *)
     echo "FATAL: Invalid gwd_opt specified: $gwd_opt"
     exit 1
-    ;;
+  ;;
 esac
+
+echo "" >> input.nml
 
 cat >> input.nml <<EOF
 &gfdl_cloud_microphysics_nml
@@ -495,7 +528,7 @@ cat >> input.nml <<EOF
   FSMCL(2) = ${FSMCL2:-99999}
   FSMCL(3) = ${FSMCL3:-99999}
   FSMCL(4) = ${FSMCL4:-99999}
-  LANDICE  = ${landice:-".false."}
+  LANDICE  = ${landice:-".true."}
   FTSFS = ${FTSFS:-90}
   FAISL = ${FAISL:-99999}
   FAISS = ${FAISS:-99999}
@@ -522,17 +555,13 @@ EOF
 # Add namelist for stochastic physics options
 echo "" >> input.nml
 #if [ $MEMBER -gt 0 ]; then
-if [ $DO_SPPT = .true. -o $DO_SHUM = .true. -o $DO_SKEB = .true. ]; then
+if [ $DO_SPPT = "YES" -o $DO_SHUM = "YES" -o $DO_SKEB = "YES" -o $DO_LAND_PERT = "YES" ]; then
 
     cat >> input.nml << EOF
 &nam_stochy
-  new_lscale = .true.
-  ntrunc = $JCAP_STP
-  lon_s = $LONB_STP
-  lat_s = $LATB_STP
 EOF
 
-  if [ $DO_SKEB = ".true." ]; then
+  if [ $DO_SKEB = "YES" ]; then
     cat >> input.nml << EOF
   skeb = $SKEB
   iseed_skeb = ${ISEED_SKEB:-$ISEED}
@@ -544,7 +573,7 @@ EOF
 EOF
   fi
 
-  if [ $DO_SHUM = ".true." ]; then
+  if [ $DO_SHUM = "YES" ]; then
     cat >> input.nml << EOF
   shum = $SHUM
   iseed_shum = ${ISEED_SHUM:-$ISEED}
@@ -553,7 +582,7 @@ EOF
 EOF
   fi
 
-  if [ $DO_SPPT = ".true." ]; then
+  if [ $DO_SPPT = "YES" ]; then
     cat >> input.nml << EOF
   sppt = $SPPT
   iseed_sppt = ${ISEED_SPPT:-$ISEED}
@@ -570,12 +599,19 @@ EOF
 /
 EOF
 
-
+  if [ $DO_LAND_PERT = "YES" ]; then
     cat >> input.nml << EOF
 &nam_sfcperts
+  lndp_type = ${lndp_type}
+  LNDP_TAU = ${LNDP_TAU}
+  LNDP_SCALE = ${LNDP_SCALE}
+  ISEED_LNDP = ${ISEED_LNDP:-$ISEED}
+  lndp_var_list = ${lndp_var_list}
+  lndp_prt_list = ${lndp_prt_list}
   $nam_sfcperts_nml
 /
 EOF
+  fi
 
 else
 

--- a/ush/parsing_namelists_MOM6.sh
+++ b/ush/parsing_namelists_MOM6.sh
@@ -6,16 +6,21 @@ MOM6_namelists(){
 OCNRES=${OCNRES:-"025"}
 MOM_INPUT=MOM_input_template_$OCNRES
 
-#TODO: Make these variables configurable 
+#TODO: Make these variables configurable
 
-#Set to False for restart reproducibility   
-MOM6_REPRO_LA=${MOM6_REPRO_LA:-'True'}
+#Set to False for restart reproducibility
+MOM6_USE_LI2016=${MOM6_USE_LI2016:-'True'}
 MOM6_THERMO_SPAN=${MOM6_THERMO_SPAN:-'False'}
 MOM6_ALLOW_LANDMASK_CHANGES=${MOM6_ALLOW_LANDMASK_CHANGES:-'False'}
 
+DO_OCN_SPPT=${DO_OCN_SPPT:-'False'}
+PERT_EPBL=${PERT_EPBL:-'False'}
+
+MOM_IAU_HRS=${MOM_IAU_HRS:-'3.0'}
+
 if [ $cplwav = ".true." ] ; then
   MOM6_USE_WAVES='True'
-else 
+else
   MOM6_USE_WAVES='False'
 fi
 
@@ -37,7 +42,7 @@ elif [ $OCNRES = '050' ]; then
   FRUNOFF="runoff.daitren.clim.${NX_GLB}x${NY_GLB}.v20180328.nc"
   MOM6_RESTART_SETTING='n'
   MOM6_RIVER_RUNOFF='True'
-elif [ $OCNRES = '100' ]; then 
+elif [ $OCNRES = '100' ]; then
   NX_GLB=360
   NY_GLB=320
   DT_DYNAM_MOM6='1800'
@@ -46,13 +51,12 @@ elif [ $OCNRES = '100' ]; then
   CHLCLIM="seawifs_1998-2006_smoothed_2X.nc"
   MOM6_RESTART_SETTING='n'
   MOM6_RIVER_RUNOFF='False'
-else 
+else
   echo "FATAL ERROR: do not have MOM6 settings defined for desired OCNRES=$OCNRES"
-  exit 1 
-fi 
+  exit 1
+fi
 
-
-  cat >> input.nml <<EOF
+cat >> input.nml <<EOF
 
 &MOM_input_nml
   output_directory = 'MOM6_OUTPUT/',
@@ -62,29 +66,65 @@ fi
   parameter_filename = 'INPUT/MOM_input',
                        'INPUT/MOM_override'
 /
+
+&nam_stochy
+  new_lscale=.true.
+EOF
+
+OCN_SPPT="False"
+if [ $DO_OCN_SPPT = "YES" ]; then
+  OCN_SPPT="True"
+  cat >> input.nml <<EOF
+  OCNSPPT=${OCNSPPT:-1.0}
+  OCNSPPT_LSCALE=${OCNSPPT_LSCALE:-500e3}
+  OCNSPPT_TAU=${OCNSPPT_TAU:-21600}
+  ISEED_OCNSPPT=${ISEED_OCNSPPT:-$ISEED}
+EOF
+  fi
+
+PERT_EPBL="False"
+if [ $DO_OCN_PERT_EPBL = "YES" ]; then
+  PERT_EPBL="True"
+  cat >> input.nml <<EOF
+  EPBL=${EPBL:-1.0}
+  EPBL_LSCALE=${EPBL_LSCALE:-500e3}
+  EPBL_TAU=${EPBL_TAU:-21600}
+  ISEED_EPBL=${ISEED_EPBL:-$ISEED}
+EOF
+  fi
+
+cat >> input.nml <<EOF
+/
+
+&nam_sfcperts
+/
+
 EOF
 
 echo "$(cat input.nml)"
 
 
-#Copy MOM_input and edit: 
+#Copy MOM_input and edit:
 $NCP -pf $HOMEgfs/parm/mom6/MOM_input_template_$OCNRES $DATA/INPUT/
-sed -e "s/DT_THERM_MOM6/$DT_THERM_MOM6/g" \
-    -e "s/DT_DYNAM_MOM6/$DT_DYNAM_MOM6/g" \
-    -e "s/MOM6_RIVER_RUNOFF/$MOM6_RIVER_RUNOFF/g" \
-    -e "s/MOM6_THERMO_SPAN/$MOM6_THERMO_SPAN/g" \
-    -e "s/MOM6_REPRO_LA/$MOM6_REPRO_LA/g" \
-    -e "s/MOM6_USE_WAVES/$MOM6_USE_WAVES/g" \
-    -e "s/MOM6_ALLOW_LANDMASK_CHANGES/$MOM6_ALLOW_LANDMASK_CHANGES/g" \
-    -e "s/NX_GLB/$NX_GLB/g" \
-    -e "s/NY_GLB/$NY_GLB/g" \
-    -e "s/CHLCLIM/$CHLCLIM/g" $DATA/INPUT/MOM_input_template_$OCNRES > $DATA/INPUT/MOM_input
+sed -e "s/@\[DT_THERM_MOM6\]/$DT_THERM_MOM6/g" \
+    -e "s/@\[DT_DYNAM_MOM6\]/$DT_DYNAM_MOM6/g" \
+    -e "s/@\[MOM6_RIVER_RUNOFF\]/$MOM6_RIVER_RUNOFF/g" \
+    -e "s/@\[MOM6_THERMO_SPAN\]/$MOM6_THERMO_SPAN/g" \
+    -e "s/@\[MOM6_USE_LI2016\]/$MOM6_USE_LI2016/g" \
+    -e "s/@\[MOM6_USE_WAVES\]/$MOM6_USE_WAVES/g" \
+    -e "s/@\[MOM6_ALLOW_LANDMASK_CHANGES\]/$MOM6_ALLOW_LANDMASK_CHANGES/g" \
+    -e "s/@\[NX_GLB\]/$NX_GLB/g" \
+    -e "s/@\[NY_GLB\]/$NY_GLB/g" \
+    -e "s/@\[CHLCLIM\]/$CHLCLIM/g" \
+    -e "s/@\[DO_OCN_SPPT\]/$OCN_SPPT/g" \
+    -e "s/@\[PERT_EPBL\]/$PERT_EPBL/g" \
+    -e "s/@\[MOM_IAU_HRS\]/$MOM_IAU_HRS/g" $DATA/INPUT/MOM_input_template_$OCNRES > $DATA/INPUT/MOM_input
 rm $DATA/INPUT/MOM_input_template_$OCNRES
 
-#data table for runoff: 
+#data table for runoff:
 DATA_TABLE=${DATA_TABLE:-$PARM_FV3DIAG/data_table}
 $NCP $DATA_TABLE $DATA/data_table_template
-sed -e "s/FRUNOFF/$FRUNOFF/g" $DATA/data_table_template > $DATA/data_table
+sed -e "s/@\[FRUNOFF\]/$FRUNOFF/g" $DATA/data_table_template > $DATA/data_table
 rm $DATA/data_table_template
 
 }

--- a/workflow/cases/prototype7.2.yaml
+++ b/workflow/cases/prototype7.2.yaml
@@ -1,0 +1,82 @@
+case:
+  places:
+    workflow_file: layout/free_forecast_gfs.yaml
+
+  settings: 
+    SDATE: 2013-04-01t00:00:00
+    EDATE: 2013-04-01t00:00:00
+    STEP_GFS: !timedelta "24:00:00"
+    STEP_DA: !timedelta "00:00:00"
+
+    onestep: .true.
+    cplmode: nems_frac
+    FRAC_GRID: .true.
+    cplwav: .true.
+    cplwav2atm: .true.
+    cplflx: .true.
+    print_esmf: .false.
+    esmf_profile: .false.
+    nems_temp: 'cpld_wave'
+    mom6ic_prepared: .false.
+    inline_post: .true. 
+    KEEPDATA: NO
+
+  nsst:
+    NST_MODEL: 2
+    NST_SPINUP: 1
+    NST_RESV: 0
+    ZSEA1: 0
+    ZSEA2: 0
+
+  output_settings:
+    OCN_INTERVAL: 24
+    FHOUT_GFS: 6
+    FHMIN_GFS: 0
+    FHMAX_GFS: 840
+    FHMAX_HF_GFS: 0
+    FHOUT_HF_GFS: -1
+
+  fv3_gfs_settings:
+    CASE: C384
+    LEVS: 128
+    DELTIM: 300
+    min_lakeice: 0.15
+    min_seaice: 1.0e-11
+    SEEDLET: 10
+    CCPP_SUITE: 'FV3_GFS_v16_coupled_nsstNoahmpUGWPv1'
+    CPL_ATMIC: GEFSwithNOAHMP-GLDASdatm-ERAsnow
+    nst_anl: yes
+    psm_bc: 1
+    dddmp: 0.1
+    FSICL: 0
+    FSICS: 0 
+    DO_SKEB: false
+    DO_SHUM: false
+    DO_SPPT: false
+    k_split: 2
+    n_split: 6
+    layout:
+       x: 12
+       y: 16
+       nth: 2
+       WGRP: 1
+       WGRP_NTASKS: 88
+       WRTIOBUF: "32M"
+
+  ocn_settings:
+    OCNPETS: 220
+
+  ice_settings:
+    ICEPETS: 80
+
+  wave_settings: 
+    WAVPETS: 160
+    CPL_WAVIC: GEFSwave20210528v2 
+    waveGRD: 'gwes_30m'
+    wavepostGRD: 'gwes_30m'
+    waveesmfGRD: ''
+    waveinterpGRD: ''    
+
+  post:
+    downset: 2
+    GOESF: no

--- a/workflow/config/fcst.yaml
+++ b/workflow/config/fcst.yaml
@@ -187,6 +187,7 @@ config_fcst:
     export min_seaice="{doc.fv3_gfs_settings.min_seaice}" 
 
     export FSICL="{doc.fv3_gfs_settings.FSICL}"
+    export FSICS="{doc.fv3_gfs_settings.FSICS}"
 
     # Stochastic physics parameters
     # nam_stochy section

--- a/workflow/defaults/fv3_gfs.yaml
+++ b/workflow/defaults/fv3_gfs.yaml
@@ -41,7 +41,7 @@ fv3_gfs_defaults: &fv3_gfs_defaults
     - when: !calc CASE=="C192"
       do: "0.23,1.5,1.0,1.0"
     - when: !calc CASE=="C384" 
-      do: "1.1,0.72,1.0,1.0"
+      do: "1.0,2.2,1.0,1.0"
     - when: !calc CASE=="C768" 
       do: "4.0,0.15,1.0,1.0"
     - when: !calc CASE=="C1152"
@@ -160,6 +160,7 @@ fv3_gfs_defaults: &fv3_gfs_defaults
            d4_bg: 0.12
 
   FSICL: 99999
+  FSICS: 99999
 
   MEDPETS: !FirstTrue
     - when: !calc QUILTING


### PR DESCRIPTION
This PR updates the ufs-weather-model to the Oct 7 commit (same as used in the feature/coupled-sprint branch).  In fact, these took the updates @WalterKolczynski-NOAA made in https://github.com/NOAA-EMC/global-workflow/pull/458 except that I did not update the way that atm forecast hour is handled. 

Updates for P7.2 include: 
-- Pointing to new ATM ICs which have a new source for land-spin up (NASA GLDAS data source instead of GDAS) 
-- Pointing to bug fixed WW3 ICs 
-- Setting cdmbgwd="1.0,2.2,1.0,1.0" for parameterized orographic gravity-wave drag for C384
-- Settings update for climatology for large lakes (FSICS=0 & FSICL=0) (in P7 lake ice fraction did not change with forecast time)

On hera one case can be seen at: 
/scratch2/NCEPDEV/climate/Jessica.Meixner/p7.2/test01/COMROOT/test01/gfs.20130401/00