### PR TITLE
Add OMP_STACKSIZE to WCOSS2.env for forecast

### DIFF
--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -19,9 +19,6 @@ export mpmd="--cpu-bind verbose,core cfp"
 
 export npe_node_max=128
 
-# Configure MPI environment
-#export MKL_CBWR=AVX2
-
 export job=${PBS_JOBNAME:-$step}
 export jobid=${job}.${PBS_JOBID:-$$}
 
@@ -122,6 +119,7 @@ elif [ $step = "eupd" ]; then
 
 elif [ $step = "fcst" ]; then
 
+    export OMP_STACKSIZE=2048M
     export FI_OFI_RXM_RX_SIZE=40000
     export FI_OFI_RXM_TX_SIZE=40000
 


### PR DESCRIPTION
- add "export OMP_STACKSIZE=2048M" to fcst block in WCOSS2.env
- needed after removing KMP variables in prior commit
- remove commented out MKL_CBWR variable, won't be using

Refs: #399