### PR TITLE
Remove hardwired ImageMagick path for file util/ush/make_tif.sh

### DIFF
--- a/util/ush/make_tif.sh
+++ b/util/ush/make_tif.sh
@@ -2,18 +2,9 @@
 
 cd $DATA
 #
-#     Use Image Magick to convert the GIF to TIF    
+#     Use Image Magick system module to convert the GIF to TIF    
 #        format
 #
-# module show  imagemagick-intel-sandybridge/6.8.3    on   CRAY
-# export PATH=$PATH:/usrx/local/prod/imagemagick/6.8.3/intel/sandybridge/bin:.
-# export LIBPATH="$LIBPATH":/usrx/local/prod/imagemagick/6.8.3/intel/sandybridge/lib
-# export DELEGATE_PATH=/usrx/local/prod/imagemagick/6.8.3/intel/sandybridge/share/ImageMagick-6
-
-# module show  imagemagick/6.9.9-25      on  DELL
-  export PATH=$PATH:/usrx/local/dev/packages/ImageMagick/6.9.9-25/bin:.
-  export LIBPATH="$LIBPATH":/usrx/local/dev/packages/ImageMagick/6.9.9-25/lib
-  export DELEGATE_PATH=/usrx/local/dev/packages/ImageMagick/6.9.9-25/share/ImageMagick-6
 
   outname=out.tif                            
 


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->
gfs_atmos_gempak_upapgif used hardwired path for ImageMagick utility as noted in issue #534. It is now removed.
**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
All 31 image files were successfully generated in the test run.
<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--

-->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
