### PR TITLE
Update ecf scripts for memory and exclusivity

### DIFF
--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
 #PBS -l place=vscatter,select=5:mpiprocs=4:ompthreads=3:ncpus=12
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f000.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f000.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f003.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f003.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f006.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f006.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f009.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f009.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f012.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f012.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f015.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f015.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f018.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f018.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f021.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f021.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f024.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f024.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f027.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f027.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f030.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f030.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f033.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f033.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f036.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f036.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f039.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f039.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f042.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f042.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f045.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f045.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f048.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f048.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f051.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f051.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f054.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f054.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f057.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f057.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f060.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f060.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f063.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f063.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f066.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f066.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f069.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f069.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f072.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f072.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f075.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f075.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f078.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f078.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f081.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f081.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f084.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f084.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f090.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f090.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f096.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f096.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f102.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f102.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f108.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f108.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f114.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f114.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f120.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f120.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f126.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f126.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f132.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f132.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f138.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f138.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f144.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f144.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f150.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f150.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f156.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f156.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f162.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f162.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f168.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f168.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f174.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f174.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f180.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f180.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f186.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f186.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f192.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f192.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f198.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f198.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f204.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f204.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f210.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f210.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f216.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f216.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f222.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f222.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f228.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f228.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f234.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f234.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f240.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_f240.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f000.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f000.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f003.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f003.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f006.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f006.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f009.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f009.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f012.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f012.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f015.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f015.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f018.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f018.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f021.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f021.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f024.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f024.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f027.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f027.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f030.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f030.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f033.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f033.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f036.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f036.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f039.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f039.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f042.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f042.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f045.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f045.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f048.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f048.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f051.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f051.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f054.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f054.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f057.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f057.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f060.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f060.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f063.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f063.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f066.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f066.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f069.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f069.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f072.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f072.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f075.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f075.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f078.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f078.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f081.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f081.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f084.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f084.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f090.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f090.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f096.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f096.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f102.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f102.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f108.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f108.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f114.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f114.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f120.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f120.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f126.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f126.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f132.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f132.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f138.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f138.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f144.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f144.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f150.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f150.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f156.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f156.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f162.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f162.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f168.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f168.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f174.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f174.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f180.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f180.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f186.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f186.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f192.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f192.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f198.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f198.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f204.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f204.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f210.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f210.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f216.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f216.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f222.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f222.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f228.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f228.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f234.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f234.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f240.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_f240.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=50GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2_0p25.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2_0p25.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f00.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f00.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f06.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f06.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f102.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f102.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f108.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f108.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f114.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f114.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f12.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f12.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f120.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f120.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f18.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f18.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f24.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f24.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f30.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f30.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f36.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f36.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f42.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f42.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f48.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f48.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f54.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f54.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f60.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f60.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f66.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f66.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f72.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f72.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f78.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f78.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f84.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f84.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f90.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f90.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f96.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_f96.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/jgfs_forecast.ecf
+++ b/ecf/scripts/gfs/jgfs_forecast.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:30:00
 #PBS -l place=vscatter,select=131:mpiprocs=24:ompthreads=5:ncpus=120
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs


### PR DESCRIPTION
This PR includes the following updates:
- update ecf scripts for jobs that will run shared to include a memory
request
- add the "excl" tag for the gfs_atmos_gempak and gfs_forecast jobs

Refs: #399