### PR TITLE
Turn on fractional grid by default for uncoupled forecasts

### DIFF
--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -86,16 +86,8 @@ cat > input.nml <<EOF
   npy = $npy
   ntiles = $ntiles
   npz = $npz
-EOF
-
-if [ $cpl = .true. ]; then
-  cat >> input.nml << EOF
-  dz_min =  ${dz_min:-"6"}    ! no longer in develop branch
-  psm_bc = ${psm_bc:-"0"}    ! no longer in develop branch
-EOF
-fi
-
-cat >> input.nml << EOF
+  dz_min =  ${dz_min:-"6"} 
+  psm_bc = ${psm_bc:-"0"} 
   grid_type = -1
   make_nh = $make_nh
   fv_debug = ${fv_debug:-".false."}
@@ -323,17 +315,12 @@ cat >> input.nml <<EOF
   do_sppt      = ${do_sppt:-".false."}
   do_shum      = ${do_shum:-".false."}
   do_skeb      = ${do_skeb:-".false."}
-EOF
-
-if [ $cpl = .true. ]; then
-  cat >> input.nml << EOF
   frac_grid    = ${FRAC_GRID:-".true."}
   cplchm       = ${cplchem:-".false."}
   cplflx       = $cplflx
   cplice       = ${cplice} 
   cplwav2atm   = ${cplwav2atm}
 EOF
-fi
 
 # Add namelist for IAU
 if [ $DOIAU = "YES" ]; then

--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -317,9 +317,9 @@ cat >> input.nml <<EOF
   do_skeb      = ${do_skeb:-".false."}
   frac_grid    = ${FRAC_GRID:-".true."}
   cplchm       = ${cplchem:-".false."}
-  cplflx       = $cplflx
-  cplice       = ${cplice} 
-  cplwav2atm   = ${cplwav2atm}
+  cplflx       = ${cplflx:-".false."}
+  cplice       = ${cplice-".false."} 
+  cplwav2atm   = ${cplwav2atm-".false."}
 EOF
 
 # Add namelist for IAU


### PR DESCRIPTION
**Description**

Updates input.nml so that there is more consistency between the cpl and standalone atm input.nml.  In particular this addresses the fact that frac_grid was only being set if cpl was true.   

Fixes Issue #571

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Testing is ongoing 

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
