### PR TITLE
Modify eobs for EnKF thinning

### DIFF
--- a/parm/config/config.eobs
+++ b/parm/config/config.eobs
@@ -14,7 +14,7 @@ export RERUN_EOMGGRP="YES"
 export npe_gsi=$npe_eobs
 
 # GSI namelist options related to observer for EnKF
-export OBSINPUT_INVOBS="dmesh(1)=225.0,dmesh(2)=225.0"
+export OBSINPUT_INVOBS="dmesh(1)=225.0,dmesh(2)=225.0,dmesh(3)=225.0,dmesh(4)=100.0"
 export OBSQC_INVOBS="tcp_width=60.0,tcp_ermin=2.0,tcp_ermax=12.0"
 if [ $LEVS = "128" ]; then
    export GRIDOPTS_INVOBS="nlayers(63)=1,nlayers(64)=1,"


### PR DESCRIPTION
Background

In the Hybrid EnKF GSI, the thinning box size, dmesh,  is different  for the full resolution analysis and EnKF respectively. There are set in GSI scripts for the full resolution analysis, and reset in global workflow in config.eobs. 
Only two thinning box sizes, dmesh(1) & dmesh(2),  are defined in GSI scripts before, recently, two more, dmesh(3) & dmesh(4) are added. Accordingly, these two need to be added in config.eobs as well.

Specifically, add dmesh(3)=225.0,demsh(4)=100.0 to config.eobs.

Fixes #595 

This is an enhancement for EnKF thinning in GSI, nothing else dependent. 