### PR TITLE
Fold GFSv16.1.6 updates into GFSv16.2.0 package

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,37 +1,37 @@
 # External sub-modules of global-workflow
 
 [FV3GFS]
-tag = GFS.v16.0.17
+tag = GFS.v16.2.0
 local_path = sorc/fv3gfs.fd
 repo_url = https://github.com/ufs-community/ufs-weather-model.git
 protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.1.6
+tag = gfsda.v16.2.0
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git
 required = True
 
 [GLDAS]
-tag = gldas_gfsv16_release.v1.12.0
+tag = gldas_gfsv16_release.v.1.28.0
 local_path = sorc/gldas.fd
 repo_url = https://github.com/NOAA-EMC/GLDAS.git
 protocol = git
 required = True
 
 [UPP]
-tag = upp_gfsv16_release.v1.1.4
+tag = upp_v8.1.0
 local_path = sorc/gfs_post.fd
 repo_url = https://github.com/NOAA-EMC/UPP.git
 protocol = git
 required = True
 
 [UFS_UTILS]
-tag = ops-gfsv16.0.0
+tag = ops-gfsv16.2.0
 local_path = sorc/ufs_utils.fd
-repo_url = https://github.com/NOAA-EMC/UFS_UTILS.git
+repo_url = https://github.com/ufs-community/UFS_UTILS.git
 protocol = git
 required = True
 
@@ -43,7 +43,7 @@ protocol = git
 required = True
 
 [EMC_gfs_wafs]
-tag = gfs_wafs.v6.0.22
+tag = gfs_wafs.v6.2.8
 local_path = sorc/gfs_wafs.fd
 repo_url = https://github.com/NOAA-EMC/EMC_gfs_wafs.git
 protocol = git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.1.5
+tag = gfsda.v16.1.6
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git

--- a/docs/Release_Notes.gfs.v16.1.6.txt
+++ b/docs/Release_Notes.gfs.v16.1.6.txt
@@ -13,7 +13,7 @@ PRELUDE
   previous delivery orders.  DO-1 was awarded to both vendors, but was used 
   for evaluation purposes only and not assimilated operationally.  DO-2 was 
   awarded to GeoOptics and subsequently assimilated in the operational GFS/GDAS 
-  as v16.1.  DO-3 was then awarded to Spire only.  The v16.1.6 implementation 
+  as v16.1.  DO-3 was then awarded to Spire only.  The v16.1.4 implementation 
   turned on the assimilation of Spire data as well as turned off the assimilation 
   of GeoOptics.  
 

--- a/docs/Release_Notes.gfs.v16.1.6.txt
+++ b/docs/Release_Notes.gfs.v16.1.6.txt
@@ -1,0 +1,138 @@
+GFS V16.1.6 RELEASE NOTES
+
+
+PRELUDE
+ 
+  NOAA awarded Delivery Order 4 (DO-4) of its commercial radio occultation (RO) 
+  data purchase to both Spire Global and GeoOptics on February 10, 2022.  This 
+  purchase covers 5500 occultations per day from Spire and 500 occultations per 
+  day from GeoOptics over a 10 month period with the data flow starting on 
+  March 16, 2022.
+
+  Both GeoOptics and Spire have been assimilated in operations as part of 
+  previous delivery orders.  DO-1 was awarded to both vendors, but was used 
+  for evaluation purposes only and not assimilated operationally.  DO-2 was 
+  awarded to GeoOptics and subsequently assimilated in the operational GFS/GDAS 
+  as v16.1.  DO-3 was then awarded to Spire only.  The v16.1.6 implementation 
+  turned on the assimilation of Spire data as well as turned off the assimilation 
+  of GeoOptics.  
+
+  If no changes are made to operations, we will assimilate the Spire portion of 
+  the purchase, but would not assimilate the new GeoOptics data. In order to 
+  assimilate data from both vendors, a single line change in the global_convinfo.txt 
+  fix file is required.  There are no other changes planned for this implementation.  
+  Once data flow begins on March 16th, a one-week evaluation of the new GeoOptics 
+  observations is needed before implementation.
+
+IMPLEMENTATION INSTRUCTIONS
+
+  The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com 
+  are used to manage the GFS.v16.1.6 code. The SPA(s) handling the GFS.v16.1.6 
+  implementation need to have permissions to clone VLab gerrit repositories and 
+  the private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are 
+  publicly readable and do not require access permissions.  Please follow the 
+  following steps to install the package on WCOSS-Dell:
+
+  1) cd $NWROOTp3
+
+  2) mkdir gfs.v16.1.6
+
+  3) cd gfs.v16.1.6
+
+  4) git clone -b EMC-v16.1.6  https://github.com/NOAA-EMC/global-workflow.git .
+
+  5) cd sorc
+
+  6) ./checkout.sh -o
+     * This script extracts the following GFS components:
+         MODEL     tag GFS.v16.0.17                  Jun.Wang@noaa.gov
+         GSI       tag gfsda.v16.1.6                 Catherine.Thomas@noaa.gov
+         GLDAS     tag gldas_gfsv16_release.v1.12.0  Helin.Wei@noaa.gov
+         UFS_UTILS tag ops-gfsv16.0.0                George.Gayno@noaa.gov
+         POST      tag upp_gfsv16_release.v1.1.4     Wen.Meng@noaa.gov
+         WAFS      tag gfs_wafs.v6.0.22              Yali.Mao@noaa.gov
+
+  7) ./build_all.sh
+     * This script compiles all GFS components. Runtime output from the build for 
+       each package is written to log files in directory logs. To build an 
+       individual program, for instance, gsi, use build_gsi.sh.
+
+  8) ./link_fv3gfs.sh nco dell	
+
+
+SORC CHANGES
+
+* sorc/
+  * checkout.sh will checkout the following changed model tags:
+    * GSI; tag gfsda.v16.1.6
+      * No changes to the source code.
+
+
+FIX CHANGES
+
+* fix/fix_gsi:
+  * global_convinfo.txt: Turn on active assimilation of GeoOptics
+  * gfsv16_historical/global_convinfo.txt.2022031612: Add dated 
+    convinfo file for retrospective parallels.  Does not impact operations.
+  * gfsv16_historical/0readme: Update documentation. Does not 
+    impact operations.
+
+
+PARM/CONFIG CHANGES
+
+* parm/config/config.anal:  Add historical fix file entry.  Does
+  not impact operations.
+
+
+JOBS CHANGES
+
+* No change from GFS v16.1.5
+
+
+SCRIPT CHANGES
+
+* No change from GFS v16.1.5
+
+
+CHANGES TO RESOURCES AND FILE SIZES
+
+  There should be no change in analysis runtime nor cnvstat file size
+  greater than the normal cycle to cycle variation.
+
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+
+* Which production jobs should be tested as part of this implementation?
+  * The entire GFS v16.1.6 package needs to be installed and tested. 
+
+* Does this change require a 30-day evaluation?
+  * No.
+
+
+DISSEMINATION INFORMATION
+
+* Where should this output be sent?
+  * No change from GFS v16.1.5
+
+* Who are the users?
+  * No change from GFS v16.1.5
+
+* Which output files should be transferred from PROD WCOSS to DEV WCOSS?
+  * No change from GFS v16.1.5
+
+* Directory changes
+  * No change from GFS v16.1.5
+
+* File changes
+  * No change from GFS v16.1.5
+
+
+HPSS ARCHIVE
+
+* No change from GFS v16.1.5
+
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+
+* No change from GFS v16.1.5
+

--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -118,7 +118,7 @@ All components updated their codes to build on WCOSS2:
 FIX CHANGES
 -----------
 
-* No changes from GFS v16.1.5
+* No changes from GFS v16.1.6
 
 PARM/CONFIG CHANGES
 -------------------
@@ -354,7 +354,7 @@ CHANGES TO RESOURCES AND FILE SIZES
 -----------------------------------
 
 * File sizes
-  * No change to GFSv16.1.5.
+  * No change to GFSv16.1.6.
 * Resource changes to meet operational time windows:
   * See updated Ecflow scripts for adjusted compute resources for WCOSS2.
   * Pre-hand-off development testing results:
@@ -379,21 +379,21 @@ DISSEMINATION INFORMATION
 -------------------------
 
 * Where should this output be sent?
-  * No change from GFS v16.1.5
+  * No change from GFS v16.1.6
 * Who are the users?
-  * No change from GFS v16.1.5
+  * No change from GFS v16.1.6
 * Which output files should be transferred from PROD WCOSS to DEV WCOSS?
-  * No change from GFS v16.1.5
+  * No change from GFS v16.1.6
 * Directory changes
-  * No change from GFS v16.1.5
+  * No change from GFS v16.1.6
 * File changes
-  * No change from GFS v16.1.5
+  * No change from GFS v16.1.6
 
 HPSS ARCHIVE
 ------------
 
-* No change from GFS v16.1.5
+* No change from GFS v16.1.6
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
-* No change from GFS v16.1.5
+* No change from GFS v16.1.6

--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -126,12 +126,12 @@ if [[ $RUN_ENVIR == "emc" ]]; then
 
 
 #   NOTE:
-#   As of 2021110312, gfsv16_historical/global_convinfo.txt.2021091612 is
+#   As of 2022021812, gfsv16_historical/global_convinfo.txt.2022031612 is
 #   identical to ../global_convinfo.txt.  Thus, the logic below is not
 #   needed at this time.
-#   Assimilate COSMIC-2 GPS
-#   if [[ "$CDATE" -ge "2021091612" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
-#     export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021091612
+#   Assimilate DO-4 (Spire and GeoOptics)
+#   if [[ "$CDATE" -ge "2022031612" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
+#     export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2022031612
 #   fi
 
 

--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -119,6 +119,11 @@ if [[ $RUN_ENVIR == "emc" ]]; then
         export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021031712
     fi
 
+#   Assimilate DO-3 Spire
+    if [[ "$CDATE" -ge "2021091612" && "$CDATE" -lt "2022031612" ]]; then
+        export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021091612
+    fi
+
 
 #   NOTE:
 #   As of 2021110312, gfsv16_historical/global_convinfo.txt.2021091612 is

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -38,7 +38,7 @@ if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
     git clone --recursive https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
-    git checkout gfsda.v16.1.5
+    git checkout gfsda.v16.1.6
     git submodule update
     cd ${topdir}
 else

--- a/ush/rocoto/setup_expt.py
+++ b/ush/rocoto/setup_expt.py
@@ -183,9 +183,9 @@ link initial condition files from $ICSDIR to $COMROT'''
 
     # Set machine defaults
     if machine == 'WCOSS2':
-      base_git = '/lfs/h2/emc/global/noscrub/Kate.Friedman/glopara/git'
-      base_svn = '/lfs/h2/emc/global/noscrub/Kate.Friedman/glopara/git'
-      dmpdir = '/lfs/h2/emc/global/noscrub/Kate.Friedman/dump'
+      base_git = '/lfs/h2/emc/global/save/emc.global/git'
+      base_svn = '/lfs/h2/emc/global/save/emc.global/git'
+      dmpdir = '/lfs/h2/emc/global/noscrub/emc.global/dump'
       packageroot = '${PACKAGEROOT:-"/lfs/h1/ops/prod/packages"}'
       comroot = '${COMROOT:-"/lfs/h1/ops/prod/com"}'
       homedir = '/lfs/h2/emc/global/noscrub/$USER'

--- a/ush/rocoto/setup_expt_fcstonly.py
+++ b/ush/rocoto/setup_expt_fcstonly.py
@@ -154,9 +154,9 @@ Create COMROT experiment directory structure'''
 
     # Set machine defaults
     if machine == 'WCOSS2':
-      base_git = '/lfs/h2/emc/global/noscrub/Kate.Friedman/glopara/git'
-      base_svn = '/lfs/h2/emc/global/noscrub/Kate.Friedman/glopara/git'
-      dmpdir = '/lfs/h2/emc/global/noscrub/Kate.Friedman/dump'
+      base_git = '/lfs/h2/emc/global/save/emc.global/git'
+      base_svn = '/lfs/h2/emc/global/save/emc.global/git'
+      dmpdir = '/lfs/h2/emc/global/noscrub/emc.global/dump'
       packageroot = '${PACKAGEROOT:-"/lfs/h1/ops/prod/packages"}'
       comroot = '${COMROOT:-"/lfs/h1/ops/prod/com"}'
       homedir = '/lfs/h2/emc/global/noscrub/$USER'


### PR DESCRIPTION
**Description**

This PR folds in the `GFSv16.1.6` DO-4 updates (Issue #656) into the `GFSv16.2.0` package. The GSI updates are already incorporated in the `gfsda.v16.2.0` tag.

- add `docs/Release_Notes.gfs.v16.1.6.txt`
- update `docs/Release_Notes.gfs.v16.2.0.md` to increment prior GFS version number from `v16.1.5` to `v16.1.6` since `v16.1.6` will technically go in before `v16.2.0`.
- update `config.anal` to add new historical fix file if-block for dates prior to the `v16.1.6` implementation

Additionally:

1. update `Externals.cfg` with `GFSv16.2.0` component version tags already set in `checkout.sh`
2. update `BASE_GIT`, `BASE_SVN`, and `DMPDIR` dev paths for WCOSS2 in the `setup_expt*` scripts; now point to emc.global group account space and not the initial personal account space set up during testing before emc.global was established

Refs: #399, #662
