### PR TITLE
Fix separate threading for GFS and GDAS forecasts.

### DIFF
--- a/env/HERA.env
+++ b/env/HERA.env
@@ -130,14 +130,17 @@ elif [ $step = "eupd" ]; then
 
 elif [ $step = "fcst" ]; then
 
+    #PEs and PEs/node can differ for GFS and GDAS forecasts if threading differs
+    if [[ $CDUMP == "gfs" ]]; then
+        npe_fcst=$npe_fcst_gfs
+        npe_node_fcst=$npe_node_fcst_gfs
+    fi
+
     nth_max=$(($npe_node_max / $npe_node_fcst))
 
     export NTHREADS_FV3=${nth_fv3:-$nth_max}
     [[ $NTHREADS_FV3 -gt $nth_max ]] && export NTHREADS_FV3=$nth_max
     export cores_per_node=$npe_node_max
-    if [[ $CDUMP == "gfs" ]]; then
-        npe_fcst=$npe_fcst_gfs
-    fi
     export APRUN_FV3="$launcher -n $npe_fcst"
 
     export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}

--- a/env/HERA.env
+++ b/env/HERA.env
@@ -134,6 +134,7 @@ elif [ $step = "fcst" ]; then
     if [[ $CDUMP == "gfs" ]]; then
         npe_fcst=$npe_fcst_gfs
         npe_node_fcst=$npe_node_fcst_gfs
+        nth_fv3=$nth_fv3_gfs
     fi
 
     nth_max=$(($npe_node_max / $npe_node_fcst))

--- a/env/JET.env
+++ b/env/JET.env
@@ -103,6 +103,7 @@ elif [ $step = "fcst" ]; then
     if [[ $CDUMP == "gfs" ]]; then
         npe_fcst=$npe_fcst_gfs
         npe_node_fcst=$npe_node_fcst_gfs
+        nth_fv3=$nth_fv3_gfs
     fi
 
     nth_max=$(($npe_node_max / $npe_node_fcst))

--- a/env/JET.env
+++ b/env/JET.env
@@ -99,6 +99,12 @@ elif [ $step = "eupd" ]; then
 
 elif [ $step = "fcst" ]; then
 
+    #PEs and PEs/node can differ for GFS and GDAS forecasts if threading differs
+    if [[ $CDUMP == "gfs" ]]; then
+        npe_fcst=$npe_fcst_gfs
+        npe_node_fcst=$npe_node_fcst_gfs
+    fi
+
     nth_max=$(($npe_node_max / $npe_node_fcst))
 
     export NTHREADS_FV3=${nth_fv3:-$nth_max}

--- a/env/ORION.env
+++ b/env/ORION.env
@@ -126,14 +126,17 @@ elif [ $step = "eupd" ]; then
 
 elif [ $step = "fcst" ]; then
 
+    #PEs and PEs/node can differ for GFS and GDAS forecasts if threading differs
+    if [[ $CDUMP == "gfs" ]]; then
+        npe_fcst=$npe_fcst_gfs
+        npe_node_fcst=$npe_node_fcst_gfs
+    fi
+
     nth_max=$(($npe_node_max / $npe_node_fcst))
 
     export NTHREADS_FV3=${nth_fv3:-$nth_max}
     [[ $NTHREADS_FV3 -gt $nth_max ]] && export NTHREADS_FV3=$nth_max
     export cores_per_node=$npe_node_max
-    if [[ $CDUMP == "gfs" ]]; then
-        npe_fcst=$npe_fcst_gfs
-    fi
     export APRUN_FV3="$launcher -n $npe_fcst"
 
     export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}

--- a/env/ORION.env
+++ b/env/ORION.env
@@ -130,6 +130,7 @@ elif [ $step = "fcst" ]; then
     if [[ $CDUMP == "gfs" ]]; then
         npe_fcst=$npe_fcst_gfs
         npe_node_fcst=$npe_node_fcst_gfs
+        nth_fv3=$nth_fv3_gfs
     fi
 
     nth_max=$(($npe_node_max / $npe_node_fcst))

--- a/env/WCOSS_C.env
+++ b/env/WCOSS_C.env
@@ -115,17 +115,19 @@ elif [ $step = "eupd" ]; then
 
 elif [ $step = "fcst" ]; then
 
+    #PEs and PEs/node can differ for GFS and GDAS forecasts if threading differs
+    if [[ $CDUMP == "gfs" ]]; then
+        npe_fcst=$npe_fcst_gfs
+        npe_node_fcst=$npe_node_fcst_gfs
+    fi
+
     nth_max=$(($npe_node_max / $npe_node_fcst))
 
     export NTHREADS_FV3=${nth_fv3:-$nth_max}
     [[ $NTHREADS_FV3 -gt $nth_max ]] && export NTHREADS_FV3=$nth_max
     export cores_per_node=$npe_node_max
     #export APRUN_FV3="$launcher -j 1 -n ${npe_fv3:-$npe_fcst} -N $npe_node_fcst -d $NTHREADS_FV3 -cc depth"
-    if [ $CDUMP = "gdas" ]; then
-      export APRUN_FV3="$launcher -j 1 -n ${npe_fcst} -N $npe_node_fcst -d $NTHREADS_FV3 -cc depth"
-    else
-      export APRUN_FV3="$launcher -j 1 -n ${npe_fcst_gfs} -N $npe_node_fcst -d $NTHREADS_FV3 -cc depth"
-    fi
+    export APRUN_FV3="$launcher -j 1 -n ${npe_fcst} -N $npe_node_fcst -d $NTHREADS_FV3 -cc depth"
 
     export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
     [[ $NTHREADS_REGRID_NEMSIO -gt $nth_max ]] && export NTHREADS_REGRID_NEMSIO=$nth_max

--- a/env/WCOSS_C.env
+++ b/env/WCOSS_C.env
@@ -119,6 +119,7 @@ elif [ $step = "fcst" ]; then
     if [[ $CDUMP == "gfs" ]]; then
         npe_fcst=$npe_fcst_gfs
         npe_node_fcst=$npe_node_fcst_gfs
+        nth_fv3=$nth_fv3_gfs
     fi
 
     nth_max=$(($npe_node_max / $npe_node_fcst))

--- a/env/WCOSS_DELL_P3.env
+++ b/env/WCOSS_DELL_P3.env
@@ -124,6 +124,7 @@ elif [ $step = "fcst" ]; then
     if [[ $CDUMP == "gfs" ]]; then
         npe_fcst=$npe_fcst_gfs
         npe_node_fcst=$npe_node_fcst_gfs
+        nth_fv3=$nth_fv3_gfs
     fi
 
     nth_max=$(($npe_node_max / $npe_node_fcst))

--- a/env/WCOSS_DELL_P3.env
+++ b/env/WCOSS_DELL_P3.env
@@ -120,17 +120,19 @@ elif [ $step = "eupd" ]; then
 
 elif [ $step = "fcst" ]; then
 
+    #PEs and PEs/node can differ for GFS and GDAS forecasts if threading differs
+    if [[ $CDUMP == "gfs" ]]; then
+        npe_fcst=$npe_fcst_gfs
+        npe_node_fcst=$npe_node_fcst_gfs
+    fi
+
     nth_max=$(($npe_node_max / $npe_node_fcst))
 
     export NTHREADS_FV3=${nth_fv3:-$nth_max}
     [[ $NTHREADS_FV3 -gt $nth_max ]] && export NTHREADS_FV3=$nth_max
     export cores_per_node=$npe_node_max
-    if [ $CDUMP = "gdas" ]; then
-      #export APRUN_FV3="$launcher ${npe_fv3:-${npe_fcst:-$PBS_NP}}"
-      export APRUN_FV3="$launcher ${npe_fcst:-$PBS_NP}"
-    else
-      export APRUN_FV3="$launcher ${npe_fcst_gfs:-$PBS_NP}"
-    fi
+    #export APRUN_FV3="$launcher ${npe_fv3:-${npe_fcst:-$PBS_NP}}"
+    export APRUN_FV3="$launcher ${npe_fcst:-$PBS_NP}"
     export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
     [[ $NTHREADS_REGRID_NEMSIO -gt $nth_max ]] && export NTHREADS_REGRID_NEMSIO=$nth_max
     export APRUN_REGRID_NEMSIO="$launcher $LEVS"

--- a/parm/config/config.fcst
+++ b/parm/config/config.fcst
@@ -9,7 +9,6 @@ echo "BEGIN: config.fcst"
 
 # Source model specific information that is resolution dependent
 . $EXPDIR/config.fv3 $CASE
-[[ "$CDUMP" == "gfs" ]] && export nth_fv3=$nth_fv3_gfs
 
 # Turn off waves if not used for this CDUMP
 case $WAVE_CDUMP in

--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -209,8 +209,11 @@ elif [ $step = "fcst" ]; then
         NTASKS_TOT=$ATMPETS
 
         export nth_fcst=${nth_fv3:-2}
+        export nth_fcst_gfs=${nth_fv3_gfs:-2}
 
         export npe_node_fcst=$(echo "$npe_node_max / $nth_fcst" | bc)
+        export npe_node_fcst_gfs=$(echo "$npe_node_max / $nth_fcst_gfs" | bc)
+
         if [[ "$machine" == "WCOSS_C" ]]; then export memory_fcst="1024M"; fi
 
         if [[ $DO_WAVE == "YES" ]]; then

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -122,7 +122,12 @@ FV3_GFS_predet(){
   #file and the value of npe_node_fcst is not correctly defined when using more than
   #one thread and sets NTHREADS_FV3=1 even when the number of threads is appropraitely >1
   #NTHREADS_FV3=${NTHREADS_FV3:-${NTHREADS_FCST:-${nth_fv3:-1}}}
-  NTHREADS_FV3=${nth_fv3:-1}
+  #Threading can be different for GFS and GDAS forecasts
+  if [[ $CDUMP == "gdas" ]]; then
+     NTHREADS_FV3=${nth_fv3:-1}
+  else
+     NTHREADS_FV3=${nth_fv3_gfs:-1}
+  fi
   cores_per_node=${cores_per_node:-${npe_node_fcst:-24}}
   ntiles=${ntiles:-6}
   if [ $MEMBER -lt 0 ]; then

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -122,12 +122,6 @@ FV3_GFS_predet(){
   #file and the value of npe_node_fcst is not correctly defined when using more than
   #one thread and sets NTHREADS_FV3=1 even when the number of threads is appropraitely >1
   #NTHREADS_FV3=${NTHREADS_FV3:-${NTHREADS_FCST:-${nth_fv3:-1}}}
-  #Threading can be different for GFS and GDAS forecasts
-  if [[ $CDUMP == "gdas" ]]; then
-     NTHREADS_FV3=${nth_fv3:-1}
-  else
-     NTHREADS_FV3=${nth_fv3_gfs:-1}
-  fi
   cores_per_node=${cores_per_node:-${npe_node_fcst:-24}}
   ntiles=${ntiles:-6}
   if [ $MEMBER -lt 0 ]; then

--- a/ush/rocoto/workflow_utils.py
+++ b/ush/rocoto/workflow_utils.py
@@ -259,7 +259,10 @@ def get_resources(machine, cfg, task, reservation, cdump='gdas'):
         ppn = cfg[f'npe_node_{ltask}']
 
     if machine in [ 'WCOSS_DELL_P3', 'HERA', 'ORION', 'JET' ]:
-        threads = cfg[f'nth_{ltask}']
+        if cdump in ['gfs'] and f'nth_{task}_gfs' in cfg.keys():
+            threads = cfg[f'nth_{ltask}_gfs']
+        else:
+            threads = cfg[f'nth_{ltask}']
 
     nodes = np.int(np.ceil(np.float(tasks) / np.float(ppn)))
 


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**
This PR fixes separate threading options for GDAS and GFS forecasts (#610).  This is performed by keeping `nth_fcst_gfs` separate from `nth_fcst` and declaring the new variable `npe_node_fcst_gfs`.
<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
- [X] Cycled test on S4 using different threading options in config.fv3
- [X] Created XML workflows on Orion and Hera using different threading options in config.fv3

I have not tested this on WCOSS as I do not have access.
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings