### PR TITLE
Remove redundant toggle for gldas build

### DIFF
--- a/sorc/cpl_build.cfg
+++ b/sorc/cpl_build.cfg
@@ -7,7 +7,6 @@
  Building gldas (gldas) ................................ no
  Building ncep_post (ncep_post) ........................ no
  Building ufs_utils (ufs_utils) ........................ no
- Building gldas (gldas) ................................ no
  Building gfs_wafs (gfs_wafs) .......................... no
  Building workflow_utils (workflow_utils)............... yes
  Building gfs_util (gfs_util) .......................... no

--- a/sorc/fv3gfs_build.cfg
+++ b/sorc/fv3gfs_build.cfg
@@ -7,7 +7,6 @@
  Building gldas (gldas) ................................ yes
  Building ncep_post (ncep_post) ........................ yes
  Building ufs_utils (ufs_utils) ........................ yes
- Building gldas (gldas) ................................ yes
  Building gfs_wafs (gfs_wafs) .......................... yes
  Building workflow_utils (workflow_utils)................yes
  Building gfs_util (gfs_util) .......................... yes

--- a/sorc/partial_build.sh
+++ b/sorc/partial_build.sh
@@ -9,7 +9,6 @@
                        "Build_gldas" \
                        "Build_ncep_post" \
                        "Build_ufs_utils" \
-                       "Build_gldas" \
                        "Build_gfs_wafs" \
                        "Build_workflow_utils" \
                        "Build_gfs_util")


### PR DESCRIPTION
The build cfg files controlling which components are built and the partial_build.sh script all have two instances trying to set the
value for gldas. This means one of the settings did nothing when changed.

Fixes: #578