### PR TITLE
Series of small WCOSS2 updates - round 4

### DIFF
--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -248,10 +248,6 @@ elif [ $step = "gempak" ]; then
     [[ $NTHREADS_GEMPAK -gt $nth_max ]] && export NTHREADS_GEMPAK=$nth_max
     export APRUN_GEMPAKCFP="$launcher -np \$ntasks $mpmd"
 
-elif [ $step = "wafsgcip" ]; then
-
-    export MPIRUN="$launcher -np $npe_wafsgcip $mpmd"
-
 elif [ $step = "waveawipsbulls" ]; then
 
     unset PERL5LIB

--- a/parm/config/config.efcs
+++ b/parm/config/config.efcs
@@ -65,14 +65,12 @@ if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
     export  ichunk3d=0; export jchunk3d=0;  export kchunk3d=0
     RESTILE=`echo $CASE_ENKF |cut -c 2-`
     export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
-    if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
-        if [ $RESTILE -ge 384 ]; then
-            export ichunk2d=$((4*RESTILE))
-            export jchunk2d=$((2*RESTILE))
-            export ichunk3d=$((4*RESTILE))
-            export jchunk3d=$((2*RESTILE))
-            export kchunk3d=1
-        fi
+    if [ $RESTILE -ge 384 ]; then
+        export ichunk2d=$((4*RESTILE))
+        export jchunk2d=$((2*RESTILE))
+        export ichunk3d=$((4*RESTILE))
+        export jchunk3d=$((2*RESTILE))
+        export kchunk3d=1
     fi
 fi
 

--- a/parm/config/config.fcst
+++ b/parm/config/config.fcst
@@ -160,18 +160,13 @@ if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
     else
         export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
     fi
-    if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
-        if [ $RESTILE -ge 768 ]; then
-            export ichunk3d=$((4*RESTILE)) 
-            export jchunk3d=$((2*RESTILE))
-            export kchunk3d=1
-        fi
-    fi
-    if [[ "$machine" == "HERA" ]] || [[ "$machine" == "ORION" ]]; then
+    if [ $RESTILE -ge 768 ]; then
         export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
-        if [ $RESTILE -le 192 ]; then
-            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
-        fi
+        export ichunk3d=$((4*RESTILE))
+        export jchunk3d=$((2*RESTILE))
+        export kchunk3d=1
+        export ichunk2d=$((4*RESTILE))
+        export jchunk2d=$((2*RESTILE))
     fi
 fi
 

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -25,9 +25,7 @@ echo $topdir
 echo fv3gfs checkout ...
 if [[ ! -d fv3gfs.fd ]] ; then
     rm -f ${topdir}/checkout-fv3gfs.log
-    git clone --recursive --branch gfs_v16.0.16_on_cactus_dogwood https://github.com/DusanJovic-NOAA/ufs-weather-model fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
-    cd fv3gfs.fd
-    git submodule update --init --recursive
+    git clone --recursive --branch GFS.v16.2.0 https://github.com/ufs-community/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory fv3gfs.fd already exists.'
@@ -38,7 +36,6 @@ if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
     git clone --recursive --branch feature/gfsda.v16.1.5_wcoss2_port https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
-    #git checkout feature/gfsda.v16.1.5_wcoss2_port
     git submodule update
     cd ${topdir}
 else
@@ -48,9 +45,7 @@ fi
 echo gldas checkout ...
 if [[ ! -d gldas.fd ]] ; then
     rm -f ${topdir}/checkout-gldas.log
-    git clone https://github.com/NOAA-EMC/GLDAS  gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
-    cd gldas.fd
-    git checkout gldas_gfsv16_release.v1.20.0
+    git clone --branch gldas_gfsv16_release.v1.22.0 https://github.com/NOAA-EMC/GLDAS  gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory gldas.fd already exists.'
@@ -59,9 +54,7 @@ fi
 echo ufs_utils checkout ...
 if [[ ! -d ufs_utils.fd ]] ; then
     rm -f ${topdir}/checkout-ufs_utils.log
-    git clone https://github.com/GeorgeGayno-NOAA/UFS_UTILS.git ufs_utils.fd >> ${topdir}/checkout-ufs_utils.fd.log 2>&1
-    cd ufs_utils.fd
-    git checkout feature/gfsv16.0.0-wcoss2
+    git clone --branch ops-gfsv16.2.0 https://github.com/ufs-community/UFS_UTILS ufs_utils.fd >> ${topdir}/checkout-ufs_utils.fd.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory ufs_utils.fd already exists.'
@@ -70,7 +63,7 @@ fi
 echo EMC_post checkout ...
 if [[ ! -d gfs_post.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_post.log
-    git clone ${gtg_git_args:-} -b upp_v8.1.0 https://github.com/NOAA-EMC/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
+    git clone ${gtg_git_args:-} --branch upp_v8.1.0 https://github.com/NOAA-EMC/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
     ################################################################################
     # checkout_gtg
     ## yes: The gtg code at NCAR private repository is available for ops. GFS only.
@@ -91,9 +84,7 @@ fi
 echo EMC_gfs_wafs checkout ...
 if [[ ! -d gfs_wafs.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_wafs.log
-    git clone --recursive https://github.com/NOAA-EMC/EMC_gfs_wafs.git gfs_wafs.fd >> ${topdir}/checkout-gfs_wafs.log 2>&1
-    cd gfs_wafs.fd
-    git checkout gfs_wafs.v6.2.1
+    git clone --recursive --branch gfs_wafs.v6.2.2 https://github.com/NOAA-EMC/EMC_gfs_wafs.git gfs_wafs.fd >> ${topdir}/checkout-gfs_wafs.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory gfs_wafs.fd already exists.'
@@ -102,9 +93,7 @@ fi
 echo EMC_verif-global checkout ...
 if [[ ! -d verif-global.fd ]] ; then
     rm -f ${topdir}/checkout-verif-global.log
-    git clone --recursive https://github.com/NOAA-EMC/EMC_verif-global.git verif-global.fd >> ${topdir}/checkout-verif-global.log 2>&1
-    cd verif-global.fd
-    git checkout verif_global_v1.11.0
+    git clone --recursive --branch verif_global_v1.11.0 https://github.com/NOAA-EMC/EMC_verif-global.git verif-global.fd >> ${topdir}/checkout-verif-global.log 2>&1
     cd ${topdir}
 else
     echo 'Skip. Directory verif-global.fd already exist.'

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -4,6 +4,7 @@ export ukmet_ver=v2.2.0
 export ecmwf_ver=v2.1.0
 export nam_ver=v4.2.0
 export rtofs_ver=v2.2.0
+export radarl2_ver=v1.2
 export COMPATH=/lfs/h1/ops/canned/com/ukmet:/lfs/h1/ops/canned/com/gfs:/lfs/h1/ops/canned/com/ecmwf:/lfs/h1/ops/canned/com/nam:/lfs/h1/ops/canned/com/hourly
 
 export envvar_ver=1.0


### PR DESCRIPTION
This PR contains the following WCOSS2 port changes:

1. remove now-unneeded `MPIRUN` setting in WCOSS2.env for the wafsgcip job; the WAFS scripts were updated to set correctly
2. update chunk setting sections in both config.efcs and config.fcst; will now always set chunk settings for C768+ deterministic and C384+ enkf fcst on all supported platforms
3. add `radarl2_ver=v1.2` to run.ver to support WAFS
4. update component versions in checkout.sh and cleanup/consolidate clone commands: 

- ufs-weather-model -> GFS.v16.2.0
- GLDAS -> gldas_gfsv16_release.v1.22.0
- UFS_UTILS -> ops-gfsv16.2.0
- WAFS -> gfs_wafs.v6.2.2