### PR TITLE
GFSv16.1.5 - GSI update to include IASI Metop-C in operations

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,7 @@
 # External sub-modules of global-workflow
 
 [FV3GFS]
-tag = GFS.v16.0.16
+tag = GFS.v16.0.17
 local_path = sorc/fv3gfs.fd
 repo_url = https://github.com/ufs-community/ufs-weather-model.git
 protocol = git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.1.1a
+tag = gfsda.v16.1.5
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git

--- a/docs/Release_Notes.gfs.v16.1.5.txt
+++ b/docs/Release_Notes.gfs.v16.1.5.txt
@@ -1,0 +1,105 @@
+GFS V16.1.5 RELEASE NOTES
+  
+PRELUDE
+ 
+Metop-A, B and C all have similar orbits. Metop-C was launched on 7 November 2018 in a low-Earth polar orbit while Metop-A was launched in 2006. The Metop-A will be decommissioned in November 2021 and IASI_Metop-A data quality has degraded since September 17, so the assimilation of IASI_Metop-A was stopped on 9/22/2021 gfs.v16.1.3 implementation. The IASI_Metop-C data have similar quality as IASI_Metop-B. This implementation will start to assimilate IASI data on Metop-C. In addition, the correlated observation errors for hyperspectral Infrared instruments both IASI and CrIS were recomputed from recent operations, which should be a more accurate representation of the observation error statistics. Both low- and high-resolution parallel experiments show reasonable results as expected.
+
+In addition, a minimum value was set in gsi source code genqsat.f90 to limit the saturation specific humidity not smaller than 1.e-7, which is a risk mitigation feature and could avoid the potential risk of generating unphysical temperature in the analysis.
+
+This implementation plans to:
+
+* Turn on the active assimilation of Metop-C IASI data with correlated observation errors
+* Update correlated observation errors for Metop-B IASI, N20 CrIS, and NPP CrIS
+* Put in a minimum threshold for saturation specific humidity to avoid potential minimization issues.
+
+These changes affect one source code and several fix files within the GSI tag of the global workflow.
+
+IMPLEMENTATION INSTRUCTIONS
+ 
+The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com are used to manage the GFS.v16.1.5 code. The SPA(s) handling the GFS.v16.1.5 implementation need to have permissions to clone VLab gerrit repositories and the private NCAR UPP_GTG repository (the “nwprod” account has access to the GTG repository). All NOAA-EMC organization repositories are publicly readable and do not require access permissions. Please follow the following steps to install the package on WCOSS-Dell.
+ 
+While logged in under the “nwprod” account:
+
+1) cd $NWROOTp3
+2) mkdir gfs.v16.1.5
+3) cd gfs.v16.1.5
+4) git clone -b EMC-v16.1.5  https://github.com/NOAA-EMC/global-workflow.git .
+5) cd sorc
+6) ./checkout.sh -o
+   * This script extracts the following GFS components:
+     MODEL      tag GFS.v16.0.16			Jun.Wang@noaa.gov
+     GSI        tag gfsda.v16.1.5   	    		Russ.Treadon@noaa.gov
+     GLDAS     	tag gldas_gfsv16_release.v1.12.0     	Helin.Wei@noaa.gov
+     UFS_UTILS 	tag ops-gfsv16.0.0  	               	George.Gayno@noaa.gov
+     POST       tag upp_gfsv16_release.v1.1.4        	Wen.Meng@noaa.gov
+     WAFS       tag gfs_wafs.v6.0.22                  	Yali.Mao@noaa.gov
+
+7) ./build_all.sh
+   * This script compiles all GFS components. Runtime output from the build for each package is written to log files in directory logs. To build an individual program, for instance, gsi, use build_gsi.sh.
+8) ./link_fv3gfs.sh nco dell  
+
+SORC CHANGES
+
+* checkout.sh will checkout the following changed model tags:
+  * GSI tag gfsda.v16.1.5
+    * src/gsi/genqsat.f90: add a lower bound of qsat to avoid unphysical saturation specific humidity to be generated.
+
+FIX CHANGES
+
+* fix/fix_gsi:
+  * new files:
+    * Rcov_iasicsea
+    * Rcov_iasicland
+  * modified files:
+    * global_satinfo.txt: Turn on assimilating Metop-C IASI data and stop monitoring CrIS_NPP MW channels (iuse changed from -1 to -2)
+    * global_anavinfo.l127.txt: Add correlated observation errors for Metop-C IASI data and remove correlated observation errors for Metop-A IASI
+    * Rcov_iasibsea: recomputed from recent operations
+    * Rcov_iasibland: recomputed from recent operations
+    * Rcov_crisn20: recomputed from recent operations
+    * Rcov_crisnpp: updated and the MW channels are deleted from Rcov
+    * gfsv16_historical/: Add fix files for retrospective parallels.  Does not impact operations.
+ 
+PARM/CONFIG CHANGES
+
+* No change from GFS v16.1.4
+ 
+JOBS CHANGES
+
+* No change from GFS v16.1.4
+ 
+SCRIPT CHANGES
+
+* No change from GFS v16.1.4
+ 
+CHANGES TO RESOURCES AND FILE SIZES
+
+* There should be no change in analysis runtime nor radstat file size greater than the normal cycle to cycle variation.
+  
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+
+* Which production jobs should be tested as part of this implementation?
+  * The entire GFS v16.1.5 package needs to be installed and tested.
+* Does this change require a 30-day evaluation?
+  * No.
+ 
+DISSEMINATION INFORMATION
+ 
+* Where should this output be sent?
+  * No change from GFS v16.1.4
+* Who are the users?
+  * No change from GFS v16.1.4
+* Which output files should be transferred from PROD WCOSS to DEV WCOSS?
+  * No change from GFS v16.1.4
+* Directory changes
+  * No change from GFS v16.1.4
+* File changes
+  * No change from GFS v16.1.4
+ 
+HPSS ARCHIVE
+ 
+* No change from GFS v16.1.4
+ 
+JOB DEPENDENCIES AND FLOW DIAGRAM
+ 
+* No change from GFS v16.1.4
+

--- a/docs/Release_Notes.gfs.v16.1.5.txt
+++ b/docs/Release_Notes.gfs.v16.1.5.txt
@@ -14,7 +14,7 @@ This implementation plans to:
 
 These changes affect one source code and several fix files within the GSI tag of the global workflow.
 
-Also bundled into this update are the new 2022 CO2 fix files. See files listed below. The files will be included during the link setup step. The CO2 fix file update does not impact results.
+Also bundled into this update are the new 2022 CO2 fix files (see files listed below) and a new FV3 model tag that adds traceback flags to compilation by default. The CO2 fix files will be included during the link setup step. Neither the CO2 fix file nor the FV3 tag updates impact model results.
 
 IMPLEMENTATION INSTRUCTIONS
  
@@ -29,7 +29,7 @@ While logged in under the “nwprod” account:
 5) cd sorc
 6) ./checkout.sh -o
    * This script extracts the following GFS components:
-     MODEL      tag GFS.v16.0.16			Jun.Wang@noaa.gov
+     MODEL      tag GFS.v16.0.17			Jun.Wang@noaa.gov
      GSI        tag gfsda.v16.1.5   	    		Russ.Treadon@noaa.gov
      GLDAS     	tag gldas_gfsv16_release.v1.12.0     	Helin.Wei@noaa.gov
      UFS_UTILS 	tag ops-gfsv16.0.0  	               	George.Gayno@noaa.gov
@@ -43,6 +43,8 @@ While logged in under the “nwprod” account:
 SORC CHANGES
 
 * checkout.sh will checkout the following changed model tags:
+  * MODEL tag GFS.v16.0.17
+    * conf/configure.fv3.wcoss_dell_p3 and other platform configure.fv3 files: add “-g -traceback” to FFLAGS_OPT, CFLAGS_OPT, and CFLAGS_REPRO compilation settings
   * GSI tag gfsda.v16.1.5
     * src/gsi/genqsat.f90: add a lower bound of qsat to avoid unphysical saturation specific humidity to be generated.
 

--- a/docs/Release_Notes.gfs.v16.1.5.txt
+++ b/docs/Release_Notes.gfs.v16.1.5.txt
@@ -14,16 +14,7 @@ This implementation plans to:
 
 These changes affect one source code and several fix files within the GSI tag of the global workflow.
 
-Also bundled into this update are the new 2022 CO2 fix files:
-
-* fix_am/co2dat_4a/global_co2historicaldata_2020.txt
-* fix_am/co2dat_4a/global_co2historicaldata_2021.txt_proj_u
-* fix_am/co2dat_4a/global_co2historicaldata_2022.txt_proj
-* fix_am/fix_co2_proj/global_co2historicaldata_2022.txt
-* fix_am/fix_co2_update/global_co2historicaldata_2021.txt
-
-The files will be included during the link setup step. The CO2 fix file update does not impact results.
-
+Also bundled into this update are the new 2022 CO2 fix files. See files listed below. The files will be included during the link setup step. The CO2 fix file update does not impact results.
 
 IMPLEMENTATION INSTRUCTIONS
  
@@ -69,6 +60,14 @@ FIX CHANGES
     * Rcov_crisn20: recomputed from recent operations
     * Rcov_crisnpp: updated and the MW channels are deleted from Rcov
     * gfsv16_historical/: Add fix files for retrospective parallels.  Does not impact operations.
+* fix_am/co2dat_4a:
+  * global_co2historicaldata_2020.txt
+  * global_co2historicaldata_2021.txt_proj_u
+  * global_co2historicaldata_2022.txt_proj
+* fix_am/fix_co2_proj:
+  * global_co2historicaldata_2022.txt
+* fix_am/fix_co2_update:
+  * global_co2historicaldata_2021.txt
  
 PARM/CONFIG CHANGES
 

--- a/docs/Release_Notes.gfs.v16.1.5.txt
+++ b/docs/Release_Notes.gfs.v16.1.5.txt
@@ -14,6 +14,17 @@ This implementation plans to:
 
 These changes affect one source code and several fix files within the GSI tag of the global workflow.
 
+Also bundled into this update are the new 2022 CO2 fix files:
+
+* fix_am/co2dat_4a/global_co2historicaldata_2020.txt
+* fix_am/co2dat_4a/global_co2historicaldata_2021.txt_proj_u
+* fix_am/co2dat_4a/global_co2historicaldata_2022.txt_proj
+* fix_am/fix_co2_proj/global_co2historicaldata_2022.txt
+* fix_am/fix_co2_update/global_co2historicaldata_2021.txt
+
+The files will be included during the link setup step. The CO2 fix file update does not impact results.
+
+
 IMPLEMENTATION INSTRUCTIONS
  
 The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com are used to manage the GFS.v16.1.5 code. The SPA(s) handling the GFS.v16.1.5 implementation need to have permissions to clone VLab gerrit repositories and the private NCAR UPP_GTG repository (the “nwprod” account has access to the GTG repository). All NOAA-EMC organization repositories are publicly readable and do not require access permissions. Please follow the following steps to install the package on WCOSS-Dell.

--- a/docs/Release_Notes.gfs.v16.1.5.txt
+++ b/docs/Release_Notes.gfs.v16.1.5.txt
@@ -73,7 +73,8 @@ FIX CHANGES
  
 PARM/CONFIG CHANGES
 
-* No change from GFS v16.1.4
+* config.anal
+  * update global_convinfo.txt notes and global_satinfo.txt if-blocks for retrospective dates; no operational impact
  
 JOBS CHANGES
 

--- a/env/WCOSS_DELL_P3.env
+++ b/env/WCOSS_DELL_P3.env
@@ -14,7 +14,7 @@ fi
 step=$1
 
 # WCOSS_DELL_P3 information
-export launcher="mpirun -n"
+export launcher="mpirun -l -n"
 export mpmd="cfp"
 
 export npe_node_max=28

--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -121,12 +121,12 @@ if [[ $RUN_ENVIR == "emc" ]]; then
 
 
 #   NOTE:
-#   As of 2020052612, gfsv16_historical/global_convinfo.txt.2020052612 is
+#   As of 2021110312, gfsv16_historical/global_convinfo.txt.2021091612 is
 #   identical to ../global_convinfo.txt.  Thus, the logic below is not
 #   needed at this time.
 #   Assimilate COSMIC-2 GPS
-#   if [[ "$CDATE" -ge "2020052612" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
-#     export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020052612
+#   if [[ "$CDATE" -ge "2021091612" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
+#     export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021091612
 #   fi
 
 
@@ -146,14 +146,29 @@ if [[ $RUN_ENVIR == "emc" ]]; then
 	export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2019110706
     fi
 
+#   Turn off assimilation of Metop-A MHS
+    if [[ "$CDATE" -ge "2020022012" && "$CDATE" -lt "2021052118" ]]; then
+	export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2020022012
+    fi
+
+#   Turn off assimilation of S-NPP CrIS
+    if [[ "$CDATE" -ge "2021052118" && "$CDATE" -lt "2021092206" ]]; then
+	export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021052118 
+    fi
+
+#   Turn off assimilation of MetOp-A IASI
+    if [[ "$CDATE" -ge "2021092206" && "$CDATE" -lt "2021102612" ]]; then
+	export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021092206 
+    fi
+
 #   NOTE:  
-#   As of 2020022012, gfsv16_historical/global_satinfo.txt.2020022012 is
+#   As of 2021110312, gfsv16_historical/global_satinfo.txt.2021102612 is
 #   identical to ../global_satinfo.txt.  Thus, the logic below is not
 #   needed at this time
 #
-#   Turn off assmilation of all Metop-A MHS
-#   if [[ "$CDATE" -ge "2020022012" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
-#       export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2020022012
+#   Turn on assimilation of MetOp-C IASI
+#   if [[ "$CDATE" -ge "2021102612" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
+#       export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021102612
 #   fi
 
 fi

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -38,7 +38,7 @@ if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
     git clone --recursive https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
-    git checkout gfsda.v16.1.1a
+    git checkout gfsda.v16.1.5
     git submodule update
     cd ${topdir}
 else

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -26,7 +26,7 @@ if [[ ! -d fv3gfs.fd ]] ; then
     rm -f ${topdir}/checkout-fv3gfs.log
     git clone https://github.com/ufs-community/ufs-weather-model fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
     cd fv3gfs.fd
-    git checkout GFS.v16.0.16
+    git checkout GFS.v16.0.17
     git submodule update --init --recursive
     cd ${topdir}
 else


### PR DESCRIPTION
RFC 8823 - On WCOSS, update GFS to v16.1.5 which includes:
* Turn on the active assimilation of Metop-C IASI (Infrared Atmospheric Sounding Interferometer) data with correlated observation errors
* Update correlated observation errors for Metop-B IASI, N20 CrIS (Cross-track Infrared Sounder), and NPP CrIS
* Put in a minimum threshold for saturation specific humidity to avoid potential minimization issues.
* Add the 2022 CO2 projection files.

Implemented on October 26 at 1430Z.

Resolves #439
Close #439