### PR TITLE
Specify memory for init job

### DIFF
--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -372,7 +372,11 @@ elif [ $step = "init" ]; then
     export npe_init=24
     export nth_init=1
     export npe_node_init=6
-    export memory_init="70G"
+    if [ $machine = "WCOSS_DELL_P3" ]; then
+        export memory_init="10G"
+    else
+        export memory_init="70G"
+    fi
 
 elif [ $step = "init_chem" ]; then
 

--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -372,6 +372,7 @@ elif [ $step = "init" ]; then
     export npe_init=24
     export nth_init=1
     export npe_node_init=6
+    export memory_init="70G"
 
 elif [ $step = "init_chem" ]; then
 


### PR DESCRIPTION
The init job has been failing on HPC using slurm due to out-of-memory errors. Now the init job specifies the amount of memory needed.

Fixes #631

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Forecast-only on Hera (as part of another experiment)

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
