### PR TITLE
Allow different threading for gdasfcst and gfsfcst

### DIFF
--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -194,6 +194,9 @@ elif [ $step = "fcst" ]; then
             export layout_y=$layout_y_gfs
             export WRITE_GROUP=$WRITE_GROUP_GFS
             export WRTTASK_PER_GROUP=$WRTTASK_PER_GROUP_GFS
+	    export nth_fcst=${nth_fv3_gfs:-2}
+	else
+	    export nth_fcst=${nth_fv3:-2}
         fi
 
         (( ATMPETS = layout_x * layout_y * 6 ))
@@ -207,8 +210,6 @@ elif [ $step = "fcst" ]; then
         fi
         export ATMPETS
         NTASKS_TOT=$ATMPETS
-
-        export nth_fcst=${nth_fv3:-2}
 
         export npe_node_fcst=$(echo "$npe_node_max / $nth_fcst" | bc)
         if [[ "$machine" == "WCOSS_C" ]]; then export memory_fcst="1024M"; fi


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**
Fixes #610.  This change allows different threading to be specified for both GDAS and GFS forecasts.
<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--
- [ ] Clone and Build tests on WCOSS Dell P3
- [ ] Cycled test on Orion
- [ ] Forecast-only test on Hera
- [x] Setup test on S4
-->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] N/A My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] N/A Any dependent changes have been merged and published
