### PR TITLE
Fix determination of GDAS forecast decomposition for workflow

### DIFF
--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -187,7 +187,7 @@ elif [ $step = "fcst" ]; then
     fi
 
     # During workflow creation, we need resources for all CDUMPs and CDUMP is undefined
-    CDUMP_LIST=${CDUMP:-"gfs gdas"}
+    CDUMP_LIST=${CDUMP:-"gdas gfs"}
     for CDUMP in $CDUMP_LIST; do
         if [[ "$CDUMP" == "gfs" ]]; then
             export layout_x=$layout_x_gfs


### PR DESCRIPTION
By determining the resources for GDAS forecast first, the GDAS grid decomposition is no longer overwritten before it is used.

Closes #541