### PR TITLE
Correct analysis walltimes in config.resources for WCOSS2

### DIFF
--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -131,8 +131,8 @@ elif [ $step = "waveawipsgridded" ]; then
 
 elif [ $step = "anal" ]; then
 
-    export wtime_anal="00:40:00"
-    export wtime_anal_gfs="00:50:00"
+    export wtime_anal="00:50:00"
+    export wtime_anal_gfs="00:40:00"
     export npe_anal=780
     export nth_anal=8
     export npe_anal_gfs=825

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -116,8 +116,8 @@ elif [ $step = "waveawipsgridded" ]; then
 
 elif [ $step = "anal" ]; then
 
-    export wtime_anal="00:40:00"
-    export wtime_anal_gfs="00:50:00"
+    export wtime_anal="00:50:00"
+    export wtime_anal_gfs="00:40:00"
     export npe_anal=780
     export nth_anal=8
     export npe_anal_gfs=825


### PR DESCRIPTION
**Description**

This PR commits a correction to the analysis job walltimes in config.resources. This change was left out of a companion change to the ecf script resource settings for the analysis jobs.

**How Has This Been Tested?**

Tested in optimization tests on Dogwood.

Refs: #399 