### PR TITLE
Update component tags based on NCO feedback 20220118

### DIFF
--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -26,7 +26,7 @@ The checkout script extracts the following GFS components:
 | --------- | ----------- | ----------------- |
 | MODEL     | GFS.v16.2.0   | Jun.Wang@noaa.gov |
 | GSI       | gfsda.v16.2.0 | Russ.Treadon@noaa.gov |
-| GLDAS     | gldas_gfsv16_release.v1.24.0 | Helin.Wei@noaa.gov |
+| GLDAS     | gldas_gfsv16_release.v1.25.0 | Helin.Wei@noaa.gov |
 | UFS_UTILS | ops-gfsv16.2.0 | George.Gayno@noaa.gov |
 | POST      | upp_v8.1.0 | Wen.Meng@noaa.gov |
 | WAFS      | gfs_wafs.v6.2.7 | Yali.Mao@noaa.gov |

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -45,7 +45,7 @@ fi
 echo gldas checkout ...
 if [[ ! -d gldas.fd ]] ; then
     rm -f ${topdir}/checkout-gldas.log
-    git clone --branch gldas_gfsv16_release.v1.24.0 https://github.com/NOAA-EMC/GLDAS  gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
+    git clone --branch gldas_gfsv16_release.v1.25.0 https://github.com/NOAA-EMC/GLDAS  gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory gldas.fd already exists.'


### PR DESCRIPTION
This PR updates relevant component tags after the CMs addressed feedback from NCO on January 18th, 2022.

- [x] GSI updates - gfsda.v16.2.0 recreated
- [x] GLDAS updates - new tag gldas_gfsv16_release.v1.25.0
- [x] UPP updates - upp_v8.1.0 tag recreated

Will submit PR when all components are checked off above.

Refs: #399