### PR TITLE
Update config missed in last GSI update

### DIFF
--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -9,40 +9,40 @@ echo "BEGIN: config.anal"
 . $EXPDIR/config.resources anal
 
 if [ $DONST = "YES" ]; then
-    . $EXPDIR/config.nsst
+	. $EXPDIR/config.nsst
 fi
 
 if [[ "$CDATE" = "$FDATE" && $EXP_WARM_START = ".false." ]]; then # Cold starting
-    export USE_RADSTAT="NO"
+	export USE_RADSTAT="NO"
 fi
 
 if [[ "$CDUMP" = "gfs" ]] ; then
-    export USE_RADSTAT="NO" # This can be only used when bias correction is not-zero.
-    export GENDIAG="NO"
-    export SETUP='diag_rad=.false.,diag_pcp=.false.,diag_conv=.false.,diag_ozone=.false.,write_diag(3)=.false.,niter(2)=100,'
-    export DIAG_TARBALL="NO"
+	export USE_RADSTAT="NO" # This can be only used when bias correction is not-zero.
+	export GENDIAG="NO"
+	export SETUP='diag_rad=.false.,diag_pcp=.false.,diag_conv=.false.,diag_ozone=.false.,write_diag(3)=.false.,niter(2)=100,'
+	export DIAG_TARBALL="NO"
 fi
 
 export npe_gsi=$npe_anal
 
 if [[ "$CDUMP" == "gfs" ]] ; then
-   export npe_gsi=$npe_anal_gfs
-   export nth_anal=$nth_anal_gfs
+	export npe_gsi=$npe_anal_gfs
+	export nth_anal=$nth_anal_gfs
 fi
 
 # Set parameters specific to L127
 if [ $LEVS = "128" ]; then
-    export GRIDOPTS="nlayers(63)=1,nlayers(64)=1,"
-    export SETUP="gpstop=55,nsig_ext=56,$SETUP"
+	export GRIDOPTS="nlayers(63)=1,nlayers(64)=1,"
+	export SETUP="gpstop=55,nsig_ext=56,$SETUP"
 fi
 
 # Set namelist option for LETKF
 export lobsdiag_forenkf=".false."  # anal does not need to write out jacobians
-                                   # set to .true. in config.eobs and config.eupd
+								   # set to .true. in config.eobs and config.eupd
 
 if [ $OUTPUT_FILE = "nemsio" ]; then
-    export DO_CALC_INCREMENT="YES"
-    export DO_CALC_ANALYSIS="NO"
+	export DO_CALC_INCREMENT="YES"
+	export DO_CALC_ANALYSIS="NO"
 fi
 
 # Do not process the following datasets
@@ -62,94 +62,116 @@ export OBERROR=$FIXgsi/prepobs_errtable.global
 
 # Use experimental dumps in EMC GFS v16 parallels
 if [[ $RUN_ENVIR == "emc" ]]; then
-    export ABIBF="/dev/null"
-    if [[ "$CDATE" -ge "2019022800" ]] ; then
-    	export ABIBF="$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.gsrcsr.tm00.bufr_d"
-    	if [[ "$CDATE" -ge "2019111000" && "$CDATE" -le "2020052612" ]]; then
-    	    export ABIBF="$DMPDIR/${CDUMP}y.${PDY}/${cyc}/${CDUMP}.t${cyc}z.gsrcsr.tm00.bufr_d"
-    	fi
-    fi
+	export ABIBF="/dev/null"
+	if [[ "$CDATE" -ge "2019022800" ]] ; then
+		export ABIBF="$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.gsrcsr.tm00.bufr_d"
+		if [[ "$CDATE" -ge "2019111000" && "$CDATE" -le "2020052612" ]]; then
+			export ABIBF="$DMPDIR/${CDUMP}y.${PDY}/${cyc}/${CDUMP}.t${cyc}z.gsrcsr.tm00.bufr_d"
+		fi
+	fi
 
-    export AHIBF="/dev/null"
-    if [[ "$CDATE" -ge "2019042300" ]]; then
-	   export AHIBF="$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.ahicsr.tm00.bufr_d"
-    fi
+	export AHIBF="/dev/null"
+	if [[ "$CDATE" -ge "2019042300" ]]; then
+		export AHIBF="$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.ahicsr.tm00.bufr_d"
+	fi
 
-    export HDOB=$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.hdob.tm00.bufr_d
+	export HDOB=$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.hdob.tm00.bufr_d
 
-    #   Use dumps from NCO GFS v16 parallel
-    if [[ "$CDATE" -ge "2020103012" ]]; then
-    	export ABIBF=""
-    	export AHIBF=""
-    	export HDOB=""
-    fi
+	#   Use dumps from NCO GFS v16 parallel
+	if [[ "$CDATE" -ge "2020103012" ]]; then
+		export ABIBF=""
+		export AHIBF=""
+		export HDOB=""
+	fi
 
-    #   Set info files and prepobs.errtable.global for GFS v16 retrospective parallels
-    if [[ "$CDATE" -ge "2019021900" && "$CDATE" -lt "2019110706" ]]; then
-    	export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2019021900
-    	export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2019021900
-    fi
+	#   Set info files and prepobs.errtable.global for GFS v16 retrospective parallels
+	if [[ "$CDATE" -ge "2019021900" && "$CDATE" -lt "2019110706" ]]; then
+		export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2019021900
+		export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2019021900
+	fi
 
-    #   Place GOES-15 AMVs in monitor, assimilate GOES-17 AMVs, assimilate KOMPSAT-5 gps
-    if [[ "$CDATE" -ge "2019110706" && "$CDATE" -lt "2020040718" ]]; then
-    	export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2019110706
-    	export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2019110706
-    fi
+	#   Place GOES-15 AMVs in monitor, assimilate GOES-17 AMVs, assimilate KOMPSAT-5 gps
+	if [[ "$CDATE" -ge "2019110706" && "$CDATE" -lt "2020040718" ]]; then
+		export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2019110706
+		export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2019110706
+	fi
 
-    #   Assimilate 135 (T) & 235 (uv) Canadian AMDAR observations
-    if [[ "$CDATE" -ge "2020040718" && "$CDATE" -lt "2020052612" ]]; then
-	   export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020040718
-    fi
+	#   Assimilate 135 (T) & 235 (uv) Canadian AMDAR observations
+	if [[ "$CDATE" -ge "2020040718" && "$CDATE" -lt "2020052612" ]]; then
+		export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020040718
+		export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.202004071
+	fi
 
-    #   NOTE:
-    #   As of 2021110312, gfsv16_historical/global_convinfo.txt.2021110312 is
-    #   identical to ../global_convinfo.txt.  Thus, the logic below is not
-    #   needed at this time.
-    #   Assimilate COSMIC-2 GPS
-    #   if [[ "$CDATE" -ge "2021110312" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
-    #     export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021110312
-    #   fi
+	#   Assimilate COSMIC-2
+	if [[ "$CDATE" -ge "2020052612" && "$CDATE" -lt "2020082412" ]]; then
+		export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020052612
+		export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2020040718
+	fi
 
-    #   Turn off assmilation of OMPS during period of bad data
-    if [[ "$CDATE" -ge "2020011600" && "$CDATE" -lt "2020011806" ]]; then
-	   export OZINFO=$FIXgsi/gfsv16_historical/global_ozinfo.txt.2020011600
-    fi
+	#   Assimilate HDOB
+	if [[ "$CDATE" -ge "2020082412" && "$CDATE" -lt "2020091612" ]]; then
+		export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020082412
+	fi
+
+	#   Assimilate Metop-C GNSSRO
+	if [[ "$CDATE" -ge "2020091612" && "$CDATE" -lt "2021031712" ]]; then
+		export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020091612
+	fi
+
+	#   Assimilate DO-2 GeoOptics
+	if [[ "$CDATE" -ge "2021031712" && "$CDATE" -lt "2021091612" ]]; then
+		export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021031712
+	fi
+
+	#   NOTE:
+	#   As of 2021110312, gfsv16_historical/global_convinfo.txt.2021110312 is
+	#   identical to ../global_convinfo.txt.  Thus, the logic below is not
+	#   needed at this time.
+	#   Assimilate COSMIC-2 GPS
+	#   if [[ "$CDATE" -ge "2021110312" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
+	#  	export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021110312
+	#   fi
+
+	#   Turn off assmilation of OMPS during period of bad data
+	if [[ "$CDATE" -ge "2020011600" && "$CDATE" -lt "2020011806" ]]; then
+		export OZINFO=$FIXgsi/gfsv16_historical/global_ozinfo.txt.2020011600
+	fi
 
 
-    #   Set satinfo for start of GFS v16 parallels
-    if [[ "$CDATE" -ge "2019021900" && "$CDATE" -lt "2019110706" ]]; then
-	   export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2019021900
-    fi
+	#   Set satinfo for start of GFS v16 parallels
+	if [[ "$CDATE" -ge "2019021900" && "$CDATE" -lt "2019110706" ]]; then
+		export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2019021900
+	fi
 
-    #   Turn on assimilation of Metop-C AMSUA and MHS
-    if [[ "$CDATE" -ge "2019110706" && "$CDATE" -lt "2020022012" ]]; then
-	   export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2019110706
-    fi
+	#   Turn on assimilation of Metop-C AMSUA and MHS
+	if [[ "$CDATE" -ge "2019110706" && "$CDATE" -lt "2020022012" ]]; then
+		export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2019110706
+	fi
 
-    #   Turn off assimilation of Metop-A MHS
-    if [[ "$CDATE" -ge "2020022012" && "$CDATE" -lt "2021052118" ]]; then
-        export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2020022012
-    fi
+	#   Turn off assimilation of Metop-A MHS
+	if [[ "$CDATE" -ge "2020022012" && "$CDATE" -lt "2021052118" ]]; then
+		export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2020022012
+	fi
 
-    #   Turn off assimilation of S-NPP CrIS
-    if [[ "$CDATE" -ge "2021052118" && "$CDATE" -lt "2021092206" ]]; then
-        export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021052118 
-    fi
+	#   Turn off assimilation of S-NPP CrIS
+	if [[ "$CDATE" -ge "2021052118" && "$CDATE" -lt "2021092206" ]]; then
+		export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021052118 
+	fi
 
-    #   Turn off assimilation of MetOp-A IASI
-    if [[ "$CDATE" -ge "2021092206" && "$CDATE" -lt "2021102612" ]]; then
-        export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021092206 
-    fi
+	#   Turn off assimilation of MetOp-A IASI
+	if [[ "$CDATE" -ge "2021092206" && "$CDATE" -lt "2021102612" ]]; then
+		export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021092206 
+	fi
 
-    #   NOTE:  
-    #   As of 2021110312, gfsv16_historical/global_satinfo.txt.2021110312 is
-    #   identical to ../global_satinfo.txt.  Thus, the logic below is not
-    #   needed at this time
-    #
-    #   Turn off assmilation of all Metop-A MHS
-    #   if [[ "$CDATE" -ge "2021110312" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
-    #       export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021110312
-    #   fi
+	#   NOTE:  
+	#   As of 2021110312, gfsv16_historical/global_satinfo.txt.2021110312 is
+	#   identical to ../global_satinfo.txt.  Thus, the logic below is not
+	#   needed at this time
+	#
+	#   Turn off assmilation of all Metop-A MHS
+	#   if [[ "$CDATE" -ge "2021110312" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
+	#    	export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021110312
+	#   fi
 fi
 
 echo "END: config.anal"

--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -64,79 +64,92 @@ export OBERROR=$FIXgsi/prepobs_errtable.global
 if [[ $RUN_ENVIR == "emc" ]]; then
     export ABIBF="/dev/null"
     if [[ "$CDATE" -ge "2019022800" ]] ; then
-	export ABIBF="$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.gsrcsr.tm00.bufr_d"
-	if [[ "$CDATE" -ge "2019111000" && "$CDATE" -le "2020052612" ]]; then
-	    export ABIBF="$DMPDIR/${CDUMP}y.${PDY}/${cyc}/${CDUMP}.t${cyc}z.gsrcsr.tm00.bufr_d"
-	fi
+    	export ABIBF="$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.gsrcsr.tm00.bufr_d"
+    	if [[ "$CDATE" -ge "2019111000" && "$CDATE" -le "2020052612" ]]; then
+    	    export ABIBF="$DMPDIR/${CDUMP}y.${PDY}/${cyc}/${CDUMP}.t${cyc}z.gsrcsr.tm00.bufr_d"
+    	fi
     fi
 
     export AHIBF="/dev/null"
     if [[ "$CDATE" -ge "2019042300" ]]; then
-	export AHIBF="$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.ahicsr.tm00.bufr_d"
+	   export AHIBF="$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.ahicsr.tm00.bufr_d"
     fi
 
     export HDOB=$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.hdob.tm00.bufr_d
 
-#   Use dumps from NCO GFS v16 parallel
+    #   Use dumps from NCO GFS v16 parallel
     if [[ "$CDATE" -ge "2020103012" ]]; then
-	export ABIBF=""
-	export AHIBF=""
-	export HDOB=""
+    	export ABIBF=""
+    	export AHIBF=""
+    	export HDOB=""
     fi
 
-#   Set info files and prepobs.errtable.global for GFS v16 retrospective parallels
+    #   Set info files and prepobs.errtable.global for GFS v16 retrospective parallels
     if [[ "$CDATE" -ge "2019021900" && "$CDATE" -lt "2019110706" ]]; then
-	export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2019021900
-	export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2019021900
+    	export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2019021900
+    	export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2019021900
     fi
 
-#   Place GOES-15 AMVs in monitor, assimilate GOES-17 AMVs, assimilate KOMPSAT-5 gps
+    #   Place GOES-15 AMVs in monitor, assimilate GOES-17 AMVs, assimilate KOMPSAT-5 gps
     if [[ "$CDATE" -ge "2019110706" && "$CDATE" -lt "2020040718" ]]; then
-	export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2019110706
-	export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2019110706
+    	export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2019110706
+    	export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2019110706
     fi
 
-#   Assimilate 135 (T) & 235 (uv) Canadian AMDAR observations
+    #   Assimilate 135 (T) & 235 (uv) Canadian AMDAR observations
     if [[ "$CDATE" -ge "2020040718" && "$CDATE" -lt "2020052612" ]]; then
-	export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020040718
+	   export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020040718
     fi
 
-#   NOTE:
-#   As of 2020052612, gfsv16_historical/global_convinfo.txt.2020052612 is
-#   identical to ../global_convinfo.txt.  Thus, the logic below is not
-#   needed at this time.
-#   Assimilate COSMIC-2 GPS
-#   if [[ "$CDATE" -ge "2020052612" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
-#     export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020052612
-#   fi
+    #   NOTE:
+    #   As of 2021110312, gfsv16_historical/global_convinfo.txt.2021110312 is
+    #   identical to ../global_convinfo.txt.  Thus, the logic below is not
+    #   needed at this time.
+    #   Assimilate COSMIC-2 GPS
+    #   if [[ "$CDATE" -ge "2021110312" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
+    #     export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021110312
+    #   fi
 
-
-#   Turn off assmilation of OMPS during period of bad data
+    #   Turn off assmilation of OMPS during period of bad data
     if [[ "$CDATE" -ge "2020011600" && "$CDATE" -lt "2020011806" ]]; then
-	export OZINFO=$FIXgsi/gfsv16_historical/global_ozinfo.txt.2020011600
+	   export OZINFO=$FIXgsi/gfsv16_historical/global_ozinfo.txt.2020011600
     fi
 
 
-#   Set satinfo for start of GFS v16 parallels
+    #   Set satinfo for start of GFS v16 parallels
     if [[ "$CDATE" -ge "2019021900" && "$CDATE" -lt "2019110706" ]]; then
-	export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2019021900
+	   export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2019021900
     fi
 
-#   Turn on assimilation of Metop-C AMSUA and MHS
+    #   Turn on assimilation of Metop-C AMSUA and MHS
     if [[ "$CDATE" -ge "2019110706" && "$CDATE" -lt "2020022012" ]]; then
-	export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2019110706
+	   export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2019110706
     fi
 
-#   NOTE:  
-#   As of 2020022012, gfsv16_historical/global_satinfo.txt.2020022012 is
-#   identical to ../global_satinfo.txt.  Thus, the logic below is not
-#   needed at this time
-#
-#   Turn off assmilation of all Metop-A MHS
-#   if [[ "$CDATE" -ge "2020022012" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
-#       export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2020022012
-#   fi
+    #   Turn off assimilation of Metop-A MHS
+    if [[ "$CDATE" -ge "2020022012" && "$CDATE" -lt "2021052118" ]]; then
+        export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2020022012
+    fi
 
+    #   Turn off assimilation of S-NPP CrIS
+    if [[ "$CDATE" -ge "2021052118" && "$CDATE" -lt "2021092206" ]]; then
+        export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021052118 
+    fi
+
+    #   Turn off assimilation of MetOp-A IASI
+    if [[ "$CDATE" -ge "2021092206" && "$CDATE" -lt "2021102612" ]]; then
+        export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021092206 
+    fi
+
+    #   NOTE:  
+    #   As of 2021110312, gfsv16_historical/global_satinfo.txt.2021110312 is
+    #   identical to ../global_satinfo.txt.  Thus, the logic below is not
+    #   needed at this time
+    #
+    #   Turn off assmilation of all Metop-A MHS
+    #   if [[ "$CDATE" -ge "2021110312" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
+    #       export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021110312
+    #   fi
 fi
 
 echo "END: config.anal"

--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -99,7 +99,7 @@ if [[ $RUN_ENVIR == "emc" ]]; then
 	#   Assimilate 135 (T) & 235 (uv) Canadian AMDAR observations
 	if [[ "$CDATE" -ge "2020040718" && "$CDATE" -lt "2020052612" ]]; then
 		export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020040718
-		export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.202004071
+		export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2020040718
 	fi
 
 	#   Assimilate COSMIC-2


### PR DESCRIPTION
When the GSI version was updated in PR #530, updates to the config.anal file were mistakenly omitted. That file is now updated following ops (PR #489).

The indentation of the config.anal file is also fixed.

Refs: PR #530