### PR TITLE
Update GLDAS tag to gldas_gfsv16_release.v1.28.0

### DIFF
--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -26,7 +26,7 @@ The checkout script extracts the following GFS components:
 | --------- | ----------- | ----------------- |
 | MODEL     | GFS.v16.2.0   | Jun.Wang@noaa.gov |
 | GSI       | gfsda.v16.2.0 | Russ.Treadon@noaa.gov |
-| GLDAS     | gldas_gfsv16_release.v1.28.0 | Helin.Wei@noaa.gov |
+| GLDAS     | gldas_gfsv16_release.v.1.28.0 | Helin.Wei@noaa.gov |
 | UFS_UTILS | ops-gfsv16.2.0 | George.Gayno@noaa.gov |
 | POST      | upp_v8.1.0 | Wen.Meng@noaa.gov |
 | WAFS      | gfs_wafs.v6.2.7 | Yali.Mao@noaa.gov |

--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -26,7 +26,7 @@ The checkout script extracts the following GFS components:
 | --------- | ----------- | ----------------- |
 | MODEL     | GFS.v16.2.0   | Jun.Wang@noaa.gov |
 | GSI       | gfsda.v16.2.0 | Russ.Treadon@noaa.gov |
-| GLDAS     | gldas_gfsv16_release.v1.25.0 | Helin.Wei@noaa.gov |
+| GLDAS     | gldas_gfsv16_release.v1.28.0 | Helin.Wei@noaa.gov |
 | UFS_UTILS | ops-gfsv16.2.0 | George.Gayno@noaa.gov |
 | POST      | upp_v8.1.0 | Wen.Meng@noaa.gov |
 | WAFS      | gfs_wafs.v6.2.7 | Yali.Mao@noaa.gov |

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -45,7 +45,7 @@ fi
 echo gldas checkout ...
 if [[ ! -d gldas.fd ]] ; then
     rm -f ${topdir}/checkout-gldas.log
-    git clone --branch gldas_gfsv16_release.v1.25.0 https://github.com/NOAA-EMC/GLDAS  gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
+    git clone --branch gldas_gfsv16_release.v.1.28.0 https://github.com/NOAA-EMC/GLDAS  gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory gldas.fd already exists.'


### PR DESCRIPTION
This PR updates the GLDAS tag to `gldas_gfsv16_release.v1.28.0`. This new tag impacts the non-WCOSS2 platforms only and changes nothing for WCOSS2.

Have tested checkout, build, and run on Dogwood. All good with new tag. @WeiWei-NCO approved tag update.

Refs: #398, #399