### PR TITLE
Update gfsmetp, gfsarch dependencies (related update of EMC_verif-global tag)

### DIFF
--- a/parm/config/config.metp
+++ b/parm/config/config.metp
@@ -21,18 +21,16 @@ export HOMEverif_global=${HOMEgfs}/sorc/verif-global.fd
 export VERIF_GLOBALSH=$HOMEverif_global/ush/run_verif_global_in_global_workflow.sh
 ## INPUT DATA SETTINGS
 export model=$PSLOT
-export model_dir=$ARCDIR/..
 export model_file_format="pgbf{lead?fmt=%2H}.${CDUMP}.{init?fmt=%Y%m%d%H}.grib2"
 export model_hpss_dir=$ATARDIR/.. 
 export get_data_from_hpss="NO"
 export hpss_walltime="10"
 ## OUTPUT SETTINGS
-export OUTPUTROOT=$RUNDIR/$CDUMP/$CDATE/vrfy/metplus_exp
 export model_stat_dir=$ARCDIR/..
 export make_met_data_by="VALID"
 export SENDMETVIEWER="NO"
 ## DATE SETTINGS
-export VRFYBACK_HRS="24"
+export VRFYBACK_HRS="0"
 ## METPLUS SETTINGS
 export METplus_verbosity="INFO"
 export MET_verbosity="2"
@@ -40,19 +38,19 @@ export log_MET_output_to_METplus="yes"
 # GRID-TO-GRID STEP 1: gfsmetpg2g1
 export g2g1_type_list="anom pres sfc"
 export g2g1_anom_truth_name="self_anl"
-export g2g1_anom_truth_file_format="pgbanl.gfs.{valid?fmt=%Y%m%d%H}.grib2"
+export g2g1_anom_truth_file_format="pgbanl.${CDUMP}.{valid?fmt=%Y%m%d%H}.grib2"
 export g2g1_anom_fhr_min=$FHMIN_GFS
 export g2g1_anom_fhr_max=$FHMAX_GFS
 export g2g1_anom_grid="G002"
 export g2g1_anom_gather_by="VSDB"
 export g2g1_pres_truth_name="self_anl"
-export g2g1_pres_truth_file_format="pgbanl.gfs.{valid?fmt=%Y%m%d%H}.grib2"
+export g2g1_pres_truth_file_format="pgbanl.${CDUMP}.{valid?fmt=%Y%m%d%H}.grib2"
 export g2g1_pres_fhr_min=$FHMIN_GFS
 export g2g1_pres_fhr_max=$FHMAX_GFS
 export g2g1_pres_grid="G002"
 export g2g1_pres_gather_by="VSDB"
 export g2g1_sfc_truth_name="self_f00"
-export g2g1_sfc_truth_file_format="pgbf00.gfs.{valid?fmt=%Y%m%d%H}.grib2"
+export g2g1_sfc_truth_file_format="pgbf00.${CDUMP}.{valid?fmt=%Y%m%d%H}.grib2"
 export g2g1_sfc_fhr_min=$FHMIN_GFS
 export g2g1_sfc_fhr_max=$FHMAX_GFS
 export g2g1_sfc_grid="G002"
@@ -88,7 +86,7 @@ export g2o1_mv_database_desc="Grid-to-obs METplus data for global workflow exper
 export precip1_type_list="ccpa_accum24hr"
 export precip1_ccpa_accum24hr_model_bucket="06"
 export precip1_ccpa_accum24hr_model_var="APCP"
-export precip1_ccpa_accum24hr_model_file_format="pgbf{lead?fmt=%2H}.gfs.{init?fmt=%Y%m%d%H}.grib2"
+export precip1_ccpa_accum24hr_model_file_format="pgbf{lead?fmt=%2H}.${CDUMP}.{init?fmt=%Y%m%d%H}.grib2"
 export precip1_ccpa_accum24hr_fhr_min=$FHMIN_GFS
 export precip1_ccpa_accum24hr_fhr_max="180"
 export precip1_ccpa_accum24hr_grid="G211"

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -113,7 +113,7 @@ if [[ ! -d verif-global.fd ]] ; then
     rm -f ${topdir}/checkout-verif-global.log
     git clone --recursive https://github.com/NOAA-EMC/EMC_verif-global.git verif-global.fd >> ${topdir}/checkout-verif-global.log 2>&1
     cd verif-global.fd
-    git checkout verif_global_v2.5.2
+    git checkout verif_global_v2.8.0
     cd ${topdir}
 else
     echo 'Skip. Directory verif-global.fd already exist.'

--- a/ush/rocoto/setup_workflow.py
+++ b/ush/rocoto/setup_workflow.py
@@ -693,8 +693,6 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
         deps = []
         dep_dict = {'type':'metatask', 'name':f'{cdump}post'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type':'task', 'name':f'{cdump}arch', 'offset':'-&INTERVAL_GFS;'}
-        deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         sdate_gfs = rocoto.create_envar(name='SDATE_GFS', value='&SDATE_GFS;')
         metpcase = rocoto.create_envar(name='METPCASE', value='#metpcase#')
@@ -919,6 +917,9 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
     deps = []
     dep_dict = {'type': 'task', 'name': f'{cdump}vrfy'}
     deps.append(rocoto.add_dependency(dep_dict))
+    if do_metp in ['Y', 'YES']:
+        dep_dict = {'type':'metatask', 'name':f'{cdump}metp'}
+        deps.append(rocoto.add_dependency(dep_dict))
     if do_wave in ['Y', 'YES']:
       dep_dict = {'type': 'task', 'name': f'{cdump}wavepostsbs'}
       deps.append(rocoto.add_dependency(dep_dict))

--- a/ush/rocoto/setup_workflow.py
+++ b/ush/rocoto/setup_workflow.py
@@ -917,7 +917,7 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
     deps = []
     dep_dict = {'type': 'task', 'name': f'{cdump}vrfy'}
     deps.append(rocoto.add_dependency(dep_dict))
-    if do_metp in ['Y', 'YES']:
+    if cdump in ['gfs'] and do_metp in ['Y', 'YES']:
         dep_dict = {'type':'metatask', 'name':f'{cdump}metp'}
         deps.append(rocoto.add_dependency(dep_dict))
     if do_wave in ['Y', 'YES']:

--- a/ush/rocoto/setup_workflow_fcstonly.py
+++ b/ush/rocoto/setup_workflow_fcstonly.py
@@ -668,8 +668,6 @@ def get_workflow(dict_configs, cdump='gdas'):
         deps = []
         dep_dict = {'type':'metatask', 'name':f'{cdump}post'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type':'task', 'name':f'{cdump}arch', 'offset':'-&INTERVAL;'}
-        deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         sdate_gfs = rocoto.create_envar(name='SDATE_GFS', value='&SDATE;')
         metpcase = rocoto.create_envar(name='METPCASE', value='#metpcase#')
@@ -687,6 +685,9 @@ def get_workflow(dict_configs, cdump='gdas'):
     deps.append(rocoto.add_dependency(dep_dict))
     if do_vrfy in ['Y', 'YES']:
         dep_dict = {'type':'task', 'name':f'{cdump}vrfy'}
+        deps.append(rocoto.add_dependency(dep_dict))
+    if do_metp in ['Y', 'YES']:
+        dep_dict = {'type':'metatask', 'name':f'{cdump}metp'}
         deps.append(rocoto.add_dependency(dep_dict))
     dep_dict = {'type':'streq', 'left':'&ARCHIVE_TO_HPSS;', 'right':f'{hpssarch}'}
     deps.append(rocoto.add_dependency(dep_dict))

--- a/ush/rocoto/setup_workflow_fcstonly.py
+++ b/ush/rocoto/setup_workflow_fcstonly.py
@@ -686,7 +686,7 @@ def get_workflow(dict_configs, cdump='gdas'):
     if do_vrfy in ['Y', 'YES']:
         dep_dict = {'type':'task', 'name':f'{cdump}vrfy'}
         deps.append(rocoto.add_dependency(dep_dict))
-    if do_metp in ['Y', 'YES']:
+    if cdump in ['gfs'] and do_metp in ['Y', 'YES']:
         dep_dict = {'type':'metatask', 'name':f'{cdump}metp'}
         deps.append(rocoto.add_dependency(dep_dict))
     dep_dict = {'type':'streq', 'left':'&ARCHIVE_TO_HPSS;', 'right':f'{hpssarch}'}


### PR DESCRIPTION
This pull request relates to/would close https://github.com/NOAA-EMC/global-workflow/issues/437. It removes the dependency of gfsmetp on the previous cycle's gfsarch, which caused the first full cycle of gfsmetp jobs not to run. 

The gfsmetp jobs were updated to run and verify the current cycle date. The EMC_verif-global global workflow connector script was updated to create a temporary directory using files from ARCDIR and ROTDIR to use for verification. This work led to a subsequent tag creation of EMC_verif-global to verif_global_v2.8.0, which would close https://github.com/NOAA-EMC/global-workflow/issues/472 since it is being updated to a higher tag version.

This was tested within both free-forecast and cycled experiments.