### PR TITLE
Provided fix to wcoss2 module load in global workflow to allow nco/4.7.9 module to load

### DIFF
--- a/versions/build.ver
+++ b/versions/build.ver
@@ -13,7 +13,7 @@ export libpng_ver=1.6.37
 export hdf5_ver=1.10.6
 export netcdf_ver=4.7.4
 export esmf_ver=8.0.1
-
+export gsl_ver=2.7
 export nco_ver=4.7.9
 export wgrib2_ver=2.0.7
 


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**
A total of three files need for this fix in which two of them were communicated in slack channel and fix was committed
- modulefiles/module_base.wcoss2.lua
- versions/run.ver
This is the third and final fix for this issue:
- versions/build.ver

Tested on wcoss2 cactus. Job require nco/4.7.9 can now successfully load the module.
Ref: #728 