### PR TITLE
Update restart_interval in forecast configs

### DIFF
--- a/parm/config/config.efcs
+++ b/parm/config/config.efcs
@@ -55,8 +55,7 @@ export restart_interval=${restart_interval:-6}
 
 # For IAU, write restarts at beginning of window also
 if [ $DOIAU_ENKF = "YES" ]; then
-    export restart_interval="6 -1"
-    if [[ "$SDATE" = "$CDATE" && $EXP_WARM_START = ".false." ]]; then export restart_interval="3 -1"; fi # Cold starting
+    export restart_interval="3 -1"
 fi
 
 export OUTPUT_FILETYPES="$OUTPUT_FILE"

--- a/parm/config/config.fcst
+++ b/parm/config/config.fcst
@@ -254,8 +254,7 @@ if [[ "$CDUMP" == "gdas" ]] ; then # GDAS cycle specific parameters
 
     # For IAU, write restarts at beginning of window also
     if [ $DOIAU = "YES" ]; then
-       export restart_interval="6 9"
-       if [[ "$SDATE" = "$CDATE" && $EXP_WARM_START = ".false." ]]; then export restart_interval="3 6"; fi # Cold starting
+       export restart_interval="3 6"
     fi
 
     # Choose coupling with wave


### PR DESCRIPTION
- set restart_interval the same regardless of whether it's cold or warm
- use prior cold-start values all the time now
- deterministic forecast job restart_interval is now "3 6"
- ensemble forecast job restart_interval is now "3 -1"

Refs: #427