### PR TITLE
Hide module load commands

### DIFF
--- a/ush/load_fv3gfs_modules.sh
+++ b/ush/load_fv3gfs_modules.sh
@@ -6,6 +6,8 @@
 ulimit_s=$( ulimit -S -s )
 #ulimit -S -s 10000
 
+set +x
+
 # Find module command and purge:
 source "$HOMEgfs/modulefiles/module-setup.sh.inc" 
 
@@ -39,6 +41,8 @@ elif [[ -d /lustre && -d /ncrc ]] ; then
 else
     echo WARNING: UNKNOWN PLATFORM 
 fi
+
+set -x
 
 # Restore stack soft limit:
 ulimit -S -s "$ulimit_s"


### PR DESCRIPTION
In order to hide the difficult to read internal commands echoed when using module load, they are wrapped with a set +x within load_fv3gfs_modules.sh script to suppress them.

Closes #389 