### PR TITLE
Add gsl module load for nco module dependency

### DIFF
--- a/modulefiles/module_base.wcoss2.lua
+++ b/modulefiles/module_base.wcoss2.lua
@@ -23,6 +23,7 @@ load(pathJoin("hdf5", os.getenv("hdf5_ver")))
 load(pathJoin("netcdf", os.getenv("netcdf_ver")))
 
 load(pathJoin("udunits", os.getenv("udunits_ver")))
+load(pathJoin("gsl", os.getenv("gsl_ver")))
 load(pathJoin("nco", os.getenv("nco_ver")))
 load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("grib_util", os.getenv("grib_util_ver")))

--- a/versions/build.ver
+++ b/versions/build.ver
@@ -13,7 +13,7 @@ export libpng_ver=1.6.37
 export hdf5_ver=1.10.6
 export netcdf_ver=4.7.4
 export esmf_ver=8.0.1
-
+export gsl_ver=2.7
 export nco_ver=4.7.9
 export wgrib2_ver=2.0.7
 

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -28,6 +28,7 @@ export netcdf_ver=4.7.4
 export esmf_ver=8.0.1
 
 export udunits_ver=2.2.28
+export gsl_ver=2.7
 export nco_ver=4.7.9
 export bufr_dump_ver=1.0.0
 export util_shared_ver=1.4.0


### PR DESCRIPTION
The `nco` module on WCOSS2 has a new module dependency on the `gsl` module:

- add the gsl module load to `module_base.wcoss2.lua`
- add gsl_ver=2.7 to `versions/run.ver`
- add gsl_ver=2.7 to `versions/build.ver`

Tested `module_base.wcoss2.lua` and `run.ver` in a clone of the `dev_v16` branch on Cactus. The `nco` module now loads correctly.

Refs: #728, #665

Close #728 