### PR TITLE
Series of small WCOSS2 updates - round 9

### DIFF
--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -15,7 +15,7 @@ The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com a
 cd $PACKAGEROOT
 mkdir gfs.v16.2.0
 cd gfs.v16.2.0
-git clone -b EMC-v16.2.0.1 https://github.com/NOAA-EMC/global-workflow.git .
+git clone -b EMC-v16.2.0.2 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```

--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_select_obs.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_select_obs.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=26:mpiprocs=16:ompthreads=8:ncpus=128
+#PBS -l place=vscatter,select=27:mpiprocs=18:ompthreads=7:ncpus=126
 #PBS -l place=excl
 #PBS -l debug=true
 

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis.ecf
@@ -3,7 +3,7 @@
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:50:00
+#PBS -l walltime=00:40:00
 #PBS -l place=vscatter,select=55:mpiprocs=15:ompthreads=8:ncpus=120
 #PBS -l place=excl
 #PBS -l debug=true

--- a/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
+++ b/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=84:ompthreads=1:ncpus=84
+#PBS -l place=vscatter,select=1:mpiprocs=5:ompthreads=1:ncpus=5:mem=100GB
 #PBS -l place=excl
 #PBS -l debug=true
 

--- a/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
+++ b/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
@@ -5,7 +5,6 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:mpiprocs=5:ompthreads=1:ncpus=5:mem=100GB
-#PBS -l place=excl
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
@@ -37,7 +37,7 @@ export cyc=%CYC%
 export cycle=t%CYC%z
 export USE_CFP=YES
 export FHRGRP=%FHRGRP% FHRLST=%FHRLST% FCSTHR=%FCSTHR% TRDRUN=%TRDRUN% fcsthrs=%FCSTHR%
-export job=jgfs_awips_f%FCSTHR%_%CYC%
+#export job=jgfs_awips_f%FCSTHR%_%CYC%
 
 ############################################################
 # CALL executable job script here

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
@@ -37,7 +37,7 @@ export cyc=%CYC%
 export cycle=t%CYC%z
 export USE_CFP=YES
 export FHRGRP=%FHRGRP% FHRLST=%FHRLST% FCSTHR=%FCSTHR% TRDRUN=%TRDRUN% fcsthrs=%FCSTHR%
-#export job=jgfs_awips_f%FCSTHR%_%CYC%
+export job=jgfs_awips_f%FCSTHR%_%CYC%
 
 ############################################################
 # CALL executable job script here

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
@@ -41,7 +41,7 @@ export cyc=%CYC%
 export cycle=t%CYC%z
 export USE_CFP=YES
 trdrun=%TRDRUN%
-#export job="jgfs_awips_f${fcsthrs}_${cyc}"
+export job="jgfs_awips_f${fcsthrs}_${cyc}"
 
 ############################################################
 # CALL executable job script here

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
@@ -41,7 +41,7 @@ export cyc=%CYC%
 export cycle=t%CYC%z
 export USE_CFP=YES
 trdrun=%TRDRUN%
-export job="jgfs_awips_f${fcsthrs}_${cyc}"
+#export job="jgfs_awips_f${fcsthrs}_${cyc}"
 
 ############################################################
 # CALL executable job script here

--- a/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
+++ b/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
@@ -3,8 +3,8 @@
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:mpiprocs=60:ompthreads=1:ncpus=60:mem=100GB
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:mpiprocs=65:ompthreads=1:ncpus=65:mem=100GB
 #PBS -l debug=true
 
 model=gfs

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -24,8 +24,6 @@ export jobid=${job}.${PBS_JOBID:-$$}
 
 if [ $step = "prep" -o $step = "prepbufr" ]; then
 
-    nth_max=$(($npe_node_max / $npe_node_prep))
-
     export POE=${POE:-"YES"}
     export BACK=${BACK:-"off"}
     export sys_tp="wcoss2"
@@ -42,14 +40,10 @@ elif [ $step = "anal" ]; then
     export OMP_STACKSIZE=1G
     export FI_OFI_RXM_SAR_LIMIT=3145728
 
-    nth_max=$(($npe_node_max / $npe_node_anal))
-
-    export NTHREADS_GSI=${nth_anal:-$nth_max}
-    [[ $NTHREADS_GSI -gt $nth_max ]] && export NTHREADS_GSI=$nth_max
+    export NTHREADS_GSI=$nth_anal
     export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_anal:-$PBS_NP}} -ppn $npe_node_anal --cpu-bind core --depth $NTHREADS_GSI"
 
     export NTHREADS_CALCINC=${nth_calcinc:-1}
-    [[ $NTHREADS_CALCINC -gt $nth_max ]] && export NTHREADS_CALCINC=$nth_max
     export APRUN_CALCINC="$launcher \$ncmd"
 
     export NTHREADS_CYCLE=${nth_cycle:-14}
@@ -71,14 +65,10 @@ elif [ $step = "anal" ]; then
 
 elif [ $step = "gldas" ]; then
 
-    nth_max=$(($npe_node_max / $npe_node_gldas))
-
-    export NTHREADS_GLDAS=${nth_gldas:-$nth_max}
-    [[ $NTHREADS_GLDAS -gt $nth_max ]] && export NTHREADS_GLDAS=$nth_max
+    export NTHREADS_GLDAS=$nth_gldas
     export APRUN_GLDAS="$launcher -n $npe_gldas -ppn $npe_node_gldas --cpu-bind core --depth $NTHREADS_GLDAS"
 
     export NTHREADS_GAUSSIAN=${nth_gaussian:-1}
-    [[ $NTHREADS_GAUSSIAN -gt $nth_max ]] && export NTHREADS_GAUSSIAN=$nth_max
     export APRUN_GAUSSIAN="$launcher -n $npe_gaussian -ppn $npe_node_gaussian --cpu-bind core --depth $NTHREADS_GAUSSIAN"
 
     export USE_CFP=${USE_CFP:-"YES"}
@@ -90,10 +80,7 @@ elif [ $step = "eobs" ]; then
     export OMP_STACKSIZE=1G
     export FI_OFI_RXM_SAR_LIMIT=3145728
 
-    nth_max=$(($npe_node_max / $npe_node_eobs))
-
-    export NTHREADS_GSI=${nth_eobs:-$nth_max}
-    [[ $NTHREADS_GSI -gt $nth_max ]] && export NTHREADS_GSI=$nth_max
+    export NTHREADS_GSI=$nth_eobs
     export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_eobs:-$PBS_NP}} -ppn $npe_node_eobs --cpu-bind core --depth $NTHREADS_GSI"
 
     export CFP_MP=${CFP_MP:-"NO"}
@@ -107,10 +94,7 @@ elif [ $step = "eupd" ]; then
     export MPICH_COLL_OPT_OFF=1
     export FI_OFI_RXM_SAR_LIMIT=3145728
 
-    nth_max=$(($npe_node_max / $npe_node_eupd))
-
-    export NTHREADS_ENKF=${nth_eupd:-$nth_max}
-    [[ $NTHREADS_ENKF -gt $nth_max ]] && export NTHREADS_ENKF=$nth_max
+    export NTHREADS_ENKF=$nth_eupd
     export APRUN_ENKF="$launcher -n ${npe_enkf:-${npe_eupd:-$PBS_NP}} -ppn $npe_node_eupd --cpu-bind core --depth $NTHREADS_ENKF"
 
     export CFP_MP=${CFP_MP:-"NO"}
@@ -123,10 +107,7 @@ elif [ $step = "fcst" ]; then
     export FI_OFI_RXM_RX_SIZE=40000
     export FI_OFI_RXM_TX_SIZE=40000
 
-    nth_max=$(($npe_node_max / $npe_node_fcst))
-
-    export NTHREADS_FV3=${nth_fv3:-$nth_max}
-    [[ $NTHREADS_FV3 -gt $nth_max ]] && export NTHREADS_FV3=$nth_max
+    export NTHREADS_FV3=$nth_fv3
     export cores_per_node=$npe_node_max
     if [ $CDUMP = "gdas" ]; then
       export APRUN_FV3="$launcher -n ${npe_fcst:-$PBS_NP} -ppn $npe_node_fcst --cpu-bind core --depth $NTHREADS_FV3"
@@ -134,11 +115,9 @@ elif [ $step = "fcst" ]; then
       export APRUN_FV3="$launcher -n ${npe_fcst_gfs:-$PBS_NP} -ppn $npe_node_fcst_gfs --cpu-bind core --depth $NTHREADS_FV3"
     fi
     export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
-    [[ $NTHREADS_REGRID_NEMSIO -gt $nth_max ]] && export NTHREADS_REGRID_NEMSIO=$nth_max
     export APRUN_REGRID_NEMSIO="$launcher -n $LEVS"
 
     export NTHREADS_REMAP=${nth_remap:-2}
-    [[ $NTHREADS_REMAP -gt $nth_max ]] && export NTHREADS_REMAP=$nth_max
     export APRUN_REMAP="$launcher -n ${npe_remap:-${npe_fcst:-$PBS_NP}}"
 
 elif [ $step = "efcs" ]; then
@@ -148,35 +127,24 @@ elif [ $step = "efcs" ]; then
     export FI_OFI_RXM_RX_SIZE=40000
     export FI_OFI_RXM_TX_SIZE=40000
 
-    nth_max=$(($npe_node_max / $npe_node_efcs))
-
-    export NTHREADS_FV3=${nth_efcs:-$nth_max}
-    [[ $NTHREADS_FV3 -gt $nth_max ]] && export NTHREADS_FV3=$nth_max
+    export NTHREADS_FV3=$nth_efcs
     export cores_per_node=$npe_node_max
     export APRUN_FV3="$launcher -n ${npe_fv3:-${npe_efcs:-$PBS_NP}} -ppn $npe_node_efcs --cpu-bind core --depth $NTHREADS_FV3"
 
     export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
-    [[ $NTHREADS_REGRID_NEMSIO -gt $nth_max ]] && export NTHREADS_REGRID_NEMSIO=$nth_max
     export APRUN_REGRID_NEMSIO="$launcher -n $LEVS"
 
 elif [ $step = "post" ]; then
 
-    nth_max=$(($npe_node_max / $npe_node_post))
-
     export NTHREADS_NP=${nth_np:-1}
-    [[ $NTHREADS_NP -gt $nth_max ]] && export NTHREADS_NP=$nth_max
     export APRUN_NP="$launcher -n ${npe_np:-${npe_post:-$PBS_NP}} -ppn $npe_node_post --cpu-bind core --depth $NTHREADS_NP"
 
     export NTHREADS_DWN=${nth_dwn:-1}
-    [[ $NTHREADS_DWN -gt $nth_max ]] && export NTHREADS_DWN=$nth_max
     export APRUN_DWN="$launcher -np ${npe_dwn:-$PBS_NP} $mpmd"
 
 elif [ $step = "ecen" ]; then
 
-    nth_max=$(($npe_node_max / $npe_node_ecen))
-
-    export NTHREADS_ECEN=${nth_ecen:-$nth_max}
-    [[ $NTHREADS_ECEN -gt $nth_max ]] && export NTHREADS_ECEN=$nth_max
+    export NTHREADS_ECEN=$nth_ecen
     export APRUN_ECEN="$launcher -n ${npe_ecen:-$PBS_NP} -ppn $npe_node_ecen --cpu-bind core --depth $NTHREADS_ECEN"
 
     export NTHREADS_CHGRES=${nth_chgres:-14}
@@ -184,7 +152,6 @@ elif [ $step = "ecen" ]; then
     export APRUN_CHGRES="time"
 
     export NTHREADS_CALCINC=${nth_calcinc:-1}
-    [[ $NTHREADS_CALCINC -gt $nth_max ]] && export NTHREADS_CALCINC=$nth_max
     export APRUN_CALCINC="$launcher -n ${npe_ecen:-$PBS_NP}"
 
     export NTHREADS_CYCLE=${nth_cycle:-14}
@@ -193,10 +160,7 @@ elif [ $step = "ecen" ]; then
 
 elif [ $step = "esfc" ]; then
 
-    nth_max=$(($npe_node_max / $npe_node_esfc))
-
-    export NTHREADS_ESFC=${nth_esfc:-$nth_max}
-    [[ $NTHREADS_ESFC -gt $nth_max ]] && export NTHREADS_ESFC=$nth_max
+    export NTHREADS_ESFC=$nth_esfc
     export APRUN_ESFC="$launcher -n ${npe_esfc:-$PBS_NP} -ppn $npe_node_esfc --cpu-bind core --depth $NTHREADS_ESFC"
 
     export NTHREADS_CYCLE=${nth_cycle:-14}
@@ -205,10 +169,7 @@ elif [ $step = "esfc" ]; then
 
 elif [ $step = "epos" ]; then
 
-    nth_max=$(($npe_node_max / $npe_node_epos))
-
-    export NTHREADS_EPOS=${nth_epos:-$nth_max}
-    [[ $NTHREADS_EPOS -gt $nth_max ]] && export NTHREADS_EPOS=$nth_max
+    export NTHREADS_EPOS=$nth_epos
     export APRUN_EPOS="$launcher -n ${npe_epos:-$PBS_NP} -ppn $npe_node_epos --cpu-bind core --depth $NTHREADS_EPOS"
 
 elif [ $step = "fv3ic" ]; then
@@ -219,29 +180,19 @@ elif [ $step = "fv3ic" ]; then
 
 elif [ $step = "postsnd" ]; then
 
-    nth_max=$(($npe_node_max / $npe_node_postsnd))
-
     export NTHREADS_POSTSND=${nth_postsnd:-1}
-    [[ $NTHREADS_POSTSND -gt $nth_max ]] && export NTHREADS_POSTSND=$nth_max
     export APRUN_POSTSND="$launcher -n $npe_postsnd --depth=6 --cpu-bind depth"
     export NTHREADS_POSTSNDCFP=${nth_postsndcfp:-1}
-    [[ $NTHREADS_POSTSNDCFP -gt $nth_max ]] && export NTHREADS_POSTSNDCFP=$nth_max
     export APRUN_POSTSNDCFP="$launcher -np $npe_postsndcfp $mpmd"
 
 elif [ $step = "awips" ]; then
 
-    nth_max=$(($npe_node_max / $npe_node_awips))
-
     export NTHREADS_AWIPS=${nth_awips:-2}
-    [[ $NTHREADS_AWIPS -gt $nth_max ]] && export NTHREADS_AWIPS=$nth_max
     export APRUN_AWIPSCFP="$launcher -np ${npe_awips:-$PBS_NP} $mpmd"
 
 elif [ $step = "gempak" ]; then
 
-    nth_max=$(($npe_node_max / $npe_node_gempak))
-
     export NTHREADS_GEMPAK=${nth_gempak:-1}
-    [[ $NTHREADS_GEMPAK -gt $nth_max ]] && export NTHREADS_GEMPAK=$nth_max
     export APRUN_GEMPAKCFP="$launcher -np \$ntasks $mpmd"
 
 elif [ $step = "waveawipsbulls" ]; then

--- a/jobs/JGDAS_ATMOS_GEMPAK
+++ b/jobs/JGDAS_ATMOS_GEMPAK
@@ -7,6 +7,24 @@ date
 ############################################
 # GDAS GEMPAK PRODUCT GENERATION
 ############################################
+echo
+echo "=============== BEGIN GEMPAK ==============="
+echo
+echo "=============== BEGIN TO SOURCE RELEVANT CONFIGS ==============="
+configs="base gempak"
+for config in $configs; do
+    . $EXPDIR/config.${config}
+    status=$?
+    [[ $status -ne 0 ]] && exit $status
+done
+
+###############################################################
+echo
+echo "=============== BEGIN TO SOURCE MACHINE RUNTIME ENVIRONMENT ==============="
+. $BASE_ENV/${machine}.env gempak
+status=$?
+[[ $status -ne 0 ]] && exit $status
+
 
 ##########################################################
 # obtain unique process id (pid) and make temp directory
@@ -50,6 +68,7 @@ export GRIB=pgrb2f
 export EXT=""
 export DBN_ALERT_TYPE=GDAS_GEMPAK
 
+export SENDCOM=${SENDCOM:-NO}
 export SENDDBN=${SENDDBN:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
@@ -99,7 +118,7 @@ ntasks=${NTASKS_GEMPAK:-$(cat $DATA/poescript | wc -l)}
 ptile=${PTILE_GEMPAK:-4}
 threads=${NTHREADS_GEMPAK:-1}
 export OMP_NUM_THREADS=$threads
-APRUN="mpiexec -l -n $ntasks -ppn $ntasks --cpu-bind verbose,core cfp"
+APRUN="mpiexec -l -np $ntasks --cpu-bind verbose,core cfp"
 APRUN_GEMPAKCFP=${APRUN_GEMPAKCFP:-$APRUN}
 APRUNCFP=$(eval echo $APRUN_GEMPAKCFP)
 

--- a/jobs/JGFS_ATMOS_GEMPAK
+++ b/jobs/JGFS_ATMOS_GEMPAK
@@ -7,6 +7,23 @@ date
 ############################################
 # GFS GEMPAK PRODUCT GENERATION
 ############################################
+echo
+echo "=============== BEGIN GEMPAK ==============="
+echo
+echo "=============== BEGIN TO SOURCE RELEVANT CONFIGS ==============="
+configs="base gempak"
+for config in $configs; do
+    . $EXPDIR/config.${config}
+    status=$?
+    [[ $status -ne 0 ]] && exit $status
+done
+
+###############################################################
+echo
+echo "=============== BEGIN TO SOURCE MACHINE RUNTIME ENVIRONMENT ==============="
+. $BASE_ENV/${machine}.env gempak
+status=$?
+[[ $status -ne 0 ]] && exit $status
 
 ##########################################################
 # obtain unique process id (pid) and make temp directory
@@ -64,6 +81,7 @@ export COMPONENT=${COMPONENT:-atmos}
 export COMIN=${COMIN:-$(compath.py ${envir}/${NET}/${gfs_ver})/${RUN}.${PDY}/${cyc}/$COMPONENT}
 export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${gfs_ver}/${RUN}.${PDY})/${cyc}/$COMPONENT/gempak}
 
+export SENDCOM=${SENDCOM:-NO}
 export SENDDBN=${SENDDBN:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
@@ -141,8 +159,7 @@ ntasks=${NTASKS_GEMPAK:-$(cat $DATA/poescript | wc -l)}
 ptile=${PTILE_GEMPAK:-4}
 threads=${NTHREADS_GEMPAK:-1}
 export OMP_NUM_THREADS=$threads
-APRUN="mpiexec -l -n $ntasks -ppn $ntasks --cpu-bind verbose,core cfp"
-
+APRUN="mpiexec -l -np $ntasks --cpu-bind verbose,core cfp"
 APRUN_GEMPAKCFP=${APRUN_GEMPAKCFP:-$APRUN}
 APRUNCFP=$(eval echo $APRUN_GEMPAKCFP)
 

--- a/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
+++ b/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
@@ -44,6 +44,7 @@ export SRCgfs=${SRCgfs:-$HOMEgfs/scripts}
 # Specify NET and RUN Name and model
 ####################################
 export NET=gfs
+#export RUN=gfs_goessim
 export RUN=gfs
 export COMPONENT=${COMPONENT:-atmos}
 export finc=3
@@ -77,6 +78,7 @@ mkdir -p $DATA
 cd $DATA
 
 export DBN_ALERT_TYPE=GFS_GOESSIM_GEMPAK
+export RUN2=gfs_goessim
 export GRIB=goessimpgrb2.0p25.f
 export EXT=" "
 export fend=180
@@ -98,7 +100,7 @@ mkdir -p $DATA
 cd $DATA
 
 export DBN_ALERT_TYPE=GFS_GOESSIM221_GEMPAK
-export RUN=gfs_goessim221
+export RUN2=gfs_goessim221
 export GRIB=goessimpgrb2f
 export EXT=".grd221"
 export fend=180

--- a/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
+++ b/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
@@ -8,7 +8,7 @@ set -x -e
 #############################
 # Source relevant config files
 #############################
-configs="base wave wavepostsbs wavepostbndpnt"
+configs="base wave wavepostsbs wavepostbndpntbll"
 export EXPDIR=${EXPDIR:-$HOMEgfs/parm/config}
 config_path=${EXPDIR:-$NWROOT/gfs.${gfs_ver}/parm/config}
 for config in $configs; do

--- a/jobs/rocoto/gempak.sh
+++ b/jobs/rocoto/gempak.sh
@@ -1,68 +1,23 @@
 #!/bin/ksh -x
 
 ###############################################################
-## Abstract:
-## Inline gempak driver script
-## RUN_ENVIR : runtime environment (emc | nco)
-## HOMEgfs   : /full/path/to/workflow
-## EXPDIR : /full/path/to/config/files
-## CDATE  : current analysis date (YYYYMMDDHH)
-## CDUMP  : cycle name (gdas / gfs)
-## PDY    : current date (YYYYMMDD)
-## cyc    : current cycle (HH)
-###############################################################
-
-###############################################################
 echo
 echo "=============== BEGIN TO SOURCE FV3GFS WORKFLOW MODULES ==============="
 . $HOMEgfs/ush/load_fv3gfs_modules.sh
 status=$?
 [[ $status -ne 0 ]] && exit $status
 
-
-###############################################################
-echo
-echo "=============== BEGIN TO SOURCE RELEVANT CONFIGS ==============="
-configs="base gempak"
-for config in $configs; do
-    . $EXPDIR/config.${config}
-    status=$?
-    [[ $status -ne 0 ]] && exit $status
-done
-
-
-###############################################################
-echo
-echo "=============== BEGIN TO SOURCE MACHINE RUNTIME ENVIRONMENT ==============="
-. $BASE_ENV/${machine}.env gempak
-status=$?
-[[ $status -ne 0 ]] && exit $status
-
-###############################################################
-export COMPONENT=${COMPONENT:-atmos}
-export CDATEm1=$($NDATE -24 $CDATE)
-export PDYm1=$(echo $CDATEm1 | cut -c1-8)
-
-export COMIN="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT"
-export DATAROOT="$RUNDIR/$CDATE/$CDUMP/gempak"
-[[ -d $DATAROOT ]] && rm -rf $DATAROOT
-mkdir -p $DATAROOT
-
-
-################################################################################
-echo
-echo "=============== BEGIN GEMPAK ==============="
-export job="jgfs_gempak_${cyc}"
-export DATA="${DATAROOT}/$job"
 export SENDCOM="YES"
+export COMPONENT=${COMPONENT:-atmos}
+export COMIN="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT"
 export COMOUT="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT/gempak"
-export FIXgfs=""  # set blank so that GEMPAKSH defaults FIXgfs to HOMEgfs/gempak/fix
-export USHgfs=""  # set blank so that GEMPAKSH defaults FIXgfs to HOMEgfs/gempak/ush
-
-$GEMPAKSH
-
 
 ###############################################################
-# Force Exit out cleanly
-if [ ${KEEPDATA:-"NO"} = "NO" ] ; then rm -rf $DATAROOT ; fi
-exit 0
+# Execute the JJOB
+if [ $CDUMP = "gdas" ]; then
+  $HOMEgfs/jobs/JGDAS_ATMOS_GEMPAK
+elif [ $CDUMP = "gfs" ]; then
+  $HOMEgfs/jobs/JGFS_ATMOS_GEMPAK
+fi
+status=$?
+exit $status

--- a/parm/config/config.gempak
+++ b/parm/config/config.gempak
@@ -8,6 +8,4 @@ echo "BEGIN: config.gempak"
 # Get task specific resources
 . $EXPDIR/config.resources gempak
 
-export GEMPAKSH=$HOMEgfs/jobs/JGFS_ATMOS_GEMPAK
-
 echo "END: config.gempak"

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -58,12 +58,12 @@ elif [ $step = "waveinit" ]; then
 elif [ $step = "waveprep" ]; then
 
     export wtime_waveprep="00:10:00"
-    export npe_waveprep=84
-    export npe_waveprep_gfs=60
+    export npe_waveprep=5
+    export npe_waveprep_gfs=65
     export nth_waveprep=1
     export npe_node_waveprep=$npe_waveprep
     export npe_node_waveprep_gfs=$npe_waveprep_gfs
-    export memory_waveprep_gfs="100GB"
+    export memory_waveprep="100GB"
     export NTASKS=$npe_waveprep
     export NTASKS_gfs=$npe_waveprep_gfs
 
@@ -193,7 +193,7 @@ elif [ $step = "fcst" ]; then
 elif [ $step = "post" ]; then
 
     export wtime_post="00:12:00"
-    export wtime_post_gfs="00:20:00"
+    export wtime_post_gfs="01:00:00"
     export npe_post=112
     export nth_post=1
     export npe_node_post=$npe_post
@@ -302,7 +302,7 @@ elif [ $step = "eobs" -o $step = "eomg" ]; then
     elif [ $CASE = "C96" -o $CASE = "C48" ]; then
       export npe_eobs=14
     fi
-    export nth_eobs=8
+    export nth_eobs=7
     if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_eobs=7; fi
     export npe_node_eobs=$(echo "$npe_node_max / $nth_eobs" | bc)
 

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -131,7 +131,8 @@ elif [ $step = "waveawipsgridded" ]; then
 
 elif [ $step = "anal" ]; then
 
-    export wtime_anal="00:50:00"
+    export wtime_anal="00:40:00"
+    export wtime_anal_gfs="00:50:00"
     export npe_anal=825
     export nth_anal=8
     export npe_anal_gfs=825
@@ -293,7 +294,7 @@ elif [ $step = "eobs" -o $step = "eomg" ]; then
     export wtime_eobs="00:10:00"
     export wtime_eomg="01:00:00"
     if [ $CASE = "C768" ]; then
-      export npe_eobs=416
+      export npe_eobs=480
     elif [ $CASE = "C384" ]; then
       export npe_eobs=42
     elif [ $CASE = "C192" ]; then

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -58,12 +58,12 @@ elif [ $step = "waveinit" ]; then
 elif [ $step = "waveprep" ]; then
 
     export wtime_waveprep="00:10:00"
-    export npe_waveprep=84
-    export npe_waveprep_gfs=60
+    export npe_waveprep=5
+    export npe_waveprep_gfs=65
     export nth_waveprep=1
     export npe_node_waveprep=$npe_waveprep
     export npe_node_waveprep_gfs=$npe_waveprep_gfs
-    export memory_waveprep_gfs="100GB"
+    export memory_waveprep="100GB"
     export NTASKS=$npe_waveprep
     export NTASKS_gfs=$npe_waveprep_gfs
 
@@ -193,7 +193,7 @@ elif [ $step = "fcst" ]; then
 elif [ $step = "post" ]; then
 
     export wtime_post="00:12:00"
-    export wtime_post_gfs="00:20:00"
+    export wtime_post_gfs="01:00:00"
     export npe_post=112
     export nth_post=1
     export npe_node_post=$npe_post
@@ -302,7 +302,7 @@ elif [ $step = "eobs" -o $step = "eomg" ]; then
     elif [ $CASE = "C96" -o $CASE = "C48" ]; then
       export npe_eobs=14
     fi
-    export nth_eobs=8
+    export nth_eobs=7
     if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_eobs=7; fi
     export npe_node_eobs=$(echo "$npe_node_max / $nth_eobs" | bc)
 

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -131,7 +131,8 @@ elif [ $step = "waveawipsgridded" ]; then
 
 elif [ $step = "anal" ]; then
 
-    export wtime_anal="00:50:00"
+    export wtime_anal="00:40:00"
+    export wtime_anal_gfs="00:50:00"
     export npe_anal=825
     export nth_anal=8
     export npe_anal_gfs=825
@@ -293,7 +294,7 @@ elif [ $step = "eobs" -o $step = "eomg" ]; then
     export wtime_eobs="00:10:00"
     export wtime_eomg="01:00:00"
     if [ $CASE = "C768" ]; then
-      export npe_eobs=416
+      export npe_eobs=480
     elif [ $CASE = "C384" ]; then
       export npe_eobs=42
     elif [ $CASE = "C192" ]; then

--- a/scripts/exgdas_atmos_nawips.sh
+++ b/scripts/exgdas_atmos_nawips.sh
@@ -12,13 +12,13 @@ echo "                    data on the CCS is properly protected."
 set -xa
 
 cd $DATA
-RUN=$1
+RUN2=$1
 fend=$2
 DBN_ALERT_TYPE=$3
 
 export 'PS4=$RUN:$SECONDS + '
 
-DATA_RUN=$DATA/$RUN
+DATA_RUN=$DATA/$RUN2
 mkdir -p $DATA_RUN
 cd $DATA_RUN
 
@@ -81,9 +81,9 @@ while [ $fhcnt -le $fend ] ; do
   fhr3=$fhcnt
   typeset -Z3 fhr3
 
-  GEMGRD=${RUN}_${PDY}${cyc}f${fhr3}
+  GEMGRD=${RUN2}_${PDY}${cyc}f${fhr3}
 
-  if [ $RUN = "gdas_0p25" ]; then 
+  if [ $RUN2 = "gdas_0p25" ]; then
     export GRIBIN=$COMIN/${model}.${cycle}.pgrb2.0p25.f${fhr}
     if [ ! -f $GRIBIN ] ; then
        echo "WARNING: $GRIBIN FILE is missing"
@@ -168,9 +168,9 @@ $GEMEXE/gpend
 #####################################################################
 # GOOD RUN
 set +x
-echo "**************JOB $RUN NAWIPS COMPLETED NORMALLY ON THE IBM"
-echo "**************JOB $RUN NAWIPS COMPLETED NORMALLY ON THE IBM"
-echo "**************JOB $RUN NAWIPS COMPLETED NORMALLY ON THE IBM"
+echo "**************JOB $RUN2 NAWIPS COMPLETED NORMALLY ON THE IBM"
+echo "**************JOB $RUN2 NAWIPS COMPLETED NORMALLY ON THE IBM"
+echo "**************JOB $RUN2 NAWIPS COMPLETED NORMALLY ON THE IBM"
 set -x
 #####################################################################
 

--- a/scripts/exgfs_atmos_gempak_meta.sh
+++ b/scripts/exgfs_atmos_gempak_meta.sh
@@ -29,16 +29,6 @@ do_all=0
 #loop through and process needed forecast hours
 while [ $fhr -le $fhend ]
 do
-   # 
-   # First check to see if this is a rerun.  If so make all Meta files
-   if [ $fhr -gt 126 -a $first_time -eq 0 ] ; then
-     do_all=1
-   fi
-   first_time=1
-
-   if [ $fhr -eq 120 ] ; then
-      fhr=126
-   fi
    icnt=1
 
    while [ $icnt -lt 1000 ]
@@ -59,7 +49,7 @@ do
       fi
    done
 
-   export fhr
+   export fhr=$fhr
 
    ########################################################
    # Create a script to be poe'd
@@ -71,22 +61,7 @@ do
       rm $DATA/poescript
 #   fi
 
-   if [ $fhr -lt 100 ] ; then
-      typeset -Z2 fhr
-   fi
-
-   if [ $do_all -eq 1 ] ; then
-     do_all=0
-     awk '{print $1}' $FIXgempak/gfs_meta > $DATA/tmpscript
-   else
-     #
-     #     Do not try to grep out 12, it will grab the 12 from 126.
-     #     This will work as long as we don't need 12 fhr metafiles
-     #
-     if [ $fhr -ne 12 ] ; then
-       grep $fhr $FIXgempak/gfs_meta |awk -F" [0-9]" '{print $1}' > $DATA/tmpscript
-     fi
-   fi
+   awk '{print $1}' $FIXgempak/gfs_meta > $DATA/tmpscript
 
    for script in `cat $DATA/tmpscript`
    do
@@ -105,12 +80,7 @@ do
    export MP_PGMMODEL=mpmd
    export MP_CMDFILE=$DATA/poescript
 
-#  If this is the final fcst hour, alert the
-#  file to all centers.
-# 
-   if [ $fhr -ge $fhend ] ; then
-      export DBN_ALERT_TYPE=GFS_METAFILE_LAST
-   fi
+   export DBN_ALERT_TYPE=GFS_METAFILE_LAST
 
    export fend=$fhr
 
@@ -126,12 +96,6 @@ do
   $APRUNCFP $DATA/poescript
   export err=$?; err_chk
 
-      typeset -Z3 fhr
-      if [ $fhr -eq 126 ] ; then
-        let fhr=fhr+6
-      else
-	let fhr=fhr+fhinc
-      fi
 done
 
 #####################################################################

--- a/scripts/exgfs_atmos_goes_nawips.sh
+++ b/scripts/exgfs_atmos_goes_nawips.sh
@@ -26,7 +26,7 @@ echo "Begin job for $job"
 NAGRIB=$GEMEXE/nagrib2
 #
 
-entry=`grep "^$RUN " $NAGRIB_TABLE | awk 'index($1,"#") != 1 {print $0}'`
+entry=`grep "^$RUN2 " $NAGRIB_TABLE | awk 'index($1,"#") != 1 {print $0}'`
 
 if [ "$entry" != "" ] ; then
   cpyfil=`echo $entry  | awk 'BEGIN {FS="|"} {print $2}'`
@@ -63,7 +63,7 @@ while [ $fhcnt -le $fend ] ; do
   fhr3=$fhcnt
   typeset -Z3 fhr3
   GRIBIN=$COMIN/${model}.${cycle}.${GRIB}${fhr}${EXT}
-  GEMGRD=${RUN}_${PDY}${cyc}f${fhr3}
+  GEMGRD=${RUN2}_${PDY}${cyc}f${fhr3}
 
   GRIBIN_chk=$GRIBIN
 
@@ -127,9 +127,9 @@ done
 #####################################################################
 # GOOD RUN
 set +x
-echo "**************JOB $RUN NAWIPS COMPLETED NORMALLY ON THE IBM"
-echo "**************JOB $RUN NAWIPS COMPLETED NORMALLY ON THE IBM"
-echo "**************JOB $RUN NAWIPS COMPLETED NORMALLY ON THE IBM"
+echo "**************JOB $RUN2 NAWIPS COMPLETED NORMALLY ON THE IBM"
+echo "**************JOB $RUN2 NAWIPS COMPLETED NORMALLY ON THE IBM"
+echo "**************JOB $RUN2 NAWIPS COMPLETED NORMALLY ON THE IBM"
 set -x
 #####################################################################
 

--- a/scripts/exgfs_atmos_nawips.sh
+++ b/scripts/exgfs_atmos_nawips.sh
@@ -17,13 +17,13 @@ set -xa
 export ILPOST=${ILPOST:-1}
 
 cd $DATA
-RUN=$1
+RUN2=$1
 fend=$2
 DBN_ALERT_TYPE=$3
 
 export 'PS4=$RUN:$SECONDS + '
 
-DATA_RUN=$DATA/$RUN
+DATA_RUN=$DATA/$RUN2
 mkdir -p $DATA_RUN
 cd $DATA_RUN
 
@@ -62,7 +62,7 @@ if mkdir lock.$fhcnt  ; then
   fhr3=$fhcnt
   typeset -Z3 fhr3
 
-  GEMGRD=${RUN}_${PDY}${cyc}f${fhr3}
+  GEMGRD=${RUN2}_${PDY}${cyc}f${fhr3}
 
 # Set type of Interpolation for WGRIB2
   export opt1=' -set_grib_type same -new_grid_winds earth '
@@ -77,10 +77,10 @@ if mkdir lock.$fhcnt  ; then
   export opt28=' -new_grid_interpolation budget -fi '
   export TRIMRH=$HOMEgfs/ush/trim_rh.sh
 
-  if [ $RUN = "gfs_0p50" ]; then
+  if [ $RUN2 = "gfs_0p50" ]; then
     export GRIBIN=$COMIN/${model}.${cycle}.pgrb2.0p50.f${fhr}
     GRIBIN_chk=$COMIN/${model}.${cycle}.pgrb2.0p50.f${fhr}.idx
-  elif [ $RUN = "gfs_0p25" -o $RUN = "gdas_0p25" -o $RUN = "gfs35_atl" -o $RUN = "gfs35_pac" -o $RUN = "gfs40" ]; then 
+  elif [ $RUN2 = "gfs_0p25" -o $RUN2 = "gdas_0p25" -o $RUN2 = "gfs35_atl" -o $RUN2 = "gfs35_pac" -o $RUN2 = "gfs40" ]; then
     export GRIBIN=$COMIN/${model}.${cycle}.pgrb2.0p25.f${fhr}
     GRIBIN_chk=$COMIN/${model}.${cycle}.pgrb2.0p25.f${fhr}.idx
   else
@@ -107,7 +107,7 @@ if mkdir lock.$fhcnt  ; then
     fi
   done
 
-case $RUN in
+case $RUN2 in
  gfs35_pac)
 #   $COPYGB2 -g "0 6 0 0 0 0 0 0 416 186 0 0 75125000 130000000 48 17000000 260000000 312000 312000 0" -x $GRIBIN grib$fhr
 #   NEW define gfs35_pac="0 6 0 0 0 0 0 0 416 186 0 -1 75125000 130000000 48 17405000 259480000 312000 312000 0"
@@ -169,12 +169,12 @@ EOF
   cd $DATA_RUN
 else
     if [ $fhcnt -ge 240 ] ; then
-	if [ $fhcnt -lt 276 -a $RUN = "gfs_0p50" ] ; then
+	if [ $fhcnt -lt 276 -a $RUN2 = "gfs_0p50" ] ; then
 	    let fhcnt=fhcnt+6
 	else
 	    let fhcnt=fhcnt+12
 	fi
-    elif [ $fhcnt -lt 120 -a $RUN = "gfs_0p25" ] ; then
+    elif [ $fhcnt -lt 120 -a $RUN2 = "gfs_0p25" ] ; then
 ####    let fhcnt=fhcnt+1
 	let fhcnt=fhcnt+$ILPOST
     else
@@ -187,9 +187,9 @@ $GEMEXE/gpend
 #####################################################################
 # GOOD RUN
 set +x
-echo "**************JOB $RUN NAWIPS COMPLETED NORMALLY ON THE IBM"
-echo "**************JOB $RUN NAWIPS COMPLETED NORMALLY ON THE IBM"
-echo "**************JOB $RUN NAWIPS COMPLETED NORMALLY ON THE IBM"
+echo "**************JOB $RUN2 NAWIPS COMPLETED NORMALLY ON THE IBM"
+echo "**************JOB $RUN2 NAWIPS COMPLETED NORMALLY ON THE IBM"
+echo "**************JOB $RUN2 NAWIPS COMPLETED NORMALLY ON THE IBM"
 set -x
 #####################################################################
 

--- a/ush/rocoto/setup_workflow.py
+++ b/ush/rocoto/setup_workflow.py
@@ -267,7 +267,7 @@ def get_gdasgfs_resources(dict_configs, cdump='gdas'):
         tasks += ['waveinit', 'waveprep', 'wavepostsbs', 'wavepostbndpnt', 'wavepostbndpntbll', 'wavepostpnt']
     if cdump in ['gfs'] and do_bufrsnd in ['Y', 'YES']:
         tasks += ['postsnd']
-    if cdump in ['gfs'] and do_gempak in ['Y', 'YES']:
+    if do_gempak in ['Y', 'YES']:
         tasks += ['gempak']
     if cdump in ['gfs'] and do_wave in ['Y', 'YES'] and do_gempak in ['Y', 'YES']:
         tasks += ['wavegempak']
@@ -743,12 +743,14 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
         dict_tasks[f'{cdump}awips'] = task
 
     # gempak
-    if cdump in ['gfs'] and do_gempak in ['Y', 'YES']:
+    if do_gempak in ['Y', 'YES']:
         deps = []
         dep_dict = {'type': 'metatask', 'name': f'{cdump}post'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
-        task = wfu.create_wf_task('gempak', cdump=cdump, envar=envars, dependency=dependencies)
+        ROTDIR = rocoto.create_envar(name='ROTDIR', value='&ROTDIR;')
+        gempakenvars = envars + [ROTDIR]
+        task = wfu.create_wf_task('gempak', cdump=cdump, envar=gempakenvars, dependency=dependencies)
 
         dict_tasks[f'{cdump}gempak'] = task
 

--- a/ush/rocoto/setup_workflow_fcstonly.py
+++ b/ush/rocoto/setup_workflow_fcstonly.py
@@ -621,7 +621,9 @@ def get_workflow(dict_configs, cdump='gdas'):
         dep_dict = {'type': 'metatask', 'name': f'{cdump}post'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
-        task = wfu.create_wf_task('gempak', cdump=cdump, envar=envars, dependency=dependencies)
+        ROTDIR = rocoto.create_envar(name='ROTDIR', value='&ROTDIR;')
+        gempakenvars = envars + [ROTDIR]
+        task = wfu.create_wf_task('gempak', cdump=cdump, envar=gempakenvars, dependency=dependencies)
         tasks.append(task)
         tasks.append('\n')
 


### PR DESCRIPTION
**Description**

This PR includes the following updates for WCOSS2:

1. update hand-off tag in release notes to EMC-v16.2.0.2
2. resource updates for gdaseobs, gdas[gfs]analysis walltimes, gdas[gfs]waveprep (made and tested with @WeiWei-NCO)
3. retire usage of nth_max in WCOSS2.env (causes problems on WCOSS2 and isn't needed there, consider removing on other platforms later)
4. update awips scripts with updates from @BoiVuong-NOAA and @WeiWei-NCO
5. update gempak scripts to move config and env file sourcing into JJOB scripts (issue in nco mode because env file not sourced to update the APRUN_GEMPAKCFP setting) [do the same with other similar instances of config/env sourcing being in jobs/rocoto/* scripts and not in JJOBs later]
6. update setup scripts to turn on gdasgempak job (for testing) and add ROTDIR to the `gempakenvars` for runtime needs
7. correct list of configs for wavepostbndpntbll job

**Type of change**

Port maintenance

**How Has This Been Tested?**

Tested on Dogwood.
 
Fixes: #599
Refs: #398, #399