### PR TITLE
Add needed gempak subfolder to gempak ush scripts

### DIFF
--- a/gempak/ush/gdas_ukmet_meta_ver.sh
+++ b/gempak/ush/gdas_ukmet_meta_ver.sh
@@ -140,7 +140,7 @@ for area in $areas
             cyclenum=$cycle9
         fi
         # JY grid="$COMROOT/nawips/${envir}/ukmet.20${sdatenum}/ukmet_20${sdatenum}${cyclenum}${dgdattim}"
-        grid="${COMINukmet}.20${sdatenum}/ukmet_20${sdatenum}${cyclenum}${dgdattim}"
+        grid="${COMINukmet}.20${sdatenum}/gempak/ukmet_20${sdatenum}${cyclenum}${dgdattim}"
 
 # 500 MB HEIGHT METAFILE
 

--- a/gempak/ush/gfs_meta_comp.sh
+++ b/gempak/ush/gfs_meta_comp.sh
@@ -218,7 +218,7 @@ export err=$?;err_chk
         # COMPARE THE 1200 UTC GFS MODEL TO THE 0000 UTC UKMET MODEL
         grid="F-${MDL} | ${PDY2}/${cyc}00"
         # JY export HPCUKMET=$COMROOT/nawips/prod/ukmet.${PDY}
-        export HPCUKMET=${COMINukmet}.${PDY}
+        export HPCUKMET=${COMINukmet}.${PDY}/gempak
         grid2="F-UKMETHPC | ${PDY2}/0000"
         # for gfsfhr in 00 12 24 36 48 60 84 108
         for gfsfhr in 00 12 24 84 108
@@ -594,7 +594,7 @@ export err=$?;err_chk
         # COMPARE THE 0000 UTC GFS MODEL TO THE 1200 UTC UKMET FROM YESTERDAY
         grid="F-${MDL} | ${PDY2}/${cyc}00"
         #XXW export HPCUKMET=${MODEL}/ukmet.${PDYm1}
-        export HPCUKMET=${COMINukmet}.${PDYm1}
+        export HPCUKMET=${COMINukmet}.${PDYm1}/gempak
         grid2="F-UKMETHPC | ${PDY2m1}/1200"
         # for gfsfhr in 00 12 24 36 48 60 84 108
         for gfsfhr in 00 12 24 84 108

--- a/gempak/ush/gfs_meta_crb.sh
+++ b/gempak/ush/gfs_meta_crb.sh
@@ -264,7 +264,7 @@ if [ ${cyc} -eq 00 ] ; then
     # JY export HPCECMWF=${MODEL}/ecmwf.${PDY}
     # JY export HPCUKMET=${MODEL}/ukmet.${PDYm1}
     export HPCECMWF=${COMINecmwf}.${PDY}/gempak
-    export HPCUKMET=${COMINukmet}.${PDYm1}
+    export HPCUKMET=${COMINukmet}.${PDYm1}/gempak
     grid1="F-${MDL} | ${PDY2}/${cyc}00"
     grid2="${COMINecmwf}.${PDYm1}/gempak/ecmwf_glob_${PDYm1}12"
     grid3="F-UKMETHPC | ${PDY2m1}/1200"

--- a/gempak/ush/gfs_meta_hur.sh
+++ b/gempak/ush/gfs_meta_hur.sh
@@ -338,7 +338,7 @@ if [ ${cyc} -eq 00 ] ; then
     # JY export HPCECMWF=${MODEL}/ecmwf.${PDY}
     # JY export HPCUKMET=${MODEL}/ukmet.${PDY}
     export HPCECMWF=${COMINecmwf}.${PDY}/gempak
-    export HPCUKMET=${COMINukmet}.${PDY}
+    export HPCUKMET=${COMINukmet}.${PDY}/gempak
     grid1="F-${MDL} | ${PDY2}/${cyc}00"
     grid2="${COMINecmwf}.${PDYm1}/gempak/ecmwf_glob_${PDYm1}12"
     grid3="F-UKMETHPC | ${PDY2}/${cyc}00"

--- a/gempak/ush/gfs_meta_mar_comp.sh
+++ b/gempak/ush/gfs_meta_mar_comp.sh
@@ -181,7 +181,7 @@ export err=$?;err_chk
         done
         # COMPARE THE 1200 UTC GFS MODEL TO THE 0000 UTC UKMET MODEL
         grid="F-${MDL} | ${PDY2}/${cyc}00"
-        export HPCUKMET=${COMINukmet}.${PDY}
+        export HPCUKMET=${COMINukmet}.${PDY}/gempak
         grid2="F-UKMETHPC | ${PDY2}/0000"
         # for gfsfhr in 00 12 24 36 48 60 84 108
         for gfsfhr in 00 12 24 84 108
@@ -534,7 +534,7 @@ export err=$?;err_chk
         done
         # COMPARE THE 0000 UTC GFS MODEL TO THE 1200 UTC UKMET FROM YESTERDAY
         grid="F-${MDL} | ${PDY2}/${cyc}00"
-	export HPCUKMET=${COMINukmet}.${PDYm1}
+	export HPCUKMET=${COMINukmet}.${PDYm1}/gempak
         grid2="F-UKMETHPC | ${PDY2m1}/1200"
         # for gfsfhr in 00 12 24 36 48 60 84 108
         for gfsfhr in 00 12 24 84 108

--- a/gempak/ush/gfs_meta_sa2.sh
+++ b/gempak/ush/gfs_meta_sa2.sh
@@ -303,7 +303,7 @@ do
         ukmetfhr=${gfsfhr}
     fi
     gfsfhr="F${gfsfhr}"
-    grid3="${COMINukmet}.${PDY}/ukmet_${PDY}00f${ukmetfhr}"
+    grid3="${COMINukmet}.${PDY}/gempak/ukmet_${PDY}00f${ukmetfhr}"
 
 $GEMEXE/gdplot2_nc << EOF25
 \$MAPFIL = mepowo.gsf


### PR DESCRIPTION
**Description**

Gempak script fix for ukmet data processing. Add "/gempak" subfolder to several HPCUKMET, grid, and grid3 path variables used in gempak ush scripts for ukmet data

**How Has This Been Tested?**

@BoiVuong-NOAA and @WeiWei-NCO tested on WCOSS2 to confirm GDAS ukmet data match in terms of size between WCOSS1 and WCOSS2.

Refs: #399