### PR TITLE
Enable issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
PR #560 added the templates for new issues, but GitHub also needs a config.yaml file to use issue forms (see https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser)