### PR TITLE
Analysis walltime adjustment and gempak script fix

### DIFF
--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis.ecf
@@ -3,7 +3,7 @@
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:40:00
+#PBS -l walltime=00:50:00
 #PBS -l place=vscatter,select=52:mpiprocs=15:ompthreads=8:ncpus=120
 #PBS -l place=excl
 #PBS -l debug=true

--- a/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis.ecf
+++ b/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis.ecf
@@ -3,7 +3,7 @@
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:50:00
+#PBS -l walltime=00:40:00
 #PBS -l place=vscatter,select=55:mpiprocs=15:ompthreads=8:ncpus=120
 #PBS -l place=excl
 #PBS -l debug=true

--- a/jobs/JGDAS_ATMOS_GEMPAK
+++ b/jobs/JGDAS_ATMOS_GEMPAK
@@ -12,6 +12,7 @@ echo "=============== BEGIN GEMPAK ==============="
 echo
 echo "=============== BEGIN TO SOURCE RELEVANT CONFIGS ==============="
 configs="base gempak"
+export EXPDIR=${EXPDIR:-$HOMEgfs/parm/config}
 for config in $configs; do
     . $EXPDIR/config.${config}
     status=$?


### PR DESCRIPTION
**Description**

This PR includes a few small WCOSS2 updates that were left out of PRs yesterday:

1. adjust analysis job walltimes (gdas -> 50mins, gfs -> 40mins)
2. add missing `EXPDIR` setting to JGDAS_ATMOS_GEMPAK

@WeiWei-NCO tested and provided gempak script fix.

Refs: #398, #399
