### PR TITLE
Series of small WCOSS2 updates - round 10

### DIFF
--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -15,7 +15,7 @@ The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com a
 cd $PACKAGEROOT
 mkdir gfs.v16.2.0
 cd gfs.v16.2.0
-git clone -b EMC-v16.2.0.2 https://github.com/NOAA-EMC/global-workflow.git .
+git clone -b EMC-v16.2.0.3 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```

--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_select_obs.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_select_obs.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=27:mpiprocs=18:ompthreads=7:ncpus=126
+#PBS -l place=vscatter,select=12:mpiprocs=40:ompthreads=3:ncpus=120
 #PBS -l place=excl
 #PBS -l debug=true
 

--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_update.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_update.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=32:mpiprocs=10:ompthreads=12:ncpus=120
+#PBS -l place=vscatter,select=35:mpiprocs=9:ompthreads=14:ncpus=126
 #PBS -l place=excl
 #PBS -l debug=true
 

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:40:00
-#PBS -l place=vscatter,select=55:mpiprocs=15:ompthreads=8:ncpus=120
+#PBS -l place=vscatter,select=52:mpiprocs=15:ompthreads=8:ncpus=120
 #PBS -l place=excl
 #PBS -l debug=true
 

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_diag.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_diag.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=115:ompthreads=1:ncpus=115:mem=48GB
+#PBS -l place=vscatter,select=1:mpiprocs=96:ompthreads=1:ncpus=96:mem=48GB
 #PBS -l debug=true
 
 export model=gfs

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_diag.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_diag.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:mpiprocs=72:ompthreads=1:ncpus=72:mem=48GB
+#PBS -l place=vscatter,select=1:mpiprocs=115:ompthreads=1:ncpus=115:mem=48GB
 #PBS -l debug=true
 
 export model=gfs

--- a/parm/config/config.fv3.nco.static
+++ b/parm/config/config.fv3.nco.static
@@ -19,21 +19,7 @@ case_in=$1
 
 echo "BEGIN: config.fv3"
 
-
-if [[ "$machine" = "WCOSS2" ]]; then
-   export npe_node_max=128
-elif [[ "$machine" = "WCOSS_DELL_P3" ]]; then
-   export npe_node_max=28
-elif [[ "$machine" = "WCOSS_C" ]]; then
-   export npe_node_max=24
-elif [[ "$machine" = "JET" ]]; then
-   export npe_node_max=24
-elif [[ "$machine" = "HERA" ]]; then
-   export npe_node_max=40
-elif [[ "$machine" = "ORION" ]]; then
-   export npe_node_max=40
-fi
-
+export npe_node_max=128
 
 # (Standard) Model resolution dependent variables
 case $case_in in

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -160,7 +160,7 @@ elif [ $step = "analcalc" ]; then
 elif [ $step = "analdiag" ]; then
 
     export wtime_analdiag="00:10:00"
-    export npe_analdiag=115		# Should be at least twice npe_ediag
+    export npe_analdiag=96		# Should be at least twice npe_ediag
     export nth_analdiag=1
     export npe_node_analdiag=$npe_analdiag
     export memory_analdiag="48GB"

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -133,7 +133,7 @@ elif [ $step = "anal" ]; then
 
     export wtime_anal="00:40:00"
     export wtime_anal_gfs="00:50:00"
-    export npe_anal=825
+    export npe_anal=780
     export nth_anal=8
     export npe_anal_gfs=825
     export nth_anal_gfs=8
@@ -160,7 +160,7 @@ elif [ $step = "analcalc" ]; then
 elif [ $step = "analdiag" ]; then
 
     export wtime_analdiag="00:10:00"
-    export npe_analdiag=72
+    export npe_analdiag=115		# Should be at least twice npe_ediag
     export nth_analdiag=1
     export npe_node_analdiag=$npe_analdiag
     export memory_analdiag="48GB"
@@ -302,9 +302,10 @@ elif [ $step = "eobs" -o $step = "eomg" ]; then
     elif [ $CASE = "C96" -o $CASE = "C48" ]; then
       export npe_eobs=14
     fi
-    export nth_eobs=7
+    export nth_eobs=3
     if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_eobs=7; fi
     export npe_node_eobs=$(echo "$npe_node_max / $nth_eobs" | bc)
+    if [[ "$machine" = "WCOSS2" ]]; then export npe_node_eobs=40; fi
 
 elif [ $step = "ediag" ]; then
 
@@ -318,8 +319,8 @@ elif [ $step = "eupd" ]; then
 
     export wtime_eupd="00:30:00"
     if [ $CASE = "C768" ]; then
-      export npe_eupd=320
-      export nth_eupd=12
+      export npe_eupd=315
+      export nth_eupd=14
       if [[ "$machine" = "WCOSS_DELL_P3" ]]; then
 	export npe_eupd=960
         export nth_eupd=7
@@ -338,7 +339,8 @@ elif [ $step = "eupd" ]; then
       export npe_eupd=42
       export nth_eupd=2
     fi
-    export npe_node_eupd=10
+    export npe_node_eupd=$(echo "$npe_node_max / $nth_eupd" | bc)
+    if [[ "$machine" = "WCOSS2" ]]; then export npe_node_eupd=9; fi
 
 elif [ $step = "ecen" ]; then
 

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -340,7 +340,6 @@ elif [ $step = "eupd" ]; then
       export nth_eupd=2
     fi
     export npe_node_eupd=$(echo "$npe_node_max / $nth_eupd" | bc)
-    if [[ "$machine" = "WCOSS2" ]]; then export npe_node_eupd=9; fi
 
 elif [ $step = "ecen" ]; then
 

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -160,7 +160,7 @@ elif [ $step = "analcalc" ]; then
 elif [ $step = "analdiag" ]; then
 
     export wtime_analdiag="00:10:00"
-    export npe_analdiag=115		# Should be at least twice npe_ediag
+    export npe_analdiag=96		# Should be at least twice npe_ediag
     export nth_analdiag=1
     export npe_node_analdiag=$npe_analdiag
     export memory_analdiag="48GB"

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -133,7 +133,7 @@ elif [ $step = "anal" ]; then
 
     export wtime_anal="00:40:00"
     export wtime_anal_gfs="00:50:00"
-    export npe_anal=825
+    export npe_anal=780
     export nth_anal=8
     export npe_anal_gfs=825
     export nth_anal_gfs=8
@@ -160,7 +160,7 @@ elif [ $step = "analcalc" ]; then
 elif [ $step = "analdiag" ]; then
 
     export wtime_analdiag="00:10:00"
-    export npe_analdiag=72
+    export npe_analdiag=115		# Should be at least twice npe_ediag
     export nth_analdiag=1
     export npe_node_analdiag=$npe_analdiag
     export memory_analdiag="48GB"
@@ -302,9 +302,10 @@ elif [ $step = "eobs" -o $step = "eomg" ]; then
     elif [ $CASE = "C96" -o $CASE = "C48" ]; then
       export npe_eobs=14
     fi
-    export nth_eobs=7
+    export nth_eobs=3
     if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_eobs=7; fi
     export npe_node_eobs=$(echo "$npe_node_max / $nth_eobs" | bc)
+    if [[ "$machine" = "WCOSS2" ]]; then export npe_node_eobs=40; fi
 
 elif [ $step = "ediag" ]; then
 
@@ -318,8 +319,8 @@ elif [ $step = "eupd" ]; then
 
     export wtime_eupd="00:30:00"
     if [ $CASE = "C768" ]; then
-      export npe_eupd=320
-      export nth_eupd=12
+      export npe_eupd=315
+      export nth_eupd=14
       if [[ "$machine" = "WCOSS_DELL_P3" ]]; then
 	export npe_eupd=960
         export nth_eupd=7
@@ -338,7 +339,8 @@ elif [ $step = "eupd" ]; then
       export npe_eupd=42
       export nth_eupd=2
     fi
-    export npe_node_eupd=10
+    export npe_node_eupd=$(echo "$npe_node_max / $nth_eupd" | bc)
+    if [[ "$machine" = "WCOSS2" ]]; then export npe_node_eupd=9; fi
 
 elif [ $step = "ecen" ]; then
 

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -22,22 +22,7 @@ step=$1
 
 echo "BEGIN: config.resources"
 
-if [[ "$machine" = "WCOSS2" ]]; then
-   export npe_node_max=128
-elif [[ "$machine" = "WCOSS_DELL_P3" ]]; then
-   export npe_node_max=28
-   if [ "$QUEUE" = "dev2" -o "$QUEUE" = "devonprod2" -o "$QUEUE" = "devmax2" ]; then # WCOSS Dell 3.5
-     export npe_node_max=40
-   fi
-elif [[ "$machine" = "WCOSS_C" ]]; then
-   export npe_node_max=24
-elif [[ "$machine" = "JET" ]]; then
-   export npe_node_max=24
-elif [[ "$machine" = "HERA" ]]; then
-   export npe_node_max=40
-elif [[ "$machine" = "ORION" ]]; then
-   export npe_node_max=40
-fi
+export npe_node_max=128
 
 if [ $step = "prep" -o $step = "prepbufr" ]; then
 
@@ -137,14 +122,7 @@ elif [ $step = "anal" ]; then
     export nth_anal=8
     export npe_anal_gfs=825
     export nth_anal_gfs=8
-    if [ $CASE = "C384" ]; then
-      export npe_anal=160
-      export nth_anal=10
-    fi
-    if [ $CASE = "C192" -o $CASE = "C96" -o $CASE = "C48" ]; then export npe_anal=84; fi
-    if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_anal=7; fi
-    export npe_node_anal=$(echo "$npe_node_max / $nth_anal" | bc)
-    if [[ "$machine" = "WCOSS2" ]]; then export npe_node_anal=15; fi
+    export npe_node_anal=15
     export nth_cycle=$npe_node_max
     export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
 
@@ -155,7 +133,6 @@ elif [ $step = "analcalc" ]; then
     export ntasks=$npe_analcalc
     export nth_analcalc=1
     export npe_node_analcalc=$npe_node_max
-    if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export npe_analcalc=127 ; fi
 
 elif [ $step = "analdiag" ]; then
 
@@ -183,12 +160,8 @@ elif [ $step = "fcst" ]; then
     export npe_fcst_gfs=$(echo "$layout_x_gfs * $layout_y_gfs * 6" | bc)
     export nth_fcst=${nth_fv3:-2}
     export nth_fcst_gfs=${nth_fv3_gfs:-2}
-    export npe_node_fcst=$(echo "$npe_node_max / $nth_fcst" | bc)
-    export npe_node_fcst_gfs=$(echo "$npe_node_max / $nth_fcst_gfs" | bc)
-    if [[ "$machine" == "WCOSS2" ]]; then
-       export npe_node_fcst=32
-       export npe_node_fcst_gfs=24
-    fi
+    export npe_node_fcst=32
+    export npe_node_fcst_gfs=24
 
 elif [ $step = "post" ]; then
 
@@ -199,7 +172,6 @@ elif [ $step = "post" ]; then
     export npe_node_post=$npe_post
     export npe_node_post_gfs=$npe_post
     export npe_node_dwn=$npe_node_max
-    if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export npe_node_post=28 ; fi
 
 elif [ $step = "wafs" ]; then
 
@@ -258,9 +230,6 @@ elif [ $step = "vrfy" ]; then
     export npe_node_vrfy=1
     export npe_vrfy_gfs=1
     export npe_node_vrfy_gfs=1
-    if [[ "$machine" == "HERA" ]]; then
-	    export memory_vrfy="16384M"
-    fi
 
 elif [ $step = "metp" ]; then
     
@@ -293,19 +262,9 @@ elif [ $step = "eobs" -o $step = "eomg" ]; then
 
     export wtime_eobs="00:10:00"
     export wtime_eomg="01:00:00"
-    if [ $CASE = "C768" ]; then
-      export npe_eobs=480
-    elif [ $CASE = "C384" ]; then
-      export npe_eobs=42
-    elif [ $CASE = "C192" ]; then
-      export npe_eobs=28
-    elif [ $CASE = "C96" -o $CASE = "C48" ]; then
-      export npe_eobs=14
-    fi
+    export npe_eobs=480
     export nth_eobs=3
-    if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_eobs=7; fi
-    export npe_node_eobs=$(echo "$npe_node_max / $nth_eobs" | bc)
-    if [[ "$machine" = "WCOSS2" ]]; then export npe_node_eobs=40; fi
+    export npe_node_eobs=40
 
 elif [ $step = "ediag" ]; then
 
@@ -318,27 +277,8 @@ elif [ $step = "ediag" ]; then
 elif [ $step = "eupd" ]; then
 
     export wtime_eupd="00:30:00"
-    if [ $CASE = "C768" ]; then
-      export npe_eupd=315
-      export nth_eupd=14
-      if [[ "$machine" = "WCOSS_DELL_P3" ]]; then
-	export npe_eupd=960
-        export nth_eupd=7
-      fi
-    elif [ $CASE = "C384" ]; then
-      export npe_eupd=270
-      export nth_eupd=2
-      if [[ "$machine" = "WCOSS_DELL_P3" ]]; then
-        export nth_eupd=9
-      fi
-      if [[ "$machine" = "HERA" ]]; then
-        export npe_eupd=84
-        export nth_eupd=10
-      fi
-    elif [ $CASE = "C192" -o $CASE = "C96" -o $CASE = "C48" ]; then
-      export npe_eupd=42
-      export nth_eupd=2
-    fi
+    export npe_eupd=315
+    export nth_eupd=14
     export npe_node_eupd=$(echo "$npe_node_max / $nth_eupd" | bc)
 
 elif [ $step = "ecen" ]; then
@@ -346,8 +286,6 @@ elif [ $step = "ecen" ]; then
     export wtime_ecen="00:10:00"
     export npe_ecen=80
     export nth_ecen=4
-    if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_ecen=7; fi
-    if [ $CASE = "C384" -o $CASE = "C192" -o $CASE = "C96" -o $CASE = "C48" ]; then export nth_ecen=2; fi
     export npe_node_ecen=$(echo "$npe_node_max / $nth_ecen" | bc)
     export nth_cycle=$nth_ecen
     export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
@@ -374,7 +312,6 @@ elif [ $step = "epos" ]; then
     export wtime_epos="00:15:00"
     export npe_epos=80
     export nth_epos=4
-    if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_epos=7; fi
     export npe_node_epos=$(echo "$npe_node_max / $nth_epos" | bc)
 
 elif [ $step = "postsnd" ]; then
@@ -385,11 +322,6 @@ elif [ $step = "postsnd" ]; then
     export npe_node_postsnd=20
     export npe_postsndcfp=9
     export npe_node_postsndcfp=1
-    if [ $OUTPUT_FILE == "nemsio" ]; then
-        export npe_postsnd=13
-        export npe_node_postsnd=4
-    fi
-    if [[ "$machine" = "HERA" ]]; then export npe_node_postsnd=2; fi
 
 elif [ $step = "awips" ]; then
 
@@ -398,11 +330,6 @@ elif [ $step = "awips" ]; then
     export npe_node_awips=1
     export nth_awips=1
     export memory_awips="1GB"
-    if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
-        export npe_awips=2
-        export npe_node_awips=2
-        export nth_awips=1
-    fi
 
 elif [ $step = "gempak" ]; then
 

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -340,7 +340,6 @@ elif [ $step = "eupd" ]; then
       export nth_eupd=2
     fi
     export npe_node_eupd=$(echo "$npe_node_max / $nth_eupd" | bc)
-    if [[ "$machine" = "WCOSS2" ]]; then export npe_node_eupd=9; fi
 
 elif [ $step = "ecen" ]; then
 

--- a/scripts/exgfs_atmos_gempak_meta.sh
+++ b/scripts/exgfs_atmos_gempak_meta.sh
@@ -33,6 +33,7 @@ do
 
    while [ $icnt -lt 1000 ]
    do
+      typeset -Z3 fhr
       ls -l $COMIN/$GEMGRD1${fhr}
       err1=$?
       if [ $err1 -eq 0 ] ; then
@@ -96,6 +97,11 @@ do
   $APRUNCFP $DATA/poescript
   export err=$?; err_chk
 
+  if [ $fhr -eq 126 ] ; then
+    fhr=`expr $fhr + 6`
+  else
+    fhr=`expr $fhr + $fhinc`
+  fi
 done
 
 #####################################################################


### PR DESCRIPTION
**Description**

This PR includes some updates for the WCOSS2 port:

1. bug fix in `scripts/exgfs_atmos_gempak_meta.sh` which was found and fixed by @WeiWei-NCO
2. resource updates for several GSI/EnKF jobs based on feedback from @RussTreadon-NOAA and @MichaelLueken-NOAA 
3. cleans up nco.static resource configs to support only operations on WCOSS2; the emc.dyn resource configs support other tier 1 platforms
4. updates the EMC tag name in the release notes to the new tag that will be cut after this PR goes in (`EMC-v16.2.0.3`)

Refs: #398, #399

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Regular port updates - resources

**How Has This Been Tested?**

Both @WeiWei-NCO and myself tested the included updates on Dogwood. We confirmed good timings on adjusted jobs.
