### PR TITLE
Cycled IAU updates part 1

### DIFF
--- a/parm/config/config.fv3
+++ b/parm/config/config.fv3
@@ -57,7 +57,7 @@ case $case_in in
         export WRTIOBUF="1M"
         ;;
     "C96")
-        export DELTIM=720
+        export DELTIM=450
         export layout_x=6
         export layout_y=4
         export layout_x_gfs=6

--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -611,6 +611,12 @@ EOF
   $nam_sfcperts_nml
 /
 EOF
+  else
+    cat >> input.nml << EOF
+&nam_sfcperts
+  $nam_sfcperts_nml
+/
+EOF
   fi
 
 else


### PR DESCRIPTION
* add missing &nam_sfcperts to ush/parsing_namelists_FV3.sh when stochastic physics is on
* reduce timestep for C96 from 720 to 450 for successful efcs jobs