### PR TITLE
Retire jlogfile from scripts

### DIFF
--- a/driver/gdas/para_config.gdas_gldas
+++ b/driver/gdas/para_config.gdas_gldas
@@ -53,9 +53,7 @@ export DCOMIN=${DCOM_IN:-${DCOMROOT}/prod}
 
 
 #export DATA_IN=/gpfs/dell2/ptmp/$LOGNAME/tmpnwprd
-#export jlogfile=$DATA_IN/jlogfile
 export DATA=/gpfs/dell2/ptmp/$LOGNAME/tmpnwprd
-export jlogfile=$DATA/jlogfile
 
 export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-NO}

--- a/driver/gdas/test_emcsfc.sh
+++ b/driver/gdas/test_emcsfc.sh
@@ -26,7 +26,6 @@ export SENDCOM="YES"
 export RUN_ENVIR="nco"
 
 export DATA="/gpfs/hps/stmp/$LOGNAME/tmpnwprd/${job}"
-export jlogfile="/gpfs/hps/stmp/$LOGNAME/jlogfile"
 
 module load prod_envir/1.0.1
 

--- a/driver/gfs/test_emcsfc.sh
+++ b/driver/gfs/test_emcsfc.sh
@@ -26,7 +26,6 @@ export SENDCOM="YES"
 export RUN_ENVIR="nco"
 
 export DATA="/gpfs/hps/stmp/$LOGNAME/tmpnwprd/${job}"
-export jlogfile="/gpfs/hps/stmp/$LOGNAME/jlogfile"
 
 module load prod_envir/1.0.1
 

--- a/driver/gfs/test_jgfs_vminmon.sh
+++ b/driver/gfs/test_jgfs_vminmon.sh
@@ -65,16 +65,6 @@ export JOBGLOBAL=${JOBGLOBAL:-${HOMEgfs}/jobs}
 export COM_IN=${COM_IN:-${DATAROOT}}
 export M_TANKverf=${M_TANKverf:-${COMROOT}/${MINMON_SUFFIX}}
 
-jlogdir=${jlogdir:-/ptmpp1/${LOGNAME}/jlogs}
-if [[ ! -d ${jlogdir} ]]; then
-   mkdir -p ${jlogdir}
-fi
-
-export jlogfile=${jlogfile:-${jlogdir}/${MINMON_SUFFIX}.${NET}.${RUN}.jlogfile}
-if [[ -e ${jlogfile} ]]; then
-  rm -f ${jlogfile}
-fi
-
 #############################################################
 # Execute job
 #############################################################

--- a/driver/product/run_JGDAS_ATMOS_GEMPAK_META_NCDC_dell.sh_00
+++ b/driver/product/run_JGDAS_ATMOS_GEMPAK_META_NCDC_dell.sh_00
@@ -62,9 +62,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGDAS_ATMOS_GEMPAK_META_NCDC_dell.sh_06
+++ b/driver/product/run_JGDAS_ATMOS_GEMPAK_META_NCDC_dell.sh_06
@@ -62,9 +62,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGDAS_ATMOS_GEMPAK_META_NCDC_dell.sh_12
+++ b/driver/product/run_JGDAS_ATMOS_GEMPAK_META_NCDC_dell.sh_12
@@ -62,9 +62,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGDAS_ATMOS_GEMPAK_META_NCDC_dell.sh_18
+++ b/driver/product/run_JGDAS_ATMOS_GEMPAK_META_NCDC_dell.sh_18
@@ -62,9 +62,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGDAS_ATMOS_GEMPAK_dell.sh_00
+++ b/driver/product/run_JGDAS_ATMOS_GEMPAK_dell.sh_00
@@ -62,9 +62,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGDAS_ATMOS_GEMPAK_dell.sh_06
+++ b/driver/product/run_JGDAS_ATMOS_GEMPAK_dell.sh_06
@@ -62,9 +62,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGDAS_ATMOS_GEMPAK_dell.sh_12
+++ b/driver/product/run_JGDAS_ATMOS_GEMPAK_dell.sh_12
@@ -62,9 +62,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGDAS_ATMOS_GEMPAK_dell.sh_18
+++ b/driver/product/run_JGDAS_ATMOS_GEMPAK_dell.sh_18
@@ -62,9 +62,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_AWIPS_20KM_1P0DEG_dell.sh_00
+++ b/driver/product/run_JGFS_ATMOS_AWIPS_20KM_1P0DEG_dell.sh_00
@@ -64,9 +64,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_AWIPS_20KM_1P0DEG_dell.sh_06
+++ b/driver/product/run_JGFS_ATMOS_AWIPS_20KM_1P0DEG_dell.sh_06
@@ -64,9 +64,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_AWIPS_20KM_1P0DEG_dell.sh_12
+++ b/driver/product/run_JGFS_ATMOS_AWIPS_20KM_1P0DEG_dell.sh_12
@@ -64,9 +64,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_AWIPS_20KM_1P0DEG_dell.sh_18
+++ b/driver/product/run_JGFS_ATMOS_AWIPS_20KM_1P0DEG_dell.sh_18
@@ -64,9 +64,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_AWIPS_G2_dell.sh_00
+++ b/driver/product/run_JGFS_ATMOS_AWIPS_G2_dell.sh_00
@@ -64,9 +64,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_AWIPS_G2_dell.sh_06
+++ b/driver/product/run_JGFS_ATMOS_AWIPS_G2_dell.sh_06
@@ -64,9 +64,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_AWIPS_G2_dell.sh_12
+++ b/driver/product/run_JGFS_ATMOS_AWIPS_G2_dell.sh_12
@@ -64,9 +64,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_AWIPS_G2_dell.sh_18
+++ b/driver/product/run_JGFS_ATMOS_AWIPS_G2_dell.sh_18
@@ -64,9 +64,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_FBWIND_dell.sh_00
+++ b/driver/product/run_JGFS_ATMOS_FBWIND_dell.sh_00
@@ -58,9 +58,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_FBWIND_dell.sh_06
+++ b/driver/product/run_JGFS_ATMOS_FBWIND_dell.sh_06
@@ -58,9 +58,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_FBWIND_dell.sh_12
+++ b/driver/product/run_JGFS_ATMOS_FBWIND_dell.sh_12
@@ -58,9 +58,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_FBWIND_dell.sh_18
+++ b/driver/product/run_JGFS_ATMOS_FBWIND_dell.sh_18
@@ -58,9 +58,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_META_dell.sh_00
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_META_dell.sh_00
@@ -63,9 +63,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles 
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################
 #set the fcst hrs for all the cycles
 #############################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_META_dell.sh_06
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_META_dell.sh_06
@@ -63,9 +63,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles 
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################
 #set the fcst hrs for all the cycles
 #############################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_META_dell.sh_12
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_META_dell.sh_12
@@ -63,9 +63,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles 
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################
 #set the fcst hrs for all the cycles
 #############################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_META_dell.sh_18
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_META_dell.sh_18
@@ -63,9 +63,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles 
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################
 #set the fcst hrs for all the cycles
 #############################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF_dell.sh_00
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF_dell.sh_00
@@ -63,9 +63,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF_dell.sh_06
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF_dell.sh_06
@@ -63,9 +63,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF_dell.sh_12
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF_dell.sh_12
@@ -63,9 +63,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF_dell.sh_18
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF_dell.sh_18
@@ -63,9 +63,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_PGRB2_SPEC_dell.sh_00
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_PGRB2_SPEC_dell.sh_00
@@ -76,9 +76,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles 
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_PGRB2_SPEC_dell.sh_06
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_PGRB2_SPEC_dell.sh_06
@@ -76,9 +76,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles 
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_PGRB2_SPEC_dell.sh_12
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_PGRB2_SPEC_dell.sh_12
@@ -76,9 +76,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles 
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_PGRB2_SPEC_dell.sh_18
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_PGRB2_SPEC_dell.sh_18
@@ -76,9 +76,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles 
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_dell.sh_00
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_dell.sh_00
@@ -62,9 +62,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_dell.sh_06
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_dell.sh_06
@@ -62,9 +62,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_dell.sh_12
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_dell.sh_12
@@ -62,9 +62,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_dell.sh_18
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_dell.sh_18
@@ -62,9 +62,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_PGRB2_SPEC_NPOESS_dell.sh_00
+++ b/driver/product/run_JGFS_ATMOS_PGRB2_SPEC_NPOESS_dell.sh_00
@@ -58,9 +58,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles 
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_PGRB2_SPEC_NPOESS_dell.sh_06
+++ b/driver/product/run_JGFS_ATMOS_PGRB2_SPEC_NPOESS_dell.sh_06
@@ -58,9 +58,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles 
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_PGRB2_SPEC_NPOESS_dell.sh_12
+++ b/driver/product/run_JGFS_ATMOS_PGRB2_SPEC_NPOESS_dell.sh_12
@@ -58,9 +58,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles 
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_JGFS_ATMOS_PGRB2_SPEC_NPOESS_dell.sh_18
+++ b/driver/product/run_JGFS_ATMOS_PGRB2_SPEC_NPOESS_dell.sh_18
@@ -58,9 +58,6 @@ export DATAROOT=/gpfs/dell2/ptmp/Boi.Vuong/output
 export NWROOT=/gpfs/dell2/emc/modeling/noscrub/Boi.Vuong/git
 export COMROOT2=/gpfs/dell2/ptmp/Boi.Vuong/com
 
-mkdir -m 775 -p ${COMROOT2} ${COMROOT2}/logs ${COMROOT2}/logs/jlogfiles 
-export jlogfile=${COMROOT2}/logs/jlogfiles/jlogfile.${jobid}
-
 #############################################################
 # Specify versions
 #############################################################

--- a/driver/product/run_postsnd.sh
+++ b/driver/product/run_postsnd.sh
@@ -125,7 +125,6 @@ export KEEPDATA="YES"
 # File To Log Msgs
 ####################################
 job=gfs_postsnd_test
-export jlogfile=/com/logs/jlogfiles/jlogfile.${job}.${pid}
 
 ####################################
 # Determine Job Output Name on System

--- a/driver/product/run_postsnd.sh.cray
+++ b/driver/product/run_postsnd.sh.cray
@@ -104,7 +104,6 @@ export ENDHOUR=180
 # File To Log Msgs
 ####################################
 job=gfs_postsnd_test
-export jlogfile=/com/logs/jlogfiles/jlogfile.${job}.${pid}
 
 ####################################
 # Determine Job Output Name on System

--- a/driver/product/run_postsnd.sh.dell
+++ b/driver/product/run_postsnd.sh.dell
@@ -125,7 +125,6 @@ export KEEPDATA="YES"
 # File To Log Msgs
 ####################################
 job=gfs_postsnd_test
-export jlogfile=/com/logs/jlogfiles/jlogfile.${job}.${pid}
 
 ####################################
 # Determine Job Output Name on System

--- a/driver/product/run_postsnd.sh.hera
+++ b/driver/product/run_postsnd.sh.hera
@@ -121,7 +121,6 @@ export ENDHOUR=180
 # File To Log Msgs
 ####################################
 job=gfs_postsnd_test
-export jlogfile=/com/logs/jlogfiles/jlogfile.${job}.${pid}
 
 ####################################
 # Determine Job Output Name on System

--- a/driver/product/run_postsnd.sh.jet
+++ b/driver/product/run_postsnd.sh.jet
@@ -110,7 +110,6 @@ export ENDHOUR=180
 # File To Log Msgs
 ####################################
 job=gfs_postsnd_test
-export jlogfile=/com/logs/jlogfiles/jlogfile.${job}.${pid}
 
 ####################################
 # Determine Job Output Name on System

--- a/driver/product/run_postsnd.sh.wcoss2
+++ b/driver/product/run_postsnd.sh.wcoss2
@@ -133,7 +133,6 @@ export KEEPDATA="YES"
 # File To Log Msgs
 ####################################
 job=gfs_postsnd_test
-export jlogfile=$DATA/jlogfile.${job}.${pid}
 
 ####################################
 # Determine Job Output Name on System

--- a/ecflow/ecf/include/envir-p1-old.h
+++ b/ecflow/ecf/include/envir-p1-old.h
@@ -11,7 +11,6 @@ module load prod_envir prod_util
 
 case $envir in
   prod)
-    export jlogfile=${jlogfile:-${COMROOT}/logs/jlogfiles/jlogfile.${jobid}}
     export DATAROOT=${DATAROOT:-/tmpnwprd1}
     if [ "$SENDDBN" == "YES" ]; then
        export DBNROOT=/iodprod/dbnet_siphon  # previously set in .bash_profile
@@ -21,7 +20,6 @@ case $envir in
     ;;
   eval)
     export envir=para
-    export jlogfile=${jlogfile:-${COMROOT}/logs/${envir}/jlogfile}
     export DATAROOT=${DATAROOT:-/tmpnwprd2}
     if [ "$SENDDBN" == "YES" ]; then
        export DBNROOT=${UTILROOT}/para_dbn
@@ -31,7 +29,6 @@ case $envir in
     fi
     ;;
   para|test)
-    export jlogfile=${jlogfile:-${COMROOT}/logs/${envir}/jlogfile}
     export DATAROOT=${DATAROOT:-/tmpnwprd2}
     export DBNROOT=${UTILROOT}/fakedbn
     ;;

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -146,6 +146,8 @@ elif [ $step = "fcst" ]; then
 
 elif [ $step = "efcs" ]; then
 
+    export MPICH_MPIIO_HINTS="*:romio_cb_write=disable"
+    export FI_OFI_RXM_SAR_LIMIT=3145728
     export FI_OFI_RXM_RX_SIZE=40000
     export FI_OFI_RXM_TX_SIZE=40000
 
@@ -248,5 +250,9 @@ elif [ $step = "gempak" ]; then
 elif [ $step = "wafsgcip" ]; then
 
     export MPIRUN="$launcher -np $npe_wafsgcip $mpmd"
+
+elif [ $step = "waveawipsbulls" ]; then
+
+    unset PERL5LIB
 
 fi

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -146,8 +146,6 @@ elif [ $step = "fcst" ]; then
 
 elif [ $step = "efcs" ]; then
 
-    export MPICH_MPIIO_HINTS="*:romio_cb_write=disable"
-    export FI_OFI_RXM_SAR_LIMIT=3145728
     export FI_OFI_RXM_RX_SIZE=40000
     export FI_OFI_RXM_TX_SIZE=40000
 
@@ -250,9 +248,5 @@ elif [ $step = "gempak" ]; then
 elif [ $step = "wafsgcip" ]; then
 
     export MPIRUN="$launcher -np $npe_wafsgcip $mpmd"
-
-elif [ $step = "waveawipsbulls" ]; then
-
-    unset PERL5LIB
 
 fi

--- a/gempak/ush/gempak_gdas_f000_gif.sh
+++ b/gempak/ush/gempak_gdas_f000_gif.sh
@@ -13,8 +13,7 @@
 #
 #########################################################################
 
-   msg=" Make GEMPAK GIFS utility"
-   postmsg "$jlogfile" "$msg"
+  echo " Make GEMPAK GIFS utility"
 
   set -x
 
@@ -489,7 +488,6 @@ fi
 
 
 
-   msg=" GEMPAK_GIF ${fhr} hour completed normally"
-   postmsg "$jlogfile" "$msg"
+   echo " GEMPAK_GIF ${fhr} hour completed normally"
 
    exit

--- a/gempak/ush/gempak_gfs_f00_gif.sh
+++ b/gempak/ush/gempak_gfs_f00_gif.sh
@@ -15,8 +15,7 @@
 #
 #########################################################################
 
-   msg=" Make GEMPAK GIFS utility"
-   postmsg "$jlogfile" "$msg"
+  echo " Make GEMPAK GIFS utility"
 
   set -x
 
@@ -596,7 +595,6 @@ if [ $SENDCOM = YES ]; then
   ${UTILgfs}/ush/make_tif.sh
 fi 
 
-   msg=" GEMPAK_GIF ${fhr} hour completed normally"
-   postmsg "$jlogfile" "$msg"
+   echo " GEMPAK_GIF ${fhr} hour completed normally"
 
    exit

--- a/gempak/ush/gempak_gfs_f12_gif.sh
+++ b/gempak/ush/gempak_gfs_f12_gif.sh
@@ -15,8 +15,7 @@
 #
 #########################################################################
 
-   msg=" Make GEMPAK GIFS utility"
-   postmsg "$jlogfile" "$msg"
+  echo " Make GEMPAK GIFS utility"
 
   set -x
 
@@ -207,7 +206,6 @@ if [ $SENDCOM = YES ]; then
 
 fi
 
-   msg=" GEMPAK_GIF ${fhr} hour completed normally"
-   postmsg "$jlogfile" "$msg"
+   echo " GEMPAK_GIF ${fhr} hour completed normally"
 
    exit

--- a/gempak/ush/gempak_gfs_f24_gif.sh
+++ b/gempak/ush/gempak_gfs_f24_gif.sh
@@ -18,8 +18,7 @@
 
 
 
-   msg=" Make GEMPAK GIFS utility"
-   postmsg "$jlogfile" "$msg"
+  echo " Make GEMPAK GIFS utility"
 
 
 
@@ -225,7 +224,6 @@ if [ $SENDCOM = YES ]; then
 fi
 
 
-   msg=" GEMPAK_GIF ${fhr} hour completed normally"
-   postmsg "$jlogfile" "$msg"
+   echo " GEMPAK_GIF ${fhr} hour completed normally"
 
    exit

--- a/gempak/ush/gempak_gfs_f36_gif.sh
+++ b/gempak/ush/gempak_gfs_f36_gif.sh
@@ -18,8 +18,7 @@
 
 
 
-   msg=" Make GEMPAK GIFS utility"
-   postmsg "$jlogfile" "$msg"
+  echo " Make GEMPAK GIFS utility"
 
 
   set -x
@@ -225,7 +224,6 @@ fi
 
 
 
-   msg=" GEMPAK_GIF ${fhr} hour completed normally"
-   postmsg "$jlogfile" "$msg"
+   echo " GEMPAK_GIF ${fhr} hour completed normally"
 
    exit

--- a/gempak/ush/gempak_gfs_f48_gif.sh
+++ b/gempak/ush/gempak_gfs_f48_gif.sh
@@ -18,8 +18,7 @@
 
 
 
-   msg=" Make GEMPAK GIFS utility"
-   postmsg "$jlogfile" "$msg"
+  echo " Make GEMPAK GIFS utility"
 
 
   set -x
@@ -225,7 +224,6 @@ fi
 
 
 
-   msg=" GEMPAK_GIF ${fhr} hour completed normally"
-   postmsg "$jlogfile" "$msg"
+   echo " GEMPAK_GIF ${fhr} hour completed normally"
 
    exit

--- a/jobs/JGDAS_ATMOS_GEMPAK
+++ b/jobs/JGDAS_ATMOS_GEMPAK
@@ -108,8 +108,7 @@ export err=$?; err_chk
 
 ########################################################
 
-msg="JOB $job HAS COMPLETED NORMALLY!"
-postmsg "$msg"
+echo "JOB $job HAS COMPLETED NORMALLY!"
 
 ############################################
 # print exec I/O output

--- a/jobs/JGDAS_ATMOS_GEMPAK_META_NCDC
+++ b/jobs/JGDAS_ATMOS_GEMPAK_META_NCDC
@@ -109,8 +109,7 @@ $SRCgfs/exgdas_atmos_gempak_gif_ncdc.sh
 export err=$?; err_chk
 ########################################################
 
-msg="JOB $job HAS COMPLETED NORMALLY!"
-postmsg $jlogfile "$msg"
+echo "JOB $job HAS COMPLETED NORMALLY!"
 
 ############################################
 # print exec I/O output

--- a/jobs/JGFS_ATMOS_AWIPS_20KM_1P0DEG
+++ b/jobs/JGFS_ATMOS_AWIPS_20KM_1P0DEG
@@ -76,8 +76,7 @@ $HOMEgfs/scripts/exgfs_atmos_awips_20km_1p0deg.sh $fcsthrs
 export err=$?; err_chk
 ########################################################
 
-msg="JOB $job HAS COMPLETED NORMALLY!"
-postmsg "$msg"
+echo "JOB $job HAS COMPLETED NORMALLY!"
 
 ############################################
 # print exec I/O output

--- a/jobs/JGFS_ATMOS_AWIPS_G2
+++ b/jobs/JGFS_ATMOS_AWIPS_G2
@@ -73,8 +73,7 @@ cd $DATA/awips_g1
 $HOMEgfs/scripts/exgfs_atmos_grib_awips.sh $fcsthrs
 export err=$?; err_chk
 
-msg="JOB $job HAS COMPLETED NORMALLY!"
-postmsg "$msg"
+echo "JOB $job HAS COMPLETED NORMALLY!"
 
 ############################################
 # print exec I/O output

--- a/jobs/JGFS_ATMOS_CYCLONE_GENESIS
+++ b/jobs/JGFS_ATMOS_CYCLONE_GENESIS
@@ -110,8 +110,7 @@ mkdir -m 775 -p $COMOUTgenvit
 # Run relevant script
 ##############################################
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on `hostname`"
 $LOGSCRIPT
 
 
@@ -126,8 +125,7 @@ if [ -e "$pgmout" ] ; then
 fi
 
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGFS_ATMOS_CYCLONE_TRACKER
+++ b/jobs/JGFS_ATMOS_CYCLONE_TRACKER
@@ -116,8 +116,7 @@ fi
 # Run relevant script
 ##############################################
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on `hostname`"
 $LOGSCRIPT
 
 #############################################################
@@ -170,9 +169,7 @@ if [ -e "$pgmout" ] ; then
 fi
 
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
-
+echo "ENDED NORMALLY."
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGFS_ATMOS_FBWIND
+++ b/jobs/JGFS_ATMOS_FBWIND
@@ -70,8 +70,7 @@ $HOMEgfs/scripts/exgfs_atmos_fbwind.sh
 export err=$?;err_chk
 ########################################################
 
-msg="JOB $job HAS COMPLETED NORMALLY!"
-postmsg "$msg"
+echo "JOB $job HAS COMPLETED NORMALLY!"
 
 ############################################
 # print exec I/O output

--- a/jobs/JGFS_ATMOS_FSU_GENESIS
+++ b/jobs/JGFS_ATMOS_FSU_GENESIS
@@ -120,8 +120,7 @@ fi
 # Run relevant script
 ##############################################
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on `hostname`"
 $LOGSCRIPT
 
 #############################################################
@@ -136,8 +135,7 @@ if [ -e "$pgmout" ] ; then
   cat $pgmout
 fi
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGFS_ATMOS_GEMPAK
+++ b/jobs/JGFS_ATMOS_GEMPAK
@@ -151,8 +151,7 @@ export err=$?; err_chk
 
 cat $DATA/gfs*.$$.?
 
-msg="JOB $job HAS COMPLETED NORMALLY!"
-postmsg "$msg"
+echo "JOB $job HAS COMPLETED NORMALLY!"
 
 ############################################
 # print exec I/O output

--- a/jobs/JGFS_ATMOS_GEMPAK_META
+++ b/jobs/JGFS_ATMOS_GEMPAK_META
@@ -86,8 +86,7 @@ export COMINnam=${COMINnam:-$(compath.py -o nam/${nam_ver}/nam)}
 export SENDDBN=${SENDDBN:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
-msg="Begin job for $job"
-postmsg "$msg"
+echo "Begin job for $job"
 
 if [ $SENDCOM = YES ] ; then
   mkdir -m 775 -p $COMOUT
@@ -103,8 +102,7 @@ $SRCgfs/exgfs_atmos_gempak_meta.sh
 export err=$?; err_chk
 ########################################################
 
-msg="JOB $job HAS COMPLETED NORMALLY!"
-postmsg "$msg"
+echo "JOB $job HAS COMPLETED NORMALLY!"
 
 ############################################
 # print exec I/O output

--- a/jobs/JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF
+++ b/jobs/JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF
@@ -86,8 +86,7 @@ export pgmout=OUTPUT.$$
 
 env
 
-msg="Begin job for $job"
-postmsg "$msg"
+echo "Begin job for $job"
 
 ########################################################
 # Execute the script.
@@ -95,8 +94,7 @@ $SRCgfs/exgfs_atmos_gempak_gif_ncdc_skew_t.sh
 export err=$?; err_chk
 ########################################################
 
-msg="JOB $job HAS COMPLETED NORMALLY!"
-postmsg "$msg"
+echo "JOB $job HAS COMPLETED NORMALLY!"
 
 ############################################
 # print exec I/O output

--- a/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
+++ b/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
@@ -67,8 +67,7 @@ env
 
 export DATA_HOLD=$DATA
 
-msg="Begin job for $job"
-postmsg "$msg"
+echo "Begin job for $job"
 
 #################################################################
 # Execute the script for the regular grib
@@ -115,8 +114,7 @@ $SRCgfs/exgfs_atmos_goes_nawips.sh
 export err=$?; err_chk
 ########################################################
 
-msg="JOB $job HAS COMPLETED NORMALLY!"
-postmsg "$msg"
+echo "JOB $job HAS COMPLETED NORMALLY!"
 
 echo "end of program"
 cd $DATA_HOLD

--- a/jobs/JGFS_ATMOS_PGRB2_SPEC_NPOESS
+++ b/jobs/JGFS_ATMOS_PGRB2_SPEC_NPOESS
@@ -108,11 +108,9 @@ then
       fi
       if test $recvy_shour -ge $FHOUR
       then
-         msg="Forecast Pgrb Generation Already Completed to $FHOUR"
-         postmsg "$jlogfile" "$msg"
+         echo "Forecast Pgrb Generation Already Completed to $FHOUR"
       else
-         msg="Starting: PDY=$PDY cycle=t${recvy_cyc}z SHOUR=$SHOUR      ."
-         postmsg "$jlogfile" "$msg"
+         echo "Starting: PDY=$PDY cycle=t${recvy_cyc}z SHOUR=$SHOUR      ."
       fi
    fi
 fi
@@ -123,8 +121,7 @@ $HOMEgfs/scripts/exgfs_atmos_grib2_special_npoess.sh
 export err=$?;err_chk
 #############################################################
 
-msg="JOB $job HAS COMPLETED NORMALLY!"
-postmsg "$msg"
+echo "JOB $job HAS COMPLETED NORMALLY!"
 
 ############################################
 # print exec I/O output

--- a/jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP
+++ b/jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP
@@ -74,8 +74,7 @@ export BLENDED_ICE_FILE_m6hrs=${BLENDED_ICE_FILE_m6hrs:-${COMINgfs_m6hrs}/${RUN}
 ###############################################################
 
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on `hostname`"
 
 ${EMCSFCPREPSH:-$SCRgfs/exemcsfc_global_sfc_prep.sh}
 status=$?
@@ -92,8 +91,7 @@ if [ -e ${pgmout} ]; then
   cat $pgmout
 fi
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
+++ b/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
@@ -105,8 +105,7 @@ export BKGFREQ=1                                # for hourly relocation
 # Run relevant script
 ##############################################
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on `hostname`"
 $LOGSCRIPT
 
 
@@ -122,9 +121,7 @@ if [ -e "$pgmout" ] ; then
   cat $pgmout
 fi
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
-
+echo "ENDED NORMALLY."
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGLOBAL_FORECAST
+++ b/jobs/JGLOBAL_FORECAST
@@ -145,8 +145,7 @@ fi
 ###############################################################
 # Run relevant exglobal script
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on `hostname`"
 $LOGSCRIPT
 
 
@@ -166,8 +165,7 @@ if [ -e "$pgmout" ] ; then
   cat $pgmout
 fi
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGLOBAL_WAVE_GEMPAK
+++ b/jobs/JGLOBAL_WAVE_GEMPAK
@@ -19,9 +19,7 @@ export cycle=${cycle:-t${cyc}z}
 setpdy.sh
 . PDY
 env
-msg="Begin job for $job"
-postmsg "$jlogfile" "$msg"
-
+echo "Begin job for $job"
 
 # 
 export NET=${NET:-gfs}

--- a/jobs/JGLOBAL_WAVE_POST_BNDPNT
+++ b/jobs/JGLOBAL_WAVE_POST_BNDPNT
@@ -91,11 +91,11 @@ export DOBNDPNT_WAV='YES'  #not boundary points
 $HOMEgfs/scripts/exgfs_wave_post_pnt.sh
 err=$?
 if [ $err -ne 0 ]; then
-  msg="FATAL ERROR: ex-script of GWES_POST failed!"
+  echo "FATAL ERROR: ex-script of GWES_POST failed!"
+  exit $err
 else
-  msg="$job completed normally!"
+  echo "$job completed normally!"
 fi
-postmsg "$jlogfile" "$msg"
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
+++ b/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
@@ -92,11 +92,11 @@ export DOBNDPNT_WAV='YES'  #boundary points
 $HOMEgfs/scripts/exgfs_wave_post_pnt.sh
 err=$?
 if [ $err -ne 0 ]; then
-  msg="FATAL ERROR: ex-script of GFS_WAVE_POST_PNT failed!"
+  echo "FATAL ERROR: ex-script of GFS_WAVE_POST_PNT failed!"
+  exit $err
 else
-  msg="$job completed normally!"
+  echo "$job completed normally!"
 fi
-postmsg "$jlogfile" "$msg"
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGLOBAL_WAVE_POST_PNT
+++ b/jobs/JGLOBAL_WAVE_POST_PNT
@@ -91,11 +91,11 @@ export DOBNDPNT_WAV='NO'  #not boundary points
 $HOMEgfs/scripts/exgfs_wave_post_pnt.sh
 err=$?
 if [ $err -ne 0 ]; then
-  msg="FATAL ERROR: ex-script of GWES_POST failed!"
+  echo "FATAL ERROR: ex-script of GWES_POST failed!"
+  exit $err
 else
-  msg="$job completed normally!"
+  echo "$job completed normally!"
 fi
-postmsg "$jlogfile" "$msg"
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGLOBAL_WAVE_POST_SBS
+++ b/jobs/JGLOBAL_WAVE_POST_SBS
@@ -89,11 +89,11 @@ export CFP_VERBOSE=1
 $HOMEgfs/scripts/exgfs_wave_post_gridded_sbs.sh
 err=$?
 if [ $err -ne 0 ]; then
-  msg="FATAL ERROR: ex-script of GWES_POST failed!"
+  echo "FATAL ERROR: ex-script of GWES_POST failed!"
+  exit $err
 else
-  msg="$job completed normally!"
+  echo "$job completed normally!"
 fi
-postmsg "$jlogfile" "$msg"
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/rocoto/awips.sh
+++ b/jobs/rocoto/awips.sh
@@ -56,7 +56,6 @@ echo "=============== BEGIN AWIPS ==============="
 export SENDCOM="YES"
 export COMOUT="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT"
 export PCOM="$COMOUT/wmo"
-export jlogfile="$ROTDIR/logs/$CDATE/jgfs_awips.log"
 
 SLEEP_TIME=1800
 SLEEP_INT=5

--- a/jobs/rocoto/gempak.sh
+++ b/jobs/rocoto/gempak.sh
@@ -53,7 +53,6 @@ mkdir -p $DATAROOT
 echo
 echo "=============== BEGIN GEMPAK ==============="
 export job="jgfs_gempak_${cyc}"
-export jlogfile="$ROTDIR/logs/$CDATE/$job.log"    
 export DATA="${DATAROOT}/$job"
 export SENDCOM="YES"
 export COMOUT="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT/gempak"

--- a/jobs/rocoto/vrfy.sh
+++ b/jobs/rocoto/vrfy.sh
@@ -123,7 +123,6 @@ if [ $VRFYRAD = "YES" -a $CDUMP = $CDFNL -a $CDATE != $SDATE ]; then
 
     export EXP=$PSLOT
     export COMOUT="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT"
-    export jlogfile="$ROTDIR/logs/$CDATE/${CDUMP}radmon.log"
     export TANKverf_rad="$TANKverf/stats/$PSLOT/$CDUMP.$PDY"
     export TANKverf_radM1="$TANKverf/stats/$PSLOT/$CDUMP.$PDYm1"
     export MY_MACHINE=$machine
@@ -140,7 +139,6 @@ if [ $VRFYOZN = "YES" -a $CDUMP = $CDFNL -a $CDATE != $SDATE ]; then
 
     export EXP=$PSLOT
     export COMOUT="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT"
-    export jlogfile="$ROTDIR/logs/$CDATE/${CDUMP}oznmon.log"
     export TANKverf_ozn="$TANKverf_ozn/stats/$PSLOT/$CDUMP.$PDY"
     export TANKverf_oznM1="$TANKverf_ozn/stats/$PSLOT/$CDUMP.$PDYm1"
     export MY_MACHINE=$machine
@@ -156,7 +154,6 @@ echo "=============== START TO RUN MINMON ==============="
 if [ $VRFYMINMON = "YES" -a $CDATE != $SDATE ]; then
 
     export COMOUT="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT"
-    export jlogfile="$ROTDIR/logs/$CDATE/${CDUMP}minmon.log"
     export M_TANKverfM0="$M_TANKverf/stats/$PSLOT/$CDUMP.$PDY"
     export M_TANKverfM1="$M_TANKverf/stats/$PSLOT/$CDUMP.$PDYm1"
     export MY_MACHINE=$machine

--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -119,7 +119,6 @@ export COMOUTatmos=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/atmos
 export COMINwave=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/wave
 export COMOUTwave=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/wave
 
-export jlogfile="${EXPDIR}/logs/jlogfile"
 export ERRSCRIPT=${ERRSCRIPT:-'eval [[ $err = 0 ]]'}
 export LOGSCRIPT=${LOGSCRIPT:-""}
 #export ERRSCRIPT=${ERRSCRIPT:-"err_chk"}

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -213,6 +213,7 @@ elif [ $step = "wafsgcip" ]; then
     export npe_wafsgcip=2
     export npe_node_wafsgcip=1
     export nth_wafsgcip=1
+    export memory_wafsgcip="50GB"
 
 elif [ $step = "wafsgrib2" ]; then
 

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -213,7 +213,6 @@ elif [ $step = "wafsgcip" ]; then
     export npe_wafsgcip=2
     export npe_node_wafsgcip=1
     export nth_wafsgcip=1
-    export memory_wafsgcip="50GB"
 
 elif [ $step = "wafsgrib2" ]; then
 

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -199,7 +199,6 @@ elif [ $step = "wafsgcip" ]; then
     export npe_wafsgcip=2
     export npe_node_wafsgcip=1
     export nth_wafsgcip=1
-    export memory_wafsgcip="50GB"
 
 elif [ $step = "wafsgrib2" ]; then
 

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -199,6 +199,7 @@ elif [ $step = "wafsgcip" ]; then
     export npe_wafsgcip=2
     export npe_node_wafsgcip=1
     export nth_wafsgcip=1
+    export memory_wafsgcip="50GB"
 
 elif [ $step = "wafsgrib2" ]; then
 

--- a/scripts/exgdas_atmos_gempak_gif_ncdc.sh
+++ b/scripts/exgdas_atmos_gempak_gif_ncdc.sh
@@ -9,8 +9,7 @@ export PS4='exgempakgif_ncdc:$SECONDS + '
 set -xa
 
 cd $DATA
-msg="The NCDC GIF processing has begun"
-postmsg "$jlogfile" "$msg"
+echo "The NCDC GIF processing has begun"
 
 export NTS=$USHgempak/restore
 
@@ -52,8 +51,6 @@ then
           $USHgempak/gempak_${RUN}_f${fhr}_gif.sh
           if [ ! -f $USHgempak/gempak_${RUN}_f${fhr}_gif.sh ] ; then
              echo "WARNING: $USHgempak/gempak_${RUN}_f${fhr}_gif.sh FILE is missing"
-             msg=" $USHgempak/gempak_${RUN}_f${fhr}_gif.sh file is missing "
-             postmsg "jlogfile" "$msg"
           fi
        fi
 

--- a/scripts/exgdas_atmos_nawips.sh
+++ b/scripts/exgdas_atmos_nawips.sh
@@ -22,8 +22,7 @@ DATA_RUN=$DATA/$RUN
 mkdir -p $DATA_RUN
 cd $DATA_RUN
 
-msg="Begin job for $job"
-postmsg "$jlogfile" "$msg"
+echo "Begin job for $job"
 
 cp $FIXgempak/g2varswmo2.tbl g2varswmo2.tbl
 export err=$?
@@ -88,16 +87,12 @@ while [ $fhcnt -le $fend ] ; do
     export GRIBIN=$COMIN/${model}.${cycle}.pgrb2.0p25.f${fhr}
     if [ ! -f $GRIBIN ] ; then
        echo "WARNING: $GRIBIN FILE is missing"
-       msg=" $GRIBIN file is missing "
-       postmsg "$jlogfile" "$msg"
     fi
     GRIBIN_chk=$COMIN/${model}.${cycle}.pgrb2.0p25.f${fhr}.idx
   else
     export GRIBIN=$COMIN/${model}.${cycle}.pgrb2.1p00.f${fhr}
     if [ ! -f $GRIBIN ] ; then
        echo "WARNING: $GRIBIN FILE is missing"
-       msg=" $GRIBIN file is missing "
-       postmsg "$jlogfile" "$msg"
     fi
     GRIBIN_chk=$COMIN/${model}.${cycle}.pgrb2.1p00.f${fhr}.idx
   fi
@@ -109,15 +104,13 @@ while [ $fhcnt -le $fend ] ; do
       sleep 5
       break
     else
-      msg="The process is waiting ... ${GRIBIN_chk} file to proceed."
-      postmsg "${jlogfile}" "$msg"
+      echo "The process is waiting ... ${GRIBIN_chk} file to proceed."
       sleep 20
       let "icnt=icnt+1"
     fi
     if [ $icnt -ge $maxtries ]
     then
-      msg="ABORTING: after 1 hour of waiting for ${GRIBIN_chk} file at F$fhr to end."
-      postmsg "${jlogfile}" "$msg"
+      echo "ABORTING: after 1 hour of waiting for ${GRIBIN_chk} file at F$fhr to end."
       export err=7 ; err_chk
       exit $err
     fi
@@ -181,8 +174,6 @@ echo "**************JOB $RUN NAWIPS COMPLETED NORMALLY ON THE IBM"
 set -x
 #####################################################################
 
-msg='Job completed normally.'
-echo $msg
-postmsg "$jlogfile" "$msg"
+echo 'Job completed normally.'
 
 ############################### END OF SCRIPT #######################

--- a/scripts/exgfs_atmos_awips_20km_1p0deg.sh
+++ b/scripts/exgfs_atmos_awips_20km_1p0deg.sh
@@ -60,11 +60,6 @@ do
   fi
 done
 
-########################################
-msg="HAS BEGUN!"
-postmsg "$jlogfile" "$msg"
-########################################
-
 echo " ------------------------------------------"
 echo " BEGIN MAKING GFS AWIPS PRODUCTS"
 echo " ------------------------------------------"
@@ -209,8 +204,7 @@ fi
         if [ "$SENDDBN" = 'YES' -o "$SENDAWIP" = 'YES' ] ; then
            $DBNROOT/bin/dbn_alert NTC_LOW $NET $job  ${COMOUTwmo}/grib2.awpgfs${fcsthrs}.${GRID}.gfs_awips_f${fcsthrs}_1p0deg_${cyc}
         else
-           msg="File ${COMOUTwmo}/grib2.awpgfs${fcsthrs}.${GRID}.gfs_awips_f${fcsthrs}_1p0deg_${cyc} not posted to db_net."
-           postmsg "$jlogfile" "$msg"
+           echo "File ${COMOUTwmo}/grib2.awpgfs${fcsthrs}.${GRID}.gfs_awips_f${fcsthrs}_1p0deg_${cyc} not posted to db_net."
         fi
       fi
    elif [ $GRID != "003" ] ; then
@@ -237,13 +231,11 @@ fi
       if [ "$SENDDBN" = 'YES' -o "$SENDAWIP" = 'YES' ] ; then
          $DBNROOT/bin/dbn_alert NTC_LOW $NET $job  ${COMOUTwmo}/grib2.awpgfs_20km_${GRID}_f${fcsthrs}.$job_name
       else
-         msg="File  ${COMOUTwmo}/grib2.awpgfs_20km_${GRID}_f${fcsthrs}.$job_name not posted to db_net."
-         postmsg "$jlogfile" "$msg"
+         echo "File ${COMOUTwmo}/grib2.awpgfs_20km_${GRID}_f${fcsthrs}.$job_name not posted to db_net."
       fi
      fi
    fi
-   msg="Awip Processing ${fcsthrs} hour completed normally"
-   postmsg "$jlogfile" "$msg"
+   echo "Awip Processing ${fcsthrs} hour completed normally"
 
 done
 
@@ -260,7 +252,6 @@ echo "**************JOB EXGFS_AWIPS_20KM_1P0DEG.SH.ECF COMPLETED NORMALLY ON THE
 set -x
 ############################################################################################
 
-msg="HAS COMPLETED NORMALLY!"
-postmsg "$jlogfile" "$msg"
+echo "HAS COMPLETED NORMALLY!"
 
 ############## END OF SCRIPT #######################

--- a/scripts/exgfs_atmos_fbwind.sh
+++ b/scripts/exgfs_atmos_fbwind.sh
@@ -19,8 +19,7 @@ cd $DATA
 ######################
 
 set -x
-msg="Begin job for $job"
-postmsg "$jlogfile" "$msg"
+echo "Begin job for $job"
 
 job_name=`echo $job|sed 's/[jpt]gfs/gfs/'`
 
@@ -109,8 +108,6 @@ echo "**************JOB JGFS_FBWIND COMPLETED NORMALLY ON IBM-SP"
 set -x
 #####################################################################
 
-msg='Job completed normally.'
-echo $msg
-postmsg "$jlogfile" "$msg"
+echo 'Job completed normally.'
 
 ############################### END OF SCRIPT #######################

--- a/scripts/exgfs_atmos_gempak_gif_ncdc_skew_t.sh
+++ b/scripts/exgfs_atmos_gempak_gif_ncdc_skew_t.sh
@@ -9,8 +9,7 @@ export PS4='exgempakgif_ncdc_skewt:$SECONDS + '
 set -xa
 
 cd $DATA
-msg="The NCDC GIF processing has begun"
-postmsg "$jlogfile" "$msg"
+echo "The NCDC GIF processing has begun"
 
 export NTS=$USHgempak/restore
 
@@ -33,15 +32,13 @@ then
 	    sleep 5  
             break
           else
-            msg="The process is waiting ... ${GRIBFILE} file to proceed."
-            postmsg "${jlogfile}" "$msg"
+            echo "The process is waiting ... ${GRIBFILE} file to proceed."
             sleep 20
             let "icnt=icnt+1"
           fi
           if [ $icnt -ge $maxtries ]
           then
-            msg="ABORTING: after 1 hour of waiting for ${GRIBFILE} file at F$fhr to end."
-            postmsg "${jlogfile}" "$msg"
+            echo "ABORTING: after 1 hour of waiting for ${GRIBFILE} file at F$fhr to end."
             export err=7 ; err_chk
             exit $err
           fi

--- a/scripts/exgfs_atmos_gempak_meta.sh
+++ b/scripts/exgfs_atmos_gempak_meta.sh
@@ -2,8 +2,7 @@
 
 set -x
 
-msg="JOB $job HAS BEGUN"
-postmsg "$jlogfile" "$msg"
+echo "JOB $job HAS BEGUN"
 
 cd $DATA
 
@@ -54,8 +53,7 @@ do
       fi
       if [ $icnt -ge $maxtries ]
       then
-         msg="ABORTING after 1 hour of waiting for gempak grid F$fhr to end."
-         postmsg "${jlogfile}" "$msg"
+         echo "ABORTING after 1 hour of waiting for gempak grid F$fhr to end."
          export err=7 ; err_chk
          exit $err
       fi

--- a/scripts/exgfs_atmos_goes_nawips.sh
+++ b/scripts/exgfs_atmos_goes_nawips.sh
@@ -19,8 +19,7 @@ cp $FIXgempak/g2vcrdwmo2.tbl g2vcrdwmo2.tbl
 cp $FIXgempak/g2varsncep1.tbl g2varsncep1.tbl
 cp $FIXgempak/g2vcrdncep1.tbl g2vcrdncep1.tbl
 
-msg="Begin job for $job"
-postmsg "$jlogfile" "$msg"
+echo "Begin job for $job"
 
 #
 # NAGRIB_TABLE=$FIXgempak/nagrib.tbl
@@ -79,8 +78,7 @@ while [ $fhcnt -le $fend ] ; do
     fi
     if [ $icnt -ge $maxtries ]
     then
-      msg="ABORTING after 1 hour of waiting for F$fhr to end."
-      postmsg "${jlogfile}" "$msg"
+      echo "ABORTING after 1 hour of waiting for F$fhr to end."
       export err=7 ; err_chk
       exit $err
     fi
@@ -135,8 +133,6 @@ echo "**************JOB $RUN NAWIPS COMPLETED NORMALLY ON THE IBM"
 set -x
 #####################################################################
 
-msg='Job completed normally.'
-echo $msg
-postmsg "$jlogfile" "$msg"
+echo 'Job completed normally.'
 
 ############################### END OF SCRIPT #######################

--- a/scripts/exgfs_atmos_grib2_special_npoess.sh
+++ b/scripts/exgfs_atmos_grib2_special_npoess.sh
@@ -10,8 +10,7 @@ set -x
 
 cd $DATA
 
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on `hostname`"
 
 ############################################################
 #  Define Variables:
@@ -88,8 +87,7 @@ do
 # Process Global NPOESS 0.50 GFS GRID PRODUCTS IN GRIB2 F000 - F024  #
 ######################################################################
     set -x
-    msg="Starting half degree grib generation for fhr=$fhr"
-    postmsg "$jlogfile" "$msg"
+    echo "Starting half degree grib generation for fhr=$fhr"
 
     paramlist=${PARMproduct}/global_npoess_paramlist_g2
     cp $COMIN/gfs.t${cyc}z.pgrb2.0p50.f${fhr}  tmpfile2
@@ -106,8 +104,7 @@ do
        then
           $DBNROOT/bin/dbn_alert MODEL GFS_PGBNPOESS $job $COMOUT/${RUN}.${cycle}.pgrb2f${fhr}.npoess
        else
-          msg="File ${RUN}.${cycle}.pgrb2f${fhr}.npoess not posted to db_net."
-          postmsg "$msg"
+          echo "File ${RUN}.${cycle}.pgrb2f${fhr}.npoess not posted to db_net."
        fi
        echo "$PDY$cyc$fhr" > $COMOUT/${RUN}.t${cyc}z.control.halfdeg.npoess
     fi
@@ -160,8 +157,7 @@ do
     done
     set -x
 
-    msg="Starting special grib file generation for fhr=$fhr"
-    postmsg "$jlogfile" "$msg"
+    echo "Starting special grib file generation for fhr=$fhr"
 
     ###############################
     # Put restart files into /nwges 
@@ -214,7 +210,6 @@ done
 
 ########################################################
 
-msg='ENDED NORMALLY.'
-postmsg "$jlogfile" "$msg"
+echo 'ENDED NORMALLY.'
 
 ################## END OF SCRIPT #######################

--- a/scripts/exgfs_atmos_grib_awips.sh
+++ b/scripts/exgfs_atmos_grib_awips.sh
@@ -71,11 +71,6 @@ do
   fi
 done
 
-########################################
-msg="HAS BEGUN!"
-postmsg "$jlogfile" "$msg"
-########################################
-
 echo " ------------------------------------------"
 echo " BEGIN MAKING GFS GRIB1 AWIPS PRODUCTS"
 echo " ------------------------------------------"
@@ -140,8 +135,7 @@ EOF
       if [ "$SENDDBN" = 'YES' -o "$SENDAWIP" = 'YES' ] ; then
          $DBNROOT/bin/dbn_alert $DBNALERT_TYPE $NET $job ${COMOUTwmo}/xtrn.awpgfs${fcsthrs}.${GRID}.$job_name
       else
-         msg="File $output_grb.$job_name not posted to db_net."
-         postmsg "$jlogfile" "$msg"
+         echo "File $output_grb.$job_name not posted to db_net."
       fi
    fi
 
@@ -158,7 +152,6 @@ echo "**************JOB EXGFS_GRIB_AWIPS.SH.ECF COMPLETED NORMALLY ON THE IBM"
 set -x
 ###############################################################################
 
-msg="HAS COMPLETED NORMALLY!"
-postmsg "$jlogfile" "$msg"
+echo "HAS COMPLETED NORMALLY!"
 
 ############## END OF SCRIPT #######################

--- a/scripts/exgfs_atmos_nawips.sh
+++ b/scripts/exgfs_atmos_nawips.sh
@@ -27,9 +27,7 @@ DATA_RUN=$DATA/$RUN
 mkdir -p $DATA_RUN
 cd $DATA_RUN
 
-msg="Begin job for $job"
-postmsg "$jlogfile" "$msg"
-
+echo "Begin job for $job"
 
 #
 NAGRIB=$GEMEXE/nagrib2_nc
@@ -97,15 +95,13 @@ if mkdir lock.$fhcnt  ; then
       sleep 5
       break
     else
-      msg="The process is waiting ... ${GRIBIN_chk} file to proceed."
-      postmsg "${jlogfile}" "$msg"
+      echo "The process is waiting ... ${GRIBIN_chk} file to proceed."
       sleep 10
       let "icnt=icnt+1"
     fi
     if [ $icnt -ge $maxtries ]
     then
-      msg="ABORTING: after 1 hour of waiting for ${GRIBIN_chk} file at F$fhr to end."
-      postmsg "${jlogfile}" "$msg"
+      echo "ABORTING: after 1 hour of waiting for ${GRIBIN_chk} file at F$fhr to end."
       export err=7 ; err_chk
       exit $err
     fi
@@ -197,8 +193,6 @@ echo "**************JOB $RUN NAWIPS COMPLETED NORMALLY ON THE IBM"
 set -x
 #####################################################################
 
-msg='Job completed normally.'
-echo $msg
-postmsg "$jlogfile" "$msg"
+echo 'Job completed normally.'
 
 ############################### END OF SCRIPT #######################

--- a/scripts/exgfs_atmos_postsnd.sh
+++ b/scripts/exgfs_atmos_postsnd.sh
@@ -22,8 +22,7 @@ set -xa
 
 cd $DATA
 ########################################
-msg="HAS BEGUN"
-#postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN"
 ########################################
 
 ###################################################
@@ -179,7 +178,6 @@ echo "**************JOB GFS_meteogrm COMPLETED NORMALLY ON THE IBM"
 set -x
 #####################################################################
 
-msg='HAS COMPLETED NORMALLY.'
-#postmsg "$jlogfile" "$msg"
+echo 'HAS COMPLETED NORMALLY.'
 
 ############## END OF SCRIPT #######################

--- a/scripts/exgfs_wave_init.sh
+++ b/scripts/exgfs_wave_init.sh
@@ -35,10 +35,8 @@
 
   cd $DATA
 
-  msg="HAS BEGUN on `hostname`"
-  postmsg "$jlogfile" "$msg"
-  msg="Starting MWW3 INIT CONFIG SCRIPT for ${CDUMP}wave"
-  postmsg "$jlogfile" "$msg"
+  echo "HAS BEGUN on `hostname`"
+  echo "Starting MWW3 INIT CONFIG SCRIPT for ${CDUMP}wave"
 
   set +x
   echo ' '
@@ -115,8 +113,6 @@
         echo ' '
         [[ "$LOUD" = YES ]] && set -x
       else
-        msg="ABNORMAL EXIT: NO INP FILE FOR MODEL DEFINITION FILE"
-        postmsg "$jlogfile" "$msg"
         set +x
         echo ' '
         echo '*********************************************************** '
@@ -124,7 +120,6 @@
         echo '*********************************************************** '
         echo "                                grdID = $grdID"
         echo ' '
-        echo $msg
         [[ "$LOUD" = YES ]] && set -x
         err=2;export err;${errchk}
       fi
@@ -204,8 +199,6 @@
       echo ' '
       [[ "$LOUD" = YES ]] && set -x
     else 
-      msg="ABNORMAL EXIT: NO MODEL DEFINITION FILE"
-      postmsg "$jlogfile" "$msg"
       set +x
       echo ' '
       echo '********************************************** '
@@ -213,7 +206,6 @@
       echo '********************************************** '
       echo "                                grdID = $grdID"
       echo ' '
-      echo $msg
       sed "s/^/$grdID.out : /g"  $grdID.out
       [[ "$LOUD" = YES ]] && set -x
       err=3;export err;${errchk}

--- a/scripts/exgfs_wave_nawips.sh
+++ b/scripts/exgfs_wave_nawips.sh
@@ -82,14 +82,12 @@ while [ $fhcnt -le $FHMAX_WAV ]; do
         sleep 20
       fi
       if [ $icnt -ge $maxtries ]; then
-        msg="ABORTING after 5 minutes of waiting for $GRIBIN."
-        postmsg "$jlogfile" "$msg"
         echo ' '
         echo '**************************** '
         echo '*** ERROR : NO GRIB FILE *** '
         echo '**************************** '
         echo ' '
-        echo $msg
+        echo "ABORTING after 5 minutes of waiting for $GRIBIN."
         [[ "$LOUD" = YES ]] && set -x
         echo "$RUNwave $grdID ${fhr} prdgen $date $cycle : GRIB file missing." >> $wavelog
         err=1;export err;${errchk} || exit ${err}
@@ -102,15 +100,13 @@ while [ $fhcnt -le $FHMAX_WAV ]; do
                                           $GRIBIN 1> out 2>&1
       OK=$?
       if [ "$OK" != '0' ]; then 
-        msg="ABNORMAL EXIT: ERROR IN interpolation the global grid"
-        postmsg "$jlogfile" "$msg"
         #set +x
         echo ' '
         echo '************************************************************* '
         echo '*** FATAL ERROR : ERROR IN making  gribfile.$grdID.f${fhr}*** '
         echo '************************************************************* '
         echo ' '
-        echo $msg
+        echo "ABNORMAL EXIT: ERROR IN interpolation the global grid"
         #[[ "$LOUD" = YES ]] && set -x
         echo "$RUNwave $grdID prdgen $date $cycle : error in grbindex." >> $wavelog
         err=2;export err;err_chk
@@ -184,7 +180,5 @@ echo "**************JOB $RUN NAWIPS COMPLETED NORMALLY ON THE IBM"
 echo "**************JOB $RUN NAWIPS COMPLETED NORMALLY ON THE IBM"
 set -x
 #####################################################################
-msg='Job completed normally.'
-echo $msg
-postmsg "$jlogfile" "$msg"
+echo 'Job completed normally.'
 ############################### END OF SCRIPT #######################

--- a/scripts/exgfs_wave_post_gridded_sbs.sh
+++ b/scripts/exgfs_wave_post_gridded_sbs.sh
@@ -43,10 +43,8 @@
 
   cd $DATA
 
-  postmsg "$jlogfile" "HAS BEGUN on `hostname`"
-
-  msg="Starting WAVE POSTPROCESSOR SCRIPT for $WAV_MOD_TAG"
-  postmsg "$jlogfile" "$msg"
+  echo "HAS BEGUN on `hostname`"
+  echo "Starting WAVE POSTPROCESSOR SCRIPT for $WAV_MOD_TAG"
 
   set +x
   echo ' '
@@ -142,7 +140,6 @@
       echo '*************************************************** '
       echo ' '
       [[ "$LOUD" = YES ]] && set -x
-      postmsg "$jlogfile" "FATAL ERROR : NO MOD_DEF file mod_def.$grdID"
       err=2; export err;${errchk}
       exit $err
       DOGRB_WAV='NO'
@@ -179,7 +176,6 @@
         echo ' '
         [[ "$LOUD" = YES ]] && set -x
         echo "$WAV_MOD_TAG post $date $cycle : GRINT template file missing."
-        postmsg "$jlogfile" "NON-FATAL ERROR : NO TEMPLATE FOR GRINT INPUT FILE"
         exit_code=1
         DOGRI_WAV='NO'
       fi
@@ -208,7 +204,6 @@
         echo '*********************************************** '
         echo ' '
         [[ "$LOUD" = YES ]] && set -x
-        postmsg "$jlogfile" "NON-FATAL ERROR : NO TEMPLATE FOR GRIB2 INPUT FILE"
         exit_code=2
         DOGRB_WAV='NO'
       fi
@@ -293,7 +288,6 @@
           echo ' '
           [[ "$LOUD" = YES ]] && set -x
           echo "$WAV_MOD_TAG post $grdID $date $cycle : field output missing." 
-          postmsg "$jlogfile" "NON-FATAL ERROR : NO RAW FIELD OUTPUT FILE out_grd.$grdID"
           err=3; export err;${errchk}
           exit $err
         fi
@@ -466,15 +460,10 @@
   if [ "$exit_code" -ne '0' ]
   then
     echo " FATAL ERROR: Problem in MWW3 POST"
-    msg="ABNORMAL EXIT: Problem in MWW3 POST"
-    postmsg "$jlogfile" "$msg"
-    echo $msg
     err=6; export err;${errchk}
     exit $err
   else
     echo " Side-by-Side Wave Post Completed Normally "
-    msg="$job completed normally"
-    postmsg "$jlogfile" "$msg"
     exit 0
   fi
 

--- a/scripts/exgfs_wave_post_pnt.sh
+++ b/scripts/exgfs_wave_post_pnt.sh
@@ -45,10 +45,8 @@
   # if ensemble; waveMEMB var empty in deterministic
   export WAV_MOD_TAG=${CDUMP}wave${waveMEMB}
 
-  postmsg "$jlogfile" "HAS BEGUN on `hostname`"
-
-  msg="Starting WAVE PNT POSTPROCESSOR SCRIPT for $WAV_MOD_TAG"
-  postmsg "$jlogfile" "$msg"
+  echo "HAS BEGUN on `hostname`"
+  echo "Starting WAVE PNT POSTPROCESSOR SCRIPT for $WAV_MOD_TAG"
 
   set +x
   echo ' '
@@ -144,7 +142,6 @@
       echo '*************************************************** '
       echo ' '
       [[ "$LOUD" = YES ]] && set -x
-      postmsg "$jlogfile" "FATAL ERROR : NO MOD_DEF file mod_def.$grdID"
       err=2; export err;${errchk}
       exit $err
     else
@@ -183,7 +180,6 @@
     echo '************************************* '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "FATAL ERROR : NO BUOY LOCATION FILE"
     err=3; export err;${errchk}
     exit $err
     DOSPC_WAV='NO'
@@ -210,7 +206,6 @@
     echo '*********************************************** '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "NON-FATAL ERROR : NO TEMPLATE FOR SPEC INPUT FILE"
     exit_code=3
     DOSPC_WAV='NO'
     DOBLL_WAV='NO'
@@ -234,7 +229,6 @@
     echo '*************************************************** '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "NON-FATAL ERROR : NO TEMPLATE FOR BULLETIN INPUT FILE"
     exit_code=4
     DOBLL_WAV='NO'
   fi
@@ -266,7 +260,6 @@
       echo ' '
       [[ "$LOUD" = YES ]] && set -x
       echo "$WAV_MOD_TAG post $waveuoutpGRD $CDATE $cycle : field output missing." 
-      postmsg "$jlogfile" "FATAL ERROR : NO RAW POINT OUTPUT FILE out_pnt.${waveuoutpGRD}.${YMD}.${HMS}"
       err=4; export err;${errchk}
     fi
     
@@ -281,8 +274,6 @@
     if [ "$err" != '0' ] && [ ! -f buoy_log.ww3 ]
     then
       pgm=wave_post
-      msg="ABNORMAL EXIT: ERROR IN ww3_outp"
-      postmsg "$jlogfile" "$msg"
       set +x
       echo ' '
       echo '******************************************** '
@@ -291,7 +282,6 @@
       echo ' '
       cat buoy_tmp.loc
       echo "$WAV_MOD_TAG post $date $cycle : buoy log file failed to be created."
-      echo $msg
       [[ "$LOUD" = YES ]] && set -x
       err=5;export err;${errchk}
       DOSPC_WAV='NO'
@@ -324,7 +314,7 @@
       echo '**************************************** '
       echo ' '
       [[ "$LOUD" = YES ]] && set -x
-      postmsg "$jlogfile" "FATAL ERROR : NO BUOY LOG FILE GENERATED FOR SPEC AND BULLETIN FILES"
+      echo "FATAL ERROR : NO BUOY LOG FILE GENERATED FOR SPEC AND BULLETIN FILES"
       err=6;export err;${errchk}
       DOSPC_WAV='NO'
       DOBLL_WAV='NO'
@@ -388,7 +378,6 @@
       echo " FATAL ERROR : NO RAW POINT OUTPUT FILE out_pnt.$waveuoutpGRD.${YMD}.${HMS} "
       echo ' '
       [[ "$LOUD" = YES ]] && set -x
-      postmsg "$jlogfile" "FATAL ERROR : NO RAW POINT OUTPUT FILE out_pnt.$waveuoutpGRD.${YMD}.${HMS}"
       err=7; export err;${errchk}
       exit $err
     fi
@@ -721,15 +710,10 @@
   if [ "$exit_code" -ne '0' ]
   then
     echo " FATAL ERROR: Problem in MWW3 PNT POST"
-    msg="ABNORMAL EXIT: Problem in MWW3 PNT POST"
-    postmsg "$jlogfile" "$msg"
-    echo $msg
     err=11; export err;${errchk}
     exit $err
   else
     echo " Point Wave Post Completed Normally "
-    msg="$job completed normally"
-    postmsg "$jlogfile" "$msg"
     exit 0
   fi
 

--- a/scripts/exgfs_wave_prdgen_bulls.sh
+++ b/scripts/exgfs_wave_prdgen_bulls.sh
@@ -40,10 +40,9 @@
  cd $DATA
  export wavelog=${DATA}/${RUNwave}_prdgbulls.log
  
- postmsg "$jlogfile" "HAS BEGUN on `hostname`"
+ echo "HAS BEGUN on `hostname`"
+ echo "Starting MWW3 BULLETINS PRODUCTS SCRIPT"
 
- msg="Starting MWW3 BULLETINS PRODUCTS SCRIPT"
- postmsg "$jlogfile" "$msg"
  touch $wavelog
 # 0.b Date and time stuff
  export date=$PDY
@@ -70,15 +69,13 @@
  if [ -f $BullIn ]; then
    cp $BullIn cbull.tar
  else
-   msg="ABNORMAL EXIT: NO BULLETIN TAR FILE"
-   postmsg "$jlogfile" "$msg"
    set +x
    echo ' '
    echo '************************************ '
    echo '*** ERROR : NO BULLETIN TAR FILE *** '
    echo '************************************ '
    echo ' '
-   echo $msg
+   echo "ABNORMAL EXIT: NO BULLETIN TAR FILE"
    [[ "$LOUD" = YES ]] && set -x
    msg="FATAL ERROR ${RUNwave} prdgen $date $cycle : bulletin tar missing."
    echo $msg >> $wavelog
@@ -98,15 +95,13 @@
    [[ "$LOUD" = YES ]] && set -x
    rm -f cbull.tar
  else
-   msg="ABNORMAL EXIT: ERROR IN BULLETIN UNTAR"
-   postmsg "$jlogfile" "$msg"
    set +x
    echo ' '
    echo '****************************************** '
    echo '*** ERROR : ERROR IN BULLETIN TAR FILE *** '
    echo '****************************************** '
    echo ' '
-   echo $msg
+   echo "ABNORMAL EXIT: ERROR IN BULLETIN UNTAR"
    [[ "$LOUD" = YES ]] && set -x
    echo "${RUNwave} prdgen $date $cycle : bulletin untar error." >> $wavelog
    err=2;export err;err_chk
@@ -126,15 +121,13 @@
  if [ -f $PARMwave/bull_awips_gfswave ]; then
    cp $PARMwave/bull_awips_gfswave awipsbull.data
  else
-   msg="ABNORMAL EXIT: NO AWIPS BULLETIN HEADER DATA FILE"
-   postmsg "$jlogfile" "$msg"
    set +x
    echo ' '
    echo '******************************************* '
    echo '*** ERROR : NO AWIPS BULLETIN DATA FILE *** '
    echo '******************************************* '
    echo ' '
-   echo $msg
+   echo "ABNORMAL EXIT: NO AWIPS BULLETIN HEADER DATA FILE"
    [[ "$LOUD" = YES ]] && set -x
    echo "${RUNwave} prdgen $date $cycle : Bulletin header data file  missing." >> $wavelog
    err=3;export err;err_chk
@@ -167,15 +160,13 @@
  
    if [ -z "$headr" ] || [ ! -s $fname ]; then
      [[ "$LOUD" = YES ]] && set -x
-     msg="ABNORMAL EXIT: MISSING BULLETING INFO"
-     postmsg "$jlogfile" "$msg"
      set +x
      echo ' '
      echo '******************************************** '
      echo '*** FATAL ERROR : MISSING BULLETING INFO *** '
      echo '******************************************** '
      echo ' '
-     echo $msg
+     echo "ABNORMAL EXIT: MISSING BULLETING INFO"
      [[ "$LOUD" = YES ]] && set -x
      echo "${RUNwave} prdgen $date $cycle : Missing bulletin data." >> $wavelog
      err=4;export err;err_chk
@@ -191,15 +182,13 @@
    if [ "$OK" != '0' ] || [ ! -f $oname ]; then
      [[ "$LOUD" = YES ]] && set -x
      cat formbul.out
-     msg="ABNORMAL EXIT: ERROR IN formbul"
-     postmsg "$jlogfile" "$msg"
      set +x
      echo ' '
      echo '************************************** '
      echo '*** FATAL ERROR : ERROR IN formbul *** '
      echo '************************************** '
      echo ' '
-     echo $msg
+     echo "ABNORMAL EXIT: ERROR IN formbul"
      [[ "$LOUD" = YES ]] && set -x
      echo "${RUNwave} prdgen $date $cycle : error in formbul." >> $wavelog
      err=5;export err;err_chk
@@ -245,7 +234,6 @@
   echo ' '
   [[ "$LOUD" = YES ]] && set -x
 
-  msg="$job completed normally"
-  postmsg "$jlogfile" "$msg"
+  echo "$job completed normally"
 
 # End of MWW3 product generation script -------------------------------------- #

--- a/scripts/exgfs_wave_prdgen_gridded.sh
+++ b/scripts/exgfs_wave_prdgen_gridded.sh
@@ -42,9 +42,8 @@
  cd $DATA
  export wavelog=${DATA}/${COMPONENTwave}_prdggridded.log
  
- postmsg "$jlogfile" "HAS BEGUN on `hostname`"
- msg="Starting MWW3 GRIDDED PRODUCTS SCRIPT"
- postmsg "$jlogfile" "$msg"
+ echo "HAS BEGUN on `hostname`"
+ echo "Starting MWW3 GRIDDED PRODUCTS SCRIPT"
 # Output grids
  grids=${grids:-ao_9km at_10m ep_10m wc_10m glo_30m}
 # grids=${grids:-ak_10m at_10m ep_10m wc_10m glo_30m}
@@ -112,14 +111,12 @@
          sleep 5
        fi
        if [ $icnt -ge $maxtries ]; then
-         msg="ABNORMAL EXIT: NO GRIB FILE FOR GRID $GRIBIN"
-         postmsg "$jlogfile" "$msg"
          echo ' '
          echo '**************************** '
          echo '*** ERROR : NO GRIB FILE *** '
          echo '**************************** '
          echo ' '
-         echo $msg
+         echo "ABNORMAL EXIT: NO GRIB FILE FOR GRID $GRIBIN"
          [[ "$LOUD" = YES ]] && set -x
          echo "$RUNwave $grdID ${fhr} prdgen $date $cycle : GRIB file missing." >> $wavelog
          err=1;export err;${errchk} || exit ${err}
@@ -188,15 +185,13 @@
 
      if [ "$OK" != '0' ]
      then
-       msg="ABNORMAL EXIT: ERROR IN grb2index MWW3 for grid $grdID"
-       postmsg "$jlogfile" "$msg"
        #set +x
        echo ' '
        echo '******************************************** '
        echo '*** FATAL ERROR : ERROR IN grb2index MWW3 *** '
        echo '******************************************** '
        echo ' '
-       echo $msg
+       echo "ABNORMAL EXIT: ERROR IN grb2index MWW3 for grid $grdID"
        #[[ "$LOUD" = YES ]] && set -x
        echo "$RUNwave $grdID prdgen $date $cycle : error in grbindex." >> $wavelog
        err=4;export err;err_chk
@@ -218,15 +213,13 @@
      OK=$?
      if [ "$OK" != '0' ]; then
        cat tocgrib2.out
-       msg="ABNORMAL EXIT: ERROR IN tocgrib2"
-       postmsg "$jlogfile" "$msg"
        #set +x
        echo ' '
        echo '*************************************** '
        echo '*** FATAL ERROR : ERROR IN tocgrib2 *** '
        echo '*************************************** '
        echo ' '
-       echo $msg
+       echo "ABNORMAL EXIT: ERROR IN tocgrib2"
        #[[ "$LOUD" = YES ]] && set -x
        echo "$RUNwave prdgen $date $cycle : error in tocgrib2." >> $wavelog
        err=5;export err;err_chk
@@ -283,7 +276,6 @@
   echo ' '
   [[ "$LOUD" = YES ]] && set -x
 
-  msg="$job completed normally"
-  postmsg "$jlogfile" "$msg"
+  echo "$job completed normally"
 
 # End of GFSWAVE product generation script -------------------------------------- #

--- a/scripts/exgfs_wave_prep.sh
+++ b/scripts/exgfs_wave_prep.sh
@@ -54,10 +54,8 @@
   cd $DATA
   mkdir outtmp
 
-  msg="HAS BEGUN on `hostname`"
-  postmsg "$jlogfile" "$msg"
-  msg="Starting MWW3 PREPROCESSOR SCRIPT for $WAV_MOD_TAG"
-  postmsg "$jlogfile" "$msg"
+  echo "HAS BEGUN on `hostname`"
+  echo "Starting MWW3 PREPROCESSOR SCRIPT for $WAV_MOD_TAG"
 
   set +x
   echo ' '
@@ -185,16 +183,12 @@
       cp $COMIN/rundata/${CDUMP}wave.mod_def.${grdID} mod_def.$grdID
 
     else
-      msg="FATAL ERROR: NO MODEL DEFINITION FILE"
-      postmsg "$jlogfile" "$msg"
-      set +x
       echo ' '
       echo '*********************************************************** '
       echo '*** FATAL ERROR : NOT FOUND WAVE  MODEL DEFINITION FILE *** '
       echo '*********************************************************** '
       echo "                                grdID = $grdID"
       echo ' '
-      echo $msg
       [[ "$LOUD" = YES ]] && set -x
       err=2;export err;${errchk}
     fi
@@ -237,8 +231,6 @@
        echo ' '
        [[ "$LOUD" = YES ]] && set -x
      else
-       msg="ABNORMAL EXIT: NO FILE $file"
-       ./postmsg "$jlogfile" "$msg"
        set +x
        echo ' '
        echo '************************************** '
@@ -246,7 +238,7 @@
        echo '************************************** '
        echo "             ww3_prnc.${type}.$grdID.inp.tmpl"
        echo ' '
-       echo $msg
+       echo "ABNORMAL EXIT: NO FILE $file"
        echo ' '
        [[ "$LOUD" = YES ]] && set -x
        err=4;export err;${errchk}
@@ -271,7 +263,6 @@
     
       if [ -d ice ]
       then
-        postmsg "$jlogfile" "FATAL ERROR ice field not generated."
         set +x
         echo ' '
         echo '      FATAL ERROR: ice field not generated '
@@ -399,7 +390,6 @@
           echo "         File for $ymdh : error in wave_g2ges.sh"
           echo ' '
           [[ "$LOUD" = YES ]] && set -x
-          postmsg "$jlogfile" "    File for $ymdh : error in wave_g2ges.sh"
           nr_err=`expr $nr_err + 1`
           rm -f gwnd.$ymdh
         else
@@ -453,20 +443,18 @@
         echo ' '
         [[ "$LOUD" = YES ]] && set -x
         mv -f grb_*.out $DATA/outtmp
-        postmsg "$jlogfile" "WARNING: NON-FATAL ERROR in wave_g2ges.sh, possibly in multiple calls."
+        echo "WARNING: NON-FATAL ERROR in wave_g2ges.sh, possibly in multiple calls."
       fi
     
       if [ "$nr_err" -gt "$err_max" ]
       then
-        msg="ABNORMAL EXIT: TOO MANY MISSING WIND INPUT GRB2 FILES"
-        postmsg "$jlogfile" "$msg"
         set +x
         echo ' '
         echo '********************************************* '
         echo '*** FATAL ERROR : ERROR(S) IN WIND  FILES *** '
         echo '********************************************* '
         echo ' '
-        echo $msg
+        echo "ABNORMAL EXIT: TOO MANY MISSING WIND INPUT GRB2 FILES"
         [[ "$LOUD" = YES ]] && set -x
         err=6;export err;${errchk}
       fi
@@ -485,14 +473,13 @@
 
       if [ -z "$files" ]
       then
-        msg="ABNORMAL EXIT: NO gwnd.* FILES FOUND"
-        postmsg "$jlogfile" "$msg"
         set +x
         echo ' '
         echo '******************************************** '
         echo '*** FATAL ERROR : CANNOT FIND WIND FILES *** '
         echo '******************************************** '
         echo ' '
+        echo "ABNORMAL EXIT: NO gwnd.* FILES FOUND"
         [[ "$LOUD" = YES ]] && set -x
         err=7;export err;${errchk}
       fi
@@ -531,22 +518,19 @@
   
         if [ "$err" != '0' ]
         then
-          msg="ABNORMAL EXIT: ERROR IN waveprnc"
-          postmsg "$jlogfile" "$msg"
           set +x
           echo ' '
           echo '*************************************** '
           echo '*** FATAL ERROR : ERROR IN waveprnc *** '
           echo '*************************************** '
           echo ' '
+          echo "ABNORMAL EXIT: ERROR IN waveprnc"
           [[ "$LOUD" = YES ]] && set -x
           err=8;export err;${errchk}
         fi
   
         if [ ! -f wind.ww3 ]
         then
-          msg="ABNORMAL EXIT: FILE wind.ww3 MISSING"
-          postmsg "$jlogfile" "$msg"
           set +x
           echo ' '
           cat waveprep.out
@@ -555,6 +539,7 @@
           echo '*** FATAL ERROR : wind.ww3 NOT FOUND ***'
           echo '****************************************'
           echo ' '
+          echo "ABNORMAL EXIT: FILE wind.ww3 MISSING"
           [[ "$LOUD" = YES ]] && set -x
           err=9;export err;${errchk}
         fi
@@ -598,7 +583,7 @@
           echo '******************************************************'
           echo ' '
           [[ "$LOUD" = YES ]] && set -x
-          postmsg "$jlogfile" "FATAL ERROR: $WAV_MOD_TAG prep $grdID $date $cycle : error in wind increment."
+          echo "FATAL ERROR: $WAV_MOD_TAG prep $grdID $date $cycle : error in wind increment."
           err=10;export err;${errchk}
         fi
     
@@ -715,7 +700,7 @@
           echo '************************************** '
           echo ' '
           set $seton
-          postmsg "$jlogfile" "FATAL ERROR - NO CURRENT FILE (RTOFS)"
+          echo "FATAL ERROR - NO CURRENT FILE (RTOFS)"
           err=11;export err;${errchk}
           exit $err
           echo ' '
@@ -779,14 +764,13 @@
 
       if [ -z "$files" ]
       then
-        msg="ABNORMAL EXIT: NO ${WAVECUR_FID}.* FILES FOUND"
-        postmsg "$jlogfile" "$msg"
         set +x
         echo ' '
         echo '******************************************** '
         echo '*** FATAL ERROR : CANNOT FIND CURR FILES *** '
         echo '******************************************** '
         echo ' '
+        echo "ABNORMAL EXIT: NO ${WAVECUR_FID}.* FILES FOUND"
         [[ "$LOUD" = YES ]] && set -x
         err=11;export err;${errchk}
       fi
@@ -827,15 +811,13 @@
 
   if [ ! -f ww3_multi.inp.tmpl ]
   then
-    msg="ABNORMAL EXIT: NO TEMPLATE FOR INPUT FILE"
-    postmsg "$jlogfile" "$msg"
     set +x
     echo ' '
     echo '************************************************ '
     echo '*** FATAL ERROR : NO TEMPLATE FOR INPUT FILE *** '
     echo '************************************************ '
     echo ' '
-    echo $msg
+    echo "ABNORMAL EXIT: NO TEMPLATE FOR INPUT FILE"
     [[ "$LOUD" = YES ]] && set -x
     err=12;export err;${errchk}
   fi
@@ -856,7 +838,7 @@
     set +x
     echo "   buoy.loc not found.                           **** WARNING **** "
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" " FATAL ERROR : buoy.loc ($FIXwave/wave_${NET}.buoys) NOT FOUND"
+    echo " FATAL ERROR : buoy.loc ($FIXwave/wave_${NET}.buoys) NOT FOUND"
     touch buoy.loc
     err=13;export err;${errchk}
   fi
@@ -1004,15 +986,13 @@
         cp -f $file ${COMOUT}/rundata
       done
     else
-      msg="NO rmp precomputed nc files found, is this OK???"
-      postmsg "$jlogfile" "$msg"
       set +x
       echo ' '
       echo '************************************************ '
       echo '*** FATAL ERROR : NO PRECOMPUTED RMP FILES FOUND *** '
       echo '************************************************ '
       echo ' '
-      echo $msg
+      echo "NO rmp precomputed nc files found, is this OK???"
       [[ "$LOUD" = YES ]] && set -x
       err=13;export err;${errchk}
     fi

--- a/scripts/exglobal_atmos_tropcy_qc_reloc.sh
+++ b/scripts/exglobal_atmos_tropcy_qc_reloc.sh
@@ -13,8 +13,7 @@ set -x
 # Make sure we are in the $DATA directory
 cd $DATA
 
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on `hostname`"
 
 cat break > $pgmout
 
@@ -26,27 +25,22 @@ cdate10=` ${NDATE:?} -$tmhr $PDY$cyc`
 NET_uc=$(echo $RUN | tr [a-z] [A-Z])
 tmmark_uc=$(echo $tmmark | tr [a-z] [A-Z])
 
-msg="$NET_uc ANALYSIS TIME IS $PDY$cyc"
-postmsg "$jlogfile" "$msg"
+echo "$NET_uc ANALYSIS TIME IS $PDY$cyc"
 
 iflag=0
 if [ $RUN = ndas ]; then
    if [ $DO_RELOCATE = NO ]; then
-      msg="CENTER PROCESSING TIME FOR NDAS TROPICAL CYCLONE QC IS $cdate10"
-      postmsg "$jlogfile" "$msg"
-      msg="Output tcvitals files will be copied forward in time to proper \
+      echo "CENTER PROCESSING TIME FOR NDAS TROPICAL CYCLONE QC IS $cdate10"
+      echo "Output tcvitals files will be copied forward in time to proper \
 output file directory path locations"
-      postmsg "$jlogfile" "$msg"
       iflag=1
    else
-      msg="CENTER PROCESSING TIME FOR $tmmark_uc NDAS TROPICAL CYCLONE \
+      echo "CENTER PROCESSING TIME FOR $tmmark_uc NDAS TROPICAL CYCLONE \
 RELOCATION IS $cdate10"
-      postmsg "$jlogfile" "$msg"
    fi
 else
-   msg="CENTER PROCESSING TIME FOR $tmmark_uc $NET_uc TROPICAL CYCLONE QC/\
+   echo "CENTER PROCESSING TIME FOR $tmmark_uc $NET_uc TROPICAL CYCLONE QC/\
 RELOCATION IS $cdate10"
-   postmsg "$jlogfile" "$msg"
 fi
 
 
@@ -63,8 +57,7 @@ if [ "$PROCESS_TROPCY" = 'YES' ]; then
    ${USHSYND:-$HOMEgfs/ush}/syndat_qctropcy.sh $cdate10
    errsc=$?
    if [ "$errsc" -ne '0' ]; then
-    msg="syndat_qctropcy.sh failed. exit"
-    postmsg "$jlogfile" "$msg"
+    echo "syndat_qctropcy.sh failed. exit"
     exit $errsc
    fi
    
@@ -175,8 +168,7 @@ cat allout
 sleep 10
 
 if [ $iflag -eq 0 ]; then
-   msg='ENDED NORMALLY.'
-   postmsg "$jlogfile" "$msg"
+   echo 'ENDED NORMALLY.'
 fi
 
 ################## END OF SCRIPT #######################

--- a/scripts/exglobal_forecast.sh
+++ b/scripts/exglobal_forecast.sh
@@ -358,8 +358,6 @@ fi
 nfiles=$(ls -1 $DATA/INPUT/* | wc -l)
 if [ $nfiles -le 0 ]; then
   echo "Initial conditions must exist in $DATA/INPUT, ABORT!"
-  msg="Initial conditions must exist in $DATA/INPUT, ABORT!"
-  postmsg "$jlogfile" "$msg"
   exit 1
 fi
 

--- a/scripts/run_gfsmos_master.sh.cray
+++ b/scripts/run_gfsmos_master.sh.cray
@@ -80,7 +80,6 @@ export stnonly=Y
 export cycle="t${cyc}z"
 export pid="gfs.$$"
 export dailylog=$PTMPROOT/dailylog/log.$PDY
-export jlogfile=$dailylog/jlogfile_gfsmos
 mkdir -p $dailylog
 
 export SENDDBN=NO

--- a/scripts/run_gfsmos_master.sh.dell
+++ b/scripts/run_gfsmos_master.sh.dell
@@ -155,7 +155,6 @@ export skipprep=n
 export cycle="t${cyc}z"
 export pid="gfs_qprod.$$"
 export dailylog=$PTMPROOT/dailylog/log.$PDY
-export jlogfile=$dailylog/jlogfile_gfsmos
 mkdir -p $dailylog
 
 export SENDDBN=NO

--- a/scripts/run_gfsmos_master.sh.hera
+++ b/scripts/run_gfsmos_master.sh.hera
@@ -178,7 +178,6 @@ export skipprep=n
 export cycle="t${cyc}z"
 export pid="gfs_qprod.$$"
 export dailylog=$PTMPROOT/dailylog/log.$PDY
-export jlogfile=$dailylog/jlogfile_gfsmos
 mkdir -p $dailylog
 
 export SENDDBN=NO

--- a/ush/gfs_sndp.sh
+++ b/ush/gfs_sndp.sh
@@ -37,9 +37,7 @@ set +x
        #. prep_step
        export FORT11=$DATA/${m}/bufrin
        export FORT51=./bufrout
-       # JY - Turn off the startmsg to reduce the update on jlogfile in this loop
-       # startmsg
-      $EXECbufrsnd/tocsbufr << EOF
+       $EXECbufrsnd/tocsbufr << EOF
  &INPUT
   BULHED="$WMOHEAD",KWBX="$CCCC",
   NCEP2STD=.TRUE.,

--- a/ush/global_extrkr.sh
+++ b/ush/global_extrkr.sh
@@ -64,7 +64,6 @@ set -x
 ##############################################################################
 
 prep_step=${prep_step:-prep_step}
-postmsg=${postmsg:-postmsg}
 
 ########################################
 echo "has begun for ${cmodel} at ${CYL}z"

--- a/ush/global_extrkr.sh
+++ b/ush/global_extrkr.sh
@@ -67,8 +67,7 @@ prep_step=${prep_step:-prep_step}
 postmsg=${postmsg:-postmsg}
 
 ########################################
-msg="has begun for ${cmodel} at ${CYL}z"
-$postmsg "$jlogfile" "$msg"
+echo "has begun for ${cmodel} at ${CYL}z"
 ########################################
 
 # This script runs the hurricane tracker using operational GRIB model output.  
@@ -171,7 +170,7 @@ while [[ "$#" -gt 0 ]] ; do
                 fi
             done
             if [[ -z "$override_fcsthrs" || -z "$override_fcstlen" ]] ; then
-                $postmsg "$jlogfile" "ERROR: requested forecast hour from $whichm is $lasthour (from parsing \"$gfharg\") but could not find any valid $nicename forecast hours at or before that time.  This is probably an error in the tracker script."
+                echo "ERROR: requested forecast hour from $whichm is $lasthour (from parsing \"$gfharg\") but could not find any valid $nicename forecast hours at or before that time.  This is probably an error in the tracker script."
             fi
             ;;
         --wait-for-data)
@@ -737,16 +736,14 @@ then
   ln -s -f ${DATA}/vitals.${atcfout}.${PDY}${CYL}         fort.31
   ln -s -f ${DATA}/vitals.upd.${atcfout}.${PDY}${CYL}     fort.51
 
-  msg="$pgm start for $atcfout at ${CYL}z"
-  $postmsg "$jlogfile" "$msg"
+  echo "$pgm start for $atcfout at ${CYL}z"
 
   ${exectrkdir}/supvit <${DATA}/suv_input.${atcfout}.${PDY}${CYL}
   suvrcc=$?
 
   if [ ${suvrcc} -eq 0 ]
   then
-    msg="$pgm end for $atcfout at ${CYL}z completed normally"
-    $postmsg "$jlogfile" "$msg"
+    echo "$pgm end for $atcfout at ${CYL}z completed normally"
   else
     set +x
     echo " "
@@ -1259,7 +1256,7 @@ if [[ ${model} -eq 1 || $model == 8 ]] ; then
   ixfile=${DATA}/gfsixfile.${PDY}${CYL}
 fi
 
-$postmsg "$jlogfile" "SUCCESS: have all inputs needed to run tracker.  Will now run the tracker."
+echo "SUCCESS: have all inputs needed to run tracker.  Will now run the tracker."
 
 #------------------------------------------------------------------------#
 #                         Now run the tracker                            #
@@ -1440,8 +1437,7 @@ echo " -----------------------------------------------"
 echo " "
 set -x
 
-msg="$pgm start for $atcfout at ${CYL}z"
-$postmsg "$jlogfile" "$msg"
+echo "$pgm start for $atcfout at ${CYL}z"
 
 set +x
 echo "+++ TIMING: BEFORE gettrk  ---> `date`"
@@ -1469,7 +1465,7 @@ echo "+++ TIMING: AFTER  gettrk  ---> `date`"
 set -x
 
 #--------------------------------------------------------------#
-# Send a message to the jlogfile for each storm that used 
+# Echo a message to stdout for each storm that used
 # tcvitals for hour 0 track/intensity info.
 #--------------------------------------------------------------#
 
@@ -1479,10 +1475,10 @@ while read line
 do
     echo "line is [$line]"
     if [[ ! ( "$pcount" -lt 30 ) ]] ; then
-      $postmsg "$jlogfile" "Hit maximum number of postmsg commands for tcvitals usage at hour 0.  Will stop warning about that, to avoid spamming jlogfile."
+      echo "Hit maximum number of echo commands for tcvitals usage at hour 0.  Will stop warning about that, to avoid spamming stdout."
       break
     fi
-    $postmsg "$jlogfile" "$line"
+    echo "$line"
     pcount=$(( pcount + 1 ))
 done
 
@@ -1499,22 +1495,22 @@ echo " "
 set -x
 
 if [[ ! -e "$track_file_path" ]] ; then
-    $postmsg "$jlogfile" "WARNING: tracker output file does not exist.  This is probably an error.  File: $track_file_path"
-    $postmsg "$jlogfile" "WARNING: exgfs_trkr will create an empty track file and deliver that."
+    echo "WARNING: tracker output file does not exist.  This is probably an error.  File: $track_file_path"
+    echo "WARNING: exgfs_trkr will create an empty track file and deliver that."
     cat /dev/null > $track_file_path
 elif [[ ! -s "$track_file_path" ]] ; then
-    $postmsg "$jlogfile" "WARNING: tracker output file is empty.  That is only an error if there are storms or genesis cases somewhere in the world.  File: $track_file_path"
+    echo "WARNING: tracker output file is empty.  That is only an error if there are storms or genesis cases somewhere in the world.  File: $track_file_path"
 else
-    $postmsg "$jlogfile" "SUCCESS: Track file exists and is non-empty: $track_file"
+    echo "SUCCESS: Track file exists and is non-empty: $track_file"
     if [[ "$PHASEFLAG" == n ]] ; then
         echo "Phase information was disabled.  I will remove the empty phase information from the track file before delivery."
         cp -p $track_file_path $track_file_path.orig
         cut -c1-112 < $track_file_path.orig > $track_file_path
         if [[ ! -s "$track_file_path" ]] ; then
-            $postmsg "$jlogfile" "WARNING: Something went wrong with \"cut\" command to remove phase information.  Will deliver original file."
+            echo "WARNING: Something went wrong with \"cut\" command to remove phase information.  Will deliver original file."
             /bin/mv -f $track_file_path.orig $track_file_path
         else
-            $postmsg "$jlogfile" "SUCCESS: Removed empty phase information because phase information is disabled."
+            echo "SUCCESS: Removed empty phase information because phase information is disabled."
         fi
     fi
 fi
@@ -1533,7 +1529,7 @@ if [ ${gettrk_rcc} -eq 0 ]; then
   then
 
     if [[ ! -s "$track_file_path" ]] ; then
-        $postmsg "$jlogfile" "WARNING: delivering empty track file to rundir."
+        echo "WARNING: delivering empty track file to rundir."
     fi
 
     cp $track_file_path ../.
@@ -1546,8 +1542,7 @@ if [ ${gettrk_rcc} -eq 0 ]; then
 #    cp ${DATA}/trak.${atcfout}.atcf_gen.${regtype}.${PDY}${CYL} ../.
   fi
 
-  msg="$pgm end for $atcfout at ${CYL}z completed normally"
-  $postmsg "$jlogfile" "$msg"
+  echo "$pgm end for $atcfout at ${CYL}z completed normally"
 
 # Now copy track files into various archives....
 
@@ -1555,7 +1550,7 @@ if [ ${gettrk_rcc} -eq 0 ]; then
   then
 
     if [[ ! -s "$track_file_path" ]] ; then
-        $postmsg "$jlogfile" "WARNING: delivering an empty track file to COM."
+        echo "WARNING: delivering an empty track file to COM."
         return
     fi
 

--- a/ush/rocoto/rocoto.py
+++ b/ush/rocoto/rocoto.py
@@ -68,7 +68,6 @@ def create_task(task_dict):
     jobname = task_dict.get('jobname', 'demojob')
     account = task_dict.get('account', 'batch')
     queue = task_dict.get('queue', 'debug')
-    nodesize = task_dict.get('nodesize', '128')
     partition = task_dict.get('partition', None)
     walltime = task_dict.get('walltime', '00:01:00')
     log = task_dict.get('log', 'demo.log')
@@ -91,7 +90,6 @@ def create_task(task_dict):
     strings.append(f'\t<jobname><cyclestr>{jobname}</cyclestr></jobname>\n')
     strings.append(f'\t<account>{account}</account>\n')
     strings.append(f'\t<queue>{queue}</queue>\n')
-    strings.append(f'\t<nodesize>{nodesize}</nodesize>\n')
     if partition is not None:
         strings.append(f'\t<partition>{partition}</partition>\n')
     if resources is not None:

--- a/ush/rocoto/rocoto.py
+++ b/ush/rocoto/rocoto.py
@@ -68,6 +68,7 @@ def create_task(task_dict):
     jobname = task_dict.get('jobname', 'demojob')
     account = task_dict.get('account', 'batch')
     queue = task_dict.get('queue', 'debug')
+    nodesize = task_dict.get('nodesize', '128')
     partition = task_dict.get('partition', None)
     walltime = task_dict.get('walltime', '00:01:00')
     log = task_dict.get('log', 'demo.log')
@@ -90,6 +91,7 @@ def create_task(task_dict):
     strings.append(f'\t<jobname><cyclestr>{jobname}</cyclestr></jobname>\n')
     strings.append(f'\t<account>{account}</account>\n')
     strings.append(f'\t<queue>{queue}</queue>\n')
+    strings.append(f'\t<nodesize>{nodesize}</nodesize>\n')
     if partition is not None:
         strings.append(f'\t<partition>{partition}</partition>\n')
     if resources is not None:

--- a/ush/rocoto/setup_workflow.py
+++ b/ush/rocoto/setup_workflow.py
@@ -447,22 +447,22 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
     # waveinit
     if do_wave in ['Y', 'YES'] and cdump in cdumps:
         deps = []
-        dep_dict = {'type': 'task', 'name': '{cdump}prep'}
+        dep_dict = {'type': 'task', 'name': f'{cdump}prep'}
         deps.append(rocoto.add_dependency(dep_dict))
         dep_dict = {'type': 'cycleexist', 'condition': 'not', 'offset': '-06:00:00'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='or', dep=deps)
         task = wfu.create_wf_task('waveinit', cdump=cdump, envar=envars, dependency=dependencies)
-        dict_tasks['{cdump}waveinit'] = task
+        dict_tasks[f'{cdump}waveinit'] = task
 
     # waveprep
     if do_wave in ['Y', 'YES'] and cdump in cdumps:
         deps = []
-        dep_dict = {'type': 'task', 'name': '{cdump}waveinit'}
+        dep_dict = {'type': 'task', 'name': f'{cdump}waveinit'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('waveprep', cdump=cdump, envar=envars, dependency=dependencies)
-        dict_tasks['{cdump}waveprep'] = task
+        dict_tasks[f'{cdump}waveprep'] = task
 
     # anal
     deps = []

--- a/ush/rocoto/setup_workflow.py
+++ b/ush/rocoto/setup_workflow.py
@@ -197,8 +197,6 @@ def get_definitions(base):
     if scheduler in ['slurm']:
         strings.append(f'''\t<!ENTITY PARTITION_SERVICE "{base['QUEUE_SERVICE']}">\n''')
     strings.append(f'\t<!ENTITY SCHEDULER  "{scheduler}">\n')
-    if machine in ['WCOSS2']:
-       strings.append(f'\t<!ENTITY NODESIZE  "128">\n')
     strings.append('\n')
     strings.append('\t<!-- Toggle HPSS archiving -->\n')
     strings.append(f'''\t<!ENTITY ARCHIVE_TO_HPSS "{base['HPSSARCH']}">\n''')
@@ -449,22 +447,22 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
     # waveinit
     if do_wave in ['Y', 'YES'] and cdump in cdumps:
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{cdump}prep'}
+        dep_dict = {'type': 'task', 'name': '{cdump}prep'}
         deps.append(rocoto.add_dependency(dep_dict))
         dep_dict = {'type': 'cycleexist', 'condition': 'not', 'offset': '-06:00:00'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='or', dep=deps)
         task = wfu.create_wf_task('waveinit', cdump=cdump, envar=envars, dependency=dependencies)
-        dict_tasks[f'{cdump}waveinit'] = task
+        dict_tasks['{cdump}waveinit'] = task
 
     # waveprep
     if do_wave in ['Y', 'YES'] and cdump in cdumps:
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{cdump}waveinit'}
+        dep_dict = {'type': 'task', 'name': '{cdump}waveinit'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         task = wfu.create_wf_task('waveprep', cdump=cdump, envar=envars, dependency=dependencies)
-        dict_tasks[f'{cdump}waveprep'] = task
+        dict_tasks['{cdump}waveprep'] = task
 
     # anal
     deps = []

--- a/ush/rocoto/setup_workflow.py
+++ b/ush/rocoto/setup_workflow.py
@@ -197,6 +197,8 @@ def get_definitions(base):
     if scheduler in ['slurm']:
         strings.append(f'''\t<!ENTITY PARTITION_SERVICE "{base['QUEUE_SERVICE']}">\n''')
     strings.append(f'\t<!ENTITY SCHEDULER  "{scheduler}">\n')
+    if machine in ['WCOSS2']:
+       strings.append(f'\t<!ENTITY NODESIZE  "128">\n')
     strings.append('\n')
     strings.append('\t<!-- Toggle HPSS archiving -->\n')
     strings.append(f'''\t<!ENTITY ARCHIVE_TO_HPSS "{base['HPSSARCH']}">\n''')

--- a/ush/rocoto/setup_workflow_fcstonly.py
+++ b/ush/rocoto/setup_workflow_fcstonly.py
@@ -130,8 +130,6 @@ def get_definitions(base):
     if scheduler in ['slurm']:
        strings.append(f'''\t<!ENTITY PARTITION_SERVICE "{base['QUEUE_SERVICE']}">\n''')
     strings.append(f'\t<!ENTITY SCHEDULER  "{scheduler}">\n')
-    if machine in ['WCOSS2']:
-       strings.append(f'\t<!ENTITY NODESIZE  "128">\n')
     strings.append('\n')
     strings.append('\t<!-- Toggle HPSS archiving -->\n')
     strings.append(f'''\t<!ENTITY ARCHIVE_TO_HPSS "{base['HPSSARCH']}">\n''')

--- a/ush/rocoto/setup_workflow_fcstonly.py
+++ b/ush/rocoto/setup_workflow_fcstonly.py
@@ -130,6 +130,8 @@ def get_definitions(base):
     if scheduler in ['slurm']:
        strings.append(f'''\t<!ENTITY PARTITION_SERVICE "{base['QUEUE_SERVICE']}">\n''')
     strings.append(f'\t<!ENTITY SCHEDULER  "{scheduler}">\n')
+    if machine in ['WCOSS2']:
+       strings.append(f'\t<!ENTITY NODESIZE  "128">\n')
     strings.append('\n')
     strings.append('\t<!-- Toggle HPSS archiving -->\n')
     strings.append(f'''\t<!ENTITY ARCHIVE_TO_HPSS "{base['HPSSARCH']}">\n''')

--- a/ush/rocoto/workflow_utils.py
+++ b/ush/rocoto/workflow_utils.py
@@ -195,6 +195,7 @@ def create_wf_task(task, cdump='gdas', cycledef=None, envar=None, dependency=Non
                  'walltime': f'&WALLTIME_{task.upper()}_{cdump.upper()};', \
                  'native': f'&NATIVE_{task.upper()}_{cdump.upper()};', \
                  'memory': f'&MEMORY_{task.upper()}_{cdump.upper()};', \
+                 'nodesize': '&NODESIZE;', \
                  'resources': f'&RESOURCES_{task.upper()}_{cdump.upper()};', \
                  'log': f'&ROTDIR;/logs/@Y@m@d@H/{taskstr}.log', \
                  'envar': envar, \
@@ -243,6 +244,7 @@ def create_firstcyc_task(cdump='gdas'):
                  'queue': '&QUEUE_SERVICE;', \
                  'walltime': f'&WALLTIME_ARCH_{cdump.upper()};', \
                  'native': f'&NATIVE_ARCH_{cdump.upper()};', \
+                 'nodesize': '&NODESIZE;', \
                  'resources': f'&RESOURCES_ARCH_{cdump.upper()};', \
                  'log': f'&ROTDIR;/logs/@Y@m@d@H/{taskstr}.log', \
                  'dependency': dependencies}

--- a/ush/rocoto/workflow_utils.py
+++ b/ush/rocoto/workflow_utils.py
@@ -195,7 +195,6 @@ def create_wf_task(task, cdump='gdas', cycledef=None, envar=None, dependency=Non
                  'walltime': f'&WALLTIME_{task.upper()}_{cdump.upper()};', \
                  'native': f'&NATIVE_{task.upper()}_{cdump.upper()};', \
                  'memory': f'&MEMORY_{task.upper()}_{cdump.upper()};', \
-                 'nodesize': '&NODESIZE;', \
                  'resources': f'&RESOURCES_{task.upper()}_{cdump.upper()};', \
                  'log': f'&ROTDIR;/logs/@Y@m@d@H/{taskstr}.log', \
                  'envar': envar, \
@@ -244,7 +243,6 @@ def create_firstcyc_task(cdump='gdas'):
                  'queue': '&QUEUE_SERVICE;', \
                  'walltime': f'&WALLTIME_ARCH_{cdump.upper()};', \
                  'native': f'&NATIVE_ARCH_{cdump.upper()};', \
-                 'nodesize': '&NODESIZE;', \
                  'resources': f'&RESOURCES_ARCH_{cdump.upper()};', \
                  'log': f'&ROTDIR;/logs/@Y@m@d@H/{taskstr}.log', \
                  'dependency': dependencies}

--- a/ush/syndat_getjtbul.sh
+++ b/ush/syndat_getjtbul.sh
@@ -21,10 +21,6 @@
 #   TANK_TROPCY  - path to home directory containing tropical cyclone record
 #                  data base
 
-# Imported variables that can be passed in:
-#   jlogfile  - path to job log file (skipped over by this script if not
-#                 passed in)
-
 
 set -xua
 
@@ -33,21 +29,9 @@ EXECSYND=${EXECSYND:-${HOMESYND}/exec}
 cd $DATA
 
 if [ "$#" -ne '1' ]; then
-   msg="**NON-FATAL ERROR PROGRAM  SYNDAT_GETJTBUL  run date not in \
+   echo "**NON-FATAL ERROR PROGRAM  SYNDAT_GETJTBUL  run date not in \
 positional parameter 1"
-   set +x
-   echo
-   echo $msg
-   echo
-   set -x
-   echo $msg >> $pgmout
-   set +u
-   [ -n "$jlogfile" ]  &&  postmsg "$jlogfile" "$msg"
-   set -u
-
-echo "Leaving sub-shell syndat_getjtbul.sh to recover JTWC Bulletins" \
- >> $pgmout
-echo " " >> $pgmout
+   echo "Leaving sub-shell syndat_getjtbul.sh to recover JTWC Bulletins"
 
    exit
 fi
@@ -124,11 +108,9 @@ fi
 perl -wpi.ORIG -e 's/(^.... ... )(\S{9,9})(\S{1,})/$1$2/' jtwcbul
 diff jtwcbul.ORIG jtwcbul > jtwcbul_changes.txt
 if [ -s jtwcbul_changes.txt ]; then
-  msg="***WARNING:  SOME JTWC VITALS SEGMENTS REQUIRED PRELIMINARY MODIFICATION!"
-  [ -n "$jlogfile" ] && postmsg "$jlogfile" "$msg"
-  echo -e "\n${msg}.  Changes follow:" >> $pgmout
-  cat jtwcbul_changes.txt >> $pgmout
-  echo -e "\n" >> $pgmout
+  echo "***WARNING:  SOME JTWC VITALS SEGMENTS REQUIRED PRELIMINARY MODIFICATION!"
+  echo "Changes follow:"
+  cat jtwcbul_changes.txt
 fi
 
 # Execute bulletin processing
@@ -175,30 +157,12 @@ available for qctropcy for $CDATE10"
         fi
       fi
    else
-      msg="**NON-FATAL ERROR PROGRAM  SYNDAT_GETJTBUL  FOR $CDATE10 \
+      echo "**NON-FATAL ERROR PROGRAM  SYNDAT_GETJTBUL  FOR $CDATE10 \
 RETURN CODE $errget"
    fi
-   set +x
-   echo
-   echo $msg
-   echo
-   set -x
-   echo $msg >> $pgmout
-   set +u
-   [ -n "$jlogfile" ] && postmsg "$jlogfile" "$msg"
-   set -u
 else
-   msg="program  SYNDAT_GETJTBUL  completed normally for $CDATE10, JTWC \
+   echo "program  SYNDAT_GETJTBUL  completed normally for $CDATE10, JTWC \
 rec. passed to qctropcy"
-   set +x
-   echo
-   echo $msg
-   echo
-   set -x
-   echo $msg >> $pgmout
-   set +u
-   [ -n "$jlogfile" ] && postmsg "$jlogfile" "$msg"
-   set -u
 fi
 set +x
 echo

--- a/ush/syndat_qctropcy.sh
+++ b/ush/syndat_qctropcy.sh
@@ -90,12 +90,6 @@ files_override=${files_override:-""}
 cd $DATA
 
 echo "Tropical Cyclone tcvitals QC processing has begun"
-set +x
-echo
-echo $msg
-echo
-set -x
-echo $msg >> $pgmout
 
 if [ "$#" -ne '1' ]; then
    echo "**NON-FATAL ERROR PROGRAM  SYNDAT_QCTROPCY  run date not in \
@@ -281,7 +275,7 @@ echo
 set -x
 
 if [ -s current ]; then
-   echo"program  SYNDAT_QCTROPCY  completed normally - tcvitals records \
+   echo "program  SYNDAT_QCTROPCY  completed normally - tcvitals records \
 processed"
 else
    echo "no records available for program  SYNDAT_QCTROPCY - null tcvitals file \

--- a/ush/syndat_qctropcy.sh
+++ b/ush/syndat_qctropcy.sh
@@ -64,8 +64,6 @@ echo "                        directories.  These must now be passed in. "
 #   copy_back - switch to copy updated files back to archive directory and
 #                to tcvitals directory
 #                (Default: YES)
-#   jlogfile  - path to job log file (skipped over by this script if not
-#                 passed in)
 #   SENDCOM     switch  copy output files to $COMSP
 #                (Default: YES)
 #   files_override - switch to override default "files" setting for given run
@@ -91,39 +89,18 @@ files_override=${files_override:-""}
 
 cd $DATA
 
-msg="Tropical Cyclone tcvitals QC processing has begun"
+echo "Tropical Cyclone tcvitals QC processing has begun"
 set +x
 echo
 echo $msg
 echo
 set -x
 echo $msg >> $pgmout
-set +u
-[ -n "$jlogfile" ]  && postmsg "$jlogfile" "$msg"
-set -u
 
 if [ "$#" -ne '1' ]; then
-   msg="**NON-FATAL ERROR PROGRAM  SYNDAT_QCTROPCY  run date not in \
+   echo "**NON-FATAL ERROR PROGRAM  SYNDAT_QCTROPCY  run date not in \
 positional parameter 1"
-   set +x
-   echo
-   echo $msg
-   echo
-   set -x
-   echo $msg >> $pgmout
-   set +u
-   [ -n "$jlogfile" ]  &&  postmsg "$jlogfile" "$msg"
-   set -u
-   msg="**NO TROPICAL CYCLONE tcvitals processed --> non-fatal"
-   set +x
-   echo
-   echo $msg
-   echo
-   set -x
-   echo $msg >> $pgmout
-   set +u
-   [ -n "$jlogfile" ]  &&  postmsg "$jlogfile" "$msg"
-   set -u
+   echo "**NO TROPICAL CYCLONE tcvitals processed --> non-fatal"
 
 # Copy null files into "${COMSP}syndata.tcvitals.$tmmark" and
 #  "${COMSP}jtwc-fnoc.tcvitals.$tmmark" so later ftp attempts will find and
@@ -164,16 +141,9 @@ cp $ARCHSYND/syndat_sthista sthista
 touch dateck
 dateck_size=`ls -l dateck  | awk '{ print $5 }'`
 if [ $dateck_size -lt 10 ]; then
-   msg="***WARNING: Archive run date check file not available or shorter than expected.\
+   echo "***WARNING: Archive run date check file not available or shorter than expected.\
   Using dummy date 1900010100 to allow code to continue"
    echo 1900010100 > dateck
-   set +x
-   echo -e "\n${msg}\n"
-   set -x
-   echo $msg >> $pgmout
-   set +u
-   [ -n "$jlogfile" ]  &&  postmsg "$jlogfile" "$msg"
-   set -u
 fi
 
 
@@ -194,18 +164,11 @@ fi
 if [ -n "$files_override" ]; then  # for testing, typically want FILES=F
   files_override=`echo "$files_override" | tr [a-z] [A-Z] | tr -d [.] | cut -c 1`
   if [ "$files_override" = 'T' -o "$files_override" = 'F' ]; then
-    msg="***WARNING: Variable files setting will be overriden from $files to $files_override. Override expected if testing." 
+    echo "***WARNING: Variable files setting will be overriden from $files to $files_override. Override expected if testing." 
     files=$files_override
   else
-    msg="***WARNING: Invalid attempt to override files setting. Will stay with default for this job" 
+    echo "***WARNING: Invalid attempt to override files setting. Will stay with default for this job" 
   fi 
-  set +x
-  echo -e "\n${msg}\n"
-  set -x
-  echo $msg >> $pgmout
-  set +u
-  [ -n "$jlogfile" ]  &&  postmsg "$jlogfile" "$msg"
-  set -u
 fi
 
 echo " &INPUT  RUNID = '${net}_${tmmark}_${cyc}', FILES = $files " > vitchk.inp
@@ -291,26 +254,8 @@ echo "The foreground exit status for SYNDAT_QCTROPCY is " $errqct
 echo
 set -x
 if [ "$errqct" -gt '0' ];then
-   msg="**NON-FATAL ERROR PROGRAM  SYNDAT_QCTROPCY  RETURN CODE $errqct"
-   set +x
-   echo
-   echo $msg
-   echo
-   set -x
-   echo $msg >> $pgmout
-   set +u
-   [ -n "$jlogfile" ]  &&  postmsg "$jlogfile" "$msg"
-   set -u
-   msg="**NO TROPICAL CYCLONE tcvitals processed --> non-fatal"
-   set +x
-   echo
-   echo $msg
-   echo
-   set -x
-   echo $msg >> $pgmout
-   set +u
-   [ -n "$jlogfile" ]  &&  postmsg "$jlogfile" "$msg"
-   set -u
+   echo "**NON-FATAL ERROR PROGRAM  SYNDAT_QCTROPCY  RETURN CODE $errqct"
+   echo "**NO TROPICAL CYCLONE tcvitals processed --> non-fatal"
 
 # In the event of a ERROR in PROGRAM SYNDAT_QCTROPCY, copy null files into
 #  "${COMSP}syndata.tcvitals.$tmmark" and "${COMSP}jtwc-fnoc.tcvitals.$tmmark"
@@ -336,16 +281,12 @@ echo
 set -x
 
 if [ -s current ]; then
-   msg="program  SYNDAT_QCTROPCY  completed normally - tcvitals records \
+   echo"program  SYNDAT_QCTROPCY  completed normally - tcvitals records \
 processed"
 else
-msg="no records available for program  SYNDAT_QCTROPCY - null tcvitals file \
+   echo "no records available for program  SYNDAT_QCTROPCY - null tcvitals file \
 produced"
 fi
-set +u
-[ -n "$jlogfile" ]  &&  postmsg "$jlogfile" "$msg"
-set -u
-
 
 if [ "$copy_back" = 'YES' ]; then
    cat lthistry>>$ARCHSYND/syndat_lthistry.$year
@@ -379,37 +320,18 @@ then
       err=$?
 
       if [ "$err" -ne '0' ]; then
-         msg="###ERROR: Previous NHC Synthetic Data Record File \
+         echo "###ERROR: Previous NHC Synthetic Data Record File \
 $HOMENHC/tcvitals not updated by syndat_qctropcy"
       else
-         msg="Previous NHC Synthetic Data Record File \
+         echo "Previous NHC Synthetic Data Record File \
 $HOMENHC/tcvitals successfully updated by syndat_qctropcy"
       fi
-
-      set +x
-      echo
-      echo $msg
-      echo
-      set -x
-      echo $msg >> $pgmout
-      set +u
-      [ -n "$jlogfile" ]  &&  postmsg "$jlogfile" "$msg"
-      set -u
    fi
 
 else
 
-   msg="Previous NHC Synthetic Data Record File $HOMENHC/tcvitals \
+   echo "Previous NHC Synthetic Data Record File $HOMENHC/tcvitals \
 not changed by syndat_qctropcy"
-   set +x
-   echo
-   echo $msg
-   echo
-   set -x
-   echo $msg >> $pgmout
-   set +u
-   [ -n "$jlogfile" ]  &&  postmsg "$jlogfile" "$msg"
-   set -u
 
 fi
 
@@ -428,16 +350,6 @@ fi
 #  Write JTWC/FNOC Tcvitals to /com path since not saved anywhere else
 [ $SENDCOM = YES ]  &&  cp fnoc ${COMSP}jtwc-fnoc.tcvitals.$tmmark
 
-msg="TROPICAL CYCLONE TCVITALS QC PROCESSING HAS COMPLETED FOR $CDATE10"
-set +x
-echo
-echo $msg
-echo
-set -x
-echo $msg >> $pgmout
-echo " "  >> $pgmout
-set +u
-[ -n "$jlogfile" ]  &&  postmsg "$jlogfile" "$msg"
-set -u
+echo "TROPICAL CYCLONE TCVITALS QC PROCESSING HAS COMPLETED FOR $CDATE10"
 
 exit

--- a/ush/tropcy_relocate.sh
+++ b/ush/tropcy_relocate.sh
@@ -157,8 +157,6 @@
 #      be used by the script.  If they are not, they will be skipped
 #      over by the script.
 #
-#     jlogfile      String indicating path to joblog file
-#
 #   Exported Shell Variables:
 #     CDATE10       String indicating the center date/time for the relocation
 #                   processing <yyyymmddhh>
@@ -182,9 +180,7 @@
 #                        $USHRELO/tropcy_relocate_extrkr.sh)
 #                  $DATA/err_chk (here and in child script
 #                        $USHRELO/tropcy_relocate_extrkr.sh)
-#        NOTE 1: postmsg above is required ONLY if "$jlogfile" is
-#                present.
-#        NOTE 2: The last three scripts above are NOT REQUIRED utilities.
+#        NOTE 1: The last three scripts above are NOT REQUIRED utilities.
 #                If $DATA/prep_step not found, a scaled down version of it is
 #                executed in-line.  If $DATA/err_exit or $DATA/err_chk are not
 #                found and a fatal error has occurred, then the script calling
@@ -326,11 +322,7 @@ GETTX=${GETTX:-$EXECRELO/gettrk}
 #  attempt to perform tropical cyclone relocation
 #  ----------------------------------------------
 
-msg="Attempt to perform tropical cyclone relocation for $CDATE10"
-set +u
-##[ -n "$jlogfile" ] && $DATA/postmsg "$jlogfile" "$msg"
-[ -n "$jlogfile" ] && postmsg "$jlogfile" "$msg"
-set -u
+echo "Attempt to perform tropical cyclone relocation for $CDATE10"
 
 if [ $modhr -ne 0 ]; then
 
@@ -523,11 +515,8 @@ grep "$pdy $cyc" VITL
 errgrep=$?
 > tcvitals
 if [ $errgrep -ne 0 ] ; then
-   msg="NO TCVITAL RECORDS FOUND FOR $CDATE10 - EXIT TROPICAL CYCLONE \
+   echo "NO TCVITAL RECORDS FOUND FOR $CDATE10 - EXIT TROPICAL CYCLONE \
 RELOCATION PROCESSING"
-   set +u
-   [ -n "$jlogfile" ] && postmsg "$jlogfile" "$msg"
-   set -u
 
 # The existence of ${COMSP}tropcy_relocation_status.$tmmark file will tell the
 #  subsequent PREP processing that RELOCATION processing occurred, echo
@@ -726,11 +715,8 @@ else
 
    rm ${COMSP}sgesprep_pathname.$tmmark
 
-   msg="TROPICAL CYCLONE RELOCATION PROCESSING SUCCESSFULLY COMPLETED FOR \
+   echo "TROPICAL CYCLONE RELOCATION PROCESSING SUCCESSFULLY COMPLETED FOR \
 $CDATE10"
-   set +u
-   [ -n "$jlogfile" ] && postmsg "$jlogfile" "$msg"
-   set -u
 
 # end GFDL ges manipulation
 # -------------------------

--- a/ush/tropcy_relocate.sh
+++ b/ush/tropcy_relocate.sh
@@ -173,7 +173,6 @@
 #                  $NDATE (here and in child script
 #                        $USHRELO/tropcy_relocate_extrkr.sh)
 #                  /usr/bin/poe
-#                  postmsg
 #                  $DATA/prep_step (here and in child script
 #                        $USHRELO/tropcy_relocate_extrkr.sh)
 #                  $DATA/err_exit (here and in child script

--- a/ush/wave_grib2_sbs.sh
+++ b/ush/wave_grib2_sbs.sh
@@ -36,7 +36,6 @@
   [[ "$LOUD" != YES ]] && set +x
 
   cd $GRIBDATA
-#  postmsg "$jlogfile" "Making GRIB2 Files."   # commented to reduce unnecessary output to jlogfile
 
   alertName=`echo $RUN|tr [a-z] [A-Z]`
 
@@ -54,7 +53,6 @@
     echo '******************************************************************************* '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "FATAL ERROR : ERROR IN ww3_grib2 (Could not create temp directory)"
     exit 1
   fi
 
@@ -103,7 +101,6 @@
     echo '***************************************************'
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "EXPORTED VARIABLES IN postprocessor NOT SET"
     exit 1
   fi
 
@@ -163,7 +160,6 @@
       echo '************************************************ '
       echo ' '
       [[ "$LOUD" = YES ]] && set -x
-      postmsg "$jlogfile" "FATAL ERROR : ERROR IN ww3_grib2"
       exit 3
     fi
 
@@ -184,7 +180,6 @@
     echo '********************************************* '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "FATAL ERROR : ERROR IN ww3_grib2"
     exit 3
   fi
 
@@ -216,7 +211,6 @@
       echo " Error in moving grib file ${outfile} to com"
       echo ' '
       [[ "$LOUD" = YES ]] && set -x
-      postmsg "$jlogfile" "FATAL ERROR : ERROR IN ww3_grib2"
       exit 4
     fi
     if [ ! -s $COMOUT/gridded/${outfile} ]
@@ -230,7 +224,6 @@
       echo " Error in moving grib file ${outfile}.idx to com"
       echo ' '
       [[ "$LOUD" = YES ]] && set -x
-      postmsg "$jlogfile" "FATAL ERROR : ERROR IN creating ww3_grib2 index"
       exit 4
     fi
 

--- a/ush/wave_grid_interp.sh
+++ b/ush/wave_grid_interp.sh
@@ -33,7 +33,7 @@
   ymdh=$2
   dt=$3
   nst=$4
-  postmsg "$jlogfile" "Making GRID Interpolation Files for $grdID."
+  echo "Making GRID Interpolation Files for $grdID."
   rm -rf grint_${grdID}_${ymdh}
   mkdir grint_${grdID}_${ymdh}
   err=$?
@@ -47,7 +47,6 @@
     echo '************************************************************************************* '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "FATAL ERROR : ERROR IN ww3_grid_interp (Could not create temp directory)"
     exit 1
   fi
 
@@ -76,7 +75,6 @@
     echo ' '
     echo "$YMDH $cycle $EXECwave $COMOUT $WAV_MOD_TAG $SENDCOM $SENDDBN $waveGRD"
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "EXPORTED VARIABLES IN postprocessor NOT SET"
     exit 1
   fi
 
@@ -160,7 +158,6 @@
     echo '*************************************************** '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "FATAL ERROR : ERROR IN ww3_gint interpolation"
     exit 3
   fi
 

--- a/ush/wave_grid_interp_sbs.sh
+++ b/ush/wave_grid_interp_sbs.sh
@@ -41,7 +41,7 @@
   ymdh=$2
   dt=$3
   nst=$4
-  postmsg "$jlogfile" "Making GRID Interpolation Files for $grdID."
+  echo "Making GRID Interpolation Files for $grdID."
   rm -rf grint_${grdID}_${ymdh}
   mkdir grint_${grdID}_${ymdh}
   err=$?
@@ -55,7 +55,6 @@
     echo '************************************************************************************* '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "FATAL ERROR : ERROR IN ww3_grid_interp (Could not create temp directory)"
     exit 1
   fi
 
@@ -84,7 +83,6 @@
     echo ' '
     echo "$CDATE $cycle $EXECwave $COMOUT $WAV_MOD_TAG $SENDCOM $SENDDBN $waveGRD"
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "EXPORTED VARIABLES IN postprocessor NOT SET"
     exit 1
   fi
 
@@ -169,7 +167,6 @@
     echo '*************************************************** '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "FATAL ERROR : ERROR IN ww3_gint interpolation"
     exit 3
   fi
 

--- a/ush/wave_grid_moddef.sh
+++ b/ush/wave_grid_moddef.sh
@@ -29,8 +29,6 @@
   export LOUD=${LOUD:-YES}; [[ $LOUD = yes ]] && export LOUD=YES
   [[ "$LOUD" != YES ]] && set +x
 
-  postmsg "$jlogfile" "Generating mod_def file"
-
   mkdir -p moddef_${1}
   cd moddef_${1}
 
@@ -56,7 +54,6 @@
     echo '**************************************************'
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "GRID IN ww3_mod_def.sh NOT SET"
     exit 1
   else
     grdID=$1
@@ -74,7 +71,6 @@
     echo '*********************************************************'
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "EXPORTED VARIABLES IN ww3_mod_def.sh NOT SET"
     exit 2
   fi
 
@@ -103,7 +99,6 @@
     echo '******************************************** '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "FATAL ERROR : ERROR IN ww3_grid"
     exit 3
   fi
  
@@ -119,7 +114,6 @@
     echo '******************************************** '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "FATAL ERROR : Mod def File creation FAILED"
     exit 4
   fi
 

--- a/ush/wave_outp_cat.sh
+++ b/ush/wave_outp_cat.sh
@@ -46,7 +46,6 @@
     echo '***********************************************'
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "LOCATION ID IN ww3_outp_cat.sh NOT SET"
     exit 1
   else
     buoy=$bloc
@@ -65,7 +64,6 @@
     echo '******************************************************'
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "EXPORTED VARIABLES IN ww3_outp_cat.sh NOT SET"
     exit 3
   fi
 

--- a/ush/wave_outp_spec.sh
+++ b/ush/wave_outp_spec.sh
@@ -53,7 +53,6 @@
     echo '****************************************************************************** '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "FATAL ERROR : ERROR IN ww3_outp_spec (Could not create temp directory)"
     exit 1
   fi
 
@@ -78,7 +77,6 @@
     echo '***********************************************'
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "LOCATION ID IN ww3_outp_spec.sh NOT SET"
     exit 1
   else
     buoy=$bloc
@@ -105,7 +103,6 @@
       echo '******************************************************'
       echo ' '
       [[ "$LOUD" = YES ]] && set -x
-      postmsg "$jlogfile" "LOCATION ID IN ww3_outp_spec.sh NOT RECOGNIZED"
       exit 2
     fi
   fi
@@ -124,7 +121,6 @@
     echo '******************************************************'
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "EXPORTED VARIABLES IN ww3_outp_spec.sh NOT SET"
     exit 3
   fi
 
@@ -198,7 +194,6 @@
     echo '******************************************** '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "FATAL ERROR : ERROR IN ww3_outp"
     exit 4
   fi
 
@@ -243,7 +238,6 @@
     echo '***************************************************************** '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "FATAL ERROR : OUTPUT DATA FILE FOR BOUY $bouy NOT FOUND"
     exit 5
   fi
 

--- a/ush/wave_prnc_cur.sh
+++ b/ush/wave_prnc_cur.sh
@@ -88,7 +88,6 @@ then
   echo '******************************************** '
   echo ' '
   set $seton
-  postmsg "$jlogfile" "WARNING: NON-FATAL ERROR IN ww3_prnc."
   exit 4
 fi
 

--- a/ush/wave_prnc_ice.sh
+++ b/ush/wave_prnc_ice.sh
@@ -51,7 +51,6 @@
   echo "   Ice file        : $WAVICEFILE"
   echo ' '
   set $seton
-  postmsg "$jlogfile" "Making ice fields."
 
   if [ -z "$YMDH" ] || [ -z "$cycle" ] || \
      [ -z "$COMOUT" ] || [ -z "$FIXwave" ] || [ -z "$EXECwave" ] || \
@@ -66,7 +65,6 @@
     echo ' '
     exit 1
     set $seton
-    postmsg "$jlogfile" "NON-FATAL ERROR - EXPORTED VARIABLES IN preprocessor NOT SET"
   fi
 
 # 0.c Links to working directory
@@ -97,7 +95,6 @@
     echo '************************************** '
     echo ' '
     set $seton
-    postmsg "$jlogfile" "FATAL ERROR - NO ICE FILE (GFS GRIB)"
     exit 2
   fi
 
@@ -124,7 +121,6 @@
     echo '**************************************** '
     echo ' '
     set $seton
-    postmsg "$jlogfile" "ERROR IN UNPACKING GRIB ICE FILE."
     exit 3
   fi
 
@@ -157,7 +153,6 @@
     echo '******************************************** '
     echo ' '
     set $seton
-    postmsg "$jlogfile" "WARNING: NON-FATAL ERROR IN ww3_prnc."
     exit 4
   fi
 

--- a/ush/wave_tar.sh
+++ b/ush/wave_tar.sh
@@ -34,7 +34,6 @@
   [[ "$LOUD" != YES ]] && set -x
 
   cd $DATA
-  postmsg "$jlogfile" "Making TAR FILE"
 
   alertName=`echo $RUN|tr [a-z] [A-Z]`
 
@@ -60,7 +59,6 @@
     echo '********************************************'
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "TYPE IN ww3_tar.sh NOT SET"
     exit 1
   else
     ID=$1
@@ -91,7 +89,6 @@
     echo '*****************************************************'
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "EXPORTED VARIABLES IN ww3_tar.sh NOT SET"
     exit 2
   fi
 
@@ -128,7 +125,6 @@
         echo '***************************************** '
         echo ' '
         [[ "$LOUD" = YES ]] && set -x
-        postmsg "$jlogfile" "FATAL ERROR : TAR CREATION FAILED"
         exit 3
       fi
       
@@ -155,7 +151,6 @@
     echo '***************************************** '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "FATAL ERROR : TAR CREATION FAILED"
     exit 3
   fi
 
@@ -176,7 +171,6 @@
         echo '***************************************************** '
         echo ' '
         [[ "$LOUD" = YES ]] && set -x
-        postmsg "$jlogfile" "FATAL ERROR : SPECTRAL TAR COMPRESSION FAILED"
         exit 4
       fi
     fi
@@ -205,7 +199,6 @@
     echo '************************************* '
     echo ' '
     [[ "$LOUD" = YES ]] && set -x
-    postmsg "$jlogfile" "FATAL ERROR : TAR COPY FAILED"
     exit 4
   fi
 

--- a/util/ush/mkawpgrb.sh
+++ b/util/ush/mkawpgrb.sh
@@ -37,7 +37,6 @@ then
 #  export EXECutil=${EXECutil:-${NWROOT}/util/exec}
 #  export PARMutil=${PARMutil:-${NWROOT}/util/parm}
    export envir=${envir:-prod}
-   export jlogfile=${jlogfile:-jlogfile}
    export NET=${NET:-gfs}
    export RUN=${RUN:-gfs}
    export DBNALERT_TYPE=${DBNALERT_TYPE:-GRIB_LOW}
@@ -77,8 +76,7 @@ echo " BEGIN MAKING $NET XTRN/GRIB AWIPS PRODUCTS"
 echo " ------------------------------------------"
 set -x
 
-msg="Enter Make AWIP GRIB utility."
-postmsg "$jlogfile" "$msg"
+echo "Enter Make AWIP GRIB utility."
 
 ############################################
 # Figure out INPUT/OUTPUT/PARM/EXEC Fields
@@ -396,13 +394,11 @@ do
      if [ "$SENDDBN" = 'YES' -o "$SENDAWIP" = 'YES' ] ; then
         $DBNROOT/bin/dbn_alert $DBNALERT_TYPE $NET $job $COMOUTwmo/$output_grb.$job
      else
-        msg="File $output_grb.$job not posted to db_net."
-        postmsg "$jlogfile" "$msg"
+        echo "File $output_grb.$job not posted to db_net."
      fi
   fi
 
-   msg="Awip Processing ${hour} hour  completed normally"
-   postmsg "$jlogfile" "$msg"
+   echo "Awip Processing ${hour} hour  completed normally"
 
 done
 

--- a/util/ush/snd2forgn
+++ b/util/ush/snd2forgn
@@ -31,7 +31,7 @@ VERS="version: ${MEMBER} 2000-03-23 10:55L "
 #
 # Remarks  : This script assumes that the following values have been 
 #            exported by the parent shell:
-#            job JOBID USHutil UTILhome jlogfile model COMOUTwmo 
+#            job JOBID USHutil UTILhome model COMOUTwmo 
 #            DBNROOT is exported in the production Profile.
 #
 # FOR TESTING 
@@ -139,7 +139,6 @@ set -x
  whatdir=$LOGNAME
   mkdir -m 775 -p $DATA  >/dev/null 2>&1
   mkdir -m 775 -p $COMOUTwmo  >/dev/null 2>&1
-  jlogfile=$DATA/snd2forgn_log
   reqid=${$}
   PID=$$
   JOB=$LOGNAME
@@ -155,7 +154,7 @@ set -x
  else 
   SENDDBN=NO 
  fi
-  export  model jlogfile jobid reqid  COMOUTwmo pgmout 
+  export  model jobid reqid  COMOUTwmo pgmout 
   export  JOB DATA PID 
   cd $DATA
   
@@ -288,15 +287,15 @@ then
        echo dbn_alert: Ended with return code = $istat
        if test "$istat" = 0 
        then
-         msg="Posting $filename with ${SUBTYP}!"
+         echo "Posting $filename with ${SUBTYP}!"
        else
-         msg="ERROR FROM dbn_alert = $istat, Posting $filename with ${SUBTYP}!"
+         echo "ERROR FROM dbn_alert = $istat, Posting $filename with ${SUBTYP}!"
         sndfrc=1
         echo $sndfrc >$DATA/sndfrc
        fi   
       else
        set -x
-       msg="snd2forgn testing, $SUBTYP $filename not sent!" 
+       echo "snd2forgn testing, $SUBTYP $filename not sent!" 
        set +x   
 
       fi
@@ -312,7 +311,6 @@ then
  
   if [ -z "$newstr" ] ; then
    echo " newstr > is empty < will exit!"
-   postmsg "$jlogfile" "$msg"
    exit
   fi
     ttype=${newstr}     
@@ -376,22 +374,20 @@ then
         echo dbn_alert: Ended with return code = $istat
          if test "$istat" = 0 
          then
-          msg="Posting $filename with $TYPE!"
+          echo "Posting $filename with $TYPE!"
          else
-          msg="ERROR FROM dbn_alert = $istat, Posting $filename with ${TYPE}!"
+          echo "ERROR FROM dbn_alert = $istat, Posting $filename with ${TYPE}!"
           sndfrc=1
           echo $sndfrc >$DATA/sndfrc
          fi     
        else
-        msg="snd2forgn testing, ${TYPE} $filename not sent!"       
+        echo "snd2forgn testing, ${TYPE} $filename not sent!"       
        fi 
-     postmsg "$jlogfile" "$msg"
      snd=NO  
      exit 0
     fi          
 else
- msg "ERROR TYPE MISSING BECAUSE $numprt is ZERO!"
- postmsg "$jlogfile" "$msg"
+ echo "ERROR TYPE MISSING BECAUSE $numprt is ZERO!"
  exit 
 fi
 
@@ -466,36 +462,33 @@ then
   echo dbn_alert: Ended with return code = $istat
 #
 #______________________________________________________________
-#      make message for jlogfile.
-#_______________________________________________________________
 #
   if test "$istat" = 0 
   then
   if [ "$actn"  = "Posting" ]
    then 
-    msg="$actn $filename with $JAG !"
+    echo "$actn $filename with $JAG !"
 
    elif [ "$actn"  = "Posting-copying" ]
     then
-     msg="POSTING file to OSO and COPYING into $FORFIL!"
+     echo "POSTING file to OSO and COPYING into $FORFIL!"
    elif [ "$actn"  = "Copying" ]
     then
-     msg="COPYING into file: $FORFIL!"
+     echo "COPYING into file: $FORFIL!"
    elif [ "$actn"  = "Sending" ]
     then 
-      msg="$actn a nmc6bit file with $JAG."            
+      echo "$actn a nmc6bit file with $JAG."            
     else  
-      msg="COPYING into file: $FORFIL!"  
+      echo "COPYING into file: $FORFIL!"  
     fi
   else
-    msg="ERROR FROM dbn_alert = $istat, trying to $actn with $JAG ! "
-     sndfrc=1
-     echo $sndfrc >$DATA/sndfrc 
+    echo "ERROR FROM dbn_alert = $istat, trying to $actn with $JAG ! "
+    sndfrc=1
+    echo $sndfrc >$DATA/sndfrc 
   fi
 else
-       msg="snd2forgn testing, $JAG $FORFIL $FLG $INFILE not sent!"    
+    echo "snd2forgn testing, $JAG $FORFIL $FLG $INFILE not sent!"    
 fi
- postmsg "$jlogfile" "$msg"
 
 rm ${CONCARD}
 exit 0

--- a/util/ush/snd2forgn
+++ b/util/ush/snd2forgn
@@ -31,7 +31,7 @@ VERS="version: ${MEMBER} 2000-03-23 10:55L "
 #
 # Remarks  : This script assumes that the following values have been 
 #            exported by the parent shell:
-#            job JOBID USHutil UTILhome model COMOUTwmo 
+#            job JOBID USHutil UTILhome model COMOUTwmo
 #            DBNROOT is exported in the production Profile.
 #
 # FOR TESTING 
@@ -152,9 +152,9 @@ set -x
  then
   SENDDBN=NO
  else 
-  SENDDBN=NO 
+  SENDDBN=NO
  fi
-  export  model jobid reqid  COMOUTwmo pgmout 
+  export  model jobid reqid COMOUTwmo pgmout
   export  JOB DATA PID 
   cd $DATA
   
@@ -285,7 +285,7 @@ then
  
        export istat=$?
        echo dbn_alert: Ended with return code = $istat
-       if test "$istat" = 0 
+       if test "$istat" = 0
        then
          echo "Posting $filename with ${SUBTYP}!"
        else
@@ -295,7 +295,7 @@ then
        fi   
       else
        set -x
-       echo "snd2forgn testing, $SUBTYP $filename not sent!" 
+       echo "snd2forgn testing, $SUBTYP $filename not sent!"
        set +x   
 
       fi

--- a/util/ush/snd2forgntbl.sh
+++ b/util/ush/snd2forgntbl.sh
@@ -54,13 +54,11 @@ then
 
       if test $sndfrc -eq '0'
       then
-        msg="snd2forgntbl.sh successfully ended!"
-        postmsg "$jlogfile" "$msg"
+        echo "snd2forgntbl.sh successfully ended!"
       else
-        msg="ERROR $filename NOT POSTED!"
-        postmsg "$jlogfile" "$msg"
-        msg="snd2forgn: ABNORMAL STOP = $sndfrc!:"
-        postmsg "$jlogfile" "$msg"
+        echo "ERROR $filename NOT POSTED!"
+        echo "snd2forgn: ABNORMAL STOP = $sndfrc!:"
+        exit 1
       fi
 else
    echo Sendkey $sendkey is not in the snd2forgn.names table

--- a/util/ush/sndncdc
+++ b/util/ush/sndncdc
@@ -23,7 +23,7 @@ VERS="version: ${SMEMBER} 2000-02-02 09:40L "
 #
 # Remarks  : This script assumes that the following values have been 
 #            exported by the parent shell:
-#            job JOBID SENDDBN jlogfile model COMOUTwmo.
+#            job JOBID SENDDBN model COMOUTwmo.
 #
 #          : Arg1 ncdcbasename this is the ncdc base name to which 
 #            the extenion of CCYYMMDDHH will be added.
@@ -120,16 +120,15 @@ istat=0
       then
         if test "$dir" = '${COMROOT}/foreign/ncdc'
         then
-          msg="SENT ${dir}/${ncdcfil}.${YMDZ} to NCDC !"
+          echo "SENT ${dir}/${ncdcfil}.${YMDZ} to NCDC !"
         else
-          msg="SENT ${ncdcfil}.${YMDZ} to NCDC !" 
+          echo "SENT ${ncdcfil}.${YMDZ} to NCDC !" 
         fi
       else
-       msg="ERROR FROM dbn_alert = $istat, trying to send to NCDC!"
+       echo "ERROR FROM dbn_alert = $istat, trying to send to NCDC!"
       fi            
    else 
-       msg="sndncdc testing, ${dir}/${ncdcfil}.${YMDZ} not sent!"    
+       echo "sndncdc testing, ${dir}/${ncdcfil}.${YMDZ} not sent!"    
    fi
- postmsg "$jlogfile" "$msg" 
  set +x    
 exit 

--- a/util/ush/sndncdc
+++ b/util/ush/sndncdc
@@ -122,13 +122,13 @@ istat=0
         then
           echo "SENT ${dir}/${ncdcfil}.${YMDZ} to NCDC !"
         else
-          echo "SENT ${ncdcfil}.${YMDZ} to NCDC !" 
+          echo "SENT ${ncdcfil}.${YMDZ} to NCDC !"
         fi
       else
        echo "ERROR FROM dbn_alert = $istat, trying to send to NCDC!"
       fi            
    else 
-       echo "sndncdc testing, ${dir}/${ncdcfil}.${YMDZ} not sent!"    
+       echo "sndncdc testing, ${dir}/${ncdcfil}.${YMDZ} not sent!"
    fi
  set +x    
 exit 


### PR DESCRIPTION
This PR retires the reference and usage of the jlogfile from scripts owned by global-workflow. This is per a request from NCO during the WCOSS2 port.

- jlogfile postmsg replaced by echo to stdout/stderr (NCO request)
- cleanup surrounding lines and messaging as needed
- add a few missing error exits after fatal errors

Refs: #399 