### PR TITLE
Set EXP_WARM_START properly from setup_expt.py

### DIFF
--- a/ush/rocoto/setup_expt.py
+++ b/ush/rocoto/setup_expt.py
@@ -135,7 +135,7 @@ def edit_baseconfig(host, inputs):
         "@QUEUE@": host.info["queue"],
         "@QUEUE_SERVICE@": host.info["queue_service"],
         "@PARTITION_BATCH@": host.info["partition_batch"],
-        "@EXP_WARM_START@": inputs.start,
+        "@EXP_WARM_START@": inputs.warm_start,
         "@MODE@": inputs.mode,
         "@CHGRP_RSTPROD@": host.info["chgrp_rstprod"],
         "@CHGRP_CMD@": host.info["chgrp_cmd"],
@@ -234,6 +234,12 @@ def input_args():
     if args.app in ['S2S', 'S2SW'] and args.icsdir is None:
         raise SyntaxError("An IC directory must be specified with --icsdir when running the S2S or S2SW app")
 
+    # Add an entry for warm_start = .true. or .false.
+    if args.start == "warm":
+        args.warm_start = ".true."
+    else:
+        args.warm_start = ".false."
+        
     return args
 
 


### PR DESCRIPTION

<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->
Corrects the assignment of `EXP_WARM_START` to either `.true.` or `.false.` depending on the value passed to setup_expt.py via `--start`.  Fixes #643 

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- [X] Ran setup_expt on S4
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
