### PR TITLE
Series of small WCOSS2 updates - round 2

### DIFF
--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -61,7 +61,7 @@ elif [ $step = "anal" ]; then
     export NTHREADS_CYCLE=${nth_cycle:-14}
     [[ $NTHREADS_CYCLE -gt $npe_node_max ]] && export NTHREADS_CYCLE=$npe_node_max
     npe_cycle=${ntiles:-6}
-    export APRUN_CYCLE="$launcher -n $npe_cycle"
+    export APRUN_CYCLE="$launcher -n $npe_cycle -ppn $npe_node_cycle --cpu-bind core --depth $NTHREADS_CYCLE"
 
     export NTHREADS_GAUSFCANL=1
     npe_gausfcanl=${npe_gausfcanl:-1}
@@ -81,7 +81,7 @@ elif [ $step = "gldas" ]; then
 
     export NTHREADS_GLDAS=${nth_gldas:-$nth_max}
     [[ $NTHREADS_GLDAS -gt $nth_max ]] && export NTHREADS_GLDAS=$nth_max
-    export APRUN_GLDAS="$launcher -n $npe_gldas -ppn $npe_node_gldas"
+    export APRUN_GLDAS="$launcher -n $npe_gldas -ppn $npe_node_gldas --cpu-bind core --depth $nth_gldas"
 
     export NTHREADS_GAUSSIAN=${nth_gaussian:-1}
     [[ $NTHREADS_GAUSSIAN -gt $nth_max ]] && export NTHREADS_GAUSSIAN=$nth_max
@@ -135,7 +135,6 @@ elif [ $step = "fcst" ]; then
     [[ $NTHREADS_FV3 -gt $nth_max ]] && export NTHREADS_FV3=$nth_max
     export cores_per_node=$npe_node_max
     if [ $CDUMP = "gdas" ]; then
-      #export APRUN_FV3="$launcher ${npe_fv3:-${npe_fcst:-$PBS_NP}}"
       export APRUN_FV3="$launcher -n ${npe_fcst:-$PBS_NP} -ppn $npe_node_fcst --depth $NTHREADS_FV3"
     else
       export APRUN_FV3="$launcher -n ${npe_fcst_gfs:-$PBS_NP} -ppn $npe_node_fcst --depth $NTHREADS_FV3"
@@ -170,7 +169,7 @@ elif [ $step = "post" ]; then
 
     export NTHREADS_NP=${nth_np:-1}
     [[ $NTHREADS_NP -gt $nth_max ]] && export NTHREADS_NP=$nth_max
-    export APRUN_NP="$launcher -n ${npe_np:-${npe_post:-$PBS_NP}} -ppn $npe_node_post"
+    export APRUN_NP="$launcher -n ${npe_np:-${npe_post:-$PBS_NP}} -ppn $npe_node_post --cpu-bind core --depth $NTHREADS_NP"
 
     export NTHREADS_DWN=${nth_dwn:-1}
     [[ $NTHREADS_DWN -gt $nth_max ]] && export NTHREADS_DWN=$nth_max
@@ -182,7 +181,7 @@ elif [ $step = "ecen" ]; then
 
     export NTHREADS_ECEN=${nth_ecen:-$nth_max}
     [[ $NTHREADS_ECEN -gt $nth_max ]] && export NTHREADS_ECEN=$nth_max
-    export APRUN_ECEN="$launcher -n ${npe_ecen:-$PBS_NP} -ppn $npe_node_ecen"
+    export APRUN_ECEN="$launcher -n ${npe_ecen:-$PBS_NP} -ppn $npe_node_ecen --cpu-bind core --depth $NTHREADS_ECEN"
 
     export NTHREADS_CHGRES=${nth_chgres:-14}
     [[ $NTHREADS_CHGRES -gt $npe_node_max ]] && export NTHREADS_CHGRES=$npe_node_max
@@ -194,7 +193,7 @@ elif [ $step = "ecen" ]; then
 
     export NTHREADS_CYCLE=${nth_cycle:-14}
     [[ $NTHREADS_CYCLE -gt $npe_node_max ]] && export NTHREADS_CYCLE=$npe_node_max
-    export APRUN_CYCLE="$launcher -n $npe_ecen"
+    export APRUN_CYCLE="$launcher -n $npe_ecen -ppn $npe_node_cycle --cpu-bind core --depth $NTHREADS_CYCLE"
 
 elif [ $step = "esfc" ]; then
 
@@ -202,11 +201,11 @@ elif [ $step = "esfc" ]; then
 
     export NTHREADS_ESFC=${nth_esfc:-$nth_max}
     [[ $NTHREADS_ESFC -gt $nth_max ]] && export NTHREADS_ESFC=$nth_max
-    export APRUN_ESFC="$launcher -n ${npe_esfc:-$PBS_NP} -ppn $npe_node_esfc"
+    export APRUN_ESFC="$launcher -n ${npe_esfc:-$PBS_NP} -ppn $npe_node_esfc --cpu-bind core --depth $NTHREADS_ESFC"
 
     export NTHREADS_CYCLE=${nth_cycle:-14}
     [[ $NTHREADS_CYCLE -gt $npe_node_max ]] && export NTHREADS_CYCLE=$npe_node_max
-    export APRUN_CYCLE="$launcher -n $npe_esfc"
+    export APRUN_CYCLE="$launcher -n $npe_esfc -ppn $npe_node_cycle --cpu-bind core --depth $NTHREADS_CYCLE"
 
 elif [ $step = "epos" ]; then
 
@@ -214,7 +213,7 @@ elif [ $step = "epos" ]; then
 
     export NTHREADS_EPOS=${nth_epos:-$nth_max}
     [[ $NTHREADS_EPOS -gt $nth_max ]] && export NTHREADS_EPOS=$nth_max
-    export APRUN_EPOS="$launcher -n ${npe_epos:-$PBS_NP} -ppn $npe_node_epos"
+    export APRUN_EPOS="$launcher -n ${npe_epos:-$PBS_NP} -ppn $npe_node_epos --cpu-bind core --depth $NTHREADS_EPOS"
 
 elif [ $step = "fv3ic" ]; then
 

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -100,7 +100,7 @@ elif [ $step = "eobs" ]; then
 
     export NTHREADS_GSI=${nth_eobs:-$nth_max}
     [[ $NTHREADS_GSI -gt $nth_max ]] && export NTHREADS_GSI=$nth_max
-    export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_eobs:-$PBS_NP}} -ppn $npe_node_eobs --cpu-bind core --depth $nth_eobs"
+    export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_eobs:-$PBS_NP}} -ppn $npe_node_eobs --cpu-bind core --depth $NTHREADS_GSI"
 
     export CFP_MP=${CFP_MP:-"NO"}
     export USE_CFP=${USE_CFP:-"YES"}

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -20,10 +20,10 @@ export mpmd="--cpu-bind verbose,core cfp"
 export npe_node_max=128
 
 # Configure MPI environment
-export MPI_LABELIO=YES
-export MP_STDOUTMODE="ORDERED"
 export KMP_STACKSIZE=2048M
 export KMP_AFFINITY=scatter
+export MKL_CBWR=AVX2
+
 export job=${PBS_JOBNAME:-$step}
 export jobid=${job}.${PBS_JOBID:-$$}
 
@@ -43,11 +43,29 @@ elif [ $step = "waveinit" -o $step = "waveprep" -o $step = "wavepostsbs" -o $ste
 
 elif [ $step = "anal" ]; then
 
+    # OMP settings
+    export OMP_PLACES=cores
+    export OMP_NUM_THREADS=$nth_anal
+    export MP_EAGER_LIMIT=165536
+    export MP_COREFILE_FORMAT=lite
+    export MP_EUIDEVELOP=min
+    export MP_EUIDEVICE=sn_all
+    export MP_EUILIB=us
+    export MP_MPILIB=mpich2
+    export MP_LABELIO=yes
+    export MP_SINGLE_THREAD=yes
+    export MP_USE_BULK_XFER=yes
+    export MP_SHARED_MEMORY=yes
+    #export MPICH_ALLTOALL_THROTTLE=0
+    export MP_COLLECTIVE_OFFLOAD=no
+    export KMP_STACKSIZE=1024m
+    export FI_OFI_RXM_SAR_LIMIT=3145728
+
     nth_max=$(($npe_node_max / $npe_node_anal))
 
     export NTHREADS_GSI=${nth_anal:-$nth_max}
     [[ $NTHREADS_GSI -gt $nth_max ]] && export NTHREADS_GSI=$nth_max
-    export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_anal:-$PBS_NP}} -ppn $npe_node_anal"
+    export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_anal:-$PBS_NP}} -ppn $npe_node_anal --cpu-bind core --depth $NTHREADS_GSI"
 
     export NTHREADS_CALCINC=${nth_calcinc:-1}
     [[ $NTHREADS_CALCINC -gt $nth_max ]] && export NTHREADS_CALCINC=$nth_max
@@ -90,7 +108,7 @@ elif [ $step = "eobs" ]; then
 
     export NTHREADS_GSI=${nth_eobs:-$nth_max}
     [[ $NTHREADS_GSI -gt $nth_max ]] && export NTHREADS_GSI=$nth_max
-    export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_eobs:-$PBS_NP}} -ppn $npe_node_eobs"
+    export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_eobs:-$PBS_NP}} -ppn $npe_node_eobs --cpu-bind core --depth $nth_eobs"
 
     export CFP_MP=${CFP_MP:-"NO"}
     export USE_CFP=${USE_CFP:-"YES"}
@@ -98,17 +116,26 @@ elif [ $step = "eobs" ]; then
 
 elif [ $step = "eupd" ]; then
 
+    export OMP_PLACES=cores
+    export OMP_NUM_THREADS=$nth_eupd
+    export OMP_STACKSIZE=2G
+    export MPICH_COLL_OPT_OFF=1
+    export FI_OFI_RXM_SAR_LIMIT=3145728
+
     nth_max=$(($npe_node_max / $npe_node_eupd))
 
     export NTHREADS_ENKF=${nth_eupd:-$nth_max}
     [[ $NTHREADS_ENKF -gt $nth_max ]] && export NTHREADS_ENKF=$nth_max
-    export APRUN_ENKF="$launcher -n ${npe_enkf:-${npe_eupd:-$PBS_NP}} -ppn $npe_node_eupd"
+    export APRUN_ENKF="$launcher -n ${npe_enkf:-${npe_eupd:-$PBS_NP}} -ppn $npe_node_eupd --cpu-bind core --depth $nth_eupd"
 
     export CFP_MP=${CFP_MP:-"NO"}
     export USE_CFP=${USE_CFP:-"YES"}
     export APRUNCFP="$launcher -np \$ncmd $mpmd"
 
 elif [ $step = "fcst" ]; then
+
+    export FI_OFI_RXM_RX_SIZE=40000
+    export FI_OFI_RXM_TX_SIZE=40000
 
     nth_max=$(($npe_node_max / $npe_node_fcst))
 
@@ -117,9 +144,9 @@ elif [ $step = "fcst" ]; then
     export cores_per_node=$npe_node_max
     if [ $CDUMP = "gdas" ]; then
       #export APRUN_FV3="$launcher ${npe_fv3:-${npe_fcst:-$PBS_NP}}"
-      export APRUN_FV3="$launcher -n ${npe_fcst:-$PBS_NP} -ppn $npe_node_fcst"
+      export APRUN_FV3="$launcher -n ${npe_fcst:-$PBS_NP} -ppn $npe_node_fcst --depth $NTHREADS_FV3"
     else
-      export APRUN_FV3="$launcher -n ${npe_fcst_gfs:-$PBS_NP} -ppn $npe_node_fcst"
+      export APRUN_FV3="$launcher -n ${npe_fcst_gfs:-$PBS_NP} -ppn $npe_node_fcst --depth $NTHREADS_FV3"
     fi
     export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
     [[ $NTHREADS_REGRID_NEMSIO -gt $nth_max ]] && export NTHREADS_REGRID_NEMSIO=$nth_max
@@ -131,12 +158,15 @@ elif [ $step = "fcst" ]; then
 
 elif [ $step = "efcs" ]; then
 
+    export FI_OFI_RXM_RX_SIZE=40000
+    export FI_OFI_RXM_TX_SIZE=40000
+
     nth_max=$(($npe_node_max / $npe_node_efcs))
 
     export NTHREADS_FV3=${nth_efcs:-$nth_max}
     [[ $NTHREADS_FV3 -gt $nth_max ]] && export NTHREADS_FV3=$nth_max
     export cores_per_node=$npe_node_max
-    export APRUN_FV3="$launcher -n ${npe_fv3:-${npe_efcs:-$PBS_NP}} -ppn $npe_node_efcs"
+    export APRUN_FV3="$launcher -n ${npe_fv3:-${npe_efcs:-$PBS_NP}} -ppn $npe_node_efcs --depth $NTHREADS_FV3"
 
     export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
     [[ $NTHREADS_REGRID_NEMSIO -gt $nth_max ]] && export NTHREADS_REGRID_NEMSIO=$nth_max
@@ -227,5 +257,8 @@ elif [ $step = "gempak" ]; then
     [[ $NTHREADS_GEMPAK -gt $nth_max ]] && export NTHREADS_GEMPAK=$nth_max
     export APRUN_GEMPAKCFP="$launcher -np \$ntasks $mpmd"
 
+elif [ $step = "wafsgcip" ]; then
+
+    export MPIRUN="$launcher -np $npe_wafsgcip $mpmd"
 
 fi

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -118,7 +118,7 @@ elif [ $step = "eupd" ]; then
 
     export NTHREADS_ENKF=${nth_eupd:-$nth_max}
     [[ $NTHREADS_ENKF -gt $nth_max ]] && export NTHREADS_ENKF=$nth_max
-    export APRUN_ENKF="$launcher -n ${npe_enkf:-${npe_eupd:-$PBS_NP}} -ppn $npe_node_eupd --cpu-bind core --depth $nth_eupd"
+    export APRUN_ENKF="$launcher -n ${npe_enkf:-${npe_eupd:-$PBS_NP}} -ppn $npe_node_eupd --cpu-bind core --depth $NTHREADS_ENKF"
 
     export CFP_MP=${CFP_MP:-"NO"}
     export USE_CFP=${USE_CFP:-"YES"}

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -43,7 +43,6 @@ elif [ $step = "waveinit" -o $step = "waveprep" -o $step = "wavepostsbs" -o $ste
 
 elif [ $step = "anal" ]; then
 
-    # OMP settings
     export OMP_PLACES=cores
     export OMP_NUM_THREADS=$nth_anal
     export OMP_STACKSIZE=1G
@@ -91,6 +90,11 @@ elif [ $step = "gldas" ]; then
     export APRUN_GLDAS_DATA_PROC="$launcher -np $npe_gldas $mpmd"
 
 elif [ $step = "eobs" ]; then
+
+    export OMP_PLACES=cores
+    export OMP_NUM_THREADS=$nth_eobs
+    export OMP_STACKSIZE=1G
+    export FI_OFI_RXM_SAR_LIMIT=3145728
 
     nth_max=$(($npe_node_max / $npe_node_eobs))
 

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -46,19 +46,7 @@ elif [ $step = "anal" ]; then
     # OMP settings
     export OMP_PLACES=cores
     export OMP_NUM_THREADS=$nth_anal
-    export MP_EAGER_LIMIT=165536
-    export MP_COREFILE_FORMAT=lite
-    export MP_EUIDEVELOP=min
-    export MP_EUIDEVICE=sn_all
-    export MP_EUILIB=us
-    export MP_MPILIB=mpich2
-    export MP_LABELIO=yes
-    export MP_SINGLE_THREAD=yes
-    export MP_USE_BULK_XFER=yes
-    export MP_SHARED_MEMORY=yes
-    #export MPICH_ALLTOALL_THROTTLE=0
-    export MP_COLLECTIVE_OFFLOAD=no
-    export KMP_STACKSIZE=1024m
+    export OMP_STACKSIZE=1G
     export FI_OFI_RXM_SAR_LIMIT=3145728
 
     nth_max=$(($npe_node_max / $npe_node_anal))

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -135,9 +135,9 @@ elif [ $step = "fcst" ]; then
     [[ $NTHREADS_FV3 -gt $nth_max ]] && export NTHREADS_FV3=$nth_max
     export cores_per_node=$npe_node_max
     if [ $CDUMP = "gdas" ]; then
-      export APRUN_FV3="$launcher -n ${npe_fcst:-$PBS_NP} -ppn $npe_node_fcst --depth $NTHREADS_FV3"
+      export APRUN_FV3="$launcher -n ${npe_fcst:-$PBS_NP} -ppn $npe_node_fcst --cpu-bind core --depth $NTHREADS_FV3"
     else
-      export APRUN_FV3="$launcher -n ${npe_fcst_gfs:-$PBS_NP} -ppn $npe_node_fcst --depth $NTHREADS_FV3"
+      export APRUN_FV3="$launcher -n ${npe_fcst_gfs:-$PBS_NP} -ppn $npe_node_fcst --cpu-bind core --depth $NTHREADS_FV3"
     fi
     export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
     [[ $NTHREADS_REGRID_NEMSIO -gt $nth_max ]] && export NTHREADS_REGRID_NEMSIO=$nth_max
@@ -157,7 +157,7 @@ elif [ $step = "efcs" ]; then
     export NTHREADS_FV3=${nth_efcs:-$nth_max}
     [[ $NTHREADS_FV3 -gt $nth_max ]] && export NTHREADS_FV3=$nth_max
     export cores_per_node=$npe_node_max
-    export APRUN_FV3="$launcher -n ${npe_fv3:-${npe_efcs:-$PBS_NP}} -ppn $npe_node_efcs --depth $NTHREADS_FV3"
+    export APRUN_FV3="$launcher -n ${npe_fv3:-${npe_efcs:-$PBS_NP}} -ppn $npe_node_efcs --cpu-bind core --depth $NTHREADS_FV3"
 
     export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
     [[ $NTHREADS_REGRID_NEMSIO -gt $nth_max ]] && export NTHREADS_REGRID_NEMSIO=$nth_max

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -44,7 +44,6 @@ elif [ $step = "waveinit" -o $step = "waveprep" -o $step = "wavepostsbs" -o $ste
 elif [ $step = "anal" ]; then
 
     export OMP_PLACES=cores
-    export OMP_NUM_THREADS=$nth_anal
     export OMP_STACKSIZE=1G
     export FI_OFI_RXM_SAR_LIMIT=3145728
 
@@ -92,7 +91,6 @@ elif [ $step = "gldas" ]; then
 elif [ $step = "eobs" ]; then
 
     export OMP_PLACES=cores
-    export OMP_NUM_THREADS=$nth_eobs
     export OMP_STACKSIZE=1G
     export FI_OFI_RXM_SAR_LIMIT=3145728
 
@@ -109,7 +107,6 @@ elif [ $step = "eobs" ]; then
 elif [ $step = "eupd" ]; then
 
     export OMP_PLACES=cores
-    export OMP_NUM_THREADS=$nth_eupd
     export OMP_STACKSIZE=2G
     export MPICH_COLL_OPT_OFF=1
     export FI_OFI_RXM_SAR_LIMIT=3145728

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -81,7 +81,7 @@ elif [ $step = "gldas" ]; then
 
     export NTHREADS_GLDAS=${nth_gldas:-$nth_max}
     [[ $NTHREADS_GLDAS -gt $nth_max ]] && export NTHREADS_GLDAS=$nth_max
-    export APRUN_GLDAS="$launcher -n $npe_gldas -ppn $npe_node_gldas --cpu-bind core --depth $nth_gldas"
+    export APRUN_GLDAS="$launcher -n $npe_gldas -ppn $npe_node_gldas --cpu-bind core --depth $NTHREADS_GLDAS"
 
     export NTHREADS_GAUSSIAN=${nth_gaussian:-1}
     [[ $NTHREADS_GAUSSIAN -gt $nth_max ]] && export NTHREADS_GAUSSIAN=$nth_max

--- a/jobs/rocoto/wafsgcip.sh
+++ b/jobs/rocoto/wafsgcip.sh
@@ -16,6 +16,13 @@ for config in $configs; do
     [[ $status -ne 0 ]] && exit $status
 done
 
+##########################################
+# Source machine runtime environment
+##########################################
+. $HOMEgfs/env/${machine}.env wafsgcip
+status=$?
+[[ $status -ne 0 ]] && exit $status
+
 ###############################################################
 
 export DATAROOT="$RUNDIR/$CDATE/$CDUMP/wafsgcip"

--- a/jobs/rocoto/wavepostbndpnt.sh
+++ b/jobs/rocoto/wavepostbndpnt.sh
@@ -15,7 +15,5 @@ $HOMEgfs/jobs/JGLOBAL_WAVE_POST_BNDPNT
 status=$?
 [[ $status -ne 0 ]] && exit $status
 
-###############################################################
-# Force Exit out cleanly
-if [ ${KEEPDATA:-"NO"} = "NO" ] ; then rm -rf $DATAROOT ; fi
+# Exit out cleanly
 exit 0

--- a/jobs/rocoto/wavepostbndpntbll.sh
+++ b/jobs/rocoto/wavepostbndpntbll.sh
@@ -15,7 +15,5 @@ $HOMEgfs/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
 status=$?
 [[ $status -ne 0 ]] && exit $status
 
-###############################################################
-# Force Exit out cleanly
-if [ ${KEEPDATA:-"NO"} = "NO" ] ; then rm -rf $DATAROOT ; fi
+# Exit out cleanly
 exit 0

--- a/jobs/rocoto/wavepostpnt.sh
+++ b/jobs/rocoto/wavepostpnt.sh
@@ -15,7 +15,5 @@ $HOMEgfs/jobs/JGLOBAL_WAVE_POST_PNT
 status=$?
 [[ $status -ne 0 ]] && exit $status
 
-###############################################################
-# Force Exit out cleanly
-if [ ${KEEPDATA:-"NO"} = "NO" ] ; then rm -rf $DATAROOT ; fi
+# Exit out cleanly
 exit 0

--- a/jobs/rocoto/wavepostsbs.sh
+++ b/jobs/rocoto/wavepostsbs.sh
@@ -15,7 +15,5 @@ $HOMEgfs/jobs/JGLOBAL_WAVE_POST_SBS
 status=$?
 [[ $status -ne 0 ]] && exit $status
 
-###############################################################
-# Force Exit out cleanly
-if [ ${KEEPDATA:-"NO"} = "NO" ] ; then rm -rf $DATAROOT ; fi
+# Exit out cleanly
 exit 0

--- a/parm/config/config.efcs
+++ b/parm/config/config.efcs
@@ -56,7 +56,7 @@ export restart_interval=${restart_interval:-6}
 # For IAU, write restarts at beginning of window also
 if [ $DOIAU_ENKF = "YES" ]; then
     export restart_interval="6 -1"
-    if [[ "$SDATE" = "$CDATE" ]]; then export restart_interval="3 -1"; fi
+    if [[ "$SDATE" = "$CDATE" && $EXP_WARM_START = ".false." ]]; then export restart_interval="3 -1"; fi # Cold starting
 fi
 
 export OUTPUT_FILETYPES="$OUTPUT_FILE"
@@ -64,7 +64,10 @@ if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
     export  ichunk2d=0; export jchunk2d=0
     export  ichunk3d=0; export jchunk3d=0;  export kchunk3d=0
     RESTILE=`echo $CASE_ENKF |cut -c 2-`
-    if [[ "$machine" == "WCOSS_DELL_P3" ]] || [[ "$machine" == "WCOSS2" ]]; then
+    if [[ "$machine" == "WCOSS2" ]]; then
+        export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
+    fi
+    if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
         if [ $RESTILE -ge 384 ]; then
             export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
             export ichunk2d=$((4*RESTILE))

--- a/parm/config/config.efcs
+++ b/parm/config/config.efcs
@@ -64,25 +64,14 @@ if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
     export  ichunk2d=0; export jchunk2d=0
     export  ichunk3d=0; export jchunk3d=0;  export kchunk3d=0
     RESTILE=`echo $CASE_ENKF |cut -c 2-`
-    if [[ "$machine" == "WCOSS2" ]]; then
-        export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
-    fi
+    export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
     if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
         if [ $RESTILE -ge 384 ]; then
-            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
             export ichunk2d=$((4*RESTILE))
             export jchunk2d=$((2*RESTILE))
             export ichunk3d=$((4*RESTILE))
             export jchunk3d=$((2*RESTILE))
             export kchunk3d=1
-        else
-            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
-        fi
-    fi
-    if [[ "$machine" == "HERA" ]]; then
-        export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
-        if [ $RESTILE -le 192 ]; then
-            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
         fi
     fi
 fi

--- a/parm/config/config.fcst
+++ b/parm/config/config.fcst
@@ -155,12 +155,10 @@ if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
     export  ichunk2d=0; export jchunk2d=0
     export  ichunk3d=0; export jchunk3d=0;  export kchunk3d=0
     RESTILE=`echo $CASE |cut -c 2-`
-    if [[ "$machine" == "WCOSS2" ]]; then
-        if [ $RESTILE -ge 768 ]; then
-            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
-        else
-            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
-        fi
+    if [ $RESTILE -ge 768 ]; then
+        export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
+    else
+        export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
     fi
     if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
         if [ $RESTILE -ge 768 ]; then
@@ -168,20 +166,6 @@ if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
             export ichunk3d=$((4*RESTILE)) 
             export jchunk3d=$((2*RESTILE))
             export kchunk3d=1
-        else
-            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
-        fi
-    fi
-    if [[ "$machine" == "HERA" ]]; then
-        export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
-        if [ $RESTILE -le 192 ]; then
-            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
-        fi
-    fi
-    if [[ "$machine" == "ORION" ]]; then
-        export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
-        if [ $RESTILE -le 192 ]; then
-            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
         fi
     fi
 fi

--- a/parm/config/config.fcst
+++ b/parm/config/config.fcst
@@ -155,7 +155,14 @@ if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
     export  ichunk2d=0; export jchunk2d=0
     export  ichunk3d=0; export jchunk3d=0;  export kchunk3d=0
     RESTILE=`echo $CASE |cut -c 2-`
-    if [[ "$machine" == "WCOSS_DELL_P3" ]] || [[ "$machine" == "WCOSS2" ]]; then
+    if [[ "$machine" == "WCOSS2" ]]; then
+        if [ $RESTILE -ge 768 ]; then
+            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
+        else
+            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
+        fi
+    fi
+    if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
         if [ $RESTILE -ge 768 ]; then
             export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
             export ichunk3d=$((4*RESTILE)) 
@@ -206,7 +213,7 @@ if [[ "$CDUMP" == "gdas" ]] ; then # GDAS cycle specific parameters
     # For IAU, write restarts at beginning of window also
     if [ $DOIAU = "YES" ]; then
        export restart_interval="6 9"
-       if [[ "$SDATE" = "$CDATE" ]]; then export restart_interval="3 6"; fi
+       if [[ "$SDATE" = "$CDATE" && $EXP_WARM_START = ".false." ]]; then export restart_interval="3 6"; fi # Cold starting
     fi
 
     # Choose coupling with wave

--- a/parm/config/config.fcst
+++ b/parm/config/config.fcst
@@ -162,10 +162,15 @@ if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
     fi
     if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
         if [ $RESTILE -ge 768 ]; then
-            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
             export ichunk3d=$((4*RESTILE)) 
             export jchunk3d=$((2*RESTILE))
             export kchunk3d=1
+        fi
+    fi
+    if [[ "$machine" == "HERA" ]] || [[ "$machine" == "ORION" ]]; then
+        export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
+        if [ $RESTILE -le 192 ]; then
+            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
         fi
     fi
 fi

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -139,15 +139,18 @@ elif [ $step = "anal" ]; then
     fi
     export npe_node_anal=$(echo "$npe_node_max / $nth_anal" | bc)
     export nth_cycle=$npe_node_max
+    export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_anal="3072M"; fi
 
 elif [ $step = "analcalc" ]; then
 
     export wtime_analcalc="00:10:00"
     export npe_analcalc=127
+    export ntasks=$npe_analcalc
     export nth_analcalc=1
     export npe_node_analcalc=$npe_node_max
     if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export npe_analcalc=127 ; fi
+    if [[ "$machine" = "WCOSS2" ]]; then export memory_analcalc="500GB" ; fi
 
 elif [ $step = "analdiag" ]; then
 
@@ -356,6 +359,7 @@ elif [ $step = "ecen" ]; then
     if [ $CASE = "C384" -o $CASE = "C192" -o $CASE = "C96" -o $CASE = "C48" ]; then export nth_ecen=2; fi
     export npe_node_ecen=$(echo "$npe_node_max / $nth_ecen" | bc)
     export nth_cycle=$nth_ecen
+    export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_ecen="3072M"; fi
 
 elif [ $step = "esfc" ]; then
@@ -365,6 +369,7 @@ elif [ $step = "esfc" ]; then
     export npe_node_esfc=$npe_node_max
     export nth_esfc=1
     export nth_cycle=$nth_esfc
+    export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_esfc="3072M"; fi
 
 elif [ $step = "efcs" ]; then
@@ -396,13 +401,13 @@ elif [ $step = "postsnd" ]; then
     export npe_node_postsnd=20
     export npe_postsndcfp=9
     export npe_node_postsndcfp=1
-    export memory_postsnd="500GB"
     if [ $OUTPUT_FILE == "nemsio" ]; then
         export npe_postsnd=13
         export npe_node_postsnd=4
     fi
     if [[ "$machine" = "HERA" ]]; then export npe_node_postsnd=2; fi
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_postsnd="254M"; fi
+    if [[ "$machine" == "WCOSS2" ]]; then export memory_postsnd="500GB" ; fi
 
 elif [ $step = "awips" ]; then
 

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -132,15 +132,18 @@ elif [ $step = "anal" ]; then
     if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_anal=7; fi
     export npe_node_anal=$(echo "$npe_node_max / $nth_anal" | bc)
     export nth_cycle=$npe_node_max
+    export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_anal="3072M"; fi
 
 elif [ $step = "analcalc" ]; then
 
     export wtime_analcalc="00:10:00"
     export npe_analcalc=127
+    export ntasks=$npe_analcalc
     export nth_analcalc=1
     export npe_node_analcalc=$npe_node_max
     if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export npe_analcalc=127 ; fi
+    if [[ "$machine" = "WCOSS2" ]]; then export memory_analcalc="500GB" ; fi
 
 elif [ $step = "analdiag" ]; then
 
@@ -334,6 +337,7 @@ elif [ $step = "ecen" ]; then
     if [ $CASE = "C384" -o $CASE = "C192" -o $CASE = "C96" -o $CASE = "C48" ]; then export nth_ecen=2; fi
     export npe_node_ecen=$(echo "$npe_node_max / $nth_ecen" | bc)
     export nth_cycle=$nth_ecen
+    export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_ecen="3072M"; fi
 
 elif [ $step = "esfc" ]; then
@@ -343,6 +347,7 @@ elif [ $step = "esfc" ]; then
     export npe_node_esfc=$npe_node_max
     export nth_esfc=1
     export nth_cycle=$nth_esfc
+    export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_esfc="3072M"; fi
 
 elif [ $step = "efcs" ]; then
@@ -370,13 +375,13 @@ elif [ $step = "postsnd" ]; then
     export npe_node_postsnd=20
     export npe_postsndcfp=9
     export npe_node_postsndcfp=1
-    export memory_postsnd="500GB"
     if [ $OUTPUT_FILE == "nemsio" ]; then
         export npe_postsnd=13
         export npe_node_postsnd=4
     fi
     if [[ "$machine" = "HERA" ]]; then export npe_node_postsnd=2; fi
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_postsnd="254M"; fi
+    if [[ "$machine" == "WCOSS2" ]]; then export memory_postsnd="500GB" ; fi
 
 elif [ $step = "awips" ]; then
 

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -70,7 +70,7 @@ fi
 echo EMC_post checkout ...
 if [[ ! -d gfs_post.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_post.log
-    git clone ${gtg_git_args:-} -b post_gfsv16_wcoss2 https://github.com/WenMeng-NOAA/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
+    git clone ${gtg_git_args:-} -b upp_v8.1.0 https://github.com/NOAA-EMC/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
     ################################################################################
     # checkout_gtg
     ## yes: The gtg code at NCAR private repository is available for ops. GFS only.

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -7,6 +7,7 @@ do
   o)
    echo "Received -o flag for optional checkout of GTG, will check out GTG with EMC_post"
    checkout_gtg="YES"
+   gtg_git_args="--recursive"
    ;;
   :)
    echo "option -$OPTARG needs an argument"
@@ -49,7 +50,7 @@ if [[ ! -d gldas.fd ]] ; then
     rm -f ${topdir}/checkout-gldas.log
     git clone https://github.com/NOAA-EMC/GLDAS  gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
     cd gldas.fd
-    git checkout gldas_gfsv16_release.v1.19.0
+    git checkout gldas_gfsv16_release.v1.20.0
     cd ${topdir}
 else
     echo 'Skip.  Directory gldas.fd already exists.'
@@ -69,9 +70,7 @@ fi
 echo EMC_post checkout ...
 if [[ ! -d gfs_post.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_post.log
-    git clone https://github.com/WenMeng-NOAA/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
-    cd gfs_post.fd
-    git checkout post_gfsv16_wcoss2
+    git clone ${gtg_git_args:-} -b post_gfsv16_wcoss2 https://github.com/WenMeng-NOAA/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
     ################################################################################
     # checkout_gtg
     ## yes: The gtg code at NCAR private repository is available for ops. GFS only.
@@ -80,7 +79,7 @@ if [[ ! -d gfs_post.fd ]] ; then
     ################################################################################
     checkout_gtg=${checkout_gtg:-"NO"}
     if [[ ${checkout_gtg} == "YES" ]] ; then
-      ./manage_externals/checkout_externals
+      cd gfs_post.fd
       cp sorc/post_gtg.fd/*f90 sorc/ncep_post.fd/.
       cp sorc/post_gtg.fd/gtg.config.gfs parm/gtg.config.gfs
     fi
@@ -94,7 +93,7 @@ if [[ ! -d gfs_wafs.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_wafs.log
     git clone --recursive https://github.com/NOAA-EMC/EMC_gfs_wafs.git gfs_wafs.fd >> ${topdir}/checkout-gfs_wafs.log 2>&1
     cd gfs_wafs.fd
-    git checkout gfs_wafs.v6.2.0
+    git checkout gfs_wafs.v6.2.1
     cd ${topdir}
 else
     echo 'Skip.  Directory gfs_wafs.fd already exists.'

--- a/sorc/gaussian_sfcanl.fd/makefile.sh
+++ b/sorc/gaussian_sfcanl.fd/makefile.sh
@@ -5,7 +5,7 @@ export FFLAGS="-O3 -fp-model precise -g -r8 -i4"
 #export FFLAGS="-g -r8 -i4 -warn unused -check bounds"
 
 export NETCDF_INCLUDE="-I${NETCDF}/include"
-export NETCDF_LDFLAGS_F="-L${NETCDF}/lib -lnetcdf -lnetcdff -L${HDF5}/lib -lhdf5 "
+export NETCDF_LDFLAGS_F="-L${NETCDF}/lib -lnetcdf -lnetcdff -L${HDF5_LIBRARIES} -lhdf5 "
 
 make clean
 make build

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -16,6 +16,8 @@ else
     __ms_shell=sh
 fi
 
+HOMEgfs=${HOMEgfs:-`pwd`/../}
+echo "HOMEgfs=$HOMEgfs"
 target=""
 USERNAME=`echo $LOGNAME | awk '{ print tolower($0)'}`
 ##---------------------------------------------------------------------------
@@ -209,7 +211,7 @@ fi
 
 # Source versions file for build
 
-. ../versions/build.ver
+. ${HOMEgfs}/versions/build.ver
 
 unset __ms_shell
 unset __ms_ksh_test

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -17,7 +17,6 @@ else
 fi
 
 HOMEgfs=${HOMEgfs:-`pwd`/../}
-echo "HOMEgfs=$HOMEgfs"
 target=""
 USERNAME=`echo $LOGNAME | awk '{ print tolower($0)'}`
 ##---------------------------------------------------------------------------

--- a/util/sorc/compile_gfs_util_wcoss.sh
+++ b/util/sorc/compile_gfs_util_wcoss.sh
@@ -7,8 +7,9 @@
 ######################################################################
 
 LMOD_EXACT_MATCH=no
-source ../../sorc/machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
+export HOMEgfs="${cwd}/../../"
+source ../../sorc/machine-setup.sh > /dev/null 2>&1
 
 if [ "$target" = "wcoss_dell_p3" ] || [ "$target" = "wcoss_cray" ] || [ "$target" = "wcoss2" ] ; then
    echo " "


### PR DESCRIPTION
This PR contains the following:

1. WCOSS2.env updates based on testing and feedback from developers thus far
2. update to wafsgcip rocoto job script to source the env file
3. checkout updates for the GLDAS and WAFS versions, as well as converting UPP GTG checkout to use the new submodules (used to be manage_externals)
4. build updates for gaussian_sfcanl and compile_gfs_utils (includes change to machine-setup.sh for sourcing version files)
5. updates to fcst/efcs configs to set OUTPUT_FILETYPES on WCOSS2 and include EXP_WARM_START variable when adjusting restart_interval for cold-starting
6. remove duplicate DATA removal from wavepost rocoto job scripts

The next PRs will mostly cover workflow updates and resource optimization (depending on testing status).

Refs: #399 