### PR TITLE
Update ecf scripts for memory and exclusivity; update release notes

### DIFF
--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -31,15 +31,21 @@ The checkout script extracts the following GFS components:
 | POST      | upp_v8.1.0 | Wen.Meng@noaa.gov |
 | WAFS      | gfs_wafs.v6.2.7 | Yali.Mao@noaa.gov |
 
-To build all the GFS components, execute
+To build all the GFS components, execute:
 ```bash
 ./build_all.sh
 ```
 The `build_all.sh` script compiles all GFS components. Runtime output from the build for each package is written to log files in directory logs. To build an individual program, for instance, gsi, use `build_gsi.sh`.
 
-Finally, link the executables, fix files, parm files etc in their final respective locations by executing:
+Next, link the executables, fix files, parm files etc in their final respective locations by executing:
 ```bash
 ./link_fv3gfs.sh nco wcoss2
+```
+
+Lastly, link the ecf scripts by moving back up to the ecf folder and executing:
+```bash
+cd ../ecf
+./setup_ecf_links.sh
 ```
 
 SORC CHANGES

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
 #PBS -l place=vscatter,select=5:mpiprocs=4:ompthreads=3:ncpus=12
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8
+#PBS -l place=vscatter,select=1:mpiprocs=4:ompthreads=2:ncpus=8:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=50GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2_0p25.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2_0p25.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1
+#PBS -l place=vscatter,select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/jgfs_forecast.ecf
+++ b/ecf/scripts/gfs/jgfs_forecast.ecf
@@ -5,6 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:30:00
 #PBS -l place=vscatter,select=131:mpiprocs=24:ompthreads=5:ncpus=120
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs


### PR DESCRIPTION
This PR includes the following updates:

* update ecf scripts for jobs that will run shared to include a memory request
* add the "excl" tag for the gfs_atmos_gempak and gfs_forecast jobs
* update release notes instructions to include step for linking ecf scripts

Refs: #399