### PR TITLE
feature/coupled-crow: Updating p7.2 case file settings 

### DIFF
--- a/workflow/cases/prototype7.2-aero.yaml
+++ b/workflow/cases/prototype7.2-aero.yaml
@@ -49,8 +49,8 @@ case:
     nst_anl: yes
     psm_bc: 1
     dddmp: 0.1
-    FSICL: 0
-    FSICS: 0 
+    FSICL: 99999
+    FSICS: 99999
     DO_SKEB: false
     DO_SHUM: false
     DO_SPPT: false

--- a/workflow/cases/prototype7.2.yaml
+++ b/workflow/cases/prototype7.2.yaml
@@ -48,8 +48,8 @@ case:
     nst_anl: yes
     psm_bc: 1
     dddmp: 0.1
-    FSICL: 0
-    FSICS: 0 
+    FSICL: 99999
+    FSICS: 99999
     DO_SKEB: false
     DO_SHUM: false
     DO_SPPT: false


### PR DESCRIPTION
Reverting FSICL and FSICS to 99999 from 0 as this was determined to be the source of the earlier model crashes. 