### PR TITLE
WCOSS2 GFS ops updates to address two issues (anal_calc & gfs_forecast)

### DIFF
--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_calc.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_calc.ecf
@@ -6,6 +6,7 @@
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=128:ompthreads=1:ncpus=128
 #PBS -l place=vscatter:excl
+#PBS -l hyper=true
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/jgfs_forecast.ecf
+++ b/ecf/scripts/gfs/jgfs_forecast.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:30:00
-#PBS -l select=101:mpiprocs=42:ompthreads=3:ncpus=126
+#PBS -l select=112:mpiprocs=24:ompthreads=5:ncpus=120
 #PBS -l place=vscatter:excl
 #PBS -l debug=true
 

--- a/parm/config/config.fv3.nco.static
+++ b/parm/config/config.fv3.nco.static
@@ -95,17 +95,17 @@ case $case_in in
         export DELTIM=150
         export layout_x=8
         export layout_y=12
-        export layout_x_gfs=24
+        export layout_x_gfs=12
         export layout_y_gfs=24
         export npe_wav=140
         export npe_wav_gfs=448
         export nth_fv3=3
-        export nth_fv3_gfs=3
+        export nth_fv3_gfs=5
         export cdmbgwd="4.0,0.15,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=2
         export WRTTASK_PER_GROUP=64
-        export WRITE_GROUP_GFS=7
-        export WRTTASK_PER_GROUP_GFS=48
+        export WRITE_GROUP_GFS=8
+        export WRTTASK_PER_GROUP_GFS=64
         export WRTIOBUF="32M"
         ;;
     "C1152")

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -159,7 +159,7 @@ elif [ $step = "fcst" ]; then
     export nth_fcst=${nth_fv3:-2}
     export nth_fcst_gfs=${nth_fv3_gfs:-2}
     export npe_node_fcst=32
-    export npe_node_fcst_gfs=42
+    export npe_node_fcst_gfs=24
 
 elif [ $step = "post" ]; then
 


### PR DESCRIPTION
**Description**

This PR includes changes to address two open issues with the GFS in ops on WCOSS2:

1. gdas_atmos_analysis_calc runtime variability (set hyper=true)
2. gfs_forecast initialization and output frequency timing issues (adjusted resource configuration)

These changes have been tested and vetted by team investigating issues on WCOSS2. NCO/@WeiWei-NCO is making these changes in ops.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

@RussTreadon-NOAA and @JamesAbeles-NOAA tested/vetted the `hyper-true` setting for the analysis_calc job on WCOSS2. This job will continue to be watched and investigated as more runtime samples on Cactus become available.

@GeorgeVandenberghe-NOAA and @KateFriedman-NOAA tested/vetted the gfs_forecast resource configuration on WCOSS2.
