### PR TITLE
Correct MODE comparisons for forecast only

### DIFF
--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -279,7 +279,7 @@ export DOIAU_ENKF=${DOIAU:-"YES"}   # Enable 4DIAU for EnKF ensemble
 export IAUFHRS_ENKF="3,6,9"
 export IAU_DELTHRS_ENKF=6
 # Check if cycle is cold starting, DOIAU off, or free-forecast mode
-if [[ "$MODE" = "cycled" && "$SDATE" = "$CDATE" && $EXP_WARM_START = ".false." ]] || [[ "$DOIAU" = "NO" ]] || [[ "$MODE" = "free" && $EXP_WARM_START = ".false." ]] ; then
+if [[ "$MODE" = "cycled" && "$SDATE" = "$CDATE" && $EXP_WARM_START = ".false." ]] || [[ "$DOIAU" = "NO" ]] || [[ "$MODE" = "forecast-only" && $EXP_WARM_START = ".false." ]] ; then
   export IAU_OFFSET=0
   export IAU_FHROT=0
 fi

--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -188,7 +188,7 @@ if [ $type = "gfs" ]; then
     echo  "${dirname}RESTART/*0000.sfcanl_data.tile4.nc  " >>gfs_restarta.txt
     echo  "${dirname}RESTART/*0000.sfcanl_data.tile5.nc  " >>gfs_restarta.txt
     echo  "${dirname}RESTART/*0000.sfcanl_data.tile6.nc  " >>gfs_restarta.txt
-  elif [ $MODE = "free" ]; then
+  elif [ $MODE = "forecast-only" ]; then
     echo  "${dirname}INPUT/gfs_ctrl.nc        " >>gfs_restarta.txt
     echo  "${dirname}INPUT/gfs_data.tile1.nc  " >>gfs_restarta.txt
     echo  "${dirname}INPUT/gfs_data.tile2.nc  " >>gfs_restarta.txt


### PR DESCRIPTION
**Description**

When the setup_expt scripts were combined, the forecast mode became a mandatory argument. The value of this option is then directly used for the MODE variable, but the argument name (forecast-only) does not match what was previously used
for MODE in the forecast-only script (free) and some scripts were still testing against the old value instead of the new one. Those comparisons have now been updated to use the new MODE name.

Fixes #657

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] Forecast-only test on Hera
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
