### PR TITLE
Update GLDAS tag to gldas_gfsv16_release.v.2.0.0

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -15,7 +15,7 @@ protocol = git
 required = True
 
 [GLDAS]
-tag = gldas_gfsv16_release.v.1.28.0
+tag = gldas_gfsv16_release.v.2.0.0
 local_path = sorc/gldas.fd
 repo_url = https://github.com/NOAA-EMC/GLDAS.git
 protocol = git

--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -26,7 +26,7 @@ The checkout script extracts the following GFS components:
 | --------- | ----------- | ----------------- |
 | MODEL     | GFS.v16.2.0   | Jun.Wang@noaa.gov |
 | GSI       | gfsda.v16.2.0 | Russ.Treadon@noaa.gov |
-| GLDAS     | gldas_gfsv16_release.v.1.28.0 | Helin.Wei@noaa.gov |
+| GLDAS     | gldas_gfsv16_release.v.2.0.0 | Helin.Wei@noaa.gov |
 | UFS_UTILS | ops-gfsv16.2.0 | George.Gayno@noaa.gov |
 | POST      | upp_v8.1.0 | Wen.Meng@noaa.gov |
 | WAFS      | gfs_wafs.v6.2.8 | Yali.Mao@noaa.gov |

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -45,7 +45,7 @@ fi
 echo gldas checkout ...
 if [[ ! -d gldas.fd ]] ; then
     rm -f ${topdir}/checkout-gldas.log
-    git clone --branch gldas_gfsv16_release.v.1.28.0 https://github.com/NOAA-EMC/GLDAS  gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
+    git clone --branch gldas_gfsv16_release.v.2.0.0 https://github.com/NOAA-EMC/GLDAS  gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory gldas.fd already exists.'


### PR DESCRIPTION
New GLDAS tag fixes default path for CPCGAUGE to point to group account space for GDA on WCOSS2 instead of personal account

Refs: #399, #662
