### PR TITLE
Use cmake for ww3 pre and post exe build

### DIFF
--- a/modulefiles/modulefile.ww3.hera
+++ b/modulefiles/modulefile.ww3.hera
@@ -1,7 +1,9 @@
 #%Module######################################################################
 ##
-##      S2S prerequisites
+##      WW3 hera
 ##
+
+module load cmake/3.20.1
 
 module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack
 
@@ -18,3 +20,5 @@ module load g2/3.4.1
 
 module load hdf5/1.10.6
 module load netcdf/4.7.4
+
+module load w3nco/2.4.1

--- a/modulefiles/modulefile.ww3.orion
+++ b/modulefiles/modulefile.ww3.orion
@@ -2,7 +2,7 @@
 # module for ww3 before base uses hpc-stack
 module load contrib noaatools
 
-module load cmake/3.17.3
+module load cmake/3.22.1
 
 module use /apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack
 
@@ -19,3 +19,5 @@ module load g2/3.4.1
 
 module load hdf5/1.10.6
 module load netcdf/4.7.4
+
+module load w3nco/2.4.1

--- a/modulefiles/modulefile.ww3.wcoss_dell_p3
+++ b/modulefiles/modulefile.ww3.wcoss_dell_p3
@@ -2,6 +2,7 @@
 
 module use /usrx/local/nceplibs/dev/hpc-stack/libs/hpc-stack/modulefiles/stack
 module load hpc/1.1.0
+module load cmake/3.20.0
 module load hpc-ips/18.0.1.163
 module load hpc-impi/18.0.1
 
@@ -14,3 +15,5 @@ module load g2/3.4.1
 
 module load hdf5/1.10.6
 module load netcdf/4.7.4
+
+module load w3nco/2.4.1


### PR DESCRIPTION
**Description**

Updates sorc/build_ww3prepost.sh to use CMAKE when building the pre-and post- execs for waves.   This is possible due to work from @kgerheiser adding the cmake build to WW3.   

Fixes #688

**Type of change**

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

- [x] Clone and Build tests on WCOSS Dell P3
- [x] Clone and Build tests on Orion
- [x] Forecast-only coupled test on Hera

develop: /scratch2/NCEPDEV/climate/Jessica.Meixner/ww3cmakegw/develop/dev01/COMROOT/dev01/gfs.20130401/00/wave
this branch: /scratch2/NCEPDEV/climate/Jessica.Meixner/ww3cmakegw/cmake/cmake01/COMROOT/cmake01/gfs.20130401/00/wave

Only log files and the tar files are different. The log files are expected to have diffs and I un-tarr'd the tar files and the files themselves are the same.  

A cycled test was not performed as cycled is atm-only at this time. 
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
