### PR TITLE
Series of small WCOSS2 updates - round 8

### DIFF
--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -32,7 +32,7 @@ if [ $step = "prep" -o $step = "prepbufr" ]; then
 
 elif [ $step = "waveinit" -o $step = "waveprep" -o $step = "wavepostsbs" -o $step = "wavepostbndpnt" -o $step = "wavepostbndpntbll"  -o $step = "wavepostpnt" ]; then
 
-    if [ $step = "waveprep" ]; then export MP_PULSE=0 ; fi
+    if [ $step = "waveprep" -a $CDUMP = "gfs" ]; then NTASKS=$NTASKS_gfs ; fi
     export wavempexec="$launcher -np"
     export wave_mpmd=${mpmd}
 

--- a/jobs/JGLOBAL_WAVE_POST_SBS
+++ b/jobs/JGLOBAL_WAVE_POST_SBS
@@ -63,8 +63,6 @@ export EXECwave=${EXECwave:-$HOMEgfs/exec}
 export COMIN=${COMIN:-${ROTDIR}/${CDUMP}.${PDY}/${cyc}/$COMPONENT}
 export COMOUT=${COMOUT:-${ROTDIR}/${CDUMP}.${PDY}/${cyc}/$COMPONENT}
 
-export COMINice=${COMINice:-${COMROOTp2}/omb/prod}
-export COMINwnd=${COMINwnd:-$(compath.py ${envir}/gfs/${gfs_ver})}
 export COMIN_WAV_CUR=${COMIN_WAV_CUR:-$(compath.py ${envir}/rtofs/${rtofs_ver})}
 
 mkdir -p $COMOUT/gridded

--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -118,6 +118,8 @@ export COMINatmos=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/atmos
 export COMOUTatmos=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/atmos
 export COMINwave=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/wave
 export COMOUTwave=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/wave
+export COMIN_OBS=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/atmos
+export COMIN_GES_OBS=${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/atmos
 
 export ERRSCRIPT=${ERRSCRIPT:-'eval [[ $err = 0 ]]'}
 export LOGSCRIPT=${LOGSCRIPT:-""}

--- a/ush/rocoto/setup_workflow.py
+++ b/ush/rocoto/setup_workflow.py
@@ -397,6 +397,10 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
     envars.append(rocoto.create_envar(name='CDUMP', value=f'{cdump}'))
     envars.append(rocoto.create_envar(name='PDY', value='<cyclestr>@Y@m@d</cyclestr>'))
     envars.append(rocoto.create_envar(name='cyc', value='<cyclestr>@H</cyclestr>'))
+    envars.append(rocoto.create_envar(name='GDATE', value='<cyclestr offset="-6:00:00">@Y@m@d@H</cyclestr>'))
+    envars.append(rocoto.create_envar(name='GDUMP', value='gdas'))
+    envars.append(rocoto.create_envar(name='gPDY', value='<cyclestr offset="-6:00:00">@Y@m@d</cyclestr>'))
+    envars.append(rocoto.create_envar(name='gcyc', value='<cyclestr offset="-6:00:00">@H</cyclestr>'))
 
     base = dict_configs['base']
     gfs_cyc = base.get('gfs_cyc', 0)

--- a/ush/rocoto/setup_workflow_fcstonly.py
+++ b/ush/rocoto/setup_workflow_fcstonly.py
@@ -673,6 +673,40 @@ def get_workflow(dict_configs, cdump='gdas'):
     return ''.join(tasks)
 
 
+def get_awipsgroups(awips, cdump='gfs'):
+
+    fhmin = awips['FHMIN']
+    fhmax = awips['FHMAX']
+    fhout = awips['FHOUT']
+
+    # Get a list of all forecast hours
+    if cdump in ['gdas']:
+        fhrs = range(fhmin, fhmax+fhout, fhout)
+    elif cdump in ['gfs']:
+        fhmax = np.max([awips['FHMAX_GFS_00'],awips['FHMAX_GFS_06'],awips['FHMAX_GFS_12'],awips['FHMAX_GFS_18']])
+        fhout = awips['FHOUT_GFS']
+        fhmax_hf = awips['FHMAX_HF_GFS']
+        fhout_hf = awips['FHOUT_HF_GFS']
+        if fhmax > 240:
+            fhmax = 240
+        if fhmax_hf > 240:
+            fhmax_hf = 240
+        fhrs_hf = range(fhmin, fhmax_hf+fhout_hf, fhout_hf)
+        fhrs = list(fhrs_hf) + list(range(fhrs_hf[-1]+fhout, fhmax+fhout, fhout))
+
+    nawipsgrp = awips['NAWIPSGRP']
+    ngrps = nawipsgrp if len(fhrs) > nawipsgrp else len(fhrs)
+
+    fhrs = [f'f{f:03d}' for f in fhrs]
+    fhrs = np.array_split(fhrs, ngrps)
+    fhrs = [f.tolist() for f in fhrs]
+
+    fhrgrp = ' '.join([f'{x:03d}' for x in range(0, ngrps)])
+    fhrdep = ' '.join([f[-1] for f in fhrs])
+    fhrlst = ' '.join(['_'.join(f) for f in fhrs])
+
+    return fhrgrp, fhrdep, fhrlst
+
 def get_workflow_body(dict_configs, cdump='gdas'):
     '''
         Create the workflow body

--- a/ush/rocoto/setup_workflow_fcstonly.py
+++ b/ush/rocoto/setup_workflow_fcstonly.py
@@ -239,6 +239,10 @@ def get_workflow(dict_configs, cdump='gdas'):
     envars.append(rocoto.create_envar(name='CDUMP', value='&CDUMP;'))
     envars.append(rocoto.create_envar(name='PDY', value='<cyclestr>@Y@m@d</cyclestr>'))
     envars.append(rocoto.create_envar(name='cyc', value='<cyclestr>@H</cyclestr>'))
+    envars.append(rocoto.create_envar(name='GDATE', value='<cyclestr offset="-6:00:00">@Y@m@d@H</cyclestr>'))
+    envars.append(rocoto.create_envar(name='GDUMP', value='gdas'))
+    envars.append(rocoto.create_envar(name='gPDY', value='<cyclestr offset="-6:00:00">@Y@m@d</cyclestr>'))
+    envars.append(rocoto.create_envar(name='gcyc', value='<cyclestr offset="-6:00:00">@H</cyclestr>'))
 
     base = dict_configs['base']
     machine = base.get('machine', wfu.detectMachine())

--- a/ush/rocoto/workflow_utils.py
+++ b/ush/rocoto/workflow_utils.py
@@ -287,7 +287,10 @@ def get_resources(machine, cfg, task, reservation, cdump='gdas'):
 
     ltask = 'eobs' if task in ['eomg'] else task
 
-    memory = cfg.get(f'memory_{ltask}', None)
+    if cdump in ['gfs'] and f'memory_{task}_gfs' in cfg.keys():
+        memory = cfg.get(f'memory_{ltask}_gfs', None)
+    else:
+        memory = cfg.get(f'memory_{ltask}', None)
 
     if cdump in ['gfs'] and f'npe_{task}_gfs' in cfg.keys():
         tasks = cfg[f'npe_{ltask}_gfs']


### PR DESCRIPTION
**Description**

This PR brings in some changes for the WCOSS2 port:

1. Add `NTASKS_gfs` support in `WCOSS2.env` (for waveprep job that needs to run with different # of tasks in gfs suite compared to gdas suite - need to update wave scripts to not use NTASKS in future work, this is just a patch for WCOSS2 ops).
2. Remove unneeded `COMINice` and `COMINwnd` from `jobs/JGLOBAL_WAVE_POST_SBS`.
3. Add support for gfs suite memory settings in `ush/rocoto/workflow_utils.py`, previously only accepted one memory setting for both gdas and gfs suite versions of a job, now users can set memory separately between the gdas and gfs suite versions of the same job. This aligns with similar support for the other resource variables.
4. Add missing `get_awipsgroups` function to setup_workflow_fcstonly.py.
5. Add `COMIN_OBS` and `COMIN_GES_OBS` in config.base.emc.dyn to properly set both variables when run in emc/dev mode. These two variables will be set via compath.py in NCO mode so this change is only to support emc/dev mode users. Will be working to change this in the future, want to use compath.py everywhere and not need emc/nco mode checks.
6. Add rocoto xml envars for `GDATE`, `GDUMP`, `gPDY`, and `gcyc`. This supports the new `COMIN_GES_OBS` variable, which needs to be built off of these variables before being used. This aligns with similar support in the rocoto xml for setting the `CDATE`, `CDUMP`, `PDY`, `cyc` variables used by all jobs.

Refs: #398, #399

**Type of change**

Port updates and maintenance.

**How Has This Been Tested?**

By rerunning affected jobs in test on Dogwood.