### PR TITLE
Load compiler env. and modules in the ecf scripts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__
 *.pyc
 *.[aox]
 *.mod
+*.sw[a-p]
 
 # Ignore folders
 #-------------------

--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_diag.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_diag.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_select_obs.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_select_obs.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_update.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_update.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/enkfgdas/analysis/recenter/ecen/jenkfgdas_ecen.ecf
+++ b/ecf/scripts/enkfgdas/analysis/recenter/ecen/jenkfgdas_ecen.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load python/${python_ver}

--- a/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
+++ b/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load python/${python_ver}

--- a/ecf/scripts/enkfgdas/forecast/jenkfgdas_fcst.ecf
+++ b/ecf/scripts/enkfgdas/forecast/jenkfgdas_fcst.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load esmf/${esmf_ver}

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_f003.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_f003.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load hdf5/${hdf5_ver}

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_f004.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_f004.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load hdf5/${hdf5_ver}

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_f005.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_f005.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load hdf5/${hdf5_ver}

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_f006.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_f006.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load hdf5/${hdf5_ver}

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_f007.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_f007.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load hdf5/${hdf5_ver}

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_f008.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_f008.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load hdf5/${hdf5_ver}

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_f009.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_f009.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load hdf5/${hdf5_ver}

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_calc.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_calc.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load python/${python_ver}

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_diag.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_diag.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak.ecf
+++ b/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak_meta_ncdc.ecf
+++ b/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak_meta_ncdc.ecf
@@ -21,6 +21,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load gempak/${gempak_ver}
 module load libjpeg/${libjpeg_ver}

--- a/ecf/scripts/gdas/atmos/init/jgdas_atmos_gldas.ecf
+++ b/ecf/scripts/gdas/atmos/init/jgdas_atmos_gldas.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/obsproc/dump/jgdas_atmos_dump.ecf
+++ b/ecf/scripts/gdas/atmos/obsproc/dump/jgdas_atmos_dump.ecf
@@ -28,6 +28,9 @@ module use /lfs/h2/emc/obsproc/noscrub/Shelley.Melchior/install/bufr-dump/module
 module load bufr_dump/1.0.0
 ####
 
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load netcdf/${netcdf_ver}

--- a/ecf/scripts/gdas/atmos/obsproc/dump/jgdas_atmos_dump_alert.ecf
+++ b/ecf/scripts/gdas/atmos/obsproc/dump/jgdas_atmos_dump_alert.ecf
@@ -27,6 +27,9 @@ module use /lfs/h2/emc/obsproc/noscrub/Shelley.Melchior/install/bufr-dump/module
 module load bufr_dump/1.0.0
 ####
 
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load netcdf/${netcdf_ver}

--- a/ecf/scripts/gdas/atmos/obsproc/dump/jgdas_atmos_dump_post.ecf
+++ b/ecf/scripts/gdas/atmos/obsproc/dump/jgdas_atmos_dump_post.ecf
@@ -28,6 +28,9 @@ module use /lfs/h2/emc/obsproc/noscrub/Shelley.Melchior/install/bufr-dump/module
 module load bufr_dump/1.0.0
 ####
 
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load netcdf/${netcdf_ver}

--- a/ecf/scripts/gdas/atmos/obsproc/dump/jgdas_atmos_tropcy_qc_reloc.ecf
+++ b/ecf/scripts/gdas/atmos/obsproc/dump/jgdas_atmos_tropcy_qc_reloc.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_emcsfc_sfc_prep.ecf
+++ b/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_emcsfc_sfc_prep.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_prep.ecf
+++ b/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_prep.ecf
@@ -28,6 +28,9 @@ module use /lfs/h2/emc/obsproc/noscrub/Shelley.Melchior/install/bufr-dump/module
 module load bufr_dump/1.0.0
 ####
 
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load netcdf/${netcdf_ver}

--- a/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_prep_post.ecf
+++ b/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_prep_post.ecf
@@ -27,6 +27,9 @@ export model=obsproc
 module use /lfs/h2/emc/obsproc/noscrub/Shelley.Melchior/install/bufr-dump/modulefiles
 module load bufr_dump/1.0.0
 ####
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load netcdf/${netcdf_ver}

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_anl.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_anl.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f000.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f000.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f001.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f001.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f002.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f002.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f003.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f003.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f004.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f004.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f005.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f005.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f006.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f006.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f007.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f007.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f008.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f008.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f009.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_f009.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/post_processing/jgdas_atmos_chgres_forenkf.ecf
+++ b/ecf/scripts/gdas/atmos/post_processing/jgdas_atmos_chgres_forenkf.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfozn.ecf
+++ b/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfozn.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load netcdf/${netcdf_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfrad.ecf
+++ b/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfrad.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load netcdf/${netcdf_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gdas/atmos/verf/jgdas_atmos_vminmon.ecf
+++ b/ecf/scripts/gdas/atmos/verf/jgdas_atmos_vminmon.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load perl/${perl_ver}
 module load util_shared/${util_shared_ver}
 

--- a/ecf/scripts/gdas/enkf/analysis/create/jgdas_enkf_diag.ecf
+++ b/ecf/scripts/gdas/enkf/analysis/create/jgdas_enkf_diag.ecf
@@ -22,6 +22,9 @@ model=gfs
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/enkf/analysis/create/jgdas_enkf_select_obs.ecf
+++ b/ecf/scripts/gdas/enkf/analysis/create/jgdas_enkf_select_obs.ecf
@@ -22,6 +22,9 @@ model=gfs
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/enkf/analysis/create/jgdas_enkf_update.ecf
+++ b/ecf/scripts/gdas/enkf/analysis/create/jgdas_enkf_update.ecf
@@ -22,6 +22,9 @@ model=gfs
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/enkf/analysis/recenter/ecen/jgdas_enkf_ecen.ecf
+++ b/ecf/scripts/gdas/enkf/analysis/recenter/ecen/jgdas_enkf_ecen.ecf
@@ -22,6 +22,9 @@ model=gfs
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load python/${python_ver}

--- a/ecf/scripts/gdas/enkf/analysis/recenter/jgdas_enkf_sfc.ecf
+++ b/ecf/scripts/gdas/enkf/analysis/recenter/jgdas_enkf_sfc.ecf
@@ -22,6 +22,9 @@ model=gfs
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load python/${python_ver}

--- a/ecf/scripts/gdas/enkf/forecast/jgdas_enkf_fcst.ecf
+++ b/ecf/scripts/gdas/enkf/forecast/jgdas_enkf_fcst.ecf
@@ -22,6 +22,9 @@ model=gfs
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load esmf/${esmf_ver}

--- a/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f003.ecf
+++ b/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f003.ecf
@@ -23,6 +23,9 @@ model=gfs
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load hdf5/${hdf5_ver}

--- a/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f004.ecf
+++ b/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f004.ecf
@@ -23,6 +23,9 @@ model=gfs
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load hdf5/${hdf5_ver}

--- a/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f005.ecf
+++ b/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f005.ecf
@@ -23,6 +23,9 @@ model=gfs
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load hdf5/${hdf5_ver}

--- a/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f006.ecf
+++ b/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f006.ecf
@@ -23,6 +23,9 @@ model=gfs
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load hdf5/${hdf5_ver}

--- a/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f007.ecf
+++ b/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f007.ecf
@@ -23,6 +23,9 @@ model=gfs
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load hdf5/${hdf5_ver}

--- a/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f008.ecf
+++ b/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f008.ecf
@@ -23,6 +23,9 @@ model=gfs
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load hdf5/${hdf5_ver}

--- a/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f009.ecf
+++ b/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f009.ecf
@@ -23,6 +23,9 @@ model=gfs
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load hdf5/${hdf5_ver}

--- a/ecf/scripts/gdas/jgdas_forecast.ecf
+++ b/ecf/scripts/gdas/jgdas_forecast.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load esmf/${esmf_ver}

--- a/ecf/scripts/gdas/wave/post/jgdas_wave_postpnt.ecf
+++ b/ecf/scripts/gdas/wave/post/jgdas_wave_postpnt.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 ## Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/wave/post/jgdas_wave_postsbs.ecf
+++ b/ecf/scripts/gdas/wave/post/jgdas_wave_postsbs.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 ## Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
+++ b/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 ## Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis.ecf
+++ b/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis_calc.ecf
+++ b/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis_calc.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load python/${python_ver}

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_meta.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_meta.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_ncdc_upapgif.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_ncdc_upapgif.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load gempak/${gempak_ver}
 module load libjpeg/${libjpeg_ver}

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_npoess_pgrb2_0p5deg.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_npoess_pgrb2_0p5deg.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_pgrb2_spec_gempak.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_pgrb2_spec_gempak.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_dump.ecf
+++ b/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_dump.ecf
@@ -26,6 +26,9 @@ export model=obsproc
 module use /lfs/h2/emc/obsproc/noscrub/Shelley.Melchior/install/bufr-dump/modulefiles
 module load bufr_dump/1.0.0
 ####
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load netcdf/${netcdf_ver}

--- a/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_dump_alert.ecf
+++ b/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_dump_alert.ecf
@@ -25,6 +25,9 @@ export model=obsproc
 module use /lfs/h2/emc/obsproc/noscrub/Shelley.Melchior/install/bufr-dump/modulefiles
 module load bufr_dump/1.0.0
 ####
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load netcdf/${netcdf_ver}

--- a/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_dump_post.ecf
+++ b/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_dump_post.ecf
@@ -26,6 +26,9 @@ export model=obsproc
 module use /lfs/h2/emc/obsproc/noscrub/Shelley.Melchior/install/bufr-dump/modulefiles
 module load bufr_dump/1.0.0
 ####
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load netcdf/${netcdf_ver}

--- a/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_tropcy_qc_reloc.ecf
+++ b/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_tropcy_qc_reloc.ecf
@@ -23,6 +23,9 @@ export EXPDIR=${HOMEgfs}/parm/config
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_emcsfc_sfc_prep.ecf
+++ b/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_emcsfc_sfc_prep.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_prep.ecf
+++ b/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_prep.ecf
@@ -26,6 +26,9 @@ model=obsproc
 module use /lfs/h2/emc/obsproc/noscrub/Shelley.Melchior/install/bufr-dump/modulefiles
 module load bufr_dump/1.0.0
 ####
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load netcdf/${netcdf_ver}

--- a/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_prep_post.ecf
+++ b/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_prep_post.ecf
@@ -26,6 +26,9 @@ export model=obsproc
 module use /lfs/h2/emc/obsproc/noscrub/Shelley.Melchior/install/bufr-dump/modulefiles
 module load bufr_dump/1.0.0
 ####
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load netcdf/${netcdf_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_anl.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_anl.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f000.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f000.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f001.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f001.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f002.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f002.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f003.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f003.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f004.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f004.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f005.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f005.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f006.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f006.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f007.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f007.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f008.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f008.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f009.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f009.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f010.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f010.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f011.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f011.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f012.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f012.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f013.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f013.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f014.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f014.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f015.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f015.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f016.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f016.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f017.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f017.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f018.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f018.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f019.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f019.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f020.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f020.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f021.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f021.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f022.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f022.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f023.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f023.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f024.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f024.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f025.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f025.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f026.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f026.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f027.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f027.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f028.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f028.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f029.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f029.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f030.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f030.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f031.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f031.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f032.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f032.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f033.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f033.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f034.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f034.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f035.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f035.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f036.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f036.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f037.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f037.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f038.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f038.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f039.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f039.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f040.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f040.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f041.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f041.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f042.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f042.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f043.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f043.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f044.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f044.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f045.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f045.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f046.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f046.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f047.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f047.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f048.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f048.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f049.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f049.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f050.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f050.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f051.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f051.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f052.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f052.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f053.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f053.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f054.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f054.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f055.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f055.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f056.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f056.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f057.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f057.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f058.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f058.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f059.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f059.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f060.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f060.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f061.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f061.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f062.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f062.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f063.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f063.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f064.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f064.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f065.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f065.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f066.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f066.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f067.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f067.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f068.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f068.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f069.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f069.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f070.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f070.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f071.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f071.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f072.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f072.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f073.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f073.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f074.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f074.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f075.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f075.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f076.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f076.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f077.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f077.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f078.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f078.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f079.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f079.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f080.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f080.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f081.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f081.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f082.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f082.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f083.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f083.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f084.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f084.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f085.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f085.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f086.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f086.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f087.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f087.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f088.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f088.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f089.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f089.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f090.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f090.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f091.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f091.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f092.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f092.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f093.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f093.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f094.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f094.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f095.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f095.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f096.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f096.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f097.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f097.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f098.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f098.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f099.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f099.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f100.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f100.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f101.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f101.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f102.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f102.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f103.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f103.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f104.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f104.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f105.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f105.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f106.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f106.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f107.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f107.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f108.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f108.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f109.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f109.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f110.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f110.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f111.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f111.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f112.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f112.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f113.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f113.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f114.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f114.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f115.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f115.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f116.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f116.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f117.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f117.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f118.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f118.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f119.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f119.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f120.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f120.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f123.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f123.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f126.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f126.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f129.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f129.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f132.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f132.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f135.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f135.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f138.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f138.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f141.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f141.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f144.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f144.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f147.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f147.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f150.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f150.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f153.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f153.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f156.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f156.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f159.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f159.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f162.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f162.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f165.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f165.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f168.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f168.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f171.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f171.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f174.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f174.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f177.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f177.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f180.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f180.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f183.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f183.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f186.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f186.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f189.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f189.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f192.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f192.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f195.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f195.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f198.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f198.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f201.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f201.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f204.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f204.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f207.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f207.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f210.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f210.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f213.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f213.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f216.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f216.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f219.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f219.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f222.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f222.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f225.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f225.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f228.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f228.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f231.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f231.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f234.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f234.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f237.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f237.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f240.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f240.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f243.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f243.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f246.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f246.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f249.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f249.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f252.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f252.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f255.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f255.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f258.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f258.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f261.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f261.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f264.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f264.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f267.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f267.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f270.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f270.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f273.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f273.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f276.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f276.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f279.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f279.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f282.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f282.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f285.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f285.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f288.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f288.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f291.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f291.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f294.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f294.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f297.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f297.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f300.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f300.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f303.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f303.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f306.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f306.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f309.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f309.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f312.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f312.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f315.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f315.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f318.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f318.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f321.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f321.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f324.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f324.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f327.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f327.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f330.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f330.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f333.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f333.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f336.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f336.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f339.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f339.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f342.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f342.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f345.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f345.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f348.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f348.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f351.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f351.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f354.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f354.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f357.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f357.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f360.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f360.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f363.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f363.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f366.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f366.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f369.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f369.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f372.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f372.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f375.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f375.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f378.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f378.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f381.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f381.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f384.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_f384.ecf
@@ -25,6 +25,9 @@ export post_times=%HR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f000.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f000.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f003.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f003.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f006.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f006.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f009.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f009.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f012.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f012.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f015.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f015.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f018.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f018.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f021.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f021.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f024.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f024.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f027.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f027.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f030.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f030.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f033.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f033.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f036.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f036.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f039.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f039.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f042.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f042.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f045.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f045.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f048.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f048.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f051.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f051.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f054.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f054.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f057.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f057.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f060.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f060.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f063.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f063.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f066.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f066.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f069.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f069.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f072.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f072.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f075.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f075.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f078.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f078.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f081.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f081.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f084.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f084.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f090.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f090.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f096.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f096.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f102.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f102.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f108.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f108.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f114.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f114.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f120.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f120.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f126.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f126.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f132.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f132.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f138.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f138.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f144.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f144.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f150.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f150.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f156.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f156.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f162.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f162.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f168.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f168.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f174.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f174.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f180.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f180.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f186.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f186.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f192.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f192.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f198.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f198.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f204.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f204.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f210.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f210.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f216.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f216.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f222.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f222.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f228.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f228.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f234.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f234.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f240.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f240.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f000.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f000.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f003.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f003.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f006.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f006.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f009.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f009.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f012.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f012.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f015.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f015.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f018.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f018.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f021.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f021.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f024.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f024.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f027.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f027.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f030.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f030.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f033.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f033.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f036.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f036.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f039.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f039.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f042.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f042.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f045.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f045.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f048.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f048.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f051.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f051.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f054.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f054.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f057.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f057.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f060.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f060.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f063.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f063.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f066.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f066.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f069.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f069.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f072.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f072.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f075.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f075.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f078.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f078.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f081.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f081.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f084.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f084.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f090.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f090.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f096.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f096.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f102.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f102.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f108.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f108.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f114.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f114.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f120.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f120.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f126.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f126.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f132.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f132.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f138.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f138.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f144.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f144.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f150.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f150.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f156.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f156.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f162.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f162.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f168.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f168.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f174.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f174.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f180.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f180.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f186.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f186.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f192.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f192.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f198.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f198.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f204.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f204.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f210.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f210.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f216.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f216.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f222.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f222.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f228.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f228.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f234.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f234.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f240.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f240.ecf
@@ -24,6 +24,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/bufr_sounding/jgfs_atmos_postsnd.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/bufr_sounding/jgfs_atmos_postsnd.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}
 module load util_shared/${util_shared_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}
 module load util_shared/${util_shared_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2_0p25.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2_0p25.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f00.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f00.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f06.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f06.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f102.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f102.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f108.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f108.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f114.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f114.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f12.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f12.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f120.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f120.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f18.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f18.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f24.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f24.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f30.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f30.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f36.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f36.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f42.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f42.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f48.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f48.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f54.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f54.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f60.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f60.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f66.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f66.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f72.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f72.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f78.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f78.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f84.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f84.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f90.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f90.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f96.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f96.ecf
@@ -22,6 +22,9 @@ export fcsthrs=%FCSTHR%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/$grib_util_ver
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/atmos/post_processing/jgfs_atmos_wafs_gcip.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/jgfs_atmos_wafs_gcip.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/atmos/verf/jgfs_atmos_vminmon.ecf
+++ b/ecf/scripts/gfs/atmos/verf/jgfs_atmos_vminmon.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load perl/${perl_ver}
 module load util_shared/${util_shared_ver}
 

--- a/ecf/scripts/gfs/jgfs_forecast.ecf
+++ b/ecf/scripts/gfs/jgfs_forecast.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 # Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load esmf/${esmf_ver}

--- a/ecf/scripts/gfs/wave/gempak/jgfs_wave_gempak.ecf
+++ b/ecf/scripts/gfs/wave/gempak/jgfs_wave_gempak.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 ## Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}
 module load gempak/${gempak_ver}

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 ## Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 ## Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_postsbs.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_postsbs.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 ## Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_bulls.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_bulls.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 ## Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cfp/${cfp_ver}
 module load gempak/${gempak_ver}
 module load libjpeg/${libjpeg_ver}

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_gridded.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_gridded.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 ## Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}
 module load wgrib2/${wgrib2_ver}

--- a/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
+++ b/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
@@ -20,6 +20,9 @@ export CDUMP=%RUN%
 ############################################################
 ## Load modules
 ############################################################
+module load PrgEnv-intel/${PrgEnv_intel_ver}
+module load craype/${craype_ver}
+module load intel/${intel_ver}
 module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}


### PR DESCRIPTION
This PR:
- loads the `PrgEnv-intel`, `craype` and `intel` module in the `.ecf` scripts as required by NCO.  Every single `.ecf` script needs these modules to be loaded.
- Ignores `.swp` files through an entry in `.gitignore`.

This work is part of #398, #399

Including @WeiWei-NCO for awareness and comment.