### PR TITLE
Merge GFSv16.1.6 updates into operations branch

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.1.5
+tag = gfsda.v16.1.6
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git

--- a/docs/Release_Notes.gfs.v16.1.6.txt
+++ b/docs/Release_Notes.gfs.v16.1.6.txt
@@ -24,6 +24,14 @@ PRELUDE
   Once data flow begins on March 16th, a one-week evaluation of the new GeoOptics 
   observations is needed before implementation.
 
+  In addition to DO-4, a small change is needed to accompany a change in the
+  observation processing.  Winds "NeXRaD VAD WINDS FROM LEVEL 2 DECODER"
+  (tank b002/xx017) will soon be included in the global observation processing.
+  Since these observations have not yet been evaluated in the GFS, this observation
+  type (uv 224) will be set to monitor mode.  This requires a single line change
+  in the global_convinfo.txt file.
+
+
 IMPLEMENTATION INSTRUCTIONS
 
   The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com 
@@ -71,7 +79,8 @@ SORC CHANGES
 FIX CHANGES
 
 * fix/fix_gsi:
-  * global_convinfo.txt: Turn on active assimilation of GeoOptics
+  * global_convinfo.txt: Turn on active assimilation of GeoOptics and
+    turn off active assimilation of uv 224 VADWND.
   * gfsv16_historical/global_convinfo.txt.2022031612: Add dated 
     convinfo file for retrospective parallels.  Does not impact operations.
   * gfsv16_historical/0readme: Update documentation. Does not 

--- a/docs/Release_Notes.gfs.v16.1.6.txt
+++ b/docs/Release_Notes.gfs.v16.1.6.txt
@@ -13,7 +13,7 @@ PRELUDE
   previous delivery orders.  DO-1 was awarded to both vendors, but was used 
   for evaluation purposes only and not assimilated operationally.  DO-2 was 
   awarded to GeoOptics and subsequently assimilated in the operational GFS/GDAS 
-  as v16.1.  DO-3 was then awarded to Spire only.  The v16.1.6 implementation 
+  as v16.1.  DO-3 was then awarded to Spire only.  The v16.1.4 implementation 
   turned on the assimilation of Spire data as well as turned off the assimilation 
   of GeoOptics.  
 

--- a/docs/Release_Notes.gfs.v16.1.6.txt
+++ b/docs/Release_Notes.gfs.v16.1.6.txt
@@ -47,7 +47,7 @@ IMPLEMENTATION INSTRUCTIONS
 
   3) cd gfs.v16.1.6
 
-  4) git clone -b EMC-v16.1.6  https://github.com/NOAA-EMC/global-workflow.git .
+  4) git clone -b EMC-v16.1.6.2  https://github.com/NOAA-EMC/global-workflow.git .
 
   5) cd sorc
 

--- a/docs/Release_Notes.gfs.v16.1.6.txt
+++ b/docs/Release_Notes.gfs.v16.1.6.txt
@@ -1,0 +1,138 @@
+GFS V16.1.6 RELEASE NOTES
+
+
+PRELUDE
+ 
+  NOAA awarded Delivery Order 4 (DO-4) of its commercial radio occultation (RO) 
+  data purchase to both Spire Global and GeoOptics on February 10, 2022.  This 
+  purchase covers 5500 occultations per day from Spire and 500 occultations per 
+  day from GeoOptics over a 10 month period with the data flow starting on 
+  March 16, 2022.
+
+  Both GeoOptics and Spire have been assimilated in operations as part of 
+  previous delivery orders.  DO-1 was awarded to both vendors, but was used 
+  for evaluation purposes only and not assimilated operationally.  DO-2 was 
+  awarded to GeoOptics and subsequently assimilated in the operational GFS/GDAS 
+  as v16.1.  DO-3 was then awarded to Spire only.  The v16.1.6 implementation 
+  turned on the assimilation of Spire data as well as turned off the assimilation 
+  of GeoOptics.  
+
+  If no changes are made to operations, we will assimilate the Spire portion of 
+  the purchase, but would not assimilate the new GeoOptics data. In order to 
+  assimilate data from both vendors, a single line change in the global_convinfo.txt 
+  fix file is required.  There are no other changes planned for this implementation.  
+  Once data flow begins on March 16th, a one-week evaluation of the new GeoOptics 
+  observations is needed before implementation.
+
+IMPLEMENTATION INSTRUCTIONS
+
+  The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com 
+  are used to manage the GFS.v16.1.6 code. The SPA(s) handling the GFS.v16.1.6 
+  implementation need to have permissions to clone VLab gerrit repositories and 
+  the private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are 
+  publicly readable and do not require access permissions.  Please follow the 
+  following steps to install the package on WCOSS-Dell:
+
+  1) cd $NWROOTp3
+
+  2) mkdir gfs.v16.1.6
+
+  3) cd gfs.v16.1.6
+
+  4) git clone -b EMC-v16.1.6  https://github.com/NOAA-EMC/global-workflow.git .
+
+  5) cd sorc
+
+  6) ./checkout.sh -o
+     * This script extracts the following GFS components:
+         MODEL     tag GFS.v16.0.17                  Jun.Wang@noaa.gov
+         GSI       tag gfsda.v16.1.6                 Catherine.Thomas@noaa.gov
+         GLDAS     tag gldas_gfsv16_release.v1.12.0  Helin.Wei@noaa.gov
+         UFS_UTILS tag ops-gfsv16.0.0                George.Gayno@noaa.gov
+         POST      tag upp_gfsv16_release.v1.1.4     Wen.Meng@noaa.gov
+         WAFS      tag gfs_wafs.v6.0.22              Yali.Mao@noaa.gov
+
+  7) ./build_all.sh
+     * This script compiles all GFS components. Runtime output from the build for 
+       each package is written to log files in directory logs. To build an 
+       individual program, for instance, gsi, use build_gsi.sh.
+
+  8) ./link_fv3gfs.sh nco dell	
+
+
+SORC CHANGES
+
+* sorc/
+  * checkout.sh will checkout the following changed model tags:
+    * GSI; tag gfsda.v16.1.6
+      * No changes to the source code.
+
+
+FIX CHANGES
+
+* fix/fix_gsi:
+  * global_convinfo.txt: Turn on active assimilation of GeoOptics
+  * gfsv16_historical/global_convinfo.txt.2022031612: Add dated 
+    convinfo file for retrospective parallels.  Does not impact operations.
+  * gfsv16_historical/0readme: Update documentation. Does not 
+    impact operations.
+
+
+PARM/CONFIG CHANGES
+
+* parm/config/config.anal:  Add historical fix file entry.  Does
+  not impact operations.
+
+
+JOBS CHANGES
+
+* No change from GFS v16.1.5
+
+
+SCRIPT CHANGES
+
+* No change from GFS v16.1.5
+
+
+CHANGES TO RESOURCES AND FILE SIZES
+
+  There should be no change in analysis runtime nor cnvstat file size
+  greater than the normal cycle to cycle variation.
+
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+
+* Which production jobs should be tested as part of this implementation?
+  * The entire GFS v16.1.6 package needs to be installed and tested. 
+
+* Does this change require a 30-day evaluation?
+  * No.
+
+
+DISSEMINATION INFORMATION
+
+* Where should this output be sent?
+  * No change from GFS v16.1.5
+
+* Who are the users?
+  * No change from GFS v16.1.5
+
+* Which output files should be transferred from PROD WCOSS to DEV WCOSS?
+  * No change from GFS v16.1.5
+
+* Directory changes
+  * No change from GFS v16.1.5
+
+* File changes
+  * No change from GFS v16.1.5
+
+
+HPSS ARCHIVE
+
+* No change from GFS v16.1.5
+
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+
+* No change from GFS v16.1.5
+

--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -126,12 +126,12 @@ if [[ $RUN_ENVIR == "emc" ]]; then
 
 
 #   NOTE:
-#   As of 2021110312, gfsv16_historical/global_convinfo.txt.2021091612 is
+#   As of 2022021812, gfsv16_historical/global_convinfo.txt.2022031612 is
 #   identical to ../global_convinfo.txt.  Thus, the logic below is not
 #   needed at this time.
-#   Assimilate COSMIC-2 GPS
-#   if [[ "$CDATE" -ge "2021091612" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
-#     export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021091612
+#   Assimilate DO-4 (Spire and GeoOptics)
+#   if [[ "$CDATE" -ge "2022031612" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
+#     export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2022031612
 #   fi
 
 

--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -119,6 +119,11 @@ if [[ $RUN_ENVIR == "emc" ]]; then
         export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021031712
     fi
 
+#   Assimilate DO-3 Spire
+    if [[ "$CDATE" -ge "2021091612" && "$CDATE" -lt "2022031612" ]]; then
+        export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021091612
+    fi
+
 
 #   NOTE:
 #   As of 2021110312, gfsv16_historical/global_convinfo.txt.2021091612 is

--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -129,7 +129,7 @@ if [[ $RUN_ENVIR == "emc" ]]; then
 #   As of 2022021812, gfsv16_historical/global_convinfo.txt.2022031612 is
 #   identical to ../global_convinfo.txt.  Thus, the logic below is not
 #   needed at this time.
-#   Assimilate DO-4 (Spire and GeoOptics)
+#   Assimilate DO-4 (Spire and GeoOptics) and turn off uv 224 VADWND
 #   if [[ "$CDATE" -ge "2022031612" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
 #     export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2022031612
 #   fi

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -38,7 +38,7 @@ if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
     git clone --recursive https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
-    git checkout gfsda.v16.1.5
+    git checkout gfsda.v16.1.6
     git submodule update
     cd ${topdir}
 else

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -39,7 +39,7 @@ if [[ ! -d gsi.fd ]] ; then
     git clone --recursive https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
     git checkout gfsda.v16.1.6
-    git submodule update
+    git submodule update --init
     cd ${topdir}
 else
     echo 'Skip.  Directory gsi.fd already exists.'


### PR DESCRIPTION
**Description**

This PR merges the GFSv16.1.6 updates into the operations branch.

From release notes prelude:
```
  NOAA awarded Delivery Order 4 (DO-4) of its commercial radio occultation (RO) 
  data purchase to both Spire Global and GeoOptics on February 10, 2022.  This 
  purchase covers 5500 occultations per day from Spire and 500 occultations per 
  day from GeoOptics over a 10 month period with the data flow starting on 
  March 16, 2022.
```

Changes:

1. GSI tag update to `gfsda.v16.1.6` and add `--init` flag to GSI submodule command
2. add release notes for upgrade (`docs/Release_Notes.gfs.v16.1.6.txt`)
3. update `parm/config/config.anal` to add new `global_convinfo.txt.2022031612` and associated date if-block check

Implementation is currently scheduled for April 4th 1430z (during the 12z cycle). Previously delayed due to CWD.

**Type of change**

Operational implementation.

**How Has This Been Tested?**

The GFSv16.1.6 package has been tested on WCOSS-Dell in a parallel production test ahead of scheduled implementation.

Closes: #656 