### PR TITLE
Remove prepbufr_pre-qc from gdas_restarta and gfsa archive list

### DIFF
--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -101,7 +101,6 @@ if [ $type = "gfs" ]; then
     echo  "${dirname}${head}gsistat                          " >>gfsa.txt
     echo  "${dirname}${head}nsstbufr                         " >>gfsa.txt
     echo  "${dirname}${head}prepbufr                         " >>gfsa.txt
-    echo  "${dirname}${head}prepbufr_pre-qc                  " >>gfsa.txt
     echo  "${dirname}${head}prepbufr.acft_profiles           " >>gfsa.txt
   fi
   echo  "${dirname}${head}pgrb2.0p25.anl                   " >>gfsa.txt
@@ -368,7 +367,6 @@ if [ $type = "gdas" ]; then
   fi
   echo  "${dirname}${head}nsstbufr                 " >>gdas_restarta.txt
   echo  "${dirname}${head}prepbufr                 " >>gdas_restarta.txt
-  echo  "${dirname}${head}prepbufr_pre-qc          " >>gdas_restarta.txt
   echo  "${dirname}${head}prepbufr.acft_profiles   " >>gdas_restarta.txt
   echo  "${dirname}${head}abias                    " >>gdas_restarta.txt
   echo  "${dirname}${head}abias_air                " >>gdas_restarta.txt


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->
In $HOMEgfs/ush/hpssarch_gen.sh file prepbufr_pre-qc will be removed from gdas_restarta and gfsa archive list.
closes #361 

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
A developer confirmed prepbufr_pre-qc is not been used in low resolution parallel and obsproc developer confirmed this file can be removed from the archive job.
<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--

-->
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
