### PR TITLE
Update ush/ script files with "python3" in shebang

### DIFF
--- a/ush/rocoto/rocoto.py
+++ b/ush/rocoto/rocoto.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
     MODULE:

--- a/ush/rocoto/setup_expt.py
+++ b/ush/rocoto/setup_expt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ###############################################################
 # < next few lines under version control, D O  N O T  E D I T >

--- a/ush/rocoto/setup_expt_fcstonly.py
+++ b/ush/rocoto/setup_expt_fcstonly.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ###############################################################
 # < next few lines under version control, D O  N O T  E D I T >

--- a/ush/rocoto/setup_workflow.py
+++ b/ush/rocoto/setup_workflow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
     PROGRAM:

--- a/ush/rocoto/setup_workflow_fcstonly.py
+++ b/ush/rocoto/setup_workflow_fcstonly.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
     PROGRAM:


### PR DESCRIPTION
We updated the python scripts to python3, but did not update the shebang at the top to ensure python3 is used. This causes an issue for users whose python defaults to python2. This PR updates ush/ scripts to include "python3" in the shebang.