### PR TITLE
Resolve issue of `config.base.emc.dyn` in `$EXPDIR`

### DIFF
--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -1,4 +1,4 @@
-#!/bin/ksh
+#!/bin/bash
 set -ex
 
 #--make symbolic links for EMC installation and hardcopies for NCO delivery
@@ -368,15 +368,11 @@ cd ${pwd}/../sorc   ||   exit 8
     done
 
 #------------------------------
-#--choose dynamic config.base for EMC installation 
-#--choose static config.base for NCO installation 
+#  copy $HOMEgfs/parm/config/config.base.nco.static as config.base for operations
+#  config.base in the $HOMEgfs/parm/config has no use in development
 cd $pwd/../parm/config
-[[ -s config.base ]] && rm -f config.base 
-if [ $RUN_ENVIR = nco ] ; then
- cp -p config.base.nco.static config.base
-else
- cp -p config.base.emc.dyn config.base
-fi
+[[ -s config.base ]] && rm -f config.base
+[[ $RUN_ENVIR = nco ]] && cp -p config.base.nco.static config.base
 #------------------------------
 
 

--- a/ush/rocoto/setup_expt.py
+++ b/ush/rocoto/setup_expt.py
@@ -91,6 +91,12 @@ def fill_EXPDIR(inputs):
     expdir = os.path.join(inputs.expdir, inputs.pslot)
 
     configs = glob.glob(f'{configdir}/config.*')
+    exclude_configs = ['base', 'base.emc.dyn', 'base.nco.static', 'fv3.nco.static']
+    for exclude in exclude_configs:
+        try:
+            configs.remove(f'{configdir}/config.{exclude}')
+        except ValueError:
+            pass
     if len(configs) == 0:
         raise IOError(f'no config files found in {configdir}')
     for config in configs:
@@ -104,14 +110,9 @@ def edit_baseconfig(host, inputs):
     Parses and populates the templated `config.base.emc.dyn` to `config.base`
     '''
 
-    base_config = f'{inputs.expdir}/{inputs.pslot}/config.base'
-
     here = os.path.dirname(__file__)
     top = os.path.abspath(os.path.join(
         os.path.abspath(here), '../..'))
-
-    if os.path.exists(base_config):
-        os.unlink(base_config)
 
     tmpl_dict = {
         "@MACHINE@": host.machine.upper(),
@@ -157,19 +158,25 @@ def edit_baseconfig(host, inputs):
         }
     tmpl_dict = dict(tmpl_dict, **extend_dict)
 
-    with open(base_config + '.emc.dyn', 'rt') as fi:
+    # Open and read the templated config.base.emc.dyn
+    base_tmpl = f'{inputs.configdir}/config.base.emc.dyn'
+    with open(base_tmpl, 'rt') as fi:
         basestr = fi.read()
 
     for key, val in tmpl_dict.items():
         basestr = basestr.replace(key, str(val))
+
+    # Write and clobber the experiment config.base
+    base_config = f'{inputs.expdir}/{inputs.pslot}/config.base'
+    if os.path.exists(base_config):
+        os.unlink(base_config)
 
     with open(base_config, 'wt') as fo:
         fo.write(basestr)
 
     print('')
     print(f'EDITED:  {base_config} as per user input.')
-    print(f'DEFAULT: {base_config}.emc.dyn is for reference only.')
-    print('Please verify and delete the default file before proceeding.')
+    print(f'DEFAULT: {base_tmpl} is for reference only.')
     print('')
 
     return


### PR DESCRIPTION
**Description**

This PR eliminates the `$HOMEgfs/parm/config/config.base` where `$HOMEgfs` is the location of the cloned repository.
This file is only meaningful for operations and is preserved (`RUN_ENVIR=nco`), where `config.base.nco.static` is copied to `config.base` in `$HOMEgfs`.

For development, the `setup_expt.py` parses the templated `config.base.emc.dyn` from the repository into `config.base` located in `$EXPDIR`.
A templated `config.base.emc.dyn` in the `$EXPDIR` is meaningless and is removed via this PR.

This PR also removes the copying of `config.base.nco.static` and `config.fv3.nco.static`  into `$EXPDIR`.  They are meaningless for development (`RUN_ENVIR=emc`).

Fixes #706 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] Clone and run `setup_expt.py` on a couple of machines.
- [x] No forecast or cycled tests were run as part of this bugfix.  I don't think those are necessary for this PR.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
