### PR TITLE
Explicitly set default netCDF atm and sfc filetypes

### DIFF
--- a/parm/config/config.fcst
+++ b/parm/config/config.fcst
@@ -205,6 +205,7 @@ export deflate_level=1
 
 export OUTPUT_FILETYPES="$OUTPUT_FILE"
 if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
+    export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
     export  ichunk2d=0; export jchunk2d=0
     export  ichunk3d=0; export jchunk3d=0;  export kchunk3d=0
     RESTILE=$(echo $CASE |cut -c 2-)
@@ -214,18 +215,10 @@ if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
             export ichunk3d=$((4*RESTILE)) 
             export jchunk3d=$((2*RESTILE))
             export kchunk3d=1
-        else
-            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
         fi
-    fi
-    if [[ "$machine" == "HERA" ]]; then
-        export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
     fi
     if [[ "$machine" == "ORION" ]]; then
         export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
-        if [ $RESTILE -le 192 ]; then
-            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
-        fi
     fi
 fi
 

--- a/parm/config/config.fcst
+++ b/parm/config/config.fcst
@@ -218,7 +218,9 @@ if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
         fi
     fi
     if [[ "$machine" == "ORION" ]]; then
-        export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
+        if [ $RESTILE -gt 192 ]; then
+           export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
+        fi
     fi
 fi
 

--- a/ush/parsing_model_configure_FV3.sh
+++ b/ush/parsing_model_configure_FV3.sh
@@ -12,9 +12,9 @@
 
 FV3_model_configure(){
 
-export OUTPUT_FILETYPES="$OUTPUT_FILE"
+export OUTPUT_FILETYPES=${OUTPUT_FILETYPES:-${OUTPUT_FILE:-"netcdf"}}
 if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
-   export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
+   export OUTPUT_FILETYPES=${OUTPUT_FILETYPES:-" 'netcdf_parallel' 'netcdf' "}
 fi
 
 rm -f model_configure

--- a/ush/parsing_model_configure_FV3.sh
+++ b/ush/parsing_model_configure_FV3.sh
@@ -12,11 +12,6 @@
 
 FV3_model_configure(){
 
-export OUTPUT_FILETYPES=${OUTPUT_FILETYPES:-${OUTPUT_FILE:-"netcdf"}}
-if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
-   export OUTPUT_FILETYPES=${OUTPUT_FILETYPES:-" 'netcdf_parallel' 'netcdf' "}
-fi
-
 rm -f model_configure
 cat >> model_configure <<EOF
 print_esmf:              ${print_esmf:-.true.} 


### PR DESCRIPTION
This retains the `OUTPUT_FILETYPES` option set in config.fcst while parsing the model_configure FV3 configuration file.  This fixes #588.