### PR TITLE
Series of small WCOSS2 updates - round 7

### DIFF
--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -15,7 +15,7 @@ The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com a
 cd $PACKAGEROOT
 mkdir gfs.v16.2.0
 cd gfs.v16.2.0
-git clone -b EMC-v16.2.0  https://github.com/NOAA-EMC/global-workflow.git .
+git clone -b EMC-v16.2.0.1 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_anl.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_anl.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:12:00
-#PBS -l place=vscatter,select=10
+#PBS -l place=vscatter,select=2:mpiprocs=64:ompthreads=1:ncpus=64
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_master.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_master.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:12:00
-#PBS -l place=vscatter,select=10
+#PBS -l place=vscatter,select=2:mpiprocs=64:ompthreads=1:ncpus=64
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_master.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_master.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
-#PBS -l place=vscatter,select=10
+#PBS -l place=vscatter,select=2:mpiprocs=64:ompthreads=1:ncpus=64
+#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -134,7 +134,6 @@ elif [ $step = "anal" ]; then
     export npe_node_anal=$(echo "$npe_node_max / $nth_anal" | bc)
     export nth_cycle=$npe_node_max
     export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
-    if [[ "$machine" = "WCOSS2" ]]; then export memory_anal="500GB"; fi
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_anal="3072M"; fi
 
 elif [ $step = "analcalc" ]; then
@@ -145,7 +144,6 @@ elif [ $step = "analcalc" ]; then
     export nth_analcalc=1
     export npe_node_analcalc=$npe_node_max
     if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export npe_analcalc=127 ; fi
-    if [[ "$machine" = "WCOSS2" ]]; then export memory_analcalc="500GB" ; fi
 
 elif [ $step = "analdiag" ]; then
 
@@ -154,13 +152,12 @@ elif [ $step = "analdiag" ]; then
     export nth_analdiag=1
     export npe_node_analdiag=$npe_node_max
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_analdiag="3072M"; fi
-    if [[ "$machine" = "WCOSS2" ]]; then export memory_analdiag="500GB"; fi
 
 elif [ $step = "gldas" ]; then
 
     export wtime_gldas="00:10:00"
     export npe_gldas=112
-    export nth_gldas=4
+    export nth_gldas=1
     export npe_node_gldas=$(echo "$npe_node_max / $nth_gldas" | bc)
     export npe_gaussian=96  
     export nth_gaussian=1 
@@ -190,7 +187,6 @@ elif [ $step = "post" ]; then
     export npe_node_dwn=$npe_node_max
     if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export npe_node_post=28 ; fi
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_post="3072M"; fi
-    if [[ "$machine" == "WCOSS2" ]]; then export memory_post="100GB"; fi
 
 elif [ $step = "wafs" ]; then
 
@@ -198,6 +194,7 @@ elif [ $step = "wafs" ]; then
     export npe_wafs=1
     export npe_node_wafs=1
     export nth_wafs=1
+    export memory_wafs="1GB"
 
 elif [ $step = "wafsgcip" ]; then
 
@@ -213,6 +210,7 @@ elif [ $step = "wafsgrib2" ]; then
     export npe_wafsgrib2=1
     export npe_node_wafsgrib2=1
     export nth_wafsgrib2=1
+    export memory_wafsgrib2="50GB"
 
 elif [ $step = "wafsblending" ]; then
 
@@ -220,6 +218,7 @@ elif [ $step = "wafsblending" ]; then
     export npe_wafsblending=1
     export npe_node_wafsblending=1
     export nth_wafsblending=1
+    export memory_wafsblending="1GB"
 
 elif [ $step = "wafsgrib20p25" ]; then
 
@@ -227,6 +226,7 @@ elif [ $step = "wafsgrib20p25" ]; then
     export npe_wafsgrib20p25=1
     export npe_node_wafsgrib20p25=1
     export nth_wafsgrib20p25=1
+    export memory_wafsgrib20p25="1GB"
 
 elif [ $step = "wafsblending0p25" ]; then
 
@@ -234,6 +234,7 @@ elif [ $step = "wafsblending0p25" ]; then
     export npe_wafsblending0p25=1
     export npe_node_wafsblending0p25=1
     export nth_wafsblending0p25=1
+    export memory_wafsblending0p25="1GB"
 
 elif [ $step = "vrfy" ]; then
 
@@ -299,7 +300,6 @@ elif [ $step = "eobs" -o $step = "eomg" ]; then
     if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_eobs=7; fi
     export npe_node_eobs=$(echo "$npe_node_max / $nth_eobs" | bc)
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_eobs="3072M"; fi
-    if [[ "$machine" = "WCOSS2" ]]; then export memory_eobs="500GB"; fi
 
 elif [ $step = "ediag" ]; then
 
@@ -308,7 +308,6 @@ elif [ $step = "ediag" ]; then
     export nth_ediag=1
     export npe_node_ediag=$npe_node_max
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_ediag="3072M"; fi
-    if [[ "$machine" = "WCOSS2" ]]; then export memory_ediag="500GB"; fi
 
 elif [ $step = "eupd" ]; then
 
@@ -336,7 +335,6 @@ elif [ $step = "eupd" ]; then
     fi
     export npe_node_eupd=$(echo "$npe_node_max / $nth_eupd" | bc)
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_eupd="3072M"; fi
-    if [[ "$machine" = "WCOSS2" ]]; then export memory_eupd="500GB"; fi
 
 elif [ $step = "ecen" ]; then
 
@@ -349,7 +347,6 @@ elif [ $step = "ecen" ]; then
     export nth_cycle=$nth_ecen
     export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_ecen="3072M"; fi
-    if [[ "$machine" = "WCOSS2" ]]; then export memory_ecen="500GB"; fi
 
 elif [ $step = "esfc" ]; then
 
@@ -360,7 +357,6 @@ elif [ $step = "esfc" ]; then
     export nth_cycle=$nth_esfc
     export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_esfc="3072M"; fi
-    if [[ "$machine" = "WCOSS2" ]]; then export memory_esfc="500GB"; fi
 
 elif [ $step = "efcs" ]; then
 
@@ -378,7 +374,6 @@ elif [ $step = "epos" ]; then
     if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_epos=7; fi
     export npe_node_epos=$(echo "$npe_node_max / $nth_epos" | bc)
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_epos="254M"; fi
-    if [[ "$machine" = "WCOSS2" ]]; then export memory_epos="500GB"; fi
 
 elif [ $step = "postsnd" ]; then
 
@@ -394,7 +389,6 @@ elif [ $step = "postsnd" ]; then
     fi
     if [[ "$machine" = "HERA" ]]; then export npe_node_postsnd=2; fi
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_postsnd="254M"; fi
-    if [[ "$machine" == "WCOSS2" ]]; then export memory_postsnd="500GB" ; fi
 
 elif [ $step = "awips" ]; then
 
@@ -402,6 +396,7 @@ elif [ $step = "awips" ]; then
     export npe_awips=4
     export npe_node_awips=4
     export nth_awips=2
+    export memory_awips="1GB"
     if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
         export npe_awips=2
         export npe_node_awips=2

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -181,9 +181,9 @@ elif [ $step = "post" ]; then
 
     export wtime_post="02:00:00"
     export wtime_post_gfs="06:00:00"
-    export npe_post=112
+    export npe_post=128
     export nth_post=1
-    export npe_node_post=12
+    export npe_node_post=64
     export npe_node_dwn=$npe_node_max
     if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export npe_node_post=28 ; fi
     if [[ "$machine" == "WCOSS_C" ]]; then export memory_post="3072M"; fi

--- a/ush/rocoto/workflow_utils.py
+++ b/ush/rocoto/workflow_utils.py
@@ -334,6 +334,8 @@ def get_resources(machine, cfg, task, reservation, cdump='gdas'):
 
         if machine in ['WCOSS2'] and task not in ['arch', 'earc', 'getic']:
             natstr = "-l place=vscatter"
+            if memory is None:
+               natstr += ":excl"
 
     elif machine in ['WCOSS']:
         resstr = f'<cores>{tasks}</cores>'

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -18,6 +18,7 @@ export cfp_ver=2.0.4
 export prod_envir_ver=2.0.4
 export python_ver=3.8.6
 export gempak_ver=7.14.0
+export imagemagick_ver=7.0.8-7
 export perl_ver=5.32.0
 export libjpeg_ver=9c
 export libpng_ver=1.6.37


### PR DESCRIPTION
This PR includes the following WCOSS2 changes:

* update release notes to specify newer hand-off tag (to be cut: `EMC-v16.2.0.1`)
* correct post job resources in ecf script PBS directive and change them to use 2 nodes instead of 10
* remove now-unneeded memory settings in `config.resources.nco.static` (jobs that now run exclusively)
* add needed memory settings in `config.resources.nco.static` for jobs that will run shared
* add `export imagemagick_ver=7.0.8-7` to `run.ver`
* update `workflow_utils.py` to add `excl` to NATIVE entity in xml when memory is not specified (job running exclusive)