### PR TITLE
Fix ocean resolution for fractional grid fix files at C48

### DIFF
--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -202,7 +202,7 @@ export LEVS=128
 export CASE="@CASECTL@"
 export CASE_ENKF="@CASEENS@"
 case "$CASE" in
-    "C48") export OCNRES=100;;
+    "C48") export OCNRES=400;;
     "C96") export OCNRES=100;;
     "C192") export OCNRES=050;;
     "C384") export OCNRES=025;;

--- a/parm/config/config.efcs
+++ b/parm/config/config.efcs
@@ -85,12 +85,13 @@ export cplwav=.false.
 
 # ocean model resolution
 case "$CASE_ENKF" in
-    "C48") export OCNRES=100;;
+    "C48") export OCNRES=400;;
     "C96") export OCNRES=100;;
     "C192") export OCNRES=050;;
     "C384") export OCNRES=025;;
     "C768") export OCNRES=025;;
     *) export OCNRES=025;;
 esac
+export ICERES=$OCNRES
 
 echo "END: config.efcs"

--- a/parm/config/config.ocn
+++ b/parm/config/config.ocn
@@ -1,10 +1,11 @@
 #!/bin/ksh -x
 
-case "$CASE" in
-    "C48") export OCNRES=100;;
-    "C96") export OCNRES=100;;
-    "C192") export OCNRES=050;;
-    "C384") export OCNRES=025;;
-    "C768") export OCNRES=025;;
-    *) export OCNRES=025;;
-esac
+# OCNRES is currently being set in config.base
+# case "$CASE" in
+#     "C48") export OCNRES=400;;
+#     "C96") export OCNRES=100;;
+#     "C192") export OCNRES=050;;
+#     "C384") export OCNRES=025;;
+#     "C768") export OCNRES=025;;
+#     *) export OCNRES=025;;
+# esac

--- a/ush/parsing_namelists_MOM6.sh
+++ b/ush/parsing_namelists_MOM6.sh
@@ -51,6 +51,15 @@ elif [ $OCNRES = '100' ]; then
   CHLCLIM="seawifs_1998-2006_smoothed_2X.nc"
   MOM6_RESTART_SETTING='n'
   MOM6_RIVER_RUNOFF='False'
+elif [ $OCNRES = '400' ]; then
+  NX_GLB=90
+  NY_GLB=80
+  DT_DYNAM_MOM6='1800'
+  DT_THERM_MOM6='3600'
+  FRUNOFF=""
+  CHLCLIM="seawifs_1998-2006_smoothed_2X.nc"
+  MOM6_RESTART_SETTING='n'
+  MOM6_RIVER_RUNOFF='False'
 else
   echo "FATAL ERROR: do not have MOM6 settings defined for desired OCNRES=$OCNRES"
   exit 1


### PR DESCRIPTION
**Description**
The ocean resolution for C48 was set as 1-deg, but the fractional grid fix files available at C48 are for a 4-deg ocean grid. The
ocean resolution is now set to this value when FV3 is C48.

Also commented out a currently redundant block setting OCNRES in config.ocn. The one in ecfs has to stay as it recalculates the ocean resolution based on the EnKF resolution.

Fixes #650

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [ ] Cycled test on Hera
- [ ] Cycled test on S4
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
