### PR TITLE
Fix toggle for building workflow_utils

### DIFF
--- a/sorc/fv3gfs_build.cfg
+++ b/sorc/fv3gfs_build.cfg
@@ -9,7 +9,7 @@
  Building ufs_utils (ufs_utils) ........................ yes
  Building gldas (gldas) ................................ yes
  Building gfs_wafs (gfs_wafs) .......................... yes
- Building workflow_utils (workflow_utils)................yes
+ Building workflow_utils (workflow_utils)............... yes
  Building gfs_util (gfs_util) .......................... yes
  
 # -- END --


### PR DESCRIPTION
The fv3gfs_build.cfg did not have a space between the periods and the setting for workflow_utils, which means the setting was ignored and the default of yes was always used.

Fixes: #577