### PR TITLE
Fix build on non-WCOSS2 machines

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -55,7 +55,7 @@ if [[ ! -d gldas.fd ]] ; then
     rm -f ${topdir}/checkout-gldas.log
     git clone https://github.com/NOAA-EMC/GLDAS.git gldas.fd >> ${logdir}/checkout-gldas.fd.log 2>&1
     cd gldas.fd
-    git checkout gldas_gfsv16_release.v.1.27.0
+    git checkout gldas_gfsv16_release.v.1.28.0
     cd ${topdir}
 else
     echo 'Skip.  Directory gldas.fd already exists.'

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -66,7 +66,7 @@ if [[ ! -d ufs_utils.fd ]] ; then
     rm -f ${topdir}/checkout-ufs_utils.log
     git clone --recursive https://github.com/NOAA-EMC/UFS_UTILS.git ufs_utils.fd >> ${logdir}/checkout-ufs_utils.fd.log 2>&1
     cd ufs_utils.fd
-    git checkout ufs_utils_1_6_0
+    git checkout 04ad17e
     cd ${topdir}
 else
     echo 'Skip.  Directory ufs_utils.fd already exists.'

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -64,7 +64,7 @@ fi
 echo ufs_utils checkout ...
 if [[ ! -d ufs_utils.fd ]] ; then
     rm -f ${topdir}/checkout-ufs_utils.log
-    git clone --recursive https://github.com/NOAA-EMC/UFS_UTILS.git ufs_utils.fd >> ${logdir}/checkout-ufs_utils.fd.log 2>&1
+    git clone --recursive https://github.com/ufs-community/UFS_UTILS.git ufs_utils.fd >> ${logdir}/checkout-ufs_utils.fd.log 2>&1
     cd ufs_utils.fd
     git checkout 04ad17e
     cd ${topdir}

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -55,7 +55,7 @@ if [[ ! -d gldas.fd ]] ; then
     rm -f ${topdir}/checkout-gldas.log
     git clone https://github.com/NOAA-EMC/GLDAS.git gldas.fd >> ${logdir}/checkout-gldas.fd.log 2>&1
     cd gldas.fd
-    git checkout gldas_gfsv16_release.v1.15.0
+    git checkout gldas_gfsv16_release.v.1.27.0
     cd ${topdir}
 else
     echo 'Skip.  Directory gldas.fd already exists.'


### PR DESCRIPTION
**Description**

The UFS_UTILS and GLDAS versions are updated to correct build problems on development machines. Each had been using a beta version of ESMF that was removed from the hpc-stack installation without warning. Additionally, GLDAS had introduced bugs into their build scripts during the WCOSS2 port. These issues are now all corrected in the new versions.

Also updates the UFS_UTILS repository to its new location under UFS instead of EMC.

Fixes #476, #561

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] Clone and build on Hera
- [x] Clone and build on Orion
- [x] Clone and build on WCOSS-Dell
- [x] 2½-cycle test on Hera
- [x] 1½-cycle test on WCOSS-Dell

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
