### PR TITLE
dev_v16 build and versions updates to support Hera/Orion

### DIFF
--- a/modulefiles/fv3gfs/enkf_chgres_recenter.hera.lua
+++ b/modulefiles/fv3gfs/enkf_chgres_recenter.hera.lua
@@ -2,7 +2,7 @@ help([[
 Load environment for building enkf_chgres_recenter on Hera
 ]])
 
-prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/modulefiles/fv3gfs/enkf_chgres_recenter.orion.lua
+++ b/modulefiles/fv3gfs/enkf_chgres_recenter.orion.lua
@@ -2,7 +2,7 @@ help([[
 Load environment for building enkf_chgres_recenter on Orion
 ]])
 
-prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/modulefiles/fv3gfs/enkf_chgres_recenter_nc.hera.lua
+++ b/modulefiles/fv3gfs/enkf_chgres_recenter_nc.hera.lua
@@ -2,7 +2,7 @@ help([[
 Load environment for building enkf_chgres_recenter_nc
 ]])
 
-prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/modulefiles/fv3gfs/enkf_chgres_recenter_nc.orion.lua
+++ b/modulefiles/fv3gfs/enkf_chgres_recenter_nc.orion.lua
@@ -2,7 +2,7 @@ help([[
 Load environment for building enkf_chgres_recenter_nc
 ]])
 
-prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/modulefiles/fv3gfs/gaussian_sfcanl.hera.lua
+++ b/modulefiles/fv3gfs/gaussian_sfcanl.hera.lua
@@ -2,7 +2,7 @@ help([[
 Load environment for building gaussian_sfcanl on Hera
 ]])
 
-prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/modulefiles/fv3gfs/gaussian_sfcanl.orion.lua
+++ b/modulefiles/fv3gfs/gaussian_sfcanl.orion.lua
@@ -2,7 +2,7 @@ help([[
 Load environment for building gaussian_sfcanl on Orion
 ]])
 
-prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/modulefiles/gfs_bufr.hera.lua
+++ b/modulefiles/gfs_bufr.hera.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to build gfs_bufr on Hera
 ]])
 
-prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/modulefiles/gfs_bufr.orion.lua
+++ b/modulefiles/gfs_bufr.orion.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to build gfs_bufr on Orion 
 ]])
 
-prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/modulefiles/gfs_fbwndgfs.hera.lua
+++ b/modulefiles/gfs_fbwndgfs.hera.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to build fbwndgfs on Hera
 ]])
 
-prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/modulefiles/gfs_fbwndgfs.orion.lua
+++ b/modulefiles/gfs_fbwndgfs.orion.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to build fbwndgfs on Orion
 ]])
 
-prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/modulefiles/module_base.hera.lua
+++ b/modulefiles/module_base.hera.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to run GFS on Hera
 ]])
 
-prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))
@@ -10,10 +10,8 @@ load(pathJoin("hpc-impi", os.getenv("hpc_impi_ver")))
 
 load(pathJoin("esmf", os.getenv("esmf_ver")))
 
-load(pathJoin("python", os.getenv("python_ver")))
+load(pathJoin("anaconda", os.getenv("anaconda_ver")))
 load(pathJoin("gempak", os.getenv("gempak_ver")))
-load(pathJoin("perl", os.getenv("perl_ver")))
-load(pathJoin("libjpeg", os.getenv("libjpeg_ver")))
 load(pathJoin("hpss", os.getenv("hpss_ver")))
 
 load(pathJoin("cdo", os.getenv("cdo_ver")))
@@ -25,8 +23,6 @@ load(pathJoin("udunits", os.getenv("udunits_ver")))
 load(pathJoin("nco", os.getenv("nco_ver")))
 load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("grib_util", os.getenv("grib_util_ver")))
-load(pathJoin("bufr_dump", os.getenv("bufr_dump_ver")))
-load(pathJoin("util_shared", os.getenv("util_shared_ver")))
 load(pathJoin("crtm", os.getenv("crtm_ver")))
 load(pathJoin("g2tmpl", os.getenv("g2tmpl_ver")))
 load(pathJoin("wgrib2", os.getenv("wgrib2_ver")))

--- a/modulefiles/module_base.orion.lua
+++ b/modulefiles/module_base.orion.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to run GFS on Orion
 ]])
 
-prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))
@@ -13,7 +13,6 @@ load(pathJoin("esmf", os.getenv("esmf_ver")))
 load(pathJoin("python", os.getenv("python_ver")))
 load(pathJoin("gempak", os.getenv("gempak_ver")))
 load(pathJoin("perl", os.getenv("perl_ver")))
-load(pathJoin("libjpeg", os.getenv("libjpeg_ver")))
 
 load(pathJoin("cdo", os.getenv("cdo_ver")))
 
@@ -24,8 +23,6 @@ load(pathJoin("udunits", os.getenv("udunits_ver")))
 load(pathJoin("nco", os.getenv("nco_ver")))
 load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("grib_util", os.getenv("grib_util_ver")))
-load(pathJoin("bufr_dump", os.getenv("bufr_dump_ver")))
-load(pathJoin("util_shared", os.getenv("util_shared_ver")))
 load(pathJoin("crtm", os.getenv("crtm_ver")))
 load(pathJoin("g2tmpl", os.getenv("g2tmpl_ver")))
 load(pathJoin("wgrib2", os.getenv("wgrib2_ver")))

--- a/modulefiles/modulefile.fv3nc2nemsio.hera.lua
+++ b/modulefiles/modulefile.fv3nc2nemsio.hera.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to build fv3nc2nemsio on Hera
 ]])
 
-prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/modulefiles/modulefile.fv3nc2nemsio.orion.lua
+++ b/modulefiles/modulefile.fv3nc2nemsio.orion.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to build fv3nc2nemsio on Orion
 ]])
 
-prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/modulefiles/modulefile.regrid_nemsio.hera.lua
+++ b/modulefiles/modulefile.regrid_nemsio.hera.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to build regrid_nemsio on Hera
 ]])
 
-prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/modulefiles/modulefile.regrid_nemsio.orion.lua
+++ b/modulefiles/modulefile.regrid_nemsio.orion.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to build regrid_nemsio on Orion
 ]])
 
-prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/modulefiles/modulefile.storm_reloc_v6.0.0.hera.lua
+++ b/modulefiles/modulefile.storm_reloc_v6.0.0.hera.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to build storm_reloc on Hera
 ]])
 
-prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))
@@ -10,7 +10,6 @@ load(pathJoin("hpc-impi", os.getenv("hpc_impi_ver")))
 
 load(pathJoin("jasper", os.getenv("jasper_ver")))
 load(pathJoin("libpng", os.getenv("libpng_ver")))
-load(pathJoin("png", os.getenv("1.6.35")))
 load(pathJoin("zlib", os.getenv("zlib_ver")))
 
 load(pathJoin("bacio", os.getenv("bacio_ver")))

--- a/modulefiles/modulefile.storm_reloc_v6.0.0.orion.lua
+++ b/modulefiles/modulefile.storm_reloc_v6.0.0.orion.lua
@@ -10,7 +10,6 @@ load(pathJoin("hpc-impi", os.getenv("hpc_impi_ver")))
 
 load(pathJoin("jasper", os.getenv("jasper_ver")))
 load(pathJoin("libpng", os.getenv("libpng_ver")))
-load(pathJoin("png", os.getenv("1.6.35")))
 load(pathJoin("zlib", os.getenv("zlib_ver")))
 
 load(pathJoin("bacio", os.getenv("bacio_ver")))

--- a/modulefiles/modulefile.storm_reloc_v6.0.0.orion.lua
+++ b/modulefiles/modulefile.storm_reloc_v6.0.0.orion.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to build storm_reloc on Orion
 ]])
 
-prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))

--- a/sorc/build_fv3.sh
+++ b/sorc/build_fv3.sh
@@ -20,5 +20,9 @@ if [ $target = hera ]; then target=hera.intel ; fi
 if [ $target = orion ]; then target=orion.intel ; fi
 
 cd fv3gfs.fd/tests
-./compile.sh $(pwd)/../FV3 $target "WW3=Y 32BIT=Y" 1
+if [ $target = wcoss2 ]; then
+  ./compile.sh $(pwd)/../FV3 $target "WW3=Y 32BIT=Y" 1
+else # Only supporting waves on WCOSS2 for v16.2
+  ./compile.sh $(pwd)/../FV3 $target "WW3=N 32BIT=Y" 1
+fi
 mv -f fv3_1.exe ../NEMS/exe/global_fv3gfs.x

--- a/sorc/build_fv3nc2nemsio.sh
+++ b/sorc/build_fv3nc2nemsio.sh
@@ -14,17 +14,15 @@ fi
 
 cd ./fv3nc2nemsio.fd
 
-export HDF5=$HDF5_ROOT
-
 LIBnetcdf=`$NETCDF/bin/nf-config --flibs`
 INCnetcdf=`$NETCDF/bin/nf-config --fflags`
-export NETCDF_LDFLAGS=$LIBnetcdf
+export NETCDF_LDFLAGS="$LIBnetcdf -lnetcdf -L${HDF5_LIBRARIES} -lhdf5_hl -lhdf5 -lz"
 export NETCDF_INCLUDE=$INCnetcdf
 
 $FCMP $FFLAGS -c kinds.f90
 $FCMP $FFLAGS -c constants.f90
 $FCMP $FFLAGS $NETCDF_INCLUDE -I $NEMSIO_INC -c fv3_module.f90
-$FCMP $FFLAGS $NETCDF_INCLUDE -I $NEMSIO_INC -I. -o fv3nc2nemsio.x fv3_main.f90 fv3_module.o $NETCDF_LDFLAGS $NEMSIO_LIB $BACIO_LIB4 $W3NCO_LIBd -L$HDF5/lib -lhdf5_hl -lhdf5 -lz
+$FCMP $FFLAGS $NETCDF_INCLUDE -I $NEMSIO_INC -I. -o fv3nc2nemsio.x fv3_main.f90 fv3_module.o $NETCDF_LDFLAGS $NEMSIO_LIB $BACIO_LIB4 $W3NCO_LIBd
 
 rm -f *.o *.mod
 

--- a/sorc/build_regrid_nemsio.sh
+++ b/sorc/build_regrid_nemsio.sh
@@ -18,18 +18,15 @@ export F90=${FCMP}
 export LD=${FCMP}
 export F77=${FCMP}
 
-export NETCDF_LDFLAGS="-L${NETCDF}/lib -lnetcdff -lnetcdf -L${HDF5_LIBRARIES} -lhdf5_hl -lhdf5 -lz"
 export FCFFLAGS="" # "-convert native -assume byterecl -heap-arrays -mcmodel=large -shared-intel"
 export LDFLAGS="${FCFFLAGS}"
 export OPTIMIZATION="-O3" #-axCORE-AVX2,AVX -xSSE4.2 -O3
 export DEBUG="-traceback -g" #-O0 #-C #-fp-stack-check #-check all -fp-stack-check
 
-if [ $target = wcoss2 ]; then
-  LIBnetcdf=`$NETCDF/bin/nf-config --flibs`
-  INCnetcdf=`$NETCDF/bin/nf-config --fflags`
-  export NETCDF_LDFLAGS=$LIBnetcdf
-  export NETCDF_INCLUDE=$INCnetcdf
-fi
+LIBnetcdf=`$NETCDF/bin/nf-config --flibs`
+INCnetcdf=`$NETCDF/bin/nf-config --fflags`
+export NETCDF_LDFLAGS="$LIBnetcdf -lnetcdff -lnetcdf -L${HDF5_LIBRARIES} -lhdf5_hl -lhdf5 -lz"
+export NETCDF_INCLUDE=$INCnetcdf
 
 make -f Makefile clean
 make -f Makefile

--- a/sorc/build_tropcy_NEMS.sh
+++ b/sorc/build_tropcy_NEMS.sh
@@ -28,7 +28,7 @@ export FC=$myFC
 export JASPER_LIB=${JASPER_LIB:-$JASPER_LIBRARIES/libjasper.a}
 
 export INC="${G2_INCd} -I${NEMSIO_INC}"
-export LIBS="${W3EMC_LIBd} ${W3NCO_LIBd} ${BACIO_LIB4} ${G2_LIBd} ${PNG_LIB} ${JASPER_LIB} ${Z_LIB}"
+export LIBS="${W3EMC_LIBd} ${W3NCO_LIBd} ${BACIO_LIB4} ${G2_LIBd} ${LIBPNG_LIB} ${JASPER_LIB} ${ZLIB_LIB}"
 export LIBS_SUP="${W3EMC_LIBd} ${W3NCO_LIBd}"
 echo lset
 echo lset

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -26,7 +26,7 @@ echo $topdir
 echo fv3gfs checkout ...
 if [[ ! -d fv3gfs.fd ]] ; then
     rm -f ${topdir}/checkout-fv3gfs.log
-    git clone --recursive --branch GFS.v16.2.0 https://github.com/ufs-community/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
+    git clone --recursive --branch GFS.v16.2.1 https://github.com/ufs-community/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory fv3gfs.fd already exists.'
@@ -37,7 +37,7 @@ if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
     git clone --recursive --branch gfsda.v16.2.0.1 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
-    git submodule update
+    git submodule update --init
     cd ${topdir}
 else
     echo 'Skip.  Directory gsi.fd already exists.'
@@ -55,7 +55,7 @@ fi
 echo ufs_utils checkout ...
 if [[ ! -d ufs_utils.fd ]] ; then
     rm -f ${topdir}/checkout-ufs_utils.log
-    git clone --branch ops-gfsv16.2.0 https://github.com/ufs-community/UFS_UTILS ufs_utils.fd >> ${topdir}/checkout-ufs_utils.fd.log 2>&1
+    git clone --branch ops-gfsv16.2.1 https://github.com/ufs-community/UFS_UTILS ufs_utils.fd >> ${topdir}/checkout-ufs_utils.fd.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory ufs_utils.fd already exists.'

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -35,7 +35,7 @@ fi
 echo gsi checkout ...
 if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
-    git clone --recursive --branch gfsda.v16.2.0 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
+    git clone --recursive --branch gfsda.v16.2.0.1 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
     git submodule update
     cd ${topdir}
@@ -64,7 +64,7 @@ fi
 echo EMC_post checkout ...
 if [[ ! -d gfs_post.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_post.log
-    git clone ${gtg_git_args:-} --branch upp_v8.1.0 https://github.com/NOAA-EMC/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
+    git clone ${gtg_git_args:-} --branch upp_v8.1.1 https://github.com/NOAA-EMC/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
     ################################################################################
     # checkout_gtg
     ## yes: The gtg code at NCAR private repository is available for ops. GFS only.

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -7,6 +7,7 @@ do
   o)
    echo "Received -o flag for optional checkout of GTG, will check out GTG with EMC_post"
    checkout_gtg="YES"
+   checkout_wafs="YES"
    gtg_git_args="--recursive"
    ;;
   :)
@@ -81,13 +82,16 @@ else
     echo 'Skip.  Directory gfs_post.fd already exists.'
 fi
 
-echo EMC_gfs_wafs checkout ...
-if [[ ! -d gfs_wafs.fd ]] ; then
+checkout_wafs=${checkout_wafs:-"NO"}
+if [[ ${checkout_wafs} == "YES" ]] ; then
+  echo EMC_gfs_wafs checkout ...
+  if [[ ! -d gfs_wafs.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_wafs.log
     git clone --recursive --branch gfs_wafs.v6.2.8 https://github.com/NOAA-EMC/EMC_gfs_wafs.git gfs_wafs.fd >> ${topdir}/checkout-gfs_wafs.log 2>&1
     cd ${topdir}
-else
+  else
     echo 'Skip.  Directory gfs_wafs.fd already exists.'
+  fi
 fi
 
 echo EMC_verif-global checkout ...

--- a/sorc/enkf_chgres_recenter_nc.fd/makefile
+++ b/sorc/enkf_chgres_recenter_nc.fd/makefile
@@ -1,6 +1,5 @@
 SHELL=  /bin/sh
 
-#LIBS= $(FV3GFS_NCIO_LIB) $(BACIO_LIB4) $(W3NCO_LIB4) $(IP_LIB4) $(SP_LIB4) -L$(HDF5_LIBRARIES) -lhdf5_hl -lhdf5 -lz -L$(NETCDF)/lib  -lnetcdff -lnetcdf 
 LIBS= $(FV3GFS_NCIO_LIB) $(BACIO_LIB4) $(W3NCO_LIB4) $(IP_LIB4) $(SP_LIB4) -L$(NETCDF)/lib -lnetcdff -lnetcdf -L${HDF5_LIBRARIES} -lhdf5_hl -lhdf5 -lz 
 
 CMD= enkf_chgres_recenter_nc.x

--- a/sorc/enkf_chgres_recenter_nc.fd/makefile
+++ b/sorc/enkf_chgres_recenter_nc.fd/makefile
@@ -1,6 +1,7 @@
 SHELL=  /bin/sh
 
-LIBS= $(FV3GFS_NCIO_LIB) $(BACIO_LIB4) $(W3NCO_LIB4) $(IP_LIB4) $(SP_LIB4) -L$(HDF5_LIBRARIES) -lhdf5_hl -lhdf5 -lz -L$(NETCDF)/lib  -lnetcdff -lnetcdf 
+#LIBS= $(FV3GFS_NCIO_LIB) $(BACIO_LIB4) $(W3NCO_LIB4) $(IP_LIB4) $(SP_LIB4) -L$(HDF5_LIBRARIES) -lhdf5_hl -lhdf5 -lz -L$(NETCDF)/lib  -lnetcdff -lnetcdf 
+LIBS= $(FV3GFS_NCIO_LIB) $(BACIO_LIB4) $(W3NCO_LIB4) $(IP_LIB4) $(SP_LIB4) -L$(NETCDF)/lib -lnetcdff -lnetcdf -L${HDF5_LIBRARIES} -lhdf5_hl -lhdf5 -lz 
 
 CMD= enkf_chgres_recenter_nc.x
 

--- a/sorc/link_fv3gfs.sh
+++ b/sorc/link_fv3gfs.sh
@@ -301,9 +301,9 @@ cd ${pwd}/../sorc   ||   exit 8
     for prog in filter_topo fregrid make_hgrid make_solo_mosaic ; do
         $SLINK ufs_utils.fd/sorc/fre-nctools.fd/tools/$prog                                ${prog}.fd                                
     done
-    for prog in  global_cycle.fd   nemsio_read.fd  nemsio_chgdate.fd \
+    for prog in  global_cycle.fd  \
         emcsfc_ice_blend.fd  nst_tf_chg.fd \
-        emcsfc_snow2mdl.fd   global_chgres.fd  nemsio_get.fd    orog.fd ;do
+        emcsfc_snow2mdl.fd   global_chgres.fd  orog.fd ;do
         $SLINK ufs_utils.fd/sorc/$prog                                                     $prog
     done
 

--- a/sorc/supvit.fd/makefile
+++ b/sorc/supvit.fd/makefile
@@ -1,7 +1,7 @@
 SHELL=  /bin/sh
 ISIZE = 4
 RSIZE = 8
-COMP=   ftn
+COMP=   $(FC)
 ##LIBS_SUP=   -L/contrib/nceplibs/nwprod/lib -lw3emc_d -lw3nco_d -lg2_d -lbacio_4 -ljasper -lpng -lz
 LDFLAGS= 
 ##ccs FFLAGS= -O -qflttrap=ov:zero:inv:enable -qcheck -qextchk -qwarn64 -qintsize=$(ISIZE) -qrealsize=$(RSIZE)

--- a/sorc/syndat_getjtbul.fd/makefile
+++ b/sorc/syndat_getjtbul.fd/makefile
@@ -1,7 +1,7 @@
 SHELL=		/bin/sh
 #LIBS=		-L/nwprod/lib -lw3nco_v2.0.5_4
 #LIBS=		-L/contrib/nceplibs/nwprod/lib -lw3nco_v2.0.5_4
-FC=		ftn
+COMP=   $(FC)
 #DEBUG = 	-ftrapuv  -check all  -fp-stack-check  -fstack-protector
 ##DEBUG = 	-ftrapuv  -fp-stack-check  -fstack-protector
 FFLAGS=		-O3 -g -traceback -assume noold_ldout_format $(DEBUG)
@@ -13,7 +13,7 @@ CMD=		syndat_getjtbul
 all:		$(CMD)
 
 $(CMD):		$(OBJS)
-	$(FC) $(LDFLAGS) -o $(@) $(OBJS) $(LIBS_SYN_GET)
+	$(COMP) $(LDFLAGS) -o $(@) $(OBJS) $(LIBS_SYN_GET)
 
 clean:	
 		-rm -f $(OBJS)

--- a/sorc/syndat_maksynrc.fd/makefile
+++ b/sorc/syndat_maksynrc.fd/makefile
@@ -1,7 +1,7 @@
 SHELL=		/bin/sh
 #LIBS=		-L/nwprod/lib -lw3nco_v2.0.5_4 -lbacio_v2.0.1_4 
 ##LIBS_SYN_MAK=		-L/contrib/nceplibs/nwprod/lib -lw3nco_v2.0.5_4 -lbacio_v2.0.1_4 
-FC=		ftn
+COMP=   $(FC)
 #DEBUG =          -ftrapuv -check all -check nooutput_conversion -fp-stack-check -fstack-protector
 FFLAGS=		-O3 -g -traceback -assume noold_ldout_format $(DEBUG)
 LDFLAGS=	
@@ -12,7 +12,7 @@ CMD=		syndat_maksynrc
 all:		$(CMD)
 
 $(CMD):		$(OBJS)
-		$(FC) $(LDFLAGS) -o $(@) $(OBJS) $(LIBS_SYN_MAK)
+		$(COMP) $(LDFLAGS) -o $(@) $(OBJS) $(LIBS_SYN_MAK)
 
 clean:	
 		-rm -f $(OBJS)

--- a/sorc/syndat_qctropcy.fd/makefile
+++ b/sorc/syndat_qctropcy.fd/makefile
@@ -1,7 +1,7 @@
 SHELL=		/bin/sh
 #LIBS=		-L/nwprod/lib -lw3nco_v2.0.5_8
 ##LIBS=		-L/contrib/nceplibs/nwprod/lib -lw3nco_v2.0.5_8
-FC=		ftn
+COMP=   $(FC)
 #DEBUG =		-ftrapuv -check all -check noarg_temp_created -fp-stack-check -fstack-protector
 ## if '-check all' enabled, include '-check noarg_temp_created' to avoid warning msgs indicating 
 ##   slight performance hit due to chosen method of passing array arguments to w3difdat  
@@ -14,7 +14,7 @@ CMD=		syndat_qctropcy
 all:		$(CMD)
 
 $(CMD):		$(OBJS)
-		$(FC) $(LDFLAGS) -o $(@) $(OBJS) $(LIBS_SYN_QCT)
+		$(COMP) $(LDFLAGS) -o $(@) $(OBJS) $(LIBS_SYN_QCT)
 
 clean:
 		-rm -f $(OBJS)

--- a/sorc/tave.fd/makefile
+++ b/sorc/tave.fd/makefile
@@ -1,7 +1,7 @@
 SHELL=  /bin/sh
 ISIZE = 4
 RSIZE = 8
-COMP=   ftn
+COMP=   $(FC)
 ##INC = /contrib/nceplibs/nwprod/lib/incmod/g2_d
 ##LIBS=    -L/contrib/nceplibs/nwprod/lib -lw3emc_d -lw3nco_d -lg2_d -lbacio_4 -ljasper -lpng -lz
 LDFLAGS= 

--- a/sorc/vint.fd/makefile
+++ b/sorc/vint.fd/makefile
@@ -1,7 +1,7 @@
 SHELL=  /bin/sh
 ISIZE = 4
 RSIZE = 8
-COMP=   ftn
+COMP= $(FC)
 ##INC = /contrib/nceplibs/nwprod/lib/incmod/g2_d
 ##LIBS=   -L/contrib/nceplibs/nwprod/lib -lw3emc_d -lw3nco_d -lg2_d -lbacio_4 -ljasper -lpng -lz
 LDFLAGS=

--- a/versions/hera.ver
+++ b/versions/hera.ver
@@ -5,3 +5,4 @@ export hpc_impi_ver=2018.0.4
 export hpss_ver=hpss
 export prod_util_ver=1.2.2
 export cmake_ver=3.20.0
+export anaconda_ver=anaconda3-5.3.1

--- a/versions/hera.ver
+++ b/versions/hera.ver
@@ -1,8 +1,16 @@
-export hpc_ver=1.1.0
+export hpc_ver=1.2.0
 export hpc_intel_ver=18.0.5.274
 export hpc_impi_ver=2018.0.4
 
+export obsproc_run_ver=1.0.0
+export prepobs_run_ver=1.0.0
+
 export hpss_ver=hpss
 export prod_util_ver=1.2.2
-export cmake_ver=3.20.0
+export cmake_ver=3.20.1
 export anaconda_ver=anaconda3-5.3.1
+
+export esmf_ver=8_0_1
+export nco_ver=4.9.3
+export gempak_ver=7.4.2
+export wrf_io_ver=1.2.0

--- a/versions/orion.ver
+++ b/versions/orion.ver
@@ -1,6 +1,14 @@
-export hpc_ver=1.1.0
+export hpc_ver=1.2.0
 export hpc_intel_ver=2018.4
 export hpc_impi_ver=2018.4
 
+export obsproc_run_ver=1.0.0
+export prepobs_run_ver=1.0.0
+
 export prod_util_ver=1.2.2
 export cmake_ver=3.22.1
+export gempak_ver=7.5.1
+export python_ver=3.9.2
+export wrf_io_ver=1.2.0
+export esmf_ver=8_0_1
+export nco_ver=4.9.3


### PR DESCRIPTION
**Description**

This PR contains the following updates to support building the GFSv16.2.0 package via the `dev_v16` branch on Hera/Orion:

1. update Hera/Orion global-workflow modulefiles to use special `hpc-stack-gfsv16` hpc-stack installs created by hpc-stack team
2. change `python` to `anaconda` on Hera
3. remove module loads in Hera/Orion module_base modulefiles that won't be needed or won't be available on either machine: `libjpeg`, `bufr_dump`, `util_shared`, `perl` (will need to come back and check on `perl` on Hera, likely needed for GSI monitoring package, removing for now to avoid errors at loadtime)
4. build scripts updates for supporting R&D machines: `build_fv3nc2nemsio.sh`, `build_regrid_nemsio.sh`, `build_tropcy_NEMS.sh`
5. makefile updates for supporting R&D machines: `enkf_chgres_recenter_nc.fd/makefile`, `supvit.fd/makefile`, `syndat_getjtbul.fd/makefile`, `syndat_maksynrc.fd/makefile`, `syndat_qctropcy.fd/makefile`, `tave.fd/makefile`, `vint.fd/makefile`
6. checkout.sh updates for component versions: GSI (`gfsda.v16.2.0.1` @MichaelLueken-NOAA) and UPP (`upp_v8.1.1` @WenMeng-NOAA)
7. checkout.sh update to add WAFS checkout to the `-o` operations checkout mode; won't need or support WAFS outside of WCOSS2
8. update link_fv3gfs.sh to remove `nemsio_*.fd` symlinks; nemsio codes now gone in UFS_UTILS component version
9. version file updates to `hera.ver` and `orion.ver` to add new obsproc/prepobs run versions, update `hpc_ver` to 1.2.0, and add verson overrides for module versions that differ compared to WCOSS2

Some of the above build changes are to support the fact that hpc-stack was installed differently on the R&D machines compared to WCOSS2 (dynamic instead of static).

The above updates do not impact build or run functionality on WCOSS2. The above has been tested (build and run) in cycled mode on WCOSS2 to confirm no functionality impact.

Note: there are two component versions uncommitted but tested alongside the above: ufs-weather-model `modulefileRnD` branch provided by @junwang-noaa and UFS_UTILS `hotfix/gfsv16.2.0` branch provided by @GeorgeGayno-NOAA. Can't build out of the box without those two component updates.

**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

These changes have been tested on Hera, Orion, and WCOSS2 to confirm checkout and build happen correctly. Also tested in cycled mode on WCOSS2 to confirm no impact on functionality there. Cycled tests still to be done on Hera/Orion.

Refs: #665 
