### PR TITLE
Update prep job functionality to use new WCOSS2-port obsproc/prepobs packages

### DIFF
--- a/jobs/rocoto/prep.sh
+++ b/jobs/rocoto/prep.sh
@@ -16,6 +16,11 @@ for config in $configs; do
 done
 
 ###############################################################
+# Load prepobs modulefile
+module use $HOMEprepobs/modulefiles
+module load prepobs/$prepobs_run_ver
+
+###############################################################
 # Source machine runtime environment
 . $BASE_ENV/${machine}.env prep
 status=$?
@@ -102,7 +107,7 @@ if [ $DO_MAKEPREPBUFR = "YES" ]; then
       export COMSP=${COMSP:-$ROTDIR/${CDUMP}.${PDY}/${cyc}/$COMPONENT/$CDUMP.t${cyc}z.}
     fi
 
-    $HOMEobsproc_network/jobs/JGLOBAL_PREP
+    $HOMEobsproc/jobs/JOBSPROC_GLOBAL_PREP
     status=$?
     [[ $status -ne 0 ]] && exit $status
 

--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -69,9 +69,8 @@ export REALTIME="YES"
 export FIXgsi="$HOMEgfs/fix/fix_gsi"
 export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
 export HOMEpost="$HOMEgfs"
-export HOMEobsproc_prep="$BASE_GIT/obsproc/obsproc_prep.v5.5.0"
-export HOMEobsproc_network="$BASE_GIT/obsproc/obsproc_global.v3.4.2"
-export HOMEobsproc_global=$HOMEobsproc_network
+export HOMEobsproc="$BASE_GIT/obsproc/v${obsproc_run_ver}"
+export HOMEprepobs="$BASE_GIT/prepobs/v${prepobs_run_ver}"
 export BASE_VERIF="$BASE_GIT/verif/global/tags/vsdb"
 
 # CONVENIENT utility scripts and other environment parameters

--- a/parm/config/config.base.nco.static
+++ b/parm/config/config.base.nco.static
@@ -64,9 +64,7 @@ export REALTIME="YES"
 export FIXgsi="$HOMEgfs/fix/fix_gsi"
 export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
 export HOMEpost="$HOMEgfs"
-export HOMEobsproc_prep="$PACAKAGEROOT/obsproc_prep.v5.5.0"
-export HOMEobsproc_network="$PACKAGEROOT/obsproc_global.v3.4.2"
-export HOMEobsproc_global=$HOMEobsproc_network
+export HOMEobsproc="/lfs/h1/ops/prod/packages/obsproc.v1.0.0"
 export BASE_VERIF="$BASE_GIT/verif/global/tags/vsdb"
 
 # CONVENIENT utility scripts and other environment parameters

--- a/versions/wcoss2.ver
+++ b/versions/wcoss2.ver
@@ -1,3 +1,6 @@
 export envvar_ver=1.0
 export prod_envir_ver=${prod_envir_ver:-2.0.4} # Allow override from ops ecflow
 export prod_util_ver=${prod_util_ver:-2.0.9}   # Allow override from ops ecflow
+
+export obsproc_run_ver=1.0.0
+export prepobs_run_ver=1.0.0


### PR DESCRIPTION
**Description**

This PR adds support for running the new WCOSS2-port `obsproc.v1.0.0` and `prepobs.v1.0.0` packages in the global-workflow prep job. Updates:

1. add new `obsproc_run_ver` and `prepops_run_ver` variables to `wcoss2.ver` to support developers running prep/obsproc outside of operations
2. update `parm/config/config.base.emc.dyn` `HOMEobsproc*` paths to use new packages: `HOMEobsproc` and `HOMEprepobs`
3. update `parm/config/config.base.emc.dyn` `HOMEobsproc*` paths to use new `obsproc_run_ver` and `prepobs_run_ver` variables
4. update `parm/config/config.base.nco.static` `HOMEobsproc*` paths to only use `HOMEobsproc` and point it to the NCO install (`/lfs/h1/ops/prod/packages/obsproc.v1.0.0`)
5. update `jobs/rocoto/prep.sh` to source the new prepobs modulefile to obtain needed modulefile information (package paths)
6. update `jobs/rocoto/prep.sh` to change `$HOMEobsproc_network/jobs/JGLOBAL_PREP` to `$HOMEobsproc/jobs/JOBSPROC_GLOBAL_PREP`

**Type of change**

- [ ] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

Tested in cycled test on Dogwood. Sent prep job log to OBSPROC/Shelley to confirm it worked correctly (@ShelleyMelchior-NOAA confirmed it did).