### PR TITLE
Build updates based on NCO feedback

### DIFF
--- a/driver/product/run_JGDAS_ATMOS_GEMPAK_META_NCDC_wcoss2.sh_00
+++ b/driver/product/run_JGDAS_ATMOS_GEMPAK_META_NCDC_wcoss2.sh_00
@@ -39,7 +39,6 @@ export driver=/lfs/h2/emc/vpppg/noscrub/$USER/packages/gfs.$gfs_ver/driver
 ####################################
 ##  Load the GRIB Utilities module
 #####################################
-module load envvar/$envvar_ver
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load craype/$craype_ver
 module load intel/$intel_ver

--- a/driver/product/run_JGDAS_ATMOS_GEMPAK_wcoss2.sh_00
+++ b/driver/product/run_JGDAS_ATMOS_GEMPAK_wcoss2.sh_00
@@ -40,7 +40,6 @@ export driver=/lfs/h2/emc/vpppg/noscrub/$USER/packages/gfs.$gfs_ver/driver
 ####################################
 ##  Load the GRIB Utilities module
 #####################################
-module load envvar/$envvar_ver
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load craype/$craype_ver
 module load intel/$intel_ver

--- a/driver/product/run_JGFS_ATMOS_AWIPS_20KM_1P0DEG_wcoss2.sh_00
+++ b/driver/product/run_JGFS_ATMOS_AWIPS_20KM_1P0DEG_wcoss2.sh_00
@@ -39,7 +39,6 @@ export driver=/lfs/h2/emc/vpppg/noscrub/$USER/packages/gfs.$gfs_ver/driver
 ####################################
 ##  Load the GRIB Utilities module
 #####################################
-module load envvar/$envvar_ver
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load craype/$craype_ver
 module load intel/$intel_ver

--- a/driver/product/run_JGFS_ATMOS_AWIPS_G2_wcoss2.sh_00
+++ b/driver/product/run_JGFS_ATMOS_AWIPS_G2_wcoss2.sh_00
@@ -39,7 +39,6 @@ export driver=/lfs/h2/emc/vpppg/noscrub/$USER/packages/gfs.$gfs_ver/driver
 ####################################
 ##  Load the GRIB Utilities module
 #####################################
-module load envvar/$envvar_ver
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load craype/$craype_ver
 module load intel/$intel_ver

--- a/driver/product/run_JGFS_ATMOS_FBWIND_wcoss2.sh_00
+++ b/driver/product/run_JGFS_ATMOS_FBWIND_wcoss2.sh_00
@@ -39,7 +39,6 @@ export driver=/lfs/h2/emc/vpppg/noscrub/$USER/packages/gfs.$gfs_ver/driver
 ####################################
 ##  Load the GRIB Utilities module
 #####################################
-module load envvar/$envvar_ver
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load craype/$craype_ver
 module load intel/$intel_ver

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_META_wcoss2.sh_00
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_META_wcoss2.sh_00
@@ -39,7 +39,6 @@ export driver=/lfs/h2/emc/vpppg/noscrub/$USER/packages/gfs.$gfs_ver/driver
 ####################################
 ##  Load the GRIB Utilities module
 #####################################
-module load envvar/$envvar_ver
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load craype/$craype_ver
 module load intel/$intel_ver

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_META_wcoss2.sh_12
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_META_wcoss2.sh_12
@@ -39,7 +39,6 @@ export driver=/lfs/h2/emc/vpppg/noscrub/$USER/packages/gfs.$gfs_ver/driver
 ####################################
 ##  Load the GRIB Utilities module
 #####################################
-module load envvar/$envvar_ver
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load craype/$craype_ver
 module load intel/$intel_ver

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF_wcoss2.sh_00
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF_wcoss2.sh_00
@@ -40,7 +40,6 @@ export driver=/lfs/h2/emc/vpppg/noscrub/$USER/packages/gfs.$gfs_ver/driver
 ####################################
 ##  Load the GRIB Utilities module
 #####################################
-module load envvar/$envvar_ver
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load craype/$craype_ver
 module load intel/$intel_ver

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_PGRB2_SPEC_wcoss2.sh_00
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_PGRB2_SPEC_wcoss2.sh_00
@@ -40,7 +40,6 @@ export driver=/lfs/h2/emc/vpppg/noscrub/$USER/packages/gfs.$gfs_ver/driver
 ####################################
 ##  Load the GRIB Utilities module
 #####################################
-module load envvar/$envvar_ver
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load craype/$craype_ver
 module load intel/$intel_ver

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_wcoss2.sh_00
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_wcoss2.sh_00
@@ -42,7 +42,6 @@ export driver=/lfs/h2/emc/vpppg/noscrub/$USER/packages/gfs.$gfs_ver/driver
 ####################################
 ##  Load the GRIB Utilities module
 #####################################
-module load envvar/$envvar_ver
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load craype/$craype_ver
 module load intel/$intel_ver

--- a/driver/product/run_JGFS_ATMOS_GEMPAK_wcoss2.sh_12
+++ b/driver/product/run_JGFS_ATMOS_GEMPAK_wcoss2.sh_12
@@ -42,7 +42,6 @@ export driver=/lfs/h2/emc/vpppg/noscrub/$USER/packages/gfs.$gfs_ver/driver
 ####################################
 ##  Load the GRIB Utilities module
 #####################################
-module load envvar/$envvar_ver
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load craype/$craype_ver
 module load intel/$intel_ver

--- a/driver/product/run_JGFS_ATMOS_PGRB2_SPEC_NPOESS_wcoss2.sh_00
+++ b/driver/product/run_JGFS_ATMOS_PGRB2_SPEC_NPOESS_wcoss2.sh_00
@@ -39,7 +39,6 @@ export driver=/lfs/h2/emc/vpppg/noscrub/$USER/packages/gfs.$gfs_ver/driver
 ####################################
 ##  Load the GRIB Utilities module
 #####################################
-module load envvar/$envvar_ver
 module load PrgEnv-intel/$PrgEnv_intel_ver
 module load craype/$craype_ver
 module load intel/$intel_ver

--- a/driver/product/run_postsnd.sh.wcoss2
+++ b/driver/product/run_postsnd.sh.wcoss2
@@ -14,11 +14,10 @@ set -xa
 pwd
 cd $PBS_O_WORKDIR
 module list
-module purge
+module reset
 source ../../versions/run.ver
 pwd
 
-module load envvar/$envvar_ver
 module load intel/$intel_ver
 module load prod_envir/$prod_envir_ver
 module load PrgEnv-intel/$PrgEnv_intel_ver

--- a/modulefiles/fv3gfs/enkf_chgres_recenter.wcoss2.lua
+++ b/modulefiles/fv3gfs/enkf_chgres_recenter.wcoss2.lua
@@ -16,4 +16,4 @@ load(pathJoin("nemsio", os.getenv("nemsio_ver")))
 load(pathJoin("ip", os.getenv("ip_ver")))
 load(pathJoin("sp", os.getenv("sp_ver")))
 
-setenv("FC","ifort")
+setenv("FC","ftn")

--- a/modulefiles/fv3gfs/enkf_chgres_recenter_nc.wcoss2.lua
+++ b/modulefiles/fv3gfs/enkf_chgres_recenter_nc.wcoss2.lua
@@ -15,4 +15,4 @@ load(pathJoin("w3nco", os.getenv("w3nco_ver")))
 load(pathJoin("ip", os.getenv("ip_ver")))
 load(pathJoin("sp", os.getenv("sp_ver")))
 
-setenv("FC","mpiifort")
+setenv("FC","ftn")

--- a/modulefiles/fv3gfs/gaussian_sfcanl.wcoss2.lua
+++ b/modulefiles/fv3gfs/gaussian_sfcanl.wcoss2.lua
@@ -17,4 +17,4 @@ load(pathJoin("w3nco", os.getenv("w3nco_ver")))
 load(pathJoin("nemsio", os.getenv("nemsio_ver")))
 load(pathJoin("sp", os.getenv("sp_ver")))
 
-setenv("FCOMP","ifort")
+setenv("FCOMP","ftn")

--- a/modulefiles/module-setup.csh.inc
+++ b/modulefiles/module-setup.csh.inc
@@ -52,8 +52,7 @@ else if ( { test -d /lfs/h2 } ) then
     if ( ! { module help >& /dev/null } ) then
         source /usr/share/lmod/lmod/init/$__ms_shell
     fi
-    module purge
-    module load envvar/1.0
+    module reset
 else if ( { test -d /glade } ) then
     # We are on NCAR Yellowstone
     if ( ! { module help >& /dev/null } ) then

--- a/modulefiles/module-setup.sh.inc
+++ b/modulefiles/module-setup.sh.inc
@@ -69,8 +69,7 @@ elif [[ -d /lfs/h2 ]] ; then
         echo load the module command 1>&2
         source /usr/share/lmod/lmod/init/$__ms_shell
     fi
-    module purge
-    module load envvar/1.0
+    module reset
 elif [[ -d /glade ]] ; then
     # We are on NCAR Yellowstone
     if ( ! eval module help > /dev/null 2>&1 ) ; then

--- a/modulefiles/modulefile.fv3nc2nemsio.wcoss2.lua
+++ b/modulefiles/modulefile.fv3nc2nemsio.wcoss2.lua
@@ -14,5 +14,5 @@ load(pathJoin("bacio", os.getenv("bacio_ver")))
 load(pathJoin("w3nco", os.getenv("w3nco_ver")))
 load(pathJoin("nemsio", os.getenv("nemsio_ver")))
 
-setenv("FCMP","ifort")
-setenv("FFLAGS","-free -O3 -xHOST")
+setenv("FCMP","ftn")
+setenv("FFLAGS","-free -O3")

--- a/modulefiles/modulefile.regrid_nemsio.wcoss2.lua
+++ b/modulefiles/modulefile.regrid_nemsio.wcoss2.lua
@@ -15,4 +15,4 @@ load(pathJoin("w3nco", os.getenv("w3nco_ver")))
 load(pathJoin("nemsio", os.getenv("nemsio_ver")))
 load(pathJoin("sp", os.getenv("sp_ver")))
 
-setenv("FCMP","mpiifort")
+setenv("FCMP","ftn")

--- a/modulefiles/modulefile.storm_reloc_v6.0.0.wcoss2.lua
+++ b/modulefiles/modulefile.storm_reloc_v6.0.0.wcoss2.lua
@@ -20,4 +20,4 @@ load(pathJoin("w3emc", os.getenv("w3emc_ver")))
 load(pathJoin("sp", os.getenv("sp_ver")))
 load(pathJoin("g2", os.getenv("g2_ver")))
 
-setenv("FC","ifort")
+setenv("FC","ftn")

--- a/sorc/build_regrid_nemsio.sh
+++ b/sorc/build_regrid_nemsio.sh
@@ -20,7 +20,7 @@ export F77=${FCMP}
 
 export FCFFLAGS="" # "-convert native -assume byterecl -heap-arrays -mcmodel=large -shared-intel"
 export LDFLAGS="${FCFFLAGS}"
-export OPTIMIZATION="-O3 -xHOST" #-axCORE-AVX2,AVX -xSSE4.2 -O3
+export OPTIMIZATION="-O3" #-axCORE-AVX2,AVX -xSSE4.2 -O3
 export DEBUG="-traceback -g" #-O0 #-C #-fp-stack-check #-check all -fp-stack-check
 
 if [ $target != hera ]; then

--- a/sorc/build_tropcy_NEMS.sh
+++ b/sorc/build_tropcy_NEMS.sh
@@ -29,7 +29,7 @@ if [ $target = "wcoss2" ]; then
   SIGIO_INC4=$SIGIO_INC
 fi
 
-export FC=mpiifort
+export FC=ftn
 export JASPER_LIB=${JASPER_LIB:-$JASPER_LIBRARY_DIRS/libjasper.a}
 
 export INC="${G2_INCd} -I${NEMSIO_INC}"

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -84,7 +84,7 @@ fi
 echo EMC_gfs_wafs checkout ...
 if [[ ! -d gfs_wafs.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_wafs.log
-    git clone --recursive --branch gfs_wafs.v6.2.5 https://github.com/NOAA-EMC/EMC_gfs_wafs.git gfs_wafs.fd >> ${topdir}/checkout-gfs_wafs.log 2>&1
+    git clone --recursive --branch gfs_wafs.v6.2.6 https://github.com/NOAA-EMC/EMC_gfs_wafs.git gfs_wafs.fd >> ${topdir}/checkout-gfs_wafs.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory gfs_wafs.fd already exists.'

--- a/sorc/fbwndgfs.fd/makefile.GENERIC
+++ b/sorc/fbwndgfs.fd/makefile.GENERIC
@@ -40,7 +40,7 @@ OBJS=   fbwndgfs.o
 # CMD		Name of the executable
 # PROFLIB	Library needed for profiling
 #
-FC =	        ifort
+FC =	        ftn
 LDFLAGS =	
 LIBS = ${W3NCO_LIB8} ${W3EMC_LIB8} ${BACIO_LIB8} ${IP_LIB8} ${SP_LIB8}
 CMD =		fbwndgfs

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -105,8 +105,7 @@ elif [[ -d /lfs/h2 ]] ; then
         source /usr/share/lmod/lmod/init/$__ms_shell
     fi
     target=wcoss2
-    module purge
-    module load envvar/1.0
+    module reset
 
 ##---------------------------------------------------------------------------
 

--- a/sorc/supvit.fd/makefile
+++ b/sorc/supvit.fd/makefile
@@ -1,7 +1,7 @@
 SHELL=  /bin/sh
 ISIZE = 4
 RSIZE = 8
-COMP=   ifort
+COMP=   ftn
 ##LIBS_SUP=   -L/contrib/nceplibs/nwprod/lib -lw3emc_d -lw3nco_d -lg2_d -lbacio_4 -ljasper -lpng -lz
 LDFLAGS= 
 ##ccs FFLAGS= -O -qflttrap=ov:zero:inv:enable -qcheck -qextchk -qwarn64 -qintsize=$(ISIZE) -qrealsize=$(RSIZE)

--- a/sorc/syndat_getjtbul.fd/makefile
+++ b/sorc/syndat_getjtbul.fd/makefile
@@ -1,7 +1,7 @@
 SHELL=		/bin/sh
 #LIBS=		-L/nwprod/lib -lw3nco_v2.0.5_4
 #LIBS=		-L/contrib/nceplibs/nwprod/lib -lw3nco_v2.0.5_4
-FC=		ifort   
+FC=		ftn
 #DEBUG = 	-ftrapuv  -check all  -fp-stack-check  -fstack-protector
 ##DEBUG = 	-ftrapuv  -fp-stack-check  -fstack-protector
 FFLAGS=		-O3 -g -traceback -assume noold_ldout_format $(DEBUG)

--- a/sorc/syndat_maksynrc.fd/makefile
+++ b/sorc/syndat_maksynrc.fd/makefile
@@ -1,7 +1,7 @@
 SHELL=		/bin/sh
 #LIBS=		-L/nwprod/lib -lw3nco_v2.0.5_4 -lbacio_v2.0.1_4 
 ##LIBS_SYN_MAK=		-L/contrib/nceplibs/nwprod/lib -lw3nco_v2.0.5_4 -lbacio_v2.0.1_4 
-FC=		ifort   
+FC=		ftn
 #DEBUG =          -ftrapuv -check all -check nooutput_conversion -fp-stack-check -fstack-protector
 FFLAGS=		-O3 -g -traceback -assume noold_ldout_format $(DEBUG)
 LDFLAGS=	

--- a/sorc/syndat_qctropcy.fd/makefile
+++ b/sorc/syndat_qctropcy.fd/makefile
@@ -1,7 +1,7 @@
 SHELL=		/bin/sh
 #LIBS=		-L/nwprod/lib -lw3nco_v2.0.5_8
 ##LIBS=		-L/contrib/nceplibs/nwprod/lib -lw3nco_v2.0.5_8
-FC=		ifort
+FC=		ftn
 #DEBUG =		-ftrapuv -check all -check noarg_temp_created -fp-stack-check -fstack-protector
 ## if '-check all' enabled, include '-check noarg_temp_created' to avoid warning msgs indicating 
 ##   slight performance hit due to chosen method of passing array arguments to w3difdat  

--- a/sorc/tave.fd/makefile
+++ b/sorc/tave.fd/makefile
@@ -1,7 +1,7 @@
 SHELL=  /bin/sh
 ISIZE = 4
 RSIZE = 8
-COMP=   ifort
+COMP=   ftn
 ##INC = /contrib/nceplibs/nwprod/lib/incmod/g2_d
 ##LIBS=    -L/contrib/nceplibs/nwprod/lib -lw3emc_d -lw3nco_d -lg2_d -lbacio_4 -ljasper -lpng -lz
 LDFLAGS= 

--- a/sorc/vint.fd/makefile
+++ b/sorc/vint.fd/makefile
@@ -1,7 +1,7 @@
 SHELL=  /bin/sh
 ISIZE = 4
 RSIZE = 8
-COMP=   ifort
+COMP=   ftn
 ##INC = /contrib/nceplibs/nwprod/lib/incmod/g2_d
 ##LIBS=   -L/contrib/nceplibs/nwprod/lib -lw3emc_d -lw3nco_d -lg2_d -lbacio_4 -ljasper -lpng -lz
 LDFLAGS=

--- a/util/sorc/mkgfsawps.fd/makefile.wcoss2
+++ b/util/sorc/mkgfsawps.fd/makefile.wcoss2
@@ -12,7 +12,7 @@ OBJS=	mkgfsawps.o
 # CMD		Name of the executable
 # PROFLIB	Library needed for profiling
 #
-FC =       ifort     
+FC =       ftn
 
 LDFLAGS =
 IOMP5_LIB=/pe/intel/compilers_and_libraries_2020.4.304/linux/compiler/lib/intel64/libiomp5.a

--- a/util/sorc/overgridid.fd/makefile
+++ b/util/sorc/overgridid.fd/makefile
@@ -1,7 +1,7 @@
 LIBS =    ${W3NCO_LIB4} ${BACIO_LIB4}
 OBJS=     overgridid.o
 overgridid:	overgridid.f
-	ifort -o overgridid overgridid.f $(LIBS)
+	ftn -o overgridid overgridid.f $(LIBS)
 clean:
 	-rm -f $(OBJS)
 

--- a/util/sorc/rdbfmsua.fd/makefile.wcoss2
+++ b/util/sorc/rdbfmsua.fd/makefile.wcoss2
@@ -38,7 +38,7 @@ OBJS=	rdbfmsua.o
 # LIBS		List of libraries
 # CMD		Name of the executable
 #
-FC =		ifort	
+FC =		ftn
 # FFLAGS =	-O3 -q32 -I${GEMINC} -I${NAWIPS}/os/${NA_OS}/include
 # FFLAGS =	-I${GEMINC} -I${NAWIPS}/os/${NA_OS}/include
 FFLAGS =	-I${GEMINC} -I${OS_INC}

--- a/util/sorc/terrain.fd/makefile.sh
+++ b/util/sorc/terrain.fd/makefile.sh
@@ -4,7 +4,7 @@ set -x
 machine=${machine:-WCOSS}
 
 if [ $machine = WCOSS ] ; then
- CF=ifort
+ CF=ftn
  export MP_CORE_FILE_FORMAT=lite
  #FFOPTS="-g -O0 -i4 -r8 -check all -ftrapuv -convert big_endian -fp-stack-check -fstack-protector -heap-arrays -recursiv -traceback -openmp"
  FFOPTS="-i4 -O3 -r8  -convert big_endian -fp-model precise -openmp"

--- a/util/sorc/webtitle.fd/makefile
+++ b/util/sorc/webtitle.fd/makefile
@@ -11,7 +11,7 @@ OBJS=   webtitle.o
 # CMD		Name of the executable
 # PROFLIB	Library needed for profiling
 #
-FC =	ifort 
+FC =	ftn
 
 LIBS=   ${W3NCO_LIB4}
 

--- a/versions/build.ver
+++ b/versions/build.ver
@@ -1,11 +1,12 @@
-export envvar_ver=1.0
 export PrgEnv_intel_ver=8.1.0
 export intel_ver=19.1.3.304
-export craype_ver=2.7.8
+export craype_ver=2.7.10
 export cray_mpich_ver=8.1.9
 
+export cmake_ver=3.20.2
+
 export python_ver=3.8.6
-export gempak_ver=7.14.0
+export gempak_ver=7.14.1
 export jasper_ver=2.0.25
 export libpng_ver=1.6.37
 
@@ -23,12 +24,14 @@ export bacio_ver=2.4.1
 export w3nco_ver=2.4.1
 export nemsio_ver=2.5.2
 export sigio_ver=2.3.2
-export w3emc_ver=2.7.3
+export w3emc_ver=2.9.2
 export bufr_ver=11.4.0
-export g2_ver=3.4.1
+export g2_ver=3.4.5
 export zlib_ver=1.2.11
 export sp_ver=2.3.3
 export ip_ver=3.3.3
 export wrf_io_ver=1.1.1
 export gfsio_ver=1.4.1
 export sfcio_ver=1.4.1
+
+export upp_ver=8.1.0


### PR DESCRIPTION
This PR contains the following WCOSS2 build updates based on feedback from NCO (SPA Wei):

1. update WAFS tag to `gfs_wafs.v6.2.6`
2. change `ifort` and `mpiifort` to `ftn` in builds
3. remove references to `-xHOST`
4. replace `module purge` with `module reset` throughout (for WCOSS2)
5. remove loading/instances of `envvar` module (no longer needed with a `module reset`, had been needed after a `module purge`
6. multiple updates to build.ver:

- remove `envvar` module
- add `cmake_ver=3.20.2`
- add `upp_ver=8.1.0`
- change `craype_ver` from `2.7.8` to `2.7.10`
- change `gempak_ver` from `7.14.0` to `7.14.1`
- change `w3emc_ver` from `2.7.3` to `2.9.2`
- change `g2_ver` from `3.4.1` to `3.4.5`