### PR TITLE
Request exclusive nodes for large memory jobs or jobs requesting all cores on WCOSS2 in ecf scripts.

### DIFF
--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_diag.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_diag.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:06:00
-#PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_select_obs.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_select_obs.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=30:mpiprocs=16:ompthreads=8:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=30:mpiprocs=16:ompthreads=8:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_update.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_update.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=50:mpiprocs=10:ompthreads=12:ncpus=120:mem=500GB
+#PBS -l place=vscatter,select=50:mpiprocs=10:ompthreads=12:ncpus=120
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/analysis/recenter/ecen/jenkfgdas_ecen.ecf
+++ b/ecf/scripts/enkfgdas/analysis/recenter/ecen/jenkfgdas_ecen.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
+++ b/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:06:00
-#PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/forecast/jenkfgdas_fcst.ecf
+++ b/ecf/scripts/enkfgdas/forecast/jenkfgdas_fcst.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:40:00
 #PBS -l place=vscatter,select=4:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_f003.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_f003.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_f004.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_f004.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_f005.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_f005.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_f006.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_f006.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_f007.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_f007.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_f008.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_f008.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_f009.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_f009.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:00:00
-#PBS -l place=vscatter,select=100:mpiprocs=10:ompthreads=12:ncpus=120:mem=500GB
+#PBS -l place=vscatter,select=100:mpiprocs=10:ompthreads=12:ncpus=120
+#PBS -l place=excl
 #PBS -l debug=true
 
 export model=gfs

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_calc.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_calc.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_diag.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_diag.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 export model=gfs

--- a/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak.ecf
+++ b/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak_meta_ncdc.ecf
+++ b/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak_meta_ncdc.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/init/jgdas_atmos_gldas.ecf
+++ b/ecf/scripts/gdas/atmos/init/jgdas_atmos_gldas.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
 #PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_manager.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_manager.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:15:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfozn.ecf
+++ b/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfozn.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfrad.ecf
+++ b/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfrad.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/verf/jgdas_atmos_vminmon.ecf
+++ b/ecf/scripts/gdas/atmos/verf/jgdas_atmos_vminmon.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/enkf/analysis/create/jgdas_enkf_diag.ecf
+++ b/ecf/scripts/gdas/enkf/analysis/create/jgdas_enkf_diag.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:06:00
-#PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 %include <head.h>

--- a/ecf/scripts/gdas/enkf/analysis/create/jgdas_enkf_select_obs.ecf
+++ b/ecf/scripts/gdas/enkf/analysis/create/jgdas_enkf_select_obs.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=30:mpiprocs=16:ompthreads=8:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=30:mpiprocs=16:ompthreads=8:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 %include <head.h>

--- a/ecf/scripts/gdas/enkf/analysis/create/jgdas_enkf_update.ecf
+++ b/ecf/scripts/gdas/enkf/analysis/create/jgdas_enkf_update.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=50:mpiprocs=10:ompthreads=12:ncpus=120:mem=500GB
+#PBS -l place=vscatter,select=50:mpiprocs=10:ompthreads=12:ncpus=120
+#PBS -l place=excl
 #PBS -l debug=true
 
 %include <head.h>

--- a/ecf/scripts/gdas/enkf/analysis/recenter/ecen/jgdas_enkf_ecen.ecf
+++ b/ecf/scripts/gdas/enkf/analysis/recenter/ecen/jgdas_enkf_ecen.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 %include <head.h>

--- a/ecf/scripts/gdas/enkf/analysis/recenter/jgdas_enkf_sfc.ecf
+++ b/ecf/scripts/gdas/enkf/analysis/recenter/jgdas_enkf_sfc.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:06:00
-#PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 %include <head.h>

--- a/ecf/scripts/gdas/enkf/forecast/jgdas_enkf_fcst.ecf
+++ b/ecf/scripts/gdas/enkf/forecast/jgdas_enkf_fcst.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:40:00
 #PBS -l place=vscatter,select=4:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 %include <head.h>

--- a/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f003.ecf
+++ b/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f003.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 

--- a/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f004.ecf
+++ b/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f004.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 

--- a/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f005.ecf
+++ b/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f005.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 

--- a/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f006.ecf
+++ b/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f006.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 

--- a/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f007.ecf
+++ b/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f007.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 

--- a/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f008.ecf
+++ b/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f008.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 

--- a/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f009.ecf
+++ b/ecf/scripts/gdas/enkf/post/jgdas_enkf_post_f009.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=3:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 

--- a/ecf/scripts/gdas/jgdas_forecast.ecf
+++ b/ecf/scripts/gdas/jgdas_forecast.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:00:00
 #PBS -l place=vscatter,select=39:mpiprocs=32:ompthreads=4:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/wave/init/jgdas_wave_init.ecf
+++ b/ecf/scripts/gdas/wave/init/jgdas_wave_init.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/wave/post/jgdas_wave_postpnt.ecf
+++ b/ecf/scripts/gdas/wave/post/jgdas_wave_postpnt.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:12:00
 #PBS -l place=vscatter,select=4:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/wave/post/jgdas_wave_postsbs.ecf
+++ b/ecf/scripts/gdas/wave/post/jgdas_wave_postsbs.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
 #PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
+++ b/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis.ecf
+++ b/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:40:00
-#PBS -l place=vscatter,select=100:mpiprocs=10:ompthreads=12:ncpus=120:mem=500GB
+#PBS -l place=vscatter,select=100:mpiprocs=10:ompthreads=12:ncpus=120
+#PBS -l place=excl
 #PBS -l debug=true
 
 export model=gfs

--- a/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis_calc.ecf
+++ b/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis_calc.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128:mem=500GB
+#PBS -l place=vscatter,select=1:mpiprocs=128:ompthreads=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_meta.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_meta.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
 #PBS -l place=vscatter,select=2:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_ncdc_upapgif.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_ncdc_upapgif.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_npoess_pgrb2_0p5deg.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_npoess_pgrb2_0p5deg.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_pgrb2_spec_gempak.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_pgrb2_spec_gempak.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_manager.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_manager.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=04:00:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/bufr_sounding/jgfs_atmos_postsnd.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/bufr_sounding/jgfs_atmos_postsnd.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
-#PBS -l place=vscatter,select=2:mpiprocs=20:ompthreads=1:ncpus=20:mem=500GB
+#PBS -l place=vscatter,select=2:mpiprocs=20:ompthreads=1:ncpus=20
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/verf/jgfs_atmos_vminmon.ecf
+++ b/ecf/scripts/gfs/atmos/verf/jgfs_atmos_vminmon.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/gempak/jgfs_wave_gempak.ecf
+++ b/ecf/scripts/gfs/wave/gempak/jgfs_wave_gempak.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/init/jgfs_wave_init.ecf
+++ b/ecf/scripts/gfs/wave/init/jgfs_wave_init.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:00:00
 #PBS -l place=vscatter,select=3:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpntbll.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpntbll.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:00:00
 #PBS -l place=vscatter,select=3:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:30:00
 #PBS -l place=vscatter,select=3:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_postsbs.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_postsbs.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_bulls.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_bulls.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_gridded.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_gridded.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
+++ b/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
 #PBS -l place=vscatter,select=1:ncpus=128
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs


### PR DESCRIPTION
This PR:
- removes memory requests of `500GB` or more and requests the node exclusively per NCO suggestions.
- requests the node exclusively where `ncpus=128`

Referring the PBSpro documentation at:
https://www.altair.com/pdfs/pbsworks/PBSUserGuide2021.1.pdf
Specifically for this PR, see examples for placement on pages 80-82.

Tagging @WeiWei-NCO for comment/notification.