### PR TITLE
Update UPP tag to upp_v8.1.2

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -22,7 +22,7 @@ protocol = git
 required = True
 
 [UPP]
-tag = upp_v8.1.0
+tag = upp_v8.1.2
 local_path = sorc/gfs_post.fd
 repo_url = https://github.com/NOAA-EMC/UPP.git
 protocol = git

--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -28,7 +28,7 @@ The checkout script extracts the following GFS components:
 | GSI       | gfsda.v16.2.0 | Russ.Treadon@noaa.gov |
 | GLDAS     | gldas_gfsv16_release.v.2.0.0 | Helin.Wei@noaa.gov |
 | UFS_UTILS | ops-gfsv16.2.0 | George.Gayno@noaa.gov |
-| POST      | upp_v8.1.0 | Wen.Meng@noaa.gov |
+| POST      | upp_v8.1.2 | Wen.Meng@noaa.gov |
 | WAFS      | gfs_wafs.v6.2.8 | Yali.Mao@noaa.gov |
 
 To build all the GFS components, execute:

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -63,7 +63,7 @@ fi
 echo EMC_post checkout ...
 if [[ ! -d gfs_post.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_post.log
-    git clone ${gtg_git_args:-} --branch upp_v8.1.0 https://github.com/NOAA-EMC/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
+    git clone ${gtg_git_args:-} --branch upp_v8.1.2 https://github.com/NOAA-EMC/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
     ################################################################################
     # checkout_gtg
     ## yes: The gtg code at NCAR private repository is available for ops. GFS only.


### PR DESCRIPTION
@WenMeng-NOAA cut a new UPP tag after integrating a requested change from NCO for adjusting the icnt value from 1000 to 1080 in `scripts/exglobal_atmos_pmgr.sh` to resolve a bug.

Update UPP tag in:

1. `Externals.cfg`
2. `sorc/checkout.sh`
3. release notes: `docs/Release_Notes.gfs.v16.2.0.md`

Will recut `EMC-v16.2.0.5` tag after this PR goes in.

Refs: #399