### PR TITLE
Update WCOSS2 env file cpu-bind flags: core to depth

### DIFF
--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -41,7 +41,7 @@ elif [ $step = "anal" ]; then
     export FI_OFI_RXM_SAR_LIMIT=3145728
 
     export NTHREADS_GSI=$nth_anal
-    export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_anal:-$PBS_NP}} -ppn $npe_node_anal --cpu-bind core --depth $NTHREADS_GSI"
+    export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_anal:-$PBS_NP}} -ppn $npe_node_anal --cpu-bind depth --depth $NTHREADS_GSI"
 
     export NTHREADS_CALCINC=${nth_calcinc:-1}
     export APRUN_CALCINC="$launcher \$ncmd"
@@ -49,7 +49,7 @@ elif [ $step = "anal" ]; then
     export NTHREADS_CYCLE=${nth_cycle:-14}
     [[ $NTHREADS_CYCLE -gt $npe_node_max ]] && export NTHREADS_CYCLE=$npe_node_max
     npe_cycle=${ntiles:-6}
-    export APRUN_CYCLE="$launcher -n $npe_cycle -ppn $npe_node_cycle --cpu-bind core --depth $NTHREADS_CYCLE"
+    export APRUN_CYCLE="$launcher -n $npe_cycle -ppn $npe_node_cycle --cpu-bind depth --depth $NTHREADS_CYCLE"
 
     export NTHREADS_GAUSFCANL=1
     npe_gausfcanl=${npe_gausfcanl:-1}
@@ -66,10 +66,10 @@ elif [ $step = "anal" ]; then
 elif [ $step = "gldas" ]; then
 
     export NTHREADS_GLDAS=$nth_gldas
-    export APRUN_GLDAS="$launcher -n $npe_gldas -ppn $npe_node_gldas --cpu-bind core --depth $NTHREADS_GLDAS"
+    export APRUN_GLDAS="$launcher -n $npe_gldas -ppn $npe_node_gldas --cpu-bind depth --depth $NTHREADS_GLDAS"
 
     export NTHREADS_GAUSSIAN=${nth_gaussian:-1}
-    export APRUN_GAUSSIAN="$launcher -n $npe_gaussian -ppn $npe_node_gaussian --cpu-bind core --depth $NTHREADS_GAUSSIAN"
+    export APRUN_GAUSSIAN="$launcher -n $npe_gaussian -ppn $npe_node_gaussian --cpu-bind depth --depth $NTHREADS_GAUSSIAN"
 
     export USE_CFP=${USE_CFP:-"YES"}
     export APRUN_GLDAS_DATA_PROC="$launcher -np $npe_gldas $mpmd"
@@ -81,7 +81,7 @@ elif [ $step = "eobs" ]; then
     export FI_OFI_RXM_SAR_LIMIT=3145728
 
     export NTHREADS_GSI=$nth_eobs
-    export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_eobs:-$PBS_NP}} -ppn $npe_node_eobs --cpu-bind core --depth $NTHREADS_GSI"
+    export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_eobs:-$PBS_NP}} -ppn $npe_node_eobs --cpu-bind depth --depth $NTHREADS_GSI"
 
     export CFP_MP=${CFP_MP:-"NO"}
     export USE_CFP=${USE_CFP:-"YES"}
@@ -95,7 +95,7 @@ elif [ $step = "eupd" ]; then
     export FI_OFI_RXM_SAR_LIMIT=3145728
 
     export NTHREADS_ENKF=$nth_eupd
-    export APRUN_ENKF="$launcher -n ${npe_enkf:-${npe_eupd:-$PBS_NP}} -ppn $npe_node_eupd --cpu-bind core --depth $NTHREADS_ENKF"
+    export APRUN_ENKF="$launcher -n ${npe_enkf:-${npe_eupd:-$PBS_NP}} -ppn $npe_node_eupd --cpu-bind depth --depth $NTHREADS_ENKF"
 
     export CFP_MP=${CFP_MP:-"NO"}
     export USE_CFP=${USE_CFP:-"YES"}
@@ -111,9 +111,9 @@ elif [ $step = "fcst" ]; then
     export NTHREADS_FV3=$nth_fv3
     export cores_per_node=$npe_node_max
     if [ $CDUMP = "gdas" ]; then
-      export APRUN_FV3="$launcher -n ${npe_fcst:-$PBS_NP} -ppn $npe_node_fcst --cpu-bind core --depth $NTHREADS_FV3"
+      export APRUN_FV3="$launcher -n ${npe_fcst:-$PBS_NP} -ppn $npe_node_fcst --cpu-bind depth --depth $NTHREADS_FV3"
     else
-      export APRUN_FV3="$launcher -n ${npe_fcst_gfs:-$PBS_NP} -ppn $npe_node_fcst_gfs --cpu-bind core --depth $NTHREADS_FV3"
+      export APRUN_FV3="$launcher -n ${npe_fcst_gfs:-$PBS_NP} -ppn $npe_node_fcst_gfs --cpu-bind depth --depth $NTHREADS_FV3"
     fi
     export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
     export APRUN_REGRID_NEMSIO="$launcher -n $LEVS"
@@ -130,7 +130,7 @@ elif [ $step = "efcs" ]; then
 
     export NTHREADS_FV3=$nth_efcs
     export cores_per_node=$npe_node_max
-    export APRUN_FV3="$launcher -n ${npe_fv3:-${npe_efcs:-$PBS_NP}} -ppn $npe_node_efcs --cpu-bind core --depth $NTHREADS_FV3"
+    export APRUN_FV3="$launcher -n ${npe_fv3:-${npe_efcs:-$PBS_NP}} -ppn $npe_node_efcs --cpu-bind depth --depth $NTHREADS_FV3"
 
     export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
     export APRUN_REGRID_NEMSIO="$launcher -n $LEVS"
@@ -138,7 +138,7 @@ elif [ $step = "efcs" ]; then
 elif [ $step = "post" ]; then
 
     export NTHREADS_NP=${nth_np:-1}
-    export APRUN_NP="$launcher -n ${npe_np:-${npe_post:-$PBS_NP}} -ppn $npe_node_post --cpu-bind core --depth $NTHREADS_NP"
+    export APRUN_NP="$launcher -n ${npe_np:-${npe_post:-$PBS_NP}} -ppn $npe_node_post --cpu-bind depth --depth $NTHREADS_NP"
 
     export NTHREADS_DWN=${nth_dwn:-1}
     export APRUN_DWN="$launcher -np ${npe_dwn:-$PBS_NP} $mpmd"
@@ -146,7 +146,7 @@ elif [ $step = "post" ]; then
 elif [ $step = "ecen" ]; then
 
     export NTHREADS_ECEN=$nth_ecen
-    export APRUN_ECEN="$launcher -n ${npe_ecen:-$PBS_NP} -ppn $npe_node_ecen --cpu-bind core --depth $NTHREADS_ECEN"
+    export APRUN_ECEN="$launcher -n ${npe_ecen:-$PBS_NP} -ppn $npe_node_ecen --cpu-bind depth --depth $NTHREADS_ECEN"
 
     export NTHREADS_CHGRES=${nth_chgres:-14}
     [[ $NTHREADS_CHGRES -gt $npe_node_max ]] && export NTHREADS_CHGRES=$npe_node_max
@@ -157,21 +157,21 @@ elif [ $step = "ecen" ]; then
 
     export NTHREADS_CYCLE=${nth_cycle:-14}
     [[ $NTHREADS_CYCLE -gt $npe_node_max ]] && export NTHREADS_CYCLE=$npe_node_max
-    export APRUN_CYCLE="$launcher -n $npe_ecen -ppn $npe_node_cycle --cpu-bind core --depth $NTHREADS_CYCLE"
+    export APRUN_CYCLE="$launcher -n $npe_ecen -ppn $npe_node_cycle --cpu-bind depth --depth $NTHREADS_CYCLE"
 
 elif [ $step = "esfc" ]; then
 
     export NTHREADS_ESFC=$nth_esfc
-    export APRUN_ESFC="$launcher -n ${npe_esfc:-$PBS_NP} -ppn $npe_node_esfc --cpu-bind core --depth $NTHREADS_ESFC"
+    export APRUN_ESFC="$launcher -n ${npe_esfc:-$PBS_NP} -ppn $npe_node_esfc --cpu-bind depth --depth $NTHREADS_ESFC"
 
     export NTHREADS_CYCLE=${nth_cycle:-14}
     [[ $NTHREADS_CYCLE -gt $npe_node_max ]] && export NTHREADS_CYCLE=$npe_node_max
-    export APRUN_CYCLE="$launcher -n $npe_esfc -ppn $npe_node_cycle --cpu-bind core --depth $NTHREADS_CYCLE"
+    export APRUN_CYCLE="$launcher -n $npe_esfc -ppn $npe_node_cycle --cpu-bind depth --depth $NTHREADS_CYCLE"
 
 elif [ $step = "epos" ]; then
 
     export NTHREADS_EPOS=$nth_epos
-    export APRUN_EPOS="$launcher -n ${npe_epos:-$PBS_NP} -ppn $npe_node_epos --cpu-bind core --depth $NTHREADS_EPOS"
+    export APRUN_EPOS="$launcher -n ${npe_epos:-$PBS_NP} -ppn $npe_node_epos --cpu-bind depth --depth $NTHREADS_EPOS"
 
 elif [ $step = "fv3ic" ]; then
 


### PR DESCRIPTION
**Description**

Based on conversations with NCO and EMC developers, we are now changing the `cpu-bind` launcher flag argument from `core` to `depth`. Change `--cpu-bind core` to `--cpu-bind depth`. This is to assist with runtime variability with threaded codes.

Refs: #399

Change also already made in the GSI `calcanl_gfs.py` script by @MichaelLueken-NOAA:

```
sorc/gsi.fd/ush/calcanl_gfs.py:        ExecCMDMPI1_host = 'mpiexec -l -n 1 --cpu-bind depth --depth '+str(NThreads)
sorc/gsi.fd/ush/calcanl_gfs.py:        ExecCMDMPI10_host = 'mpiexec -l -n 10 --cpu-bind depth --depth '+str(NThreads)
```

@GeorgeGayno-NOAA FYI, I found one other instance of `--cpu-bind core` outside of the GSI and global-workflow that you'll likely want to change for yourself (not used in ops):

```
sorc/ufs_utils.fd/reg_tests/global_cycle/driver.wcoss2.sh:export APRUNCY="mpiexec -n 6 -ppn 6 --cpu-bind core --depth ${OMP_NUM_THREADS_CY}"
```