### PR TITLE
GFSv16.1.7 updates and changes from NCO for GFSv16.2.0

### DIFF
--- a/docs/Release_Notes.gfs.v16.1.7.txt
+++ b/docs/Release_Notes.gfs.v16.1.7.txt
@@ -3,39 +3,18 @@ GFS V16.1.7 RELEASE NOTES
 
 PRELUDE
  
-  NOAA awarded Delivery Order 4 (DO-4) of its commercial radio occultation (RO) 
-  data purchase to both Spire Global and GeoOptics on February 10, 2022.  This 
-  purchase covers 5500 occultations per day from Spire and 500 occultations per 
-  day from GeoOptics over a 10 month period with the data flow starting on 
-  March 16, 2022.
-
-  Both GeoOptics and Spire have been assimilated in operations as part of 
-  previous delivery orders.  DO-1 was awarded to both vendors, but was used 
-  for evaluation purposes only and not assimilated operationally.  DO-2 was 
-  awarded to GeoOptics and subsequently assimilated in the operational GFS/GDAS 
-  as v16.1.  DO-3 was then awarded to Spire only.  The v16.1.4 implementation 
-  turned on the assimilation of Spire data as well as turned off the assimilation 
-  of GeoOptics.  
-
-  If no changes are made to operations, we will assimilate the Spire portion of 
-  the purchase, but would not assimilate the new GeoOptics data. In order to 
-  assimilate data from both vendors, a single line change in the global_convinfo.txt 
-  fix file is required.  There are no other changes planned for this implementation.  
-  Once data flow begins on March 16th, a one-week evaluation of the new GeoOptics 
-  observations is needed before implementation.
-
-  In addition to DO-4, a small change is needed to accompany a change in the
-  observation processing.  Winds "NeXRaD VAD WINDS FROM LEVEL 2 DECODER"
-  (tank b002/xx017) will soon be included in the global observation processing.
-  Since these observations have not yet been evaluated in the GFS, this observation
-  type (uv 224) will be set to monitor mode.  This requires a single line change
-  in the global_convinfo.txt file.
+  Two updates in GFS v16.1.7 release:
+  1) Tropical storm names are updated for 2022 hurricane season following WMO storm name
+     changes for each tropical cyclone basins. 
+  2) JTWC changed the format of the TCvital information, and the code 
+          sorc/syndat_getjtbul.fd/getjtbul.f
+     need to be updated in order to decode correctly the JTWC TCvital information
 
 
 IMPLEMENTATION INSTRUCTIONS
 
   The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com 
-  are used to manage the GFS.v16.1.6 code. The SPA(s) handling the GFS.v16.1.6 
+  are used to manage the GFS.v16.1.7 code. The SPA(s) handling the GFS.v16.1.7 
   implementation need to have permissions to clone VLab gerrit repositories and 
   the private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are 
   publicly readable and do not require access permissions.  Please follow the 

--- a/docs/Release_Notes.gfs.v16.1.7.txt
+++ b/docs/Release_Notes.gfs.v16.1.7.txt
@@ -1,0 +1,142 @@
+GFS V16.1.7 RELEASE NOTES
+
+
+PRELUDE
+ 
+  NOAA awarded Delivery Order 4 (DO-4) of its commercial radio occultation (RO) 
+  data purchase to both Spire Global and GeoOptics on February 10, 2022.  This 
+  purchase covers 5500 occultations per day from Spire and 500 occultations per 
+  day from GeoOptics over a 10 month period with the data flow starting on 
+  March 16, 2022.
+
+  Both GeoOptics and Spire have been assimilated in operations as part of 
+  previous delivery orders.  DO-1 was awarded to both vendors, but was used 
+  for evaluation purposes only and not assimilated operationally.  DO-2 was 
+  awarded to GeoOptics and subsequently assimilated in the operational GFS/GDAS 
+  as v16.1.  DO-3 was then awarded to Spire only.  The v16.1.4 implementation 
+  turned on the assimilation of Spire data as well as turned off the assimilation 
+  of GeoOptics.  
+
+  If no changes are made to operations, we will assimilate the Spire portion of 
+  the purchase, but would not assimilate the new GeoOptics data. In order to 
+  assimilate data from both vendors, a single line change in the global_convinfo.txt 
+  fix file is required.  There are no other changes planned for this implementation.  
+  Once data flow begins on March 16th, a one-week evaluation of the new GeoOptics 
+  observations is needed before implementation.
+
+  In addition to DO-4, a small change is needed to accompany a change in the
+  observation processing.  Winds "NeXRaD VAD WINDS FROM LEVEL 2 DECODER"
+  (tank b002/xx017) will soon be included in the global observation processing.
+  Since these observations have not yet been evaluated in the GFS, this observation
+  type (uv 224) will be set to monitor mode.  This requires a single line change
+  in the global_convinfo.txt file.
+
+
+IMPLEMENTATION INSTRUCTIONS
+
+  The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com 
+  are used to manage the GFS.v16.1.6 code. The SPA(s) handling the GFS.v16.1.6 
+  implementation need to have permissions to clone VLab gerrit repositories and 
+  the private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are 
+  publicly readable and do not require access permissions.  Please follow the 
+  following steps to install the package on WCOSS-Dell:
+
+  1) cd $NWROOTp3
+
+  2) mkdir gfs.v16.1.7
+
+  3) cd gfs.v16.1.7
+
+  4) git clone -b EMC-v16.1.7  https://github.com/NOAA-EMC/global-workflow.git .
+
+  5) cd sorc
+
+  6) ./checkout.sh -o
+     * This script extracts the following GFS components:
+         MODEL     tag GFS.v16.0.17                  Jun.Wang@noaa.gov
+         GSI       tag gfsda.v16.1.6                 Catherine.Thomas@noaa.gov
+         GLDAS     tag gldas_gfsv16_release.v1.12.0  Helin.Wei@noaa.gov
+         UFS_UTILS tag ops-gfsv16.0.0                George.Gayno@noaa.gov
+         POST      tag upp_gfsv16_release.v1.1.4     Wen.Meng@noaa.gov
+         WAFS      tag gfs_wafs.v6.0.22              Yali.Mao@noaa.gov
+
+  7) ./build_all.sh
+     * This script compiles all GFS components. Runtime output from the build for 
+       each package is written to log files in directory logs. To build an 
+       individual program, for instance, gsi, use build_gsi.sh.
+
+  8) ./link_fv3gfs.sh nco dell	
+
+
+SORC CHANGES
+
+* sorc/
+  * checkout.sh will checkout the following code changes:
+    * sorc/syndat_getjtbul.fd/getjtbul.fi:
+      JTWC changed the TCvitals data format (new data contains Tab and Return-Key). 
+      The code update can decode the new JTWC data correctly
+      * No changes to other source code.
+
+
+FIX CHANGES
+
+* fix/fix_am:
+  * fix_am/syndat_stmnames: update tropical storm names for 2022 hurricane season.
+
+
+PARM/CONFIG CHANGES
+
+* No changes from GFS v16.1.6
+
+
+JOBS CHANGES
+
+* No change from GFS v16.1.6
+
+
+SCRIPT CHANGES
+
+* No change from GFS v16.1.6
+
+
+CHANGES TO RESOURCES AND FILE SIZES
+
+* No change from GFS v16.1.6
+
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+
+* Which production jobs should be tested as part of this implementation?
+  * job JGLOBAL_ATMOS_TROPCY_QC_RELOC should be tested. 
+
+* Does this change require a 30-day evaluation?
+  * No.
+
+
+DISSEMINATION INFORMATION
+
+* Where should this output be sent?
+  * No change from GFS v16.1.6
+
+* Who are the users?
+  * No change from GFS v16.1.6
+
+* Which output files should be transferred from PROD WCOSS to DEV WCOSS?
+  * No change from GFS v16.1.6
+
+* Directory changes
+  * No change from GFS v16.1.6
+
+* File changes
+  * No change from GFS v16.1.6
+
+
+HPSS ARCHIVE
+
+* No change from GFS v16.1.6
+
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+
+* No change from GFS v16.1.6
+

--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -15,7 +15,7 @@ The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com a
 cd $PACKAGEROOT
 mkdir gfs.v16.2.0
 cd gfs.v16.2.0
-git clone -b EMC-v16.2.0.4 https://github.com/NOAA-EMC/global-workflow.git .
+git clone -b EMC-v16.2.0.5 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```

--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -118,7 +118,7 @@ All components updated their codes to build on WCOSS2:
 FIX CHANGES
 -----------
 
-* No changes from GFS v16.1.6
+* No changes from GFS v16.1.7
 
 PARM/CONFIG CHANGES
 -------------------
@@ -354,7 +354,7 @@ CHANGES TO RESOURCES AND FILE SIZES
 -----------------------------------
 
 * File sizes
-  * No change to GFSv16.1.6.
+  * No change to GFSv16.1.7.
 * Resource changes to meet operational time windows:
   * See updated Ecflow scripts for adjusted compute resources for WCOSS2.
   * Pre-hand-off development testing results:
@@ -379,21 +379,21 @@ DISSEMINATION INFORMATION
 -------------------------
 
 * Where should this output be sent?
-  * No change from GFS v16.1.6
+  * No change from GFS v16.1.7
 * Who are the users?
-  * No change from GFS v16.1.6
+  * No change from GFS v16.1.7
 * Which output files should be transferred from PROD WCOSS to DEV WCOSS?
-  * No change from GFS v16.1.6
+  * No change from GFS v16.1.7
 * Directory changes
-  * No change from GFS v16.1.6
+  * No change from GFS v16.1.7
 * File changes
-  * No change from GFS v16.1.6
+  * No change from GFS v16.1.7
 
 HPSS ARCHIVE
 ------------
 
-* No change from GFS v16.1.6
+* No change from GFS v16.1.7
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
-* No change from GFS v16.1.6
+* No change from GFS v16.1.7

--- a/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
+++ b/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:06:00
-#PBS -l select=1:mpiprocs=80:ompthreads=1:ncpus=80:mem=40GB
+#PBS -l select=1:mpiprocs=80:ompthreads=1:ncpus=80:mem=60GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
+++ b/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
@@ -31,6 +31,7 @@ module load cdo/${cdo_ver}
 module load hdf5/${hdf5_ver}
 module load netcdf/${netcdf_ver}
 module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
 module load nco/${nco_ver}
 module load wgrib2/${wgrib2_ver}
 

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_master.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
-#PBS -l select=1:mpiprocs=112:ompthreads=1:ncpus=112
+#PBS -l select=1:mpiprocs=126:ompthreads=1:ncpus=126
 #PBS -l place=vscatter:excl
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
+++ b/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
@@ -31,6 +31,7 @@ module load cdo/${cdo_ver}
 module load hdf5/${hdf5_ver}
 module load netcdf/${netcdf_ver}
 module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
 module load nco/${nco_ver}
 module load wgrib2/${wgrib2_ver}
 

--- a/modulefiles/module_base.wcoss2.lua
+++ b/modulefiles/module_base.wcoss2.lua
@@ -23,6 +23,7 @@ load(pathJoin("hdf5", os.getenv("hdf5_ver")))
 load(pathJoin("netcdf", os.getenv("netcdf_ver")))
 
 load(pathJoin("udunits", os.getenv("udunits_ver")))
+load(pathJoin("gsl", os.getenv("gsl_ver")))
 load(pathJoin("nco", os.getenv("nco_ver")))
 load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("grib_util", os.getenv("grib_util_ver")))

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -165,7 +165,7 @@ elif [ $step = "post" ]; then
 
     export wtime_post="00:12:00"
     export wtime_post_gfs="01:00:00"
-    export npe_post=112
+    export npe_post=126
     export nth_post=1
     export npe_node_post=$npe_post
     export npe_node_post_gfs=$npe_post

--- a/sorc/syndat_getjtbul.fd/getjtbul.f
+++ b/sorc/syndat_getjtbul.fd/getjtbul.f
@@ -92,12 +92,41 @@ c  OF THE RECORD (OLD NON-Y2K COMPLIANT FORM) OR IF A 4-DIGIT YEAR
 c  BEGINS IN COLUMN 20 (NEW Y2K COMPLIANT FORM) - TEST ON LOCATION OF
 c  LATITUDE BLANK CHARACTER TO FIND OUT ...
 
-         IF(INL1(26).EQ.' ') THEN
+c  Check TABs and replaced it with ' '  (added by Qingfu Liu)
+         DO J=1,80
+           IF(ichar(INL(J:J)).EQ.9)THEN
+              INL(J:J) = ' '
+           END IF
+         END DO
+         DO J=1,80
+           IF(ichar(INL(J:J)).EQ.13)THEN
+              INL(J:J) = ' '
+           END IF
+         END DO
+
+         IF(INL1(26).EQ.' '.or.INL1(27).EQ.' ') THEN
 
 c ... THIS RECORD STILL CONTAINS THE OLD 2-DIGIT FORM OF THE YEAR -
 c ... THIS PROGRAM WILL NOW CONVERT THE RECORD TO A 4-DIGIT YEAR USING
 c      THE "WINDOWING" TECHNIQUE SINCE SUBSEQUENT LOGIC EXPECTS THIS
 
+          IF(INL(18:19).EQ.'20') THEN
+            DUMY2K(1:17) = INL(1:17)
+            DUMY2K(18:19) = '  '
+            DUMY2K(20:80) = INL(18:78)
+            INL= DUMY2K
+            PRINT *, ' '
+            PRINT *, '==> This is an new-format record with a 4-digit '
+            PRINT *, ' '
+          ELSE IF(INL(19:20).EQ.'20') THEN
+            DUMY2K(1:18) = INL(1:18)
+            DUMY2K(19:19) = ' '
+            DUMY2K(20:80) = INL(19:79)
+            INL= DUMY2K
+            PRINT *, ' '
+            PRINT *, '==> This is an new-format record with a 4-digit '
+            PRINT *, ' '
+          ELSE
             PRINT *, ' '
             PRINT *, '==> This is an old-format record with a 2-digit ',
      $       'year "',INL(20:21),'"'
@@ -114,7 +143,7 @@ c      THE "WINDOWING" TECHNIQUE SINCE SUBSEQUENT LOGIC EXPECTS THIS
             PRINT *, '==> 2-digit year converted to 4-digit year "',
      $       INL(20:23),'" via windowing technique'
             PRINT *, ' '
-
+          ENDIF
          ELSE 
 
 c ... THIS RECORD CONTAINS THE NEW 4-DIGIT FORM OF THE YEAR

--- a/versions/build.ver
+++ b/versions/build.ver
@@ -14,7 +14,6 @@ export hdf5_ver=1.10.6
 export netcdf_ver=4.7.4
 export esmf_ver=8.0.1
 
-export nco_ver=4.7.9
 export wgrib2_ver=2.0.7
 
 export crtm_ver=2.3.0

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -28,6 +28,7 @@ export netcdf_ver=4.7.4
 export esmf_ver=8.0.1
 
 export udunits_ver=2.2.28
+export gsl_ver=2.7
 export nco_ver=4.7.9
 export bufr_dump_ver=1.0.0
 export util_shared_ver=1.4.0


### PR DESCRIPTION
**Description**

This PR brings in the following changes to the v16.2.0 system:

1. GFSv16.1.7 updates for 2022 storm names (#698):
  a) add v16.1.7 release notes `docs/Release_Notes.gfs.v16.1.7.txt`
  b) update to `syndat_getjtbul.fd/getjtbul.f`
  c) `fix_am/syndat_stmnames` update (in FIX_DIR pickup location outside of system)
2. update `docs/Release_Notes.gfs.v16.2.0.md` to reflect new hand-off tag (`EMC-v16.2.0.5`) and new prior ops version (`v16.1.7`).
3. increase job memory in `ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf` from 40GB to 60GB (had OOM kill in ops) - NCO request
4. increase task number in `ecf/scripts/gfs/atmos/post/jgfs_atmos_post_master.ecf` and `parm/config/config.resources.nco.static` from 112 to 126 - NCO request
5. add module load of `gsl/2.7` module to `ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf`, `ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf`, `modulefiles/module_base.wcoss2.lua`, and `versions/run.ver`. The `nco` module on WCOSS2 now requires the `gsl` module as a dependency.
6. remove `nco_ver` from `versions/build.ver` - discovered the `nco` module isn't required at buildtime by examining the component builds and testing `build_all.sh` without `nco_ver` in `build.ver` (no issues encountered); discussed with @WeiWei-NCO and agreed to remove `nco_ver` from `build.ver`.

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

These updates have been tested in production on WCOSS2 and on WCOSS1 in preparation for the v16.1.7 upgrade.

Refs: #399, #698
