### PR TITLE
Sync dev_v16 with feature/ops-wcoss2

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -22,7 +22,7 @@ protocol = git
 required = True
 
 [UPP]
-tag = upp_v8.1.0
+tag = upp_v8.1.2
 local_path = sorc/gfs_post.fd
 repo_url = https://github.com/NOAA-EMC/UPP.git
 protocol = git

--- a/docs/Release_Notes.gfs.v16.1.6.txt
+++ b/docs/Release_Notes.gfs.v16.1.6.txt
@@ -24,6 +24,14 @@ PRELUDE
   Once data flow begins on March 16th, a one-week evaluation of the new GeoOptics 
   observations is needed before implementation.
 
+  In addition to DO-4, a small change is needed to accompany a change in the
+  observation processing.  Winds "NeXRaD VAD WINDS FROM LEVEL 2 DECODER"
+  (tank b002/xx017) will soon be included in the global observation processing.
+  Since these observations have not yet been evaluated in the GFS, this observation
+  type (uv 224) will be set to monitor mode.  This requires a single line change
+  in the global_convinfo.txt file.
+
+
 IMPLEMENTATION INSTRUCTIONS
 
   The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com 
@@ -71,7 +79,8 @@ SORC CHANGES
 FIX CHANGES
 
 * fix/fix_gsi:
-  * global_convinfo.txt: Turn on active assimilation of GeoOptics
+  * global_convinfo.txt: Turn on active assimilation of GeoOptics and
+    turn off active assimilation of uv 224 VADWND.
   * gfsv16_historical/global_convinfo.txt.2022031612: Add dated 
     convinfo file for retrospective parallels.  Does not impact operations.
   * gfsv16_historical/0readme: Update documentation. Does not 

--- a/docs/Release_Notes.gfs.v16.1.6.txt
+++ b/docs/Release_Notes.gfs.v16.1.6.txt
@@ -47,7 +47,7 @@ IMPLEMENTATION INSTRUCTIONS
 
   3) cd gfs.v16.1.6
 
-  4) git clone -b EMC-v16.1.6  https://github.com/NOAA-EMC/global-workflow.git .
+  4) git clone -b EMC-v16.1.6.2  https://github.com/NOAA-EMC/global-workflow.git .
 
   5) cd sorc
 

--- a/docs/Release_Notes.gfs.v16.1.7.txt
+++ b/docs/Release_Notes.gfs.v16.1.7.txt
@@ -3,39 +3,18 @@ GFS V16.1.7 RELEASE NOTES
 
 PRELUDE
  
-  NOAA awarded Delivery Order 4 (DO-4) of its commercial radio occultation (RO) 
-  data purchase to both Spire Global and GeoOptics on February 10, 2022.  This 
-  purchase covers 5500 occultations per day from Spire and 500 occultations per 
-  day from GeoOptics over a 10 month period with the data flow starting on 
-  March 16, 2022.
-
-  Both GeoOptics and Spire have been assimilated in operations as part of 
-  previous delivery orders.  DO-1 was awarded to both vendors, but was used 
-  for evaluation purposes only and not assimilated operationally.  DO-2 was 
-  awarded to GeoOptics and subsequently assimilated in the operational GFS/GDAS 
-  as v16.1.  DO-3 was then awarded to Spire only.  The v16.1.4 implementation 
-  turned on the assimilation of Spire data as well as turned off the assimilation 
-  of GeoOptics.  
-
-  If no changes are made to operations, we will assimilate the Spire portion of 
-  the purchase, but would not assimilate the new GeoOptics data. In order to 
-  assimilate data from both vendors, a single line change in the global_convinfo.txt 
-  fix file is required.  There are no other changes planned for this implementation.  
-  Once data flow begins on March 16th, a one-week evaluation of the new GeoOptics 
-  observations is needed before implementation.
-
-  In addition to DO-4, a small change is needed to accompany a change in the
-  observation processing.  Winds "NeXRaD VAD WINDS FROM LEVEL 2 DECODER"
-  (tank b002/xx017) will soon be included in the global observation processing.
-  Since these observations have not yet been evaluated in the GFS, this observation
-  type (uv 224) will be set to monitor mode.  This requires a single line change
-  in the global_convinfo.txt file.
+  Two updates in GFS v16.1.7 release:
+  1) Tropical storm names are updated for 2022 hurricane season following WMO storm name
+     changes for each tropical cyclone basins. 
+  2) JTWC changed the format of the TCvital information, and the code 
+          sorc/syndat_getjtbul.fd/getjtbul.f
+     need to be updated in order to decode correctly the JTWC TCvital information
 
 
 IMPLEMENTATION INSTRUCTIONS
 
   The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com 
-  are used to manage the GFS.v16.1.6 code. The SPA(s) handling the GFS.v16.1.6 
+  are used to manage the GFS.v16.1.7 code. The SPA(s) handling the GFS.v16.1.7 
   implementation need to have permissions to clone VLab gerrit repositories and 
   the private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are 
   publicly readable and do not require access permissions.  Please follow the 

--- a/docs/Release_Notes.gfs.v16.1.7.txt
+++ b/docs/Release_Notes.gfs.v16.1.7.txt
@@ -1,0 +1,142 @@
+GFS V16.1.7 RELEASE NOTES
+
+
+PRELUDE
+ 
+  NOAA awarded Delivery Order 4 (DO-4) of its commercial radio occultation (RO) 
+  data purchase to both Spire Global and GeoOptics on February 10, 2022.  This 
+  purchase covers 5500 occultations per day from Spire and 500 occultations per 
+  day from GeoOptics over a 10 month period with the data flow starting on 
+  March 16, 2022.
+
+  Both GeoOptics and Spire have been assimilated in operations as part of 
+  previous delivery orders.  DO-1 was awarded to both vendors, but was used 
+  for evaluation purposes only and not assimilated operationally.  DO-2 was 
+  awarded to GeoOptics and subsequently assimilated in the operational GFS/GDAS 
+  as v16.1.  DO-3 was then awarded to Spire only.  The v16.1.4 implementation 
+  turned on the assimilation of Spire data as well as turned off the assimilation 
+  of GeoOptics.  
+
+  If no changes are made to operations, we will assimilate the Spire portion of 
+  the purchase, but would not assimilate the new GeoOptics data. In order to 
+  assimilate data from both vendors, a single line change in the global_convinfo.txt 
+  fix file is required.  There are no other changes planned for this implementation.  
+  Once data flow begins on March 16th, a one-week evaluation of the new GeoOptics 
+  observations is needed before implementation.
+
+  In addition to DO-4, a small change is needed to accompany a change in the
+  observation processing.  Winds "NeXRaD VAD WINDS FROM LEVEL 2 DECODER"
+  (tank b002/xx017) will soon be included in the global observation processing.
+  Since these observations have not yet been evaluated in the GFS, this observation
+  type (uv 224) will be set to monitor mode.  This requires a single line change
+  in the global_convinfo.txt file.
+
+
+IMPLEMENTATION INSTRUCTIONS
+
+  The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com 
+  are used to manage the GFS.v16.1.6 code. The SPA(s) handling the GFS.v16.1.6 
+  implementation need to have permissions to clone VLab gerrit repositories and 
+  the private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are 
+  publicly readable and do not require access permissions.  Please follow the 
+  following steps to install the package on WCOSS-Dell:
+
+  1) cd $NWROOTp3
+
+  2) mkdir gfs.v16.1.7
+
+  3) cd gfs.v16.1.7
+
+  4) git clone -b EMC-v16.1.7  https://github.com/NOAA-EMC/global-workflow.git .
+
+  5) cd sorc
+
+  6) ./checkout.sh -o
+     * This script extracts the following GFS components:
+         MODEL     tag GFS.v16.0.17                  Jun.Wang@noaa.gov
+         GSI       tag gfsda.v16.1.6                 Catherine.Thomas@noaa.gov
+         GLDAS     tag gldas_gfsv16_release.v1.12.0  Helin.Wei@noaa.gov
+         UFS_UTILS tag ops-gfsv16.0.0                George.Gayno@noaa.gov
+         POST      tag upp_gfsv16_release.v1.1.4     Wen.Meng@noaa.gov
+         WAFS      tag gfs_wafs.v6.0.22              Yali.Mao@noaa.gov
+
+  7) ./build_all.sh
+     * This script compiles all GFS components. Runtime output from the build for 
+       each package is written to log files in directory logs. To build an 
+       individual program, for instance, gsi, use build_gsi.sh.
+
+  8) ./link_fv3gfs.sh nco dell	
+
+
+SORC CHANGES
+
+* sorc/
+  * checkout.sh will checkout the following code changes:
+    * sorc/syndat_getjtbul.fd/getjtbul.fi:
+      JTWC changed the TCvitals data format (new data contains Tab and Return-Key). 
+      The code update can decode the new JTWC data correctly
+      * No changes to other source code.
+
+
+FIX CHANGES
+
+* fix/fix_am:
+  * fix_am/syndat_stmnames: update tropical storm names for 2022 hurricane season.
+
+
+PARM/CONFIG CHANGES
+
+* No changes from GFS v16.1.6
+
+
+JOBS CHANGES
+
+* No change from GFS v16.1.6
+
+
+SCRIPT CHANGES
+
+* No change from GFS v16.1.6
+
+
+CHANGES TO RESOURCES AND FILE SIZES
+
+* No change from GFS v16.1.6
+
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+
+* Which production jobs should be tested as part of this implementation?
+  * job JGLOBAL_ATMOS_TROPCY_QC_RELOC should be tested. 
+
+* Does this change require a 30-day evaluation?
+  * No.
+
+
+DISSEMINATION INFORMATION
+
+* Where should this output be sent?
+  * No change from GFS v16.1.6
+
+* Who are the users?
+  * No change from GFS v16.1.6
+
+* Which output files should be transferred from PROD WCOSS to DEV WCOSS?
+  * No change from GFS v16.1.6
+
+* Directory changes
+  * No change from GFS v16.1.6
+
+* File changes
+  * No change from GFS v16.1.6
+
+
+HPSS ARCHIVE
+
+* No change from GFS v16.1.6
+
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+
+* No change from GFS v16.1.6
+

--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -15,7 +15,7 @@ The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com a
 cd $PACKAGEROOT
 mkdir gfs.v16.2.0
 cd gfs.v16.2.0
-git clone -b EMC-v16.2.0.5 https://github.com/NOAA-EMC/global-workflow.git .
+git clone -b EMC-v16.2.0.6 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```

--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -15,7 +15,7 @@ The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com a
 cd $PACKAGEROOT
 mkdir gfs.v16.2.0
 cd gfs.v16.2.0
-git clone -b EMC-v16.2.0.4 https://github.com/NOAA-EMC/global-workflow.git .
+git clone -b EMC-v16.2.0.5 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```

--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -118,7 +118,7 @@ All components updated their codes to build on WCOSS2:
 FIX CHANGES
 -----------
 
-* No changes from GFS v16.1.6
+* No changes from GFS v16.1.7
 
 PARM/CONFIG CHANGES
 -------------------
@@ -354,7 +354,7 @@ CHANGES TO RESOURCES AND FILE SIZES
 -----------------------------------
 
 * File sizes
-  * No change to GFSv16.1.6.
+  * No change to GFSv16.1.7.
 * Resource changes to meet operational time windows:
   * See updated Ecflow scripts for adjusted compute resources for WCOSS2.
   * Pre-hand-off development testing results:
@@ -379,21 +379,21 @@ DISSEMINATION INFORMATION
 -------------------------
 
 * Where should this output be sent?
-  * No change from GFS v16.1.6
+  * No change from GFS v16.1.7
 * Who are the users?
-  * No change from GFS v16.1.6
+  * No change from GFS v16.1.7
 * Which output files should be transferred from PROD WCOSS to DEV WCOSS?
-  * No change from GFS v16.1.6
+  * No change from GFS v16.1.7
 * Directory changes
-  * No change from GFS v16.1.6
+  * No change from GFS v16.1.7
 * File changes
-  * No change from GFS v16.1.6
+  * No change from GFS v16.1.7
 
 HPSS ARCHIVE
 ------------
 
-* No change from GFS v16.1.6
+* No change from GFS v16.1.7
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
-* No change from GFS v16.1.6
+* No change from GFS v16.1.7

--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -28,7 +28,7 @@ The checkout script extracts the following GFS components:
 | GSI       | gfsda.v16.2.0 | Russ.Treadon@noaa.gov |
 | GLDAS     | gldas_gfsv16_release.v.2.0.0 | Helin.Wei@noaa.gov |
 | UFS_UTILS | ops-gfsv16.2.0 | George.Gayno@noaa.gov |
-| POST      | upp_v8.1.0 | Wen.Meng@noaa.gov |
+| POST      | upp_v8.1.2 | Wen.Meng@noaa.gov |
 | WAFS      | gfs_wafs.v6.2.8 | Yali.Mao@noaa.gov |
 
 To build all the GFS components, execute:

--- a/ecf/defs/gfs_00.def
+++ b/ecf/defs/gfs_00.def
@@ -1,0 +1,2589 @@
+  family v16.2
+    family gfs
+      edit RUN 'gfs'
+      edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/gfs'
+      family atmos
+        family obsproc
+          family dump
+            task jgfs_atmos_tropcy_qc_reloc
+              trigger :TIME >= 0241 and :TIME < 0841
+              event 1 jtwc_bull_email
+          endfamily
+          family prep
+            task jgfs_atmos_emcsfc_sfc_prep
+              trigger /prod/primary/00/obsproc/v1.0/gfs/atmos/dump/jobsproc_gfs_atmos_dump:release_sfcprep
+          endfamily
+        endfamily
+        family analysis
+          task jgfs_atmos_analysis
+            trigger /prod/primary/00/obsproc/v1.0/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete and ../obsproc/prep/jgfs_atmos_emcsfc_sfc_prep == complete
+            event 1 release_fcst
+          task jgfs_atmos_analysis_calc
+            trigger ./jgfs_atmos_analysis == complete
+        endfamily
+        family post
+          task jgfs_atmos_post_manager
+            trigger ../analysis/jgfs_atmos_analysis == complete
+            event 1 release_postanl
+            event 2 release_post000
+            event 3 release_post001
+            event 4 release_post002
+            event 5 release_post003
+            event 6 release_post004
+            event 7 release_post005
+            event 8 release_post006
+            event 9 release_post007
+            event 10 release_post008
+            event 11 release_post009
+            event 12 release_post010
+            event 13 release_post011
+            event 14 release_post012
+            event 15 release_post013
+            event 16 release_post014
+            event 17 release_post015
+            event 18 release_post016
+            event 19 release_post017
+            event 20 release_post018
+            event 21 release_post019
+            event 22 release_post020
+            event 23 release_post021
+            event 24 release_post022
+            event 25 release_post023
+            event 26 release_post024
+            event 27 release_post025
+            event 28 release_post026
+            event 29 release_post027
+            event 30 release_post028
+            event 31 release_post029
+            event 32 release_post030
+            event 33 release_post031
+            event 34 release_post032
+            event 35 release_post033
+            event 36 release_post034
+            event 37 release_post035
+            event 38 release_post036
+            event 39 release_post037
+            event 40 release_post038
+            event 41 release_post039
+            event 42 release_post040
+            event 43 release_post041
+            event 44 release_post042
+            event 45 release_post043
+            event 46 release_post044
+            event 47 release_post045
+            event 48 release_post046
+            event 49 release_post047
+            event 50 release_post048
+            event 51 release_post049
+            event 52 release_post050
+            event 53 release_post051
+            event 54 release_post052
+            event 55 release_post053
+            event 56 release_post054
+            event 57 release_post055
+            event 58 release_post056
+            event 59 release_post057
+            event 60 release_post058
+            event 61 release_post059
+            event 62 release_post060
+            event 63 release_post061
+            event 64 release_post062
+            event 65 release_post063
+            event 66 release_post064
+            event 67 release_post065
+            event 68 release_post066
+            event 69 release_post067
+            event 70 release_post068
+            event 71 release_post069
+            event 72 release_post070
+            event 73 release_post071
+            event 74 release_post072
+            event 75 release_post073
+            event 76 release_post074
+            event 77 release_post075
+            event 78 release_post076
+            event 79 release_post077
+            event 80 release_post078
+            event 81 release_post079
+            event 82 release_post080
+            event 83 release_post081
+            event 84 release_post082
+            event 85 release_post083
+            event 86 release_post084
+            event 87 release_post085
+            event 88 release_post086
+            event 89 release_post087
+            event 90 release_post088
+            event 91 release_post089
+            event 92 release_post090
+            event 93 release_post091
+            event 94 release_post092
+            event 95 release_post093
+            event 96 release_post094
+            event 97 release_post095
+            event 98 release_post096
+            event 99 release_post097
+            event 100 release_post098
+            event 101 release_post099
+            event 102 release_post100
+            event 103 release_post101
+            event 104 release_post102
+            event 105 release_post103
+            event 106 release_post104
+            event 107 release_post105
+            event 108 release_post106
+            event 109 release_post107
+            event 110 release_post108
+            event 111 release_post109
+            event 112 release_post110
+            event 113 release_post111
+            event 114 release_post112
+            event 115 release_post113
+            event 116 release_post114
+            event 117 release_post115
+            event 118 release_post116
+            event 119 release_post117
+            event 120 release_post118
+            event 121 release_post119
+            event 122 release_post120
+            event 123 release_post123
+            event 124 release_post126
+            event 125 release_post129
+            event 126 release_post132
+            event 127 release_post135
+            event 128 release_post138
+            event 129 release_post141
+            event 130 release_post144
+            event 131 release_post147
+            event 132 release_post150
+            event 133 release_post153
+            event 134 release_post156
+            event 135 release_post159
+            event 136 release_post162
+            event 137 release_post165
+            event 138 release_post168
+            event 139 release_post171
+            event 140 release_post174
+            event 141 release_post177
+            event 142 release_post180
+            event 143 release_post183
+            event 144 release_post186
+            event 145 release_post189
+            event 146 release_post192
+            event 147 release_post195
+            event 148 release_post198
+            event 149 release_post201
+            event 150 release_post204
+            event 151 release_post207
+            event 152 release_post210
+            event 153 release_post213
+            event 154 release_post216
+            event 155 release_post219
+            event 156 release_post222
+            event 157 release_post225
+            event 158 release_post228
+            event 159 release_post231
+            event 160 release_post234
+            event 161 release_post237
+            event 162 release_post240
+            event 163 release_post243
+            event 164 release_post246
+            event 165 release_post249
+            event 166 release_post252
+            event 167 release_post255
+            event 168 release_post258
+            event 169 release_post261
+            event 170 release_post264
+            event 171 release_post267
+            event 172 release_post270
+            event 173 release_post273
+            event 174 release_post276
+            event 175 release_post279
+            event 176 release_post282
+            event 177 release_post285
+            event 178 release_post288
+            event 179 release_post291
+            event 180 release_post294
+            event 181 release_post297
+            event 182 release_post300
+            event 183 release_post303
+            event 184 release_post306
+            event 185 release_post309
+            event 186 release_post312
+            event 187 release_post315
+            event 188 release_post318
+            event 189 release_post321
+            event 190 release_post324
+            event 191 release_post327
+            event 192 release_post330
+            event 193 release_post333
+            event 194 release_post336
+            event 195 release_post339
+            event 196 release_post342
+            event 197 release_post345
+            event 198 release_post348
+            event 199 release_post351
+            event 200 release_post354
+            event 201 release_post357
+            event 202 release_post360
+            event 203 release_post363
+            event 204 release_post366
+            event 205 release_post369
+            event 206 release_post372
+            event 207 release_post375
+            event 208 release_post378
+            event 209 release_post381
+            event 210 release_post384
+          task jgfs_atmos_post_anl
+            trigger ./jgfs_atmos_post_manager:release_postanl
+            edit FHRGRP '000'
+            edit FHRLST 'anl'
+            edit HR 'anl'
+            edit FHR 'anl'
+          task jgfs_atmos_post_f000
+            trigger ./jgfs_atmos_post_manager:release_post000
+            edit FHRGRP '001'
+            edit FHRLST 'f000'
+            edit FHR 'f000'
+            edit HR '000'
+          task jgfs_atmos_post_f001
+            trigger ./jgfs_atmos_post_manager:release_post001
+            edit FHRGRP '002'
+            edit FHRLST 'f001'
+            edit FHR 'f001'
+            edit HR '001'
+          task jgfs_atmos_post_f002
+            trigger ./jgfs_atmos_post_manager:release_post002
+            edit FHRGRP '003'
+            edit FHRLST 'f002'
+            edit FHR 'f002'
+            edit HR '002'
+          task jgfs_atmos_post_f003
+            trigger ./jgfs_atmos_post_manager:release_post003
+            edit FHRGRP '004'
+            edit FHRLST 'f003'
+            edit FHR 'f003'
+            edit HR '003'
+          task jgfs_atmos_post_f004
+            trigger ./jgfs_atmos_post_manager:release_post004
+            edit FHRGRP '005'
+            edit FHRLST 'f004'
+            edit FHR 'f004'
+            edit HR '004'
+          task jgfs_atmos_post_f005
+            trigger ./jgfs_atmos_post_manager:release_post005
+            edit FHRGRP '006'
+            edit FHRLST 'f005'
+            edit FHR 'f005'
+            edit HR '005'
+          task jgfs_atmos_post_f006
+            trigger ./jgfs_atmos_post_manager:release_post006
+            edit FHRGRP '007'
+            edit FHRLST 'f006'
+            edit FHR 'f006'
+            edit HR '006'
+          task jgfs_atmos_post_f007
+            trigger ./jgfs_atmos_post_manager:release_post007
+            edit FHRGRP '008'
+            edit FHRLST 'f007'
+            edit FHR 'f007'
+            edit HR '007'
+          task jgfs_atmos_post_f008
+            trigger ./jgfs_atmos_post_manager:release_post008
+            edit FHRGRP '009'
+            edit FHRLST 'f008'
+            edit FHR 'f008'
+            edit HR '008'
+          task jgfs_atmos_post_f009
+            trigger ./jgfs_atmos_post_manager:release_post009
+            edit FHRGRP '010'
+            edit FHRLST 'f009'
+            edit FHR 'f009'
+            edit HR '009'
+          task jgfs_atmos_post_f010
+            trigger ./jgfs_atmos_post_manager:release_post010
+            edit FHRGRP '011'
+            edit FHRLST 'f010'
+            edit FHR 'f010'
+            edit HR '010'
+          task jgfs_atmos_post_f011
+            trigger ./jgfs_atmos_post_manager:release_post011
+            edit FHRGRP '012'
+            edit FHRLST 'f011'
+            edit FHR 'f011'
+            edit HR '011'
+          task jgfs_atmos_post_f012
+            trigger ./jgfs_atmos_post_manager:release_post012
+            edit FHRGRP '013'
+            edit FHRLST 'f012'
+            edit FHR 'f012'
+            edit HR '012'
+          task jgfs_atmos_post_f013
+            trigger ./jgfs_atmos_post_manager:release_post013
+            edit FHRGRP '014'
+            edit FHRLST 'f013'
+            edit FHR 'f013'
+            edit HR '013'
+          task jgfs_atmos_post_f014
+            trigger ./jgfs_atmos_post_manager:release_post014
+            edit FHRGRP '015'
+            edit FHRLST 'f014'
+            edit FHR 'f014'
+            edit HR '014'
+          task jgfs_atmos_post_f015
+            trigger ./jgfs_atmos_post_manager:release_post015
+            edit FHRGRP '016'
+            edit FHRLST 'f015'
+            edit FHR 'f015'
+            edit HR '015'
+          task jgfs_atmos_post_f016
+            trigger ./jgfs_atmos_post_manager:release_post016
+            edit FHRGRP '017'
+            edit FHRLST 'f016'
+            edit FHR 'f016'
+            edit HR '016'
+          task jgfs_atmos_post_f017
+            trigger ./jgfs_atmos_post_manager:release_post017
+            edit FHRGRP '018'
+            edit FHRLST 'f017'
+            edit FHR 'f017'
+            edit HR '017'
+          task jgfs_atmos_post_f018
+            trigger ./jgfs_atmos_post_manager:release_post018
+            edit FHRGRP '019'
+            edit FHRLST 'f018'
+            edit FHR 'f018'
+            edit HR '018'
+          task jgfs_atmos_post_f019
+            trigger ./jgfs_atmos_post_manager:release_post019
+            edit FHRGRP '020'
+            edit FHRLST 'f019'
+            edit FHR 'f019'
+            edit HR '019'
+          task jgfs_atmos_post_f020
+            trigger ./jgfs_atmos_post_manager:release_post020
+            edit FHRGRP '021'
+            edit FHRLST 'f020'
+            edit FHR 'f020'
+            edit HR '020'
+          task jgfs_atmos_post_f021
+            trigger ./jgfs_atmos_post_manager:release_post021
+            edit FHRGRP '022'
+            edit FHRLST 'f021'
+            edit FHR 'f021'
+            edit HR '021'
+          task jgfs_atmos_post_f022
+            trigger ./jgfs_atmos_post_manager:release_post022
+            edit FHRGRP '023'
+            edit FHRLST 'f022'
+            edit FHR 'f022'
+            edit HR '022'
+          task jgfs_atmos_post_f023
+            trigger ./jgfs_atmos_post_manager:release_post023
+            edit FHRGRP '024'
+            edit FHRLST 'f023'
+            edit FHR 'f023'
+            edit HR '023'
+          task jgfs_atmos_post_f024
+            trigger ./jgfs_atmos_post_manager:release_post024
+            edit FHRGRP '025'
+            edit FHRLST 'f024'
+            edit FHR 'f024'
+            edit HR '024'
+          task jgfs_atmos_post_f025
+            trigger ./jgfs_atmos_post_manager:release_post025
+            edit FHRGRP '026'
+            edit FHRLST 'f025'
+            edit FHR 'f025'
+            edit HR '025'
+          task jgfs_atmos_post_f026
+            trigger ./jgfs_atmos_post_manager:release_post026
+            edit FHRGRP '027'
+            edit FHRLST 'f026'
+            edit FHR 'f026'
+            edit HR '026'
+          task jgfs_atmos_post_f027
+            trigger ./jgfs_atmos_post_manager:release_post027
+            edit FHRGRP '028'
+            edit FHRLST 'f027'
+            edit FHR 'f027'
+            edit HR '027'
+          task jgfs_atmos_post_f028
+            trigger ./jgfs_atmos_post_manager:release_post028
+            edit FHRGRP '029'
+            edit FHRLST 'f028'
+            edit FHR 'f028'
+            edit HR '028'
+          task jgfs_atmos_post_f029
+            trigger ./jgfs_atmos_post_manager:release_post029
+            edit FHRGRP '030'
+            edit FHRLST 'f029'
+            edit FHR 'f029'
+            edit HR '029'
+          task jgfs_atmos_post_f030
+            trigger ./jgfs_atmos_post_manager:release_post030
+            edit FHRGRP '031'
+            edit FHRLST 'f030'
+            edit FHR 'f030'
+            edit HR '030'
+          task jgfs_atmos_post_f031
+            trigger ./jgfs_atmos_post_manager:release_post031
+            edit FHRGRP '032'
+            edit FHRLST 'f031'
+            edit FHR 'f031'
+            edit HR '031'
+          task jgfs_atmos_post_f032
+            trigger ./jgfs_atmos_post_manager:release_post032
+            edit FHRGRP '033'
+            edit FHRLST 'f032'
+            edit FHR 'f032'
+            edit HR '032'
+          task jgfs_atmos_post_f033
+            trigger ./jgfs_atmos_post_manager:release_post033
+            edit FHRGRP '034'
+            edit FHRLST 'f033'
+            edit FHR 'f033'
+            edit HR '033'
+          task jgfs_atmos_post_f034
+            trigger ./jgfs_atmos_post_manager:release_post034
+            edit FHRGRP '035'
+            edit FHRLST 'f034'
+            edit FHR 'f034'
+            edit HR '034'
+          task jgfs_atmos_post_f035
+            trigger ./jgfs_atmos_post_manager:release_post035
+            edit FHRGRP '036'
+            edit FHRLST 'f035'
+            edit FHR 'f035'
+            edit HR '035'
+          task jgfs_atmos_post_f036
+            trigger ./jgfs_atmos_post_manager:release_post036
+            edit FHRGRP '037'
+            edit FHRLST 'f036'
+            edit FHR 'f036'
+            edit HR '036'
+          task jgfs_atmos_post_f037
+            trigger ./jgfs_atmos_post_manager:release_post037
+            edit FHRGRP '038'
+            edit FHRLST 'f037'
+            edit FHR 'f037'
+            edit HR '037'
+          task jgfs_atmos_post_f038
+            trigger ./jgfs_atmos_post_manager:release_post038
+            edit FHRGRP '039'
+            edit FHRLST 'f038'
+            edit FHR 'f038'
+            edit HR '038'
+          task jgfs_atmos_post_f039
+            trigger ./jgfs_atmos_post_manager:release_post039
+            edit FHRGRP '040'
+            edit FHRLST 'f039'
+            edit FHR 'f039'
+            edit HR '039'
+          task jgfs_atmos_post_f040
+            trigger ./jgfs_atmos_post_manager:release_post040
+            edit FHRGRP '041'
+            edit FHRLST 'f040'
+            edit FHR 'f040'
+            edit HR '040'
+          task jgfs_atmos_post_f041
+            trigger ./jgfs_atmos_post_manager:release_post041
+            edit FHRGRP '042'
+            edit FHRLST 'f041'
+            edit FHR 'f041'
+            edit HR '041'
+          task jgfs_atmos_post_f042
+            trigger ./jgfs_atmos_post_manager:release_post042
+            edit FHRGRP '043'
+            edit FHRLST 'f042'
+            edit FHR 'f042'
+            edit HR '042'
+          task jgfs_atmos_post_f043
+            trigger ./jgfs_atmos_post_manager:release_post043
+            edit FHRGRP '044'
+            edit FHRLST 'f043'
+            edit FHR 'f043'
+            edit HR '043'
+          task jgfs_atmos_post_f044
+            trigger ./jgfs_atmos_post_manager:release_post044
+            edit FHRGRP '045'
+            edit FHRLST 'f044'
+            edit FHR 'f044'
+            edit HR '044'
+          task jgfs_atmos_post_f045
+            trigger ./jgfs_atmos_post_manager:release_post045
+            edit FHRGRP '046'
+            edit FHRLST 'f045'
+            edit FHR 'f045'
+            edit HR '045'
+          task jgfs_atmos_post_f046
+            trigger ./jgfs_atmos_post_manager:release_post046
+            edit FHRGRP '047'
+            edit FHRLST 'f046'
+            edit FHR 'f046'
+            edit HR '046'
+          task jgfs_atmos_post_f047
+            trigger ./jgfs_atmos_post_manager:release_post047
+            edit FHRGRP '048'
+            edit FHRLST 'f047'
+            edit FHR 'f047'
+            edit HR '047'
+          task jgfs_atmos_post_f048
+            trigger ./jgfs_atmos_post_manager:release_post048
+            edit FHRGRP '049'
+            edit FHRLST 'f048'
+            edit FHR 'f048'
+            edit HR '048'
+          task jgfs_atmos_post_f049
+            trigger ./jgfs_atmos_post_manager:release_post049
+            edit FHRGRP '050'
+            edit FHRLST 'f049'
+            edit FHR 'f049'
+            edit HR '049'
+          task jgfs_atmos_post_f050
+            trigger ./jgfs_atmos_post_manager:release_post050
+            edit FHRGRP '051'
+            edit FHRLST 'f050'
+            edit FHR 'f050'
+            edit HR '050'
+          task jgfs_atmos_post_f051
+            trigger ./jgfs_atmos_post_manager:release_post051
+            edit FHRGRP '052'
+            edit FHRLST 'f051'
+            edit FHR 'f051'
+            edit HR '051'
+          task jgfs_atmos_post_f052
+            trigger ./jgfs_atmos_post_manager:release_post052
+            edit FHRGRP '053'
+            edit FHRLST 'f052'
+            edit FHR 'f052'
+            edit HR '052'
+          task jgfs_atmos_post_f053
+            trigger ./jgfs_atmos_post_manager:release_post053
+            edit FHRGRP '054'
+            edit FHRLST 'f053'
+            edit FHR 'f053'
+            edit HR '053'
+          task jgfs_atmos_post_f054
+            trigger ./jgfs_atmos_post_manager:release_post054
+            edit FHRGRP '055'
+            edit FHRLST 'f054'
+            edit FHR 'f054'
+            edit HR '054'
+          task jgfs_atmos_post_f055
+            trigger ./jgfs_atmos_post_manager:release_post055
+            edit FHRGRP '056'
+            edit FHRLST 'f055'
+            edit FHR 'f055'
+            edit HR '055'
+          task jgfs_atmos_post_f056
+            trigger ./jgfs_atmos_post_manager:release_post056
+            edit FHRGRP '057'
+            edit FHRLST 'f056'
+            edit FHR 'f056'
+            edit HR '056'
+          task jgfs_atmos_post_f057
+            trigger ./jgfs_atmos_post_manager:release_post057
+            edit FHRGRP '058'
+            edit FHRLST 'f057'
+            edit FHR 'f057'
+            edit HR '057'
+          task jgfs_atmos_post_f058
+            trigger ./jgfs_atmos_post_manager:release_post058
+            edit FHRGRP '059'
+            edit FHRLST 'f058'
+            edit FHR 'f058'
+            edit HR '058'
+          task jgfs_atmos_post_f059
+            trigger ./jgfs_atmos_post_manager:release_post059
+            edit FHRGRP '060'
+            edit FHRLST 'f059'
+            edit FHR 'f059'
+            edit HR '059'
+          task jgfs_atmos_post_f060
+            trigger ./jgfs_atmos_post_manager:release_post060
+            edit FHRGRP '061'
+            edit FHRLST 'f060'
+            edit FHR 'f060'
+            edit HR '060'
+          task jgfs_atmos_post_f061
+            trigger ./jgfs_atmos_post_manager:release_post061
+            edit FHRGRP '062'
+            edit FHRLST 'f061'
+            edit FHR 'f061'
+            edit HR '061'
+          task jgfs_atmos_post_f062
+            trigger ./jgfs_atmos_post_manager:release_post062
+            edit FHRGRP '063'
+            edit FHRLST 'f062'
+            edit FHR 'f062'
+            edit HR '062'
+          task jgfs_atmos_post_f063
+            trigger ./jgfs_atmos_post_manager:release_post063
+            edit FHRGRP '064'
+            edit FHRLST 'f063'
+            edit FHR 'f063'
+            edit HR '063'
+          task jgfs_atmos_post_f064
+            trigger ./jgfs_atmos_post_manager:release_post064
+            edit FHRGRP '065'
+            edit FHRLST 'f064'
+            edit FHR 'f064'
+            edit HR '064'
+          task jgfs_atmos_post_f065
+            trigger ./jgfs_atmos_post_manager:release_post065
+            edit FHRGRP '066'
+            edit FHRLST 'f065'
+            edit FHR 'f065'
+            edit HR '065'
+          task jgfs_atmos_post_f066
+            trigger ./jgfs_atmos_post_manager:release_post066
+            edit FHRGRP '067'
+            edit FHRLST 'f066'
+            edit FHR 'f066'
+            edit HR '066'
+          task jgfs_atmos_post_f067
+            trigger ./jgfs_atmos_post_manager:release_post067
+            edit FHRGRP '068'
+            edit FHRLST 'f067'
+            edit FHR 'f067'
+            edit HR '067'
+          task jgfs_atmos_post_f068
+            trigger ./jgfs_atmos_post_manager:release_post068
+            edit FHRGRP '069'
+            edit FHRLST 'f068'
+            edit FHR 'f068'
+            edit HR '068'
+          task jgfs_atmos_post_f069
+            trigger ./jgfs_atmos_post_manager:release_post069
+            edit FHRGRP '070'
+            edit FHRLST 'f069'
+            edit FHR 'f069'
+            edit HR '069'
+          task jgfs_atmos_post_f070
+            trigger ./jgfs_atmos_post_manager:release_post070
+            edit FHRGRP '071'
+            edit FHRLST 'f070'
+            edit FHR 'f070'
+            edit HR '070'
+          task jgfs_atmos_post_f071
+            trigger ./jgfs_atmos_post_manager:release_post071
+            edit FHRGRP '072'
+            edit FHRLST 'f071'
+            edit FHR 'f071'
+            edit HR '071'
+          task jgfs_atmos_post_f072
+            trigger ./jgfs_atmos_post_manager:release_post072
+            edit FHRGRP '073'
+            edit FHRLST 'f072'
+            edit FHR 'f072'
+            edit HR '072'
+          task jgfs_atmos_post_f073
+            trigger ./jgfs_atmos_post_manager:release_post073
+            edit FHRGRP '074'
+            edit FHRLST 'f073'
+            edit FHR 'f073'
+            edit HR '073'
+          task jgfs_atmos_post_f074
+            trigger ./jgfs_atmos_post_manager:release_post074
+            edit FHRGRP '075'
+            edit FHRLST 'f074'
+            edit FHR 'f074'
+            edit HR '074'
+          task jgfs_atmos_post_f075
+            trigger ./jgfs_atmos_post_manager:release_post075
+            edit FHRGRP '076'
+            edit FHRLST 'f075'
+            edit FHR 'f075'
+            edit HR '075'
+          task jgfs_atmos_post_f076
+            trigger ./jgfs_atmos_post_manager:release_post076
+            edit FHRGRP '077'
+            edit FHRLST 'f076'
+            edit FHR 'f076'
+            edit HR '076'
+          task jgfs_atmos_post_f077
+            trigger ./jgfs_atmos_post_manager:release_post077
+            edit FHRGRP '078'
+            edit FHRLST 'f077'
+            edit FHR 'f077'
+            edit HR '077'
+          task jgfs_atmos_post_f078
+            trigger ./jgfs_atmos_post_manager:release_post078
+            edit FHRGRP '079'
+            edit FHRLST 'f078'
+            edit FHR 'f078'
+            edit HR '078'
+          task jgfs_atmos_post_f079
+            trigger ./jgfs_atmos_post_manager:release_post079
+            edit FHRGRP '080'
+            edit FHRLST 'f079'
+            edit FHR 'f079'
+            edit HR '079'
+          task jgfs_atmos_post_f080
+            trigger ./jgfs_atmos_post_manager:release_post080
+            edit FHRGRP '081'
+            edit FHRLST 'f080'
+            edit FHR 'f080'
+            edit HR '080'
+          task jgfs_atmos_post_f081
+            trigger ./jgfs_atmos_post_manager:release_post081
+            edit FHRGRP '082'
+            edit FHRLST 'f081'
+            edit FHR 'f081'
+            edit HR '081'
+          task jgfs_atmos_post_f082
+            trigger ./jgfs_atmos_post_manager:release_post082
+            edit FHRGRP '083'
+            edit FHRLST 'f082'
+            edit FHR 'f082'
+            edit HR '082'
+          task jgfs_atmos_post_f083
+            trigger ./jgfs_atmos_post_manager:release_post083
+            edit FHRGRP '084'
+            edit FHRLST 'f083'
+            edit FHR 'f083'
+            edit HR '083'
+          task jgfs_atmos_post_f084
+            trigger ./jgfs_atmos_post_manager:release_post084
+            edit FHRGRP '085'
+            edit FHRLST 'f084'
+            edit FHR 'f084'
+            edit HR '084'
+          task jgfs_atmos_post_f085
+            trigger ./jgfs_atmos_post_manager:release_post085
+            edit FHRGRP '086'
+            edit FHRLST 'f085'
+            edit FHR 'f085'
+            edit HR '085'
+          task jgfs_atmos_post_f086
+            trigger ./jgfs_atmos_post_manager:release_post086
+            edit FHRGRP '087'
+            edit FHRLST 'f086'
+            edit FHR 'f086'
+            edit HR '086'
+          task jgfs_atmos_post_f087
+            trigger ./jgfs_atmos_post_manager:release_post087
+            edit FHRGRP '088'
+            edit FHRLST 'f087'
+            edit FHR 'f087'
+            edit HR '087'
+          task jgfs_atmos_post_f088
+            trigger ./jgfs_atmos_post_manager:release_post088
+            edit FHRGRP '089'
+            edit FHRLST 'f088'
+            edit FHR 'f088'
+            edit HR '088'
+          task jgfs_atmos_post_f089
+            trigger ./jgfs_atmos_post_manager:release_post089
+            edit FHRGRP '090'
+            edit FHRLST 'f089'
+            edit FHR 'f089'
+            edit HR '089'
+          task jgfs_atmos_post_f090
+            trigger ./jgfs_atmos_post_manager:release_post090
+            edit FHRGRP '091'
+            edit FHRLST 'f090'
+            edit FHR 'f090'
+            edit HR '090'
+          task jgfs_atmos_post_f091
+            trigger ./jgfs_atmos_post_manager:release_post091
+            edit FHRGRP '092'
+            edit FHRLST 'f091'
+            edit FHR 'f091'
+            edit HR '091'
+          task jgfs_atmos_post_f092
+            trigger ./jgfs_atmos_post_manager:release_post092
+            edit FHRGRP '093'
+            edit FHRLST 'f092'
+            edit FHR 'f092'
+            edit HR '092'
+          task jgfs_atmos_post_f093
+            trigger ./jgfs_atmos_post_manager:release_post093
+            edit FHRGRP '094'
+            edit FHRLST 'f093'
+            edit FHR 'f093'
+            edit HR '093'
+          task jgfs_atmos_post_f094
+            trigger ./jgfs_atmos_post_manager:release_post094
+            edit FHRGRP '095'
+            edit FHRLST 'f094'
+            edit FHR 'f094'
+            edit HR '094'
+          task jgfs_atmos_post_f095
+            trigger ./jgfs_atmos_post_manager:release_post095
+            edit FHRGRP '096'
+            edit FHRLST 'f095'
+            edit FHR 'f095'
+            edit HR '095'
+          task jgfs_atmos_post_f096
+            trigger ./jgfs_atmos_post_manager:release_post096
+            edit FHRGRP '097'
+            edit FHRLST 'f096'
+            edit FHR 'f096'
+            edit HR '096'
+          task jgfs_atmos_post_f097
+            trigger ./jgfs_atmos_post_manager:release_post097
+            edit FHRGRP '098'
+            edit FHRLST 'f097'
+            edit FHR 'f097'
+            edit HR '097'
+          task jgfs_atmos_post_f098
+            trigger ./jgfs_atmos_post_manager:release_post098
+            edit FHRGRP '099'
+            edit FHRLST 'f098'
+            edit FHR 'f098'
+            edit HR '098'
+          task jgfs_atmos_post_f099
+            trigger ./jgfs_atmos_post_manager:release_post099
+            edit FHRGRP '100'
+            edit FHRLST 'f099'
+            edit FHR 'f099'
+            edit HR '099'
+          task jgfs_atmos_post_f100
+            trigger ./jgfs_atmos_post_manager:release_post100
+            edit FHRGRP '101'
+            edit FHRLST 'f100'
+            edit FHR 'f100'
+            edit HR '100'
+          task jgfs_atmos_post_f101
+            trigger ./jgfs_atmos_post_manager:release_post101
+            edit FHRGRP '102'
+            edit FHRLST 'f101'
+            edit FHR 'f101'
+            edit HR '101'
+          task jgfs_atmos_post_f102
+            trigger ./jgfs_atmos_post_manager:release_post102
+            edit FHRGRP '103'
+            edit FHRLST 'f102'
+            edit FHR 'f102'
+            edit HR '102'
+          task jgfs_atmos_post_f103
+            trigger ./jgfs_atmos_post_manager:release_post103
+            edit FHRGRP '104'
+            edit FHRLST 'f103'
+            edit FHR 'f103'
+            edit HR '103'
+          task jgfs_atmos_post_f104
+            trigger ./jgfs_atmos_post_manager:release_post104
+            edit FHRGRP '105'
+            edit FHRLST 'f104'
+            edit FHR 'f104'
+            edit HR '104'
+          task jgfs_atmos_post_f105
+            trigger ./jgfs_atmos_post_manager:release_post105
+            edit FHRGRP '106'
+            edit FHRLST 'f105'
+            edit FHR 'f105'
+            edit HR '105'
+          task jgfs_atmos_post_f106
+            trigger ./jgfs_atmos_post_manager:release_post106
+            edit FHRGRP '107'
+            edit FHRLST 'f106'
+            edit FHR 'f106'
+            edit HR '106'
+          task jgfs_atmos_post_f107
+            trigger ./jgfs_atmos_post_manager:release_post107
+            edit FHRGRP '108'
+            edit FHRLST 'f107'
+            edit FHR 'f107'
+            edit HR '107'
+          task jgfs_atmos_post_f108
+            trigger ./jgfs_atmos_post_manager:release_post108
+            edit FHRGRP '109'
+            edit FHRLST 'f108'
+            edit FHR 'f108'
+            edit HR '108'
+          task jgfs_atmos_post_f109
+            trigger ./jgfs_atmos_post_manager:release_post109
+            edit FHRGRP '110'
+            edit FHRLST 'f109'
+            edit FHR 'f109'
+            edit HR '109'
+          task jgfs_atmos_post_f110
+            trigger ./jgfs_atmos_post_manager:release_post110
+            edit FHRGRP '111'
+            edit FHRLST 'f110'
+            edit FHR 'f110'
+            edit HR '110'
+          task jgfs_atmos_post_f111
+            trigger ./jgfs_atmos_post_manager:release_post111
+            edit FHRGRP '112'
+            edit FHRLST 'f111'
+            edit FHR 'f111'
+            edit HR '111'
+          task jgfs_atmos_post_f112
+            trigger ./jgfs_atmos_post_manager:release_post112
+            edit FHRGRP '113'
+            edit FHRLST 'f112'
+            edit FHR 'f112'
+            edit HR '112'
+          task jgfs_atmos_post_f113
+            trigger ./jgfs_atmos_post_manager:release_post113
+            edit FHRGRP '114'
+            edit FHRLST 'f113'
+            edit FHR 'f113'
+            edit HR '113'
+          task jgfs_atmos_post_f114
+            trigger ./jgfs_atmos_post_manager:release_post114
+            edit FHRGRP '115'
+            edit FHRLST 'f114'
+            edit FHR 'f114'
+            edit HR '114'
+          task jgfs_atmos_post_f115
+            trigger ./jgfs_atmos_post_manager:release_post115
+            edit FHRGRP '116'
+            edit FHRLST 'f115'
+            edit FHR 'f115'
+            edit HR '115'
+          task jgfs_atmos_post_f116
+            trigger ./jgfs_atmos_post_manager:release_post116
+            edit FHRGRP '117'
+            edit FHRLST 'f116'
+            edit FHR 'f116'
+            edit HR '116'
+          task jgfs_atmos_post_f117
+            trigger ./jgfs_atmos_post_manager:release_post117
+            edit FHRGRP '118'
+            edit FHRLST 'f117'
+            edit FHR 'f117'
+            edit HR '117'
+          task jgfs_atmos_post_f118
+            trigger ./jgfs_atmos_post_manager:release_post118
+            edit FHRGRP '119'
+            edit FHRLST 'f118'
+            edit FHR 'f118'
+            edit HR '118'
+          task jgfs_atmos_post_f119
+            trigger ./jgfs_atmos_post_manager:release_post119
+            edit FHRGRP '120'
+            edit FHRLST 'f119'
+            edit FHR 'f119'
+            edit HR '119'
+          task jgfs_atmos_post_f120
+            trigger ./jgfs_atmos_post_manager:release_post120
+            edit FHRGRP '121'
+            edit FHRLST 'f120'
+            edit FHR 'f120'
+            edit HR '120'
+          task jgfs_atmos_post_f123
+            trigger ./jgfs_atmos_post_manager:release_post123
+            edit FHRGRP '122'
+            edit FHRLST 'f123'
+            edit FHR 'f123'
+            edit HR '123'
+          task jgfs_atmos_post_f126
+            trigger ./jgfs_atmos_post_manager:release_post126
+            edit FHRGRP '123'
+            edit FHRLST 'f126'
+            edit FHR 'f126'
+            edit HR '126'
+          task jgfs_atmos_post_f129
+            trigger ./jgfs_atmos_post_manager:release_post129
+            edit FHRGRP '124'
+            edit FHRLST 'f129'
+            edit FHR 'f129'
+            edit HR '129'
+          task jgfs_atmos_post_f132
+            trigger ./jgfs_atmos_post_manager:release_post132
+            edit FHRGRP '125'
+            edit FHRLST 'f132'
+            edit FHR 'f132'
+            edit HR '132'
+          task jgfs_atmos_post_f135
+            trigger ./jgfs_atmos_post_manager:release_post135
+            edit FHRGRP '126'
+            edit FHRLST 'f135'
+            edit FHR 'f135'
+            edit HR '135'
+          task jgfs_atmos_post_f138
+            trigger ./jgfs_atmos_post_manager:release_post138
+            edit FHRGRP '127'
+            edit FHRLST 'f138'
+            edit FHR 'f138'
+            edit HR '138'
+          task jgfs_atmos_post_f141
+            trigger ./jgfs_atmos_post_manager:release_post141
+            edit FHRGRP '128'
+            edit FHRLST 'f141'
+            edit FHR 'f141'
+            edit HR '141'
+          task jgfs_atmos_post_f144
+            trigger ./jgfs_atmos_post_manager:release_post144
+            edit FHRGRP '129'
+            edit FHRLST 'f144'
+            edit FHR 'f144'
+            edit HR '144'
+          task jgfs_atmos_post_f147
+            trigger ./jgfs_atmos_post_manager:release_post147
+            edit FHRGRP '130'
+            edit FHRLST 'f147'
+            edit FHR 'f147'
+            edit HR '147'
+          task jgfs_atmos_post_f150
+            trigger ./jgfs_atmos_post_manager:release_post150
+            edit FHRGRP '131'
+            edit FHRLST 'f150'
+            edit FHR 'f150'
+            edit HR '150'
+          task jgfs_atmos_post_f153
+            trigger ./jgfs_atmos_post_manager:release_post153
+            edit FHRGRP '132'
+            edit FHRLST 'f153'
+            edit FHR 'f153'
+            edit HR '153'
+          task jgfs_atmos_post_f156
+            trigger ./jgfs_atmos_post_manager:release_post156
+            edit FHRGRP '133'
+            edit FHRLST 'f156'
+            edit FHR 'f156'
+            edit HR '156'
+          task jgfs_atmos_post_f159
+            trigger ./jgfs_atmos_post_manager:release_post159
+            edit FHRGRP '134'
+            edit FHRLST 'f159'
+            edit FHR 'f159'
+            edit HR '159'
+          task jgfs_atmos_post_f162
+            trigger ./jgfs_atmos_post_manager:release_post162
+            edit FHRGRP '135'
+            edit FHRLST 'f162'
+            edit FHR 'f162'
+            edit HR '162'
+          task jgfs_atmos_post_f165
+            trigger ./jgfs_atmos_post_manager:release_post165
+            edit FHRGRP '136'
+            edit FHRLST 'f165'
+            edit FHR 'f165'
+            edit HR '165'
+          task jgfs_atmos_post_f168
+            trigger ./jgfs_atmos_post_manager:release_post168
+            edit FHRGRP '137'
+            edit FHRLST 'f168'
+            edit FHR 'f168'
+            edit HR '168'
+          task jgfs_atmos_post_f171
+            trigger ./jgfs_atmos_post_manager:release_post171
+            edit FHRGRP '138'
+            edit FHRLST 'f171'
+            edit FHR 'f171'
+            edit HR '171'
+          task jgfs_atmos_post_f174
+            trigger ./jgfs_atmos_post_manager:release_post174
+            edit FHRGRP '139'
+            edit FHRLST 'f174'
+            edit FHR 'f174'
+            edit HR '174'
+          task jgfs_atmos_post_f177
+            trigger ./jgfs_atmos_post_manager:release_post177
+            edit FHRGRP '140'
+            edit FHRLST 'f177'
+            edit FHR 'f177'
+            edit HR '177'
+          task jgfs_atmos_post_f180
+            trigger ./jgfs_atmos_post_manager:release_post180
+            edit FHRGRP '141'
+            edit FHRLST 'f180'
+            edit FHR 'f180'
+            edit HR '180'
+          task jgfs_atmos_post_f183
+            trigger ./jgfs_atmos_post_manager:release_post183
+            edit FHRGRP '142'
+            edit FHRLST 'f183'
+            edit FHR 'f183'
+            edit HR '183'
+          task jgfs_atmos_post_f186
+            trigger ./jgfs_atmos_post_manager:release_post186
+            edit FHRGRP '143'
+            edit FHRLST 'f186'
+            edit FHR 'f186'
+            edit HR '186'
+          task jgfs_atmos_post_f189
+            trigger ./jgfs_atmos_post_manager:release_post189
+            edit FHRGRP '144'
+            edit FHRLST 'f189'
+            edit FHR 'f189'
+            edit HR '189'
+          task jgfs_atmos_post_f192
+            trigger ./jgfs_atmos_post_manager:release_post192
+            edit FHRGRP '145'
+            edit FHRLST 'f192'
+            edit FHR 'f192'
+            edit HR '192'
+          task jgfs_atmos_post_f195
+            trigger ./jgfs_atmos_post_manager:release_post195
+            edit FHRGRP '146'
+            edit FHRLST 'f195'
+            edit FHR 'f195'
+            edit HR '195'
+          task jgfs_atmos_post_f198
+            trigger ./jgfs_atmos_post_manager:release_post198
+            edit FHRGRP '147'
+            edit FHRLST 'f198'
+            edit FHR 'f198'
+            edit HR '198'
+          task jgfs_atmos_post_f201
+            trigger ./jgfs_atmos_post_manager:release_post201
+            edit FHRGRP '148'
+            edit FHRLST 'f201'
+            edit FHR 'f201'
+            edit HR '201'
+          task jgfs_atmos_post_f204
+            trigger ./jgfs_atmos_post_manager:release_post204
+            edit FHRGRP '149'
+            edit FHRLST 'f204'
+            edit FHR 'f204'
+            edit HR '204'
+          task jgfs_atmos_post_f207
+            trigger ./jgfs_atmos_post_manager:release_post207
+            edit FHRGRP '150'
+            edit FHRLST 'f207'
+            edit FHR 'f207'
+            edit HR '207'
+          task jgfs_atmos_post_f210
+            trigger ./jgfs_atmos_post_manager:release_post210
+            edit FHRGRP '151'
+            edit FHRLST 'f210'
+            edit FHR 'f210'
+            edit HR '210'
+          task jgfs_atmos_post_f213
+            trigger ./jgfs_atmos_post_manager:release_post213
+            edit FHRGRP '152'
+            edit FHRLST 'f213'
+            edit FHR 'f213'
+            edit HR '213'
+          task jgfs_atmos_post_f216
+            trigger ./jgfs_atmos_post_manager:release_post216
+            edit FHRGRP '153'
+            edit FHRLST 'f216'
+            edit FHR 'f216'
+            edit HR '216'
+          task jgfs_atmos_post_f219
+            trigger ./jgfs_atmos_post_manager:release_post219
+            edit FHRGRP '154'
+            edit FHRLST 'f219'
+            edit FHR 'f219'
+            edit HR '219'
+          task jgfs_atmos_post_f222
+            trigger ./jgfs_atmos_post_manager:release_post222
+            edit FHRGRP '155'
+            edit FHRLST 'f222'
+            edit FHR 'f222'
+            edit HR '222'
+          task jgfs_atmos_post_f225
+            trigger ./jgfs_atmos_post_manager:release_post225
+            edit FHRGRP '156'
+            edit FHRLST 'f225'
+            edit FHR 'f225'
+            edit HR '225'
+          task jgfs_atmos_post_f228
+            trigger ./jgfs_atmos_post_manager:release_post228
+            edit FHRGRP '157'
+            edit FHRLST 'f228'
+            edit FHR 'f228'
+            edit HR '228'
+          task jgfs_atmos_post_f231
+            trigger ./jgfs_atmos_post_manager:release_post231
+            edit FHRGRP '158'
+            edit FHRLST 'f231'
+            edit FHR 'f231'
+            edit HR '231'
+          task jgfs_atmos_post_f234
+            trigger ./jgfs_atmos_post_manager:release_post234
+            edit FHRGRP '159'
+            edit FHRLST 'f234'
+            edit FHR 'f234'
+            edit HR '234'
+          task jgfs_atmos_post_f237
+            trigger ./jgfs_atmos_post_manager:release_post237
+            edit FHRGRP '160'
+            edit FHRLST 'f237'
+            edit FHR 'f237'
+            edit HR '237'
+          task jgfs_atmos_post_f240
+            trigger ./jgfs_atmos_post_manager:release_post240
+            edit FHRGRP '161'
+            edit FHRLST 'f240'
+            edit FHR 'f240'
+            edit HR '240'
+          task jgfs_atmos_post_f243
+            trigger ./jgfs_atmos_post_manager:release_post243
+            edit FHRGRP '162'
+            edit FHRLST 'f243'
+            edit FHR 'f243'
+            edit HR '243'
+          task jgfs_atmos_post_f246
+            trigger ./jgfs_atmos_post_manager:release_post246
+            edit FHRGRP '163'
+            edit FHRLST 'f246'
+            edit FHR 'f246'
+            edit HR '246'
+          task jgfs_atmos_post_f249
+            trigger ./jgfs_atmos_post_manager:release_post249
+            edit FHRGRP '164'
+            edit FHRLST 'f249'
+            edit FHR 'f249'
+            edit HR '249'
+          task jgfs_atmos_post_f252
+            trigger ./jgfs_atmos_post_manager:release_post252
+            edit FHRGRP '165'
+            edit FHRLST 'f252'
+            edit FHR 'f252'
+            edit HR '252'
+          task jgfs_atmos_post_f255
+            trigger ./jgfs_atmos_post_manager:release_post255
+            edit FHRGRP '166'
+            edit FHRLST 'f255'
+            edit FHR 'f255'
+            edit HR '255'
+          task jgfs_atmos_post_f258
+            trigger ./jgfs_atmos_post_manager:release_post258
+            edit FHRGRP '167'
+            edit FHRLST 'f258'
+            edit FHR 'f258'
+            edit HR '258'
+          task jgfs_atmos_post_f261
+            trigger ./jgfs_atmos_post_manager:release_post261
+            edit FHRGRP '168'
+            edit FHRLST 'f261'
+            edit FHR 'f261'
+            edit HR '261'
+          task jgfs_atmos_post_f264
+            trigger ./jgfs_atmos_post_manager:release_post264
+            edit FHRGRP '169'
+            edit FHRLST 'f264'
+            edit FHR 'f264'
+            edit HR '264'
+          task jgfs_atmos_post_f267
+            trigger ./jgfs_atmos_post_manager:release_post267
+            edit FHRGRP '170'
+            edit FHRLST 'f267'
+            edit FHR 'f267'
+            edit HR '267'
+          task jgfs_atmos_post_f270
+            trigger ./jgfs_atmos_post_manager:release_post270
+            edit FHRGRP '171'
+            edit FHRLST 'f270'
+            edit FHR 'f270'
+            edit HR '270'
+          task jgfs_atmos_post_f273
+            trigger ./jgfs_atmos_post_manager:release_post273
+            edit FHRGRP '172'
+            edit FHRLST 'f273'
+            edit FHR 'f273'
+            edit HR '273'
+          task jgfs_atmos_post_f276
+            trigger ./jgfs_atmos_post_manager:release_post276
+            edit FHRGRP '173'
+            edit FHRLST 'f276'
+            edit FHR 'f276'
+            edit HR '276'
+          task jgfs_atmos_post_f279
+            trigger ./jgfs_atmos_post_manager:release_post279
+            edit FHRGRP '174'
+            edit FHRLST 'f279'
+            edit FHR 'f279'
+            edit HR '279'
+          task jgfs_atmos_post_f282
+            trigger ./jgfs_atmos_post_manager:release_post282
+            edit FHRGRP '175'
+            edit FHRLST 'f282'
+            edit FHR 'f282'
+            edit HR '282'
+          task jgfs_atmos_post_f285
+            trigger ./jgfs_atmos_post_manager:release_post285
+            edit FHRGRP '176'
+            edit FHRLST 'f285'
+            edit FHR 'f285'
+            edit HR '285'
+          task jgfs_atmos_post_f288
+            trigger ./jgfs_atmos_post_manager:release_post288
+            edit FHRGRP '177'
+            edit FHRLST 'f288'
+            edit FHR 'f288'
+            edit HR '288'
+          task jgfs_atmos_post_f291
+            trigger ./jgfs_atmos_post_manager:release_post291
+            edit FHRGRP '178'
+            edit FHRLST 'f291'
+            edit FHR 'f291'
+            edit HR '291'
+          task jgfs_atmos_post_f294
+            trigger ./jgfs_atmos_post_manager:release_post294
+            edit FHRGRP '179'
+            edit FHRLST 'f294'
+            edit FHR 'f294'
+            edit HR '294'
+          task jgfs_atmos_post_f297
+            trigger ./jgfs_atmos_post_manager:release_post297
+            edit FHRGRP '180'
+            edit FHRLST 'f297'
+            edit FHR 'f297'
+            edit HR '297'
+          task jgfs_atmos_post_f300
+            trigger ./jgfs_atmos_post_manager:release_post300
+            edit FHRGRP '181'
+            edit FHRLST 'f300'
+            edit FHR 'f300'
+            edit HR '300'
+          task jgfs_atmos_post_f303
+            trigger ./jgfs_atmos_post_manager:release_post303
+            edit FHRGRP '182'
+            edit FHRLST 'f303'
+            edit FHR 'f303'
+            edit HR '303'
+          task jgfs_atmos_post_f306
+            trigger ./jgfs_atmos_post_manager:release_post306
+            edit FHRGRP '183'
+            edit FHRLST 'f306'
+            edit FHR 'f306'
+            edit HR '306'
+          task jgfs_atmos_post_f309
+            trigger ./jgfs_atmos_post_manager:release_post309
+            edit FHRGRP '184'
+            edit FHRLST 'f309'
+            edit FHR 'f309'
+            edit HR '309'
+          task jgfs_atmos_post_f312
+            trigger ./jgfs_atmos_post_manager:release_post312
+            edit FHRGRP '185'
+            edit FHRLST 'f312'
+            edit FHR 'f312'
+            edit HR '312'
+          task jgfs_atmos_post_f315
+            trigger ./jgfs_atmos_post_manager:release_post315
+            edit FHRGRP '186'
+            edit FHRLST 'f315'
+            edit FHR 'f315'
+            edit HR '315'
+          task jgfs_atmos_post_f318
+            trigger ./jgfs_atmos_post_manager:release_post318
+            edit FHRGRP '187'
+            edit FHRLST 'f318'
+            edit FHR 'f318'
+            edit HR '318'
+          task jgfs_atmos_post_f321
+            trigger ./jgfs_atmos_post_manager:release_post321
+            edit FHRGRP '188'
+            edit FHRLST 'f321'
+            edit FHR 'f321'
+            edit HR '321'
+          task jgfs_atmos_post_f324
+            trigger ./jgfs_atmos_post_manager:release_post324
+            edit FHRGRP '189'
+            edit FHRLST 'f324'
+            edit FHR 'f324'
+            edit HR '324'
+          task jgfs_atmos_post_f327
+            trigger ./jgfs_atmos_post_manager:release_post327
+            edit FHRGRP '190'
+            edit FHRLST 'f327'
+            edit FHR 'f327'
+            edit HR '327'
+          task jgfs_atmos_post_f330
+            trigger ./jgfs_atmos_post_manager:release_post330
+            edit FHRGRP '191'
+            edit FHRLST 'f330'
+            edit FHR 'f330'
+            edit HR '330'
+          task jgfs_atmos_post_f333
+            trigger ./jgfs_atmos_post_manager:release_post333
+            edit FHRGRP '192'
+            edit FHRLST 'f333'
+            edit FHR 'f333'
+            edit HR '333'
+          task jgfs_atmos_post_f336
+            trigger ./jgfs_atmos_post_manager:release_post336
+            edit FHRGRP '193'
+            edit FHRLST 'f336'
+            edit FHR 'f336'
+            edit HR '336'
+          task jgfs_atmos_post_f339
+            trigger ./jgfs_atmos_post_manager:release_post339
+            edit FHRGRP '194'
+            edit FHRLST 'f339'
+            edit FHR 'f339'
+            edit HR '339'
+          task jgfs_atmos_post_f342
+            trigger ./jgfs_atmos_post_manager:release_post342
+            edit FHRGRP '195'
+            edit FHRLST 'f342'
+            edit FHR 'f342'
+            edit HR '342'
+          task jgfs_atmos_post_f345
+            trigger ./jgfs_atmos_post_manager:release_post345
+            edit FHRGRP '196'
+            edit FHRLST 'f345'
+            edit FHR 'f345'
+            edit HR '345'
+          task jgfs_atmos_post_f348
+            trigger ./jgfs_atmos_post_manager:release_post348
+            edit FHRGRP '197'
+            edit FHRLST 'f348'
+            edit FHR 'f348'
+            edit HR '348'
+          task jgfs_atmos_post_f351
+            trigger ./jgfs_atmos_post_manager:release_post351
+            edit FHRGRP '198'
+            edit FHRLST 'f351'
+            edit FHR 'f351'
+            edit HR '351'
+          task jgfs_atmos_post_f354
+            trigger ./jgfs_atmos_post_manager:release_post354
+            edit FHRGRP '199'
+            edit FHRLST 'f354'
+            edit FHR 'f354'
+            edit HR '354'
+          task jgfs_atmos_post_f357
+            trigger ./jgfs_atmos_post_manager:release_post357
+            edit FHRGRP '200'
+            edit FHRLST 'f357'
+            edit FHR 'f357'
+            edit HR '357'
+          task jgfs_atmos_post_f360
+            trigger ./jgfs_atmos_post_manager:release_post360
+            edit FHRGRP '201'
+            edit FHRLST 'f360'
+            edit FHR 'f360'
+            edit HR '360'
+          task jgfs_atmos_post_f363
+            trigger ./jgfs_atmos_post_manager:release_post363
+            edit FHRGRP '202'
+            edit FHRLST 'f363'
+            edit FHR 'f363'
+            edit HR '363'
+          task jgfs_atmos_post_f366
+            trigger ./jgfs_atmos_post_manager:release_post366
+            edit FHRGRP '203'
+            edit FHRLST 'f366'
+            edit FHR 'f366'
+            edit HR '366'
+          task jgfs_atmos_post_f369
+            trigger ./jgfs_atmos_post_manager:release_post369
+            edit FHRGRP '204'
+            edit FHRLST 'f369'
+            edit FHR 'f369'
+            edit HR '369'
+          task jgfs_atmos_post_f372
+            trigger ./jgfs_atmos_post_manager:release_post372
+            edit FHRGRP '205'
+            edit FHRLST 'f372'
+            edit FHR 'f372'
+            edit HR '372'
+          task jgfs_atmos_post_f375
+            trigger ./jgfs_atmos_post_manager:release_post375
+            edit FHRGRP '206'
+            edit FHRLST 'f375'
+            edit FHR 'f375'
+            edit HR '375'
+          task jgfs_atmos_post_f378
+            trigger ./jgfs_atmos_post_manager:release_post378
+            edit FHRGRP '207'
+            edit FHRLST 'f378'
+            edit FHR 'f378'
+            edit HR '378'
+          task jgfs_atmos_post_f381
+            trigger ./jgfs_atmos_post_manager:release_post381
+            edit FHRGRP '208'
+            edit FHRLST 'f381'
+            edit FHR 'f381'
+            edit HR '381'
+          task jgfs_atmos_post_f384
+            trigger ./jgfs_atmos_post_manager:release_post384
+            edit FHRGRP '209'
+            edit FHRLST 'f384'
+            edit FHR 'f384'
+            edit HR '384'
+        endfamily
+        family post_processing
+          task jgfs_atmos_wafs_gcip
+            trigger ( :TIME >= 0440 and :TIME < 1040 ) and ../post/jgfs_atmos_post_f003 == complete
+          family grib_wafs
+            task jgfs_atmos_wafs_f000
+              trigger ../../post/jgfs_atmos_post_f000 == complete and ../../post/jgfs_atmos_post_f120 == complete and ../grib2_wafs/jgfs_atmos_wafs_grib2 == complete
+              edit FCSTHR '00'
+            task jgfs_atmos_wafs_f006
+              trigger ../../post/jgfs_atmos_post_f006 == complete and ./jgfs_atmos_wafs_f000 == complete
+              edit FCSTHR '06'
+            task jgfs_atmos_wafs_f012
+              trigger ../../post/jgfs_atmos_post_f012 == complete and ./jgfs_atmos_wafs_f006 == complete
+              edit FCSTHR '12'
+            task jgfs_atmos_wafs_f018
+              trigger ../../post/jgfs_atmos_post_f018 == complete and ./jgfs_atmos_wafs_f012 == complete
+              edit FCSTHR '18'
+            task jgfs_atmos_wafs_f024
+              trigger ../../post/jgfs_atmos_post_f024 == complete and ./jgfs_atmos_wafs_f018 == complete
+              edit FCSTHR '24'
+            task jgfs_atmos_wafs_f030
+              trigger ../../post/jgfs_atmos_post_f030 == complete and ./jgfs_atmos_wafs_f024 == complete
+              edit FCSTHR '30'
+            task jgfs_atmos_wafs_f036
+              trigger ../../post/jgfs_atmos_post_f036 == complete and ./jgfs_atmos_wafs_f030 == complete
+              edit FCSTHR '36'
+            task jgfs_atmos_wafs_f042
+              trigger ../../post/jgfs_atmos_post_f042 == complete and ./jgfs_atmos_wafs_f036 == complete
+              edit FCSTHR '42'
+            task jgfs_atmos_wafs_f048
+              trigger ../../post/jgfs_atmos_post_f048 == complete and ./jgfs_atmos_wafs_f042 == complete
+              edit FCSTHR '48'
+            task jgfs_atmos_wafs_f054
+              trigger ../../post/jgfs_atmos_post_f054 == complete and ./jgfs_atmos_wafs_f048 == complete
+              edit FCSTHR '54'
+            task jgfs_atmos_wafs_f060
+              trigger ../../post/jgfs_atmos_post_f060 == complete and ./jgfs_atmos_wafs_f054 == complete
+              edit FCSTHR '60'
+            task jgfs_atmos_wafs_f066
+              trigger ../../post/jgfs_atmos_post_f066 == complete and ./jgfs_atmos_wafs_f060 == complete
+              edit FCSTHR '66'
+            task jgfs_atmos_wafs_f072
+              trigger ../../post/jgfs_atmos_post_f072 == complete and ./jgfs_atmos_wafs_f066 == complete
+              edit FCSTHR '72'
+            task jgfs_atmos_wafs_f078
+              trigger ../../post/jgfs_atmos_post_f078 == complete and ./jgfs_atmos_wafs_f072 == complete
+              edit FCSTHR '78'
+            task jgfs_atmos_wafs_f084
+              trigger ../../post/jgfs_atmos_post_f084 == complete and ./jgfs_atmos_wafs_f078 == complete
+              edit FCSTHR '84'
+            task jgfs_atmos_wafs_f090
+              trigger ../../post/jgfs_atmos_post_f090 == complete and ./jgfs_atmos_wafs_f084 == complete
+              edit FCSTHR '90'
+            task jgfs_atmos_wafs_f096
+              trigger ../../post/jgfs_atmos_post_f096 == complete and ./jgfs_atmos_wafs_f090 == complete
+              edit FCSTHR '96'
+            task jgfs_atmos_wafs_f102
+              trigger ../../post/jgfs_atmos_post_f102 == complete and ./jgfs_atmos_wafs_f096 == complete
+              edit FCSTHR '102'
+            task jgfs_atmos_wafs_f108
+              trigger ../../post/jgfs_atmos_post_f108 == complete and ./jgfs_atmos_wafs_f102 == complete
+              edit FCSTHR '108'
+            task jgfs_atmos_wafs_f114
+              trigger ../../post/jgfs_atmos_post_f114 == complete and ./jgfs_atmos_wafs_f108 == complete
+              edit FCSTHR '114'
+            task jgfs_atmos_wafs_f120
+              trigger ../../post/jgfs_atmos_post_f120 == complete and ./jgfs_atmos_wafs_f114 == complete
+              edit FCSTHR '120'
+          endfamily
+          family grib2_wafs
+            task jgfs_atmos_wafs_grib2
+              trigger ../../post/jgfs_atmos_post_f000 == complete
+            task jgfs_atmos_wafs_grib2_0p25
+              trigger ../../post/jgfs_atmos_post_f036 == complete
+            task jgfs_atmos_wafs_blending
+              trigger ( :TIME >= 0433 and :TIME < 1033) and ./jgfs_atmos_wafs_grib2 == complete
+            task jgfs_atmos_wafs_blending_0p25
+              trigger ( :TIME >= 0425 and :TIME < 1025) and ./jgfs_atmos_wafs_grib2_0p25 == complete
+          endfamily
+          family bufr_sounding
+            task jgfs_atmos_postsnd
+              trigger ../../post/jgfs_atmos_post_manager:release_post000
+          endfamily
+          family bulletins
+            task jgfs_atmos_fbwind
+              trigger ../../post/jgfs_atmos_post_f006 == complete and ../../post/jgfs_atmos_post_f012 == complete and ../../post/jgfs_atmos_post_f024 == complete
+          endfamily
+          family awips_20km_1p0
+            task jgfs_atmos_awips_f000
+              trigger ../../post/jgfs_atmos_post_f000 == complete
+              edit FHRGRP '000'
+              edit FHRLST 'f000'
+              edit FCSTHR '000'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f003
+              trigger ../../post/jgfs_atmos_post_f003 == complete
+              edit FHRGRP '003'
+              edit FHRLST 'f003'
+              edit FCSTHR '003'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f006
+              trigger ../../post/jgfs_atmos_post_f006 == complete
+              edit FHRGRP '006'
+              edit FHRLST 'f006'
+              edit FCSTHR '006'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f009
+              trigger ../../post/jgfs_atmos_post_f009 == complete
+              edit FHRGRP '009'
+              edit FHRLST 'f009'
+              edit FCSTHR '009'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f012
+              trigger ../../post/jgfs_atmos_post_f012 == complete
+              edit FHRGRP '012'
+              edit FHRLST 'f012'
+              edit FCSTHR '012'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f015
+              trigger ../../post/jgfs_atmos_post_f015 == complete
+              edit FHRGRP '015'
+              edit FHRLST 'f015'
+              edit FCSTHR '015'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f018
+              trigger ../../post/jgfs_atmos_post_f018 == complete
+              edit FHRGRP '018'
+              edit FHRLST 'f018'
+              edit FCSTHR '018'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f021
+              trigger ../../post/jgfs_atmos_post_f021 == complete
+              edit FHRGRP '021'
+              edit FHRLST 'f021'
+              edit FCSTHR '021'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f024
+              trigger ../../post/jgfs_atmos_post_f024 == complete
+              edit FHRGRP '024'
+              edit FHRLST 'f024'
+              edit FCSTHR '024'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f027
+              trigger ../../post/jgfs_atmos_post_f027 == complete
+              edit FHRGRP '027'
+              edit FHRLST 'f027'
+              edit FCSTHR '027'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f030
+              trigger ../../post/jgfs_atmos_post_f030 == complete
+              edit FHRGRP '030'
+              edit FHRLST 'f030'
+              edit FCSTHR '030'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f033
+              trigger ../../post/jgfs_atmos_post_f033 == complete
+              edit FHRGRP '033'
+              edit FHRLST 'f033'
+              edit FCSTHR '033'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f036
+              trigger ../../post/jgfs_atmos_post_f036 == complete
+              edit FHRGRP '036'
+              edit FHRLST 'f036'
+              edit FCSTHR '036'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f039
+              trigger ../../post/jgfs_atmos_post_f039 == complete
+              edit FHRGRP '039'
+              edit FHRLST 'f039'
+              edit FCSTHR '039'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f042
+              trigger ../../post/jgfs_atmos_post_f042 == complete
+              edit FHRGRP '042'
+              edit FHRLST 'f042'
+              edit FCSTHR '042'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f045
+              trigger ../../post/jgfs_atmos_post_f045 == complete
+              edit FHRGRP '045'
+              edit FHRLST 'f045'
+              edit FCSTHR '045'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f048
+              trigger ../../post/jgfs_atmos_post_f048 == complete
+              edit FHRGRP '048'
+              edit FHRLST 'f048'
+              edit FCSTHR '048'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f051
+              trigger ../../post/jgfs_atmos_post_f051 == complete
+              edit FHRGRP '051'
+              edit FHRLST 'f051'
+              edit FCSTHR '051'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f054
+              trigger ../../post/jgfs_atmos_post_f054 == complete
+              edit FHRGRP '054'
+              edit FHRLST 'f054'
+              edit FCSTHR '054'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f057
+              trigger ../../post/jgfs_atmos_post_f057 == complete
+              edit FHRGRP '057'
+              edit FHRLST 'f057'
+              edit FCSTHR '057'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f060
+              trigger ../../post/jgfs_atmos_post_f060 == complete
+              edit FHRGRP '060'
+              edit FHRLST 'f060'
+              edit FCSTHR '060'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f063
+              trigger ../../post/jgfs_atmos_post_f063 == complete
+              edit FHRGRP '063'
+              edit FHRLST 'f063'
+              edit FCSTHR '063'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f066
+              trigger ../../post/jgfs_atmos_post_f066 == complete
+              edit FHRGRP '066'
+              edit FHRLST 'f066'
+              edit FCSTHR '066'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f069
+              trigger ../../post/jgfs_atmos_post_f069 == complete
+              edit FHRGRP '069'
+              edit FHRLST 'f069'
+              edit FCSTHR '069'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f072
+              trigger ../../post/jgfs_atmos_post_f072 == complete
+              edit FHRGRP '072'
+              edit FHRLST 'f072'
+              edit FCSTHR '072'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f075
+              trigger ../../post/jgfs_atmos_post_f075 == complete
+              edit FHRGRP '075'
+              edit FHRLST 'f075'
+              edit FCSTHR '075'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f078
+              trigger ../../post/jgfs_atmos_post_f078 == complete
+              edit FHRGRP '078'
+              edit FHRLST 'f078'
+              edit FCSTHR '078'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f081
+              trigger ../../post/jgfs_atmos_post_f081 == complete
+              edit FHRGRP '081'
+              edit FHRLST 'f081'
+              edit FCSTHR '081'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f084
+              trigger ../../post/jgfs_atmos_post_f084 == complete
+              edit FHRGRP '084'
+              edit FHRLST 'f084'
+              edit FCSTHR '084'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f090
+              trigger ../../post/jgfs_atmos_post_f090 == complete
+              edit FHRGRP '090'
+              edit FHRLST 'f090'
+              edit FCSTHR '090'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f096
+              trigger ../../post/jgfs_atmos_post_f096 == complete
+              edit FHRGRP '096'
+              edit FHRLST 'f096'
+              edit FCSTHR '096'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f102
+              trigger ../../post/jgfs_atmos_post_f102 == complete
+              edit FHRGRP '102'
+              edit FHRLST 'f102'
+              edit FCSTHR '102'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f108
+              trigger ../../post/jgfs_atmos_post_f108 == complete
+              edit FHRGRP '108'
+              edit FHRLST 'f108'
+              edit FCSTHR '108'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f114
+              trigger ../../post/jgfs_atmos_post_f114 == complete
+              edit FHRGRP '114'
+              edit FHRLST 'f114'
+              edit FCSTHR '114'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f120
+              trigger ../../post/jgfs_atmos_post_f120 == complete
+              edit FHRGRP '120'
+              edit FHRLST 'f120'
+              edit FCSTHR '120'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f126
+              trigger ../../post/jgfs_atmos_post_f126 == complete
+              edit FHRGRP '126'
+              edit FHRLST 'f126'
+              edit FCSTHR '126'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f132
+              trigger ../../post/jgfs_atmos_post_f132 == complete
+              edit FHRGRP '132'
+              edit FHRLST 'f132'
+              edit FCSTHR '132'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f138
+              trigger ../../post/jgfs_atmos_post_f138 == complete
+              edit FHRGRP '138'
+              edit FHRLST 'f138'
+              edit FCSTHR '138'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f144
+              trigger ../../post/jgfs_atmos_post_f144 == complete
+              edit FHRGRP '144'
+              edit FHRLST 'f144'
+              edit FCSTHR '144'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f150
+              trigger ../../post/jgfs_atmos_post_f150 == complete
+              edit FHRGRP '150'
+              edit FHRLST 'f150'
+              edit FCSTHR '150'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f156
+              trigger ../../post/jgfs_atmos_post_f156 == complete
+              edit FHRGRP '156'
+              edit FHRLST 'f156'
+              edit FCSTHR '156'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f162
+              trigger ../../post/jgfs_atmos_post_f162 == complete
+              edit FHRGRP '162'
+              edit FHRLST 'f162'
+              edit FCSTHR '162'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f168
+              trigger ../../post/jgfs_atmos_post_f168 == complete
+              edit FHRGRP '168'
+              edit FHRLST 'f168'
+              edit FCSTHR '168'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f174
+              trigger ../../post/jgfs_atmos_post_f174 == complete
+              edit FHRGRP '174'
+              edit FHRLST 'f174'
+              edit FCSTHR '174'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f180
+              trigger ../../post/jgfs_atmos_post_f180 == complete
+              edit FHRGRP '180'
+              edit FHRLST 'f180'
+              edit FCSTHR '180'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f186
+              trigger ../../post/jgfs_atmos_post_f186 == complete
+              edit FHRGRP '186'
+              edit FHRLST 'f186'
+              edit FCSTHR '186'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f192
+              trigger ../../post/jgfs_atmos_post_f192 == complete
+              edit FHRGRP '192'
+              edit FHRLST 'f192'
+              edit FCSTHR '192'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f198
+              trigger ../../post/jgfs_atmos_post_f198 == complete
+              edit FHRGRP '198'
+              edit FHRLST 'f198'
+              edit FCSTHR '198'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f204
+              trigger ../../post/jgfs_atmos_post_f204 == complete
+              edit FHRGRP '204'
+              edit FHRLST 'f204'
+              edit FCSTHR '204'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f210
+              trigger ../../post/jgfs_atmos_post_f210 == complete
+              edit FHRGRP '210'
+              edit FHRLST 'f210'
+              edit FCSTHR '210'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f216
+              trigger ../../post/jgfs_atmos_post_f216 == complete
+              edit FHRGRP '216'
+              edit FHRLST 'f216'
+              edit FCSTHR '216'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f222
+              trigger ../../post/jgfs_atmos_post_f222 == complete
+              edit FHRGRP '222'
+              edit FHRLST 'f222'
+              edit FCSTHR '222'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f228
+              trigger ../../post/jgfs_atmos_post_f228 == complete
+              edit FHRGRP '228'
+              edit FHRLST 'f228'
+              edit FCSTHR '228'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f234
+              trigger ../../post/jgfs_atmos_post_f234 == complete
+              edit FHRGRP '234'
+              edit FHRLST 'f234'
+              edit FCSTHR '234'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f240
+              trigger ../../post/jgfs_atmos_post_f240 == complete
+              edit FHRGRP '240'
+              edit FHRLST 'f240'
+              edit FCSTHR '240'
+              edit TRDRUN 'YES'
+          endfamily
+          family awips_g2
+            task jgfs_atmos_awips_g2_f000
+              trigger ../../post/jgfs_atmos_post_f000 == complete
+              edit FHRGRP '000'
+              edit FHRLST 'f000'
+              edit FCSTHR '000'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f006
+              trigger ../../post/jgfs_atmos_post_f006 == complete
+              edit FHRGRP '006'
+              edit FHRLST 'f006'
+              edit FCSTHR '006'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f012
+              trigger ../../post/jgfs_atmos_post_f012 == complete
+              edit FHRGRP '012'
+              edit FHRLST 'f012'
+              edit FCSTHR '012'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f018
+              trigger ../../post/jgfs_atmos_post_f018 == complete
+              edit FHRGRP '018'
+              edit FHRLST 'f018'
+              edit FCSTHR '018'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f024
+              trigger ../../post/jgfs_atmos_post_f024 == complete
+              edit FHRGRP '024'
+              edit FHRLST 'f024'
+              edit FCSTHR '024'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f030
+              trigger ../../post/jgfs_atmos_post_f030 == complete
+              edit FHRGRP '030'
+              edit FHRLST 'f030'
+              edit FCSTHR '030'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f036
+              trigger ../../post/jgfs_atmos_post_f036 == complete
+              edit FHRGRP '036'
+              edit FHRLST 'f036'
+              edit FCSTHR '036'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f042
+              trigger ../../post/jgfs_atmos_post_f042 == complete
+              edit FHRGRP '042'
+              edit FHRLST 'f042'
+              edit FCSTHR '042'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f048
+              trigger ../../post/jgfs_atmos_post_f048 == complete
+              edit FHRGRP '048'
+              edit FHRLST 'f048'
+              edit FCSTHR '048'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f054
+              trigger ../../post/jgfs_atmos_post_f054 == complete
+              edit FHRGRP '054'
+              edit FHRLST 'f054'
+              edit FCSTHR '054'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f060
+              trigger ../../post/jgfs_atmos_post_f060 == complete
+              edit FHRGRP '060'
+              edit FHRLST 'f060'
+              edit FCSTHR '060'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f066
+              trigger ../../post/jgfs_atmos_post_f066 == complete
+              edit FHRGRP '066'
+              edit FHRLST 'f066'
+              edit FCSTHR '066'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f072
+              trigger ../../post/jgfs_atmos_post_f072 == complete
+              edit FHRGRP '072'
+              edit FHRLST 'f072'
+              edit FCSTHR '072'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f078
+              trigger ../../post/jgfs_atmos_post_f078 == complete
+              edit FHRGRP '078'
+              edit FHRLST 'f078'
+              edit FCSTHR '078'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f084
+              trigger ../../post/jgfs_atmos_post_f084 == complete
+              edit FHRGRP '084'
+              edit FHRLST 'f084'
+              edit FCSTHR '084'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f090
+              trigger ../../post/jgfs_atmos_post_f090 == complete
+              edit FHRGRP '090'
+              edit FHRLST 'f090'
+              edit FCSTHR '090'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f096
+              trigger ../../post/jgfs_atmos_post_f096 == complete
+              edit FHRGRP '096'
+              edit FHRLST 'f096'
+              edit FCSTHR '096'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f102
+              trigger ../../post/jgfs_atmos_post_f102 == complete
+              edit FHRGRP '102'
+              edit FHRLST 'f102'
+              edit FCSTHR '102'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f108
+              trigger ../../post/jgfs_atmos_post_f108 == complete
+              edit FHRGRP '108'
+              edit FHRLST 'f108'
+              edit FCSTHR '108'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f114
+              trigger ../../post/jgfs_atmos_post_f114 == complete
+              edit FHRGRP '114'
+              edit FHRLST 'f114'
+              edit FCSTHR '114'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f120
+              trigger ../../post/jgfs_atmos_post_f120 == complete
+              edit FHRGRP '120'
+              edit FHRLST 'f120'
+              edit FCSTHR '120'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f126
+              trigger ../../post/jgfs_atmos_post_f126 == complete
+              edit FHRGRP '126'
+              edit FHRLST 'f126'
+              edit FCSTHR '126'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f132
+              trigger ../../post/jgfs_atmos_post_f132 == complete
+              edit FHRGRP '132'
+              edit FHRLST 'f132'
+              edit FCSTHR '132'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f138
+              trigger ../../post/jgfs_atmos_post_f138 == complete
+              edit FHRGRP '138'
+              edit FHRLST 'f138'
+              edit FCSTHR '138'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f144
+              trigger ../../post/jgfs_atmos_post_f144 == complete
+              edit FHRGRP '144'
+              edit FHRLST 'f144'
+              edit FCSTHR '144'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f150
+              trigger ../../post/jgfs_atmos_post_f150 == complete
+              edit FHRGRP '150'
+              edit FHRLST 'f150'
+              edit FCSTHR '150'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f156
+              trigger ../../post/jgfs_atmos_post_f156 == complete
+              edit FHRGRP '156'
+              edit FHRLST 'f156'
+              edit FCSTHR '156'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f162
+              trigger ../../post/jgfs_atmos_post_f162 == complete
+              edit FHRGRP '162'
+              edit FHRLST 'f162'
+              edit FCSTHR '162'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f168
+              trigger ../../post/jgfs_atmos_post_f168 == complete
+              edit FHRGRP '168'
+              edit FHRLST 'f168'
+              edit FCSTHR '168'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f174
+              trigger ../../post/jgfs_atmos_post_f174 == complete
+              edit FHRGRP '174'
+              edit FHRLST 'f174'
+              edit FCSTHR '174'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f180
+              trigger ../../post/jgfs_atmos_post_f180 == complete
+              edit FHRGRP '180'
+              edit FHRLST 'f180'
+              edit FCSTHR '180'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f186
+              trigger ../../post/jgfs_atmos_post_f186 == complete
+              edit FHRGRP '186'
+              edit FHRLST 'f186'
+              edit FCSTHR '186'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f192
+              trigger ../../post/jgfs_atmos_post_f192 == complete
+              edit FHRGRP '192'
+              edit FHRLST 'f192'
+              edit FCSTHR '192'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f198
+              trigger ../../post/jgfs_atmos_post_f198 == complete
+              edit FHRGRP '198'
+              edit FHRLST 'f198'
+              edit FCSTHR '198'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f204
+              trigger ../../post/jgfs_atmos_post_f204 == complete
+              edit FHRGRP '204'
+              edit FHRLST 'f204'
+              edit FCSTHR '204'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f210
+              trigger ../../post/jgfs_atmos_post_f210 == complete
+              edit FHRGRP '210'
+              edit FHRLST 'f210'
+              edit FCSTHR '210'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f216
+              trigger ../../post/jgfs_atmos_post_f216 == complete
+              edit FHRGRP '216'
+              edit FHRLST 'f216'
+              edit FCSTHR '216'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f222
+              trigger ../../post/jgfs_atmos_post_f222 == complete
+              edit FHRGRP '222'
+              edit FHRLST 'f222'
+              edit FCSTHR '222'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f228
+              trigger ../../post/jgfs_atmos_post_f228 == complete
+              edit FHRGRP '228'
+              edit FHRLST 'f228'
+              edit FCSTHR '228'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f234
+              trigger ../../post/jgfs_atmos_post_f234 == complete
+              edit FHRGRP '234'
+              edit FHRLST 'f234'
+              edit FCSTHR '234'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f240
+              trigger ../../post/jgfs_atmos_post_f240 == complete
+              edit FHRGRP '240'
+              edit FHRLST 'f240'
+              edit FCSTHR '240'
+              edit TRDRUN 'YES'
+          endfamily
+        endfamily
+        family gempak
+          task jgfs_atmos_gempak
+            trigger ../../atmos/analysis/jgfs_atmos_analysis == complete
+          task jgfs_atmos_gempak_meta
+            trigger ../../atmos/analysis/jgfs_atmos_analysis == complete
+          task jgfs_atmos_gempak_ncdc_upapgif
+            trigger ./jgfs_atmos_gempak == active or ./jgfs_atmos_gempak == complete
+          task jgfs_atmos_npoess_pgrb2_0p5deg
+            trigger ../post/jgfs_atmos_post_anl eq active or ../post/jgfs_atmos_post_anl == complete
+          task jgfs_atmos_pgrb2_spec_gempak
+            trigger ./jgfs_atmos_npoess_pgrb2_0p5deg == complete
+        endfamily
+        family verf
+          task jgfs_atmos_vminmon
+            trigger ../analysis/jgfs_atmos_analysis == complete
+        endfamily
+      endfamily
+      family wave
+        family init
+          task jgfs_wave_init
+            trigger /prod/primary/00/obsproc/v1.0/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete
+        endfamily
+        family prep
+          task jgfs_wave_prep
+            trigger ../init/jgfs_wave_init == complete
+        endfamily
+        family post
+          task jgfs_wave_postsbs
+            trigger ../../atmos/post/jgfs_atmos_post_manager:release_post000
+          task jgfs_wave_postpnt
+            trigger ../../jgfs_forecast == complete
+          task jgfs_wave_post_bndpnt
+            trigger ../../atmos/post/jgfs_atmos_post_manager:release_post180
+          task jgfs_wave_post_bndpntbll
+            trigger ../../atmos/post/jgfs_atmos_post_manager:release_post180
+          task jgfs_wave_prdgen_gridded
+            trigger ./jgfs_wave_postsbs == active or ./jgfs_wave_postsbs == complete
+          task jgfs_wave_prdgen_bulls
+            trigger ./jgfs_wave_postpnt == complete and ./jgfs_wave_postsbs == complete
+        endfamily
+        family gempak
+          task jgfs_wave_gempak
+            trigger ../post/jgfs_wave_postsbs == active or ../post/jgfs_wave_postsbs == complete
+        endfamily
+      endfamily
+      task jgfs_forecast
+        trigger ./atmos/analysis/jgfs_atmos_analysis:release_fcst and ./wave/prep/jgfs_wave_prep == complete
+    endfamily
+    family gdas
+      edit RUN 'gdas'
+      edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/gdas'
+      family atmos
+        family obsproc
+          family dump
+            task jgdas_atmos_tropcy_qc_reloc
+              trigger :TIME >= 0545 and :TIME < 1145
+          endfamily
+          family prep
+            task jgdas_atmos_emcsfc_sfc_prep
+              trigger /prod/primary/00/obsproc/v1.0/gdas/atmos/dump/jobsproc_gdas_atmos_dump:release_sfcprep
+          endfamily
+        endfamily
+        family init
+          task jgdas_atmos_gldas
+            trigger ../analysis/jgdas_atmos_analysis == complete
+        endfamily
+        family analysis
+          task jgdas_atmos_analysis
+            trigger /prod/primary/00/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../obsproc/prep/jgdas_atmos_emcsfc_sfc_prep == complete
+            event 1 release_fcst
+          task jgdas_atmos_analysis_calc
+            trigger ./jgdas_atmos_analysis == complete
+          task jgdas_atmos_analysis_diag
+            trigger ./jgdas_atmos_analysis == complete
+        endfamily
+        family post
+          task jgdas_atmos_post_manager
+            trigger ../../jgdas_forecast == active
+            event 1 release_postanl
+            event 2 release_post000
+            event 3 release_post001
+            event 4 release_post002
+            event 5 release_post003
+            event 6 release_post004
+            event 7 release_post005
+            event 8 release_post006
+            event 9 release_post007
+            event 10 release_post008
+            event 11 release_post009
+          task jgdas_atmos_post_anl
+            trigger ./jgdas_atmos_post_manager:release_postanl
+            edit FHRGRP '000'
+            edit FHRLST 'anl'
+            edit HR 'anl'
+            edit FHR 'anl'
+          task jgdas_atmos_post_f000
+            trigger ./jgdas_atmos_post_manager:release_post000
+            edit FHR 'f000'
+            edit HR '000'
+            edit FHRGRP '001'
+            edit FHRLST 'f000'
+          task jgdas_atmos_post_f001
+            trigger ./jgdas_atmos_post_manager:release_post001
+            edit FHR 'f001'
+            edit HR '001'
+            edit FHRGRP '002'
+            edit FHRLST 'f001'
+          task jgdas_atmos_post_f002
+            trigger ./jgdas_atmos_post_manager:release_post002
+            edit FHR 'f002'
+            edit HR '002'
+            edit FHRGRP '003'
+            edit FHRLST 'f002'
+          task jgdas_atmos_post_f003
+            trigger ./jgdas_atmos_post_manager:release_post003
+            edit FHR 'f003'
+            edit HR '003'
+            edit FHRGRP '004'
+            edit FHRLST 'f003'
+          task jgdas_atmos_post_f004
+            trigger ./jgdas_atmos_post_manager:release_post004
+            edit FHR 'f004'
+            edit HR '004'
+            edit FHRGRP '005'
+            edit FHRLST 'f004'
+          task jgdas_atmos_post_f005
+            trigger ./jgdas_atmos_post_manager:release_post005
+            edit FHR 'f005'
+            edit HR '005'
+            edit FHRGRP '006'
+            edit FHRLST 'f005'
+          task jgdas_atmos_post_f006
+            trigger ./jgdas_atmos_post_manager:release_post006
+            edit FHR 'f006'
+            edit HR '006'
+            edit FHRGRP '007'
+            edit FHRLST 'f006'
+          task jgdas_atmos_post_f007
+            trigger ./jgdas_atmos_post_manager:release_post007
+            edit FHR 'f007'
+            edit HR '007'
+            edit FHRGRP '008'
+            edit FHRLST 'f007'
+          task jgdas_atmos_post_f008
+            trigger ./jgdas_atmos_post_manager:release_post008
+            edit FHR 'f008'
+            edit HR '008'
+            edit FHRGRP '009'
+            edit FHRLST 'f008'
+          task jgdas_atmos_post_f009
+            trigger ./jgdas_atmos_post_manager:release_post009
+            edit FHR 'f009'
+            edit HR '009'
+            edit FHRGRP '010'
+            edit FHRLST 'f009'
+        endfamily
+        family post_processing
+          task jgdas_atmos_chgres_forenkf
+            trigger ../../jgdas_forecast == complete and ../../../enkfgdas/forecast == complete
+        endfamily
+        family gempak
+          task jgdas_atmos_gempak
+            trigger ../../jgdas_forecast == complete
+          task jgdas_atmos_gempak_meta_ncdc
+            trigger ./jgdas_atmos_gempak == complete
+        endfamily
+        family verf
+          task jgdas_atmos_vminmon
+            trigger ../analysis/jgdas_atmos_analysis == complete
+          task jgdas_atmos_verfrad
+            trigger ../analysis/jgdas_atmos_analysis_diag == complete
+          task jgdas_atmos_verfozn
+            trigger ../analysis/jgdas_atmos_analysis_diag == complete
+        endfamily
+      endfamily
+      family wave
+        family init
+          task jgdas_wave_init
+            trigger /prod/primary/00/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete
+        endfamily
+        family prep
+          task jgdas_wave_prep
+            trigger ../init/jgdas_wave_init == complete
+        endfamily
+        family post
+          task jgdas_wave_postsbs
+            trigger ../../atmos/post/jgdas_atmos_post_manager:release_post000
+          task jgdas_wave_postpnt
+            trigger ../../jgdas_forecast == complete
+        endfamily
+      endfamily
+      task jgdas_forecast
+        trigger ./atmos/analysis/jgdas_atmos_analysis:release_fcst and ./wave/prep/jgdas_wave_prep == complete and ./atmos/init/jgdas_atmos_gldas == complete
+    endfamily
+    family enkfgdas
+      edit RUN 'gdas'
+      edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/enkfgdas'
+      family analysis
+        family create
+          task jenkfgdas_select_obs
+            trigger /prod/primary/00/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and /prod/primary/18/gfs/v16.2/enkfgdas/post == complete
+          task jenkfgdas_diag
+            trigger ./jenkfgdas_select_obs == complete
+          task jenkfgdas_update
+            trigger ./jenkfgdas_diag == complete
+        endfamily
+        family recenter
+          family ecen
+            trigger ../create/jenkfgdas_update == complete and ../../../gdas/atmos/analysis/jgdas_atmos_analysis_calc == complete and /prod/primary/18/gfs/v16.2/gdas/atmos/post_processing/jgdas_atmos_chgres_forenkf == complete
+            edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/enkfgdas/analysis/recenter/ecen'
+            family grp1
+              edit FHRGRP '003'
+              task jenkfgdas_ecen
+            endfamily
+            family grp2
+              edit FHRGRP '006'
+              task jenkfgdas_ecen
+            endfamily
+            family grp3
+              edit FHRGRP '009'
+              task jenkfgdas_ecen
+            endfamily
+          endfamily
+          task jenkfgdas_sfc
+            trigger ../create/jenkfgdas_update == complete and ../../../gdas/atmos/analysis/jgdas_atmos_analysis_calc == complete
+        endfamily
+      endfamily
+      family forecast
+        trigger ./analysis/recenter/ecen == complete and ./analysis/recenter/jenkfgdas_sfc == complete
+        edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/enkfgdas/forecast'
+        family grp1
+          edit ENSGRP '01'
+          task jenkfgdas_fcst
+        endfamily
+        family grp2
+          edit ENSGRP '02'
+          task jenkfgdas_fcst
+        endfamily
+        family grp3
+          edit ENSGRP '03'
+          task jenkfgdas_fcst
+        endfamily
+        family grp4
+          edit ENSGRP '04'
+          task jenkfgdas_fcst
+        endfamily
+        family grp5
+          edit ENSGRP '05'
+          task jenkfgdas_fcst
+        endfamily
+        family grp6
+          edit ENSGRP '06'
+          task jenkfgdas_fcst
+        endfamily
+        family grp7
+          edit ENSGRP '07'
+          task jenkfgdas_fcst
+        endfamily
+        family grp8
+          edit ENSGRP '08'
+          task jenkfgdas_fcst
+        endfamily
+        family grp9
+          edit ENSGRP '09'
+          task jenkfgdas_fcst
+        endfamily
+        family grp10
+          edit ENSGRP '10'
+          task jenkfgdas_fcst
+        endfamily
+        family grp11
+          edit ENSGRP '11'
+          task jenkfgdas_fcst
+        endfamily
+        family grp12
+          edit ENSGRP '12'
+          task jenkfgdas_fcst
+        endfamily
+        family grp13
+          edit ENSGRP '13'
+          task jenkfgdas_fcst
+        endfamily
+        family grp14
+          edit ENSGRP '14'
+          task jenkfgdas_fcst
+        endfamily
+        family grp15
+          edit ENSGRP '15'
+          task jenkfgdas_fcst
+        endfamily
+        family grp16
+          edit ENSGRP '16'
+          task jenkfgdas_fcst
+        endfamily
+        family grp17
+          edit ENSGRP '17'
+          task jenkfgdas_fcst
+        endfamily
+        family grp18
+          edit ENSGRP '18'
+          task jenkfgdas_fcst
+        endfamily
+        family grp19
+          edit ENSGRP '19'
+          task jenkfgdas_fcst
+        endfamily
+        family grp20
+          edit ENSGRP '20'
+          task jenkfgdas_fcst
+        endfamily
+        family grp21
+          edit ENSGRP '21'
+          task jenkfgdas_fcst
+        endfamily
+        family grp22
+          edit ENSGRP '22'
+          task jenkfgdas_fcst
+        endfamily
+        family grp23
+          edit ENSGRP '23'
+          task jenkfgdas_fcst
+        endfamily
+        family grp24
+          edit ENSGRP '24'
+          task jenkfgdas_fcst
+        endfamily
+        family grp25
+          edit ENSGRP '25'
+          task jenkfgdas_fcst
+        endfamily
+        family grp26
+          edit ENSGRP '26'
+          task jenkfgdas_fcst
+        endfamily
+        family grp27
+          edit ENSGRP '27'
+          task jenkfgdas_fcst
+        endfamily
+        family grp28
+          edit ENSGRP '28'
+          task jenkfgdas_fcst
+        endfamily
+        family grp29
+          edit ENSGRP '29'
+          task jenkfgdas_fcst
+        endfamily
+        family grp30
+          edit ENSGRP '30'
+          task jenkfgdas_fcst
+        endfamily
+        family grp31
+          edit ENSGRP '31'
+          task jenkfgdas_fcst
+        endfamily
+        family grp32
+          edit ENSGRP '32'
+          task jenkfgdas_fcst
+        endfamily
+        family grp33
+          edit ENSGRP '33'
+          task jenkfgdas_fcst
+        endfamily
+        family grp34
+          edit ENSGRP '34'
+          task jenkfgdas_fcst
+        endfamily
+        family grp35
+          edit ENSGRP '35'
+          task jenkfgdas_fcst
+        endfamily
+        family grp36
+          edit ENSGRP '36'
+          task jenkfgdas_fcst
+        endfamily
+        family grp37
+          edit ENSGRP '37'
+          task jenkfgdas_fcst
+        endfamily
+        family grp38
+          edit ENSGRP '38'
+          task jenkfgdas_fcst
+        endfamily
+        family grp39
+          edit ENSGRP '39'
+          task jenkfgdas_fcst
+        endfamily
+        family grp40
+          edit ENSGRP '40'
+          task jenkfgdas_fcst
+        endfamily
+      endfamily
+      family post
+        trigger ./forecast == complete
+        task jenkfgdas_post_f003
+          edit FHMIN_EPOS '003'
+          edit FHMAX_EPOS '003'
+          edit FHOUT_EPOS '003'
+        task jenkfgdas_post_f004
+          edit FHMIN_EPOS '004'
+          edit FHMAX_EPOS '004'
+          edit FHOUT_EPOS '004'
+        task jenkfgdas_post_f005
+          edit FHMIN_EPOS '005'
+          edit FHMAX_EPOS '005'
+          edit FHOUT_EPOS '005'
+        task jenkfgdas_post_f006
+          edit FHMIN_EPOS '006'
+          edit FHMAX_EPOS '006'
+          edit FHOUT_EPOS '006'
+        task jenkfgdas_post_f007
+          edit FHMIN_EPOS '007'
+          edit FHMAX_EPOS '007'
+          edit FHOUT_EPOS '007'
+        task jenkfgdas_post_f008
+          edit FHMIN_EPOS '008'
+          edit FHMAX_EPOS '008'
+          edit FHOUT_EPOS '008'
+        task jenkfgdas_post_f009
+          edit FHMIN_EPOS '009'
+          edit FHMAX_EPOS '009'
+          edit FHOUT_EPOS '009'
+      endfamily
+    endfamily
+  endfamily
+

--- a/ecf/defs/gfs_06.def
+++ b/ecf/defs/gfs_06.def
@@ -1,0 +1,2589 @@
+  family v16.2
+    family gfs
+      edit RUN 'gfs'
+      edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/gfs'
+      family atmos
+        family obsproc
+          family dump
+            task jgfs_atmos_tropcy_qc_reloc
+              trigger :TIME >= 0841 and :TIME < 1441
+              event 1 jtwc_bull_email
+          endfamily
+          family prep
+            task jgfs_atmos_emcsfc_sfc_prep
+              trigger /prod/primary/06/obsproc/v1.0/gfs/atmos/dump/jobsproc_gfs_atmos_dump:release_sfcprep
+          endfamily
+        endfamily
+        family analysis
+          task jgfs_atmos_analysis
+            trigger /prod/primary/06/obsproc/v1.0/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete and ../obsproc/prep/jgfs_atmos_emcsfc_sfc_prep == complete
+            event 1 release_fcst
+          task jgfs_atmos_analysis_calc
+            trigger ./jgfs_atmos_analysis == complete
+        endfamily
+        family post
+          task jgfs_atmos_post_manager
+            trigger ../analysis/jgfs_atmos_analysis == complete
+            event 1 release_postanl
+            event 2 release_post000
+            event 3 release_post001
+            event 4 release_post002
+            event 5 release_post003
+            event 6 release_post004
+            event 7 release_post005
+            event 8 release_post006
+            event 9 release_post007
+            event 10 release_post008
+            event 11 release_post009
+            event 12 release_post010
+            event 13 release_post011
+            event 14 release_post012
+            event 15 release_post013
+            event 16 release_post014
+            event 17 release_post015
+            event 18 release_post016
+            event 19 release_post017
+            event 20 release_post018
+            event 21 release_post019
+            event 22 release_post020
+            event 23 release_post021
+            event 24 release_post022
+            event 25 release_post023
+            event 26 release_post024
+            event 27 release_post025
+            event 28 release_post026
+            event 29 release_post027
+            event 30 release_post028
+            event 31 release_post029
+            event 32 release_post030
+            event 33 release_post031
+            event 34 release_post032
+            event 35 release_post033
+            event 36 release_post034
+            event 37 release_post035
+            event 38 release_post036
+            event 39 release_post037
+            event 40 release_post038
+            event 41 release_post039
+            event 42 release_post040
+            event 43 release_post041
+            event 44 release_post042
+            event 45 release_post043
+            event 46 release_post044
+            event 47 release_post045
+            event 48 release_post046
+            event 49 release_post047
+            event 50 release_post048
+            event 51 release_post049
+            event 52 release_post050
+            event 53 release_post051
+            event 54 release_post052
+            event 55 release_post053
+            event 56 release_post054
+            event 57 release_post055
+            event 58 release_post056
+            event 59 release_post057
+            event 60 release_post058
+            event 61 release_post059
+            event 62 release_post060
+            event 63 release_post061
+            event 64 release_post062
+            event 65 release_post063
+            event 66 release_post064
+            event 67 release_post065
+            event 68 release_post066
+            event 69 release_post067
+            event 70 release_post068
+            event 71 release_post069
+            event 72 release_post070
+            event 73 release_post071
+            event 74 release_post072
+            event 75 release_post073
+            event 76 release_post074
+            event 77 release_post075
+            event 78 release_post076
+            event 79 release_post077
+            event 80 release_post078
+            event 81 release_post079
+            event 82 release_post080
+            event 83 release_post081
+            event 84 release_post082
+            event 85 release_post083
+            event 86 release_post084
+            event 87 release_post085
+            event 88 release_post086
+            event 89 release_post087
+            event 90 release_post088
+            event 91 release_post089
+            event 92 release_post090
+            event 93 release_post091
+            event 94 release_post092
+            event 95 release_post093
+            event 96 release_post094
+            event 97 release_post095
+            event 98 release_post096
+            event 99 release_post097
+            event 100 release_post098
+            event 101 release_post099
+            event 102 release_post100
+            event 103 release_post101
+            event 104 release_post102
+            event 105 release_post103
+            event 106 release_post104
+            event 107 release_post105
+            event 108 release_post106
+            event 109 release_post107
+            event 110 release_post108
+            event 111 release_post109
+            event 112 release_post110
+            event 113 release_post111
+            event 114 release_post112
+            event 115 release_post113
+            event 116 release_post114
+            event 117 release_post115
+            event 118 release_post116
+            event 119 release_post117
+            event 120 release_post118
+            event 121 release_post119
+            event 122 release_post120
+            event 123 release_post123
+            event 124 release_post126
+            event 125 release_post129
+            event 126 release_post132
+            event 127 release_post135
+            event 128 release_post138
+            event 129 release_post141
+            event 130 release_post144
+            event 131 release_post147
+            event 132 release_post150
+            event 133 release_post153
+            event 134 release_post156
+            event 135 release_post159
+            event 136 release_post162
+            event 137 release_post165
+            event 138 release_post168
+            event 139 release_post171
+            event 140 release_post174
+            event 141 release_post177
+            event 142 release_post180
+            event 143 release_post183
+            event 144 release_post186
+            event 145 release_post189
+            event 146 release_post192
+            event 147 release_post195
+            event 148 release_post198
+            event 149 release_post201
+            event 150 release_post204
+            event 151 release_post207
+            event 152 release_post210
+            event 153 release_post213
+            event 154 release_post216
+            event 155 release_post219
+            event 156 release_post222
+            event 157 release_post225
+            event 158 release_post228
+            event 159 release_post231
+            event 160 release_post234
+            event 161 release_post237
+            event 162 release_post240
+            event 163 release_post243
+            event 164 release_post246
+            event 165 release_post249
+            event 166 release_post252
+            event 167 release_post255
+            event 168 release_post258
+            event 169 release_post261
+            event 170 release_post264
+            event 171 release_post267
+            event 172 release_post270
+            event 173 release_post273
+            event 174 release_post276
+            event 175 release_post279
+            event 176 release_post282
+            event 177 release_post285
+            event 178 release_post288
+            event 179 release_post291
+            event 180 release_post294
+            event 181 release_post297
+            event 182 release_post300
+            event 183 release_post303
+            event 184 release_post306
+            event 185 release_post309
+            event 186 release_post312
+            event 187 release_post315
+            event 188 release_post318
+            event 189 release_post321
+            event 190 release_post324
+            event 191 release_post327
+            event 192 release_post330
+            event 193 release_post333
+            event 194 release_post336
+            event 195 release_post339
+            event 196 release_post342
+            event 197 release_post345
+            event 198 release_post348
+            event 199 release_post351
+            event 200 release_post354
+            event 201 release_post357
+            event 202 release_post360
+            event 203 release_post363
+            event 204 release_post366
+            event 205 release_post369
+            event 206 release_post372
+            event 207 release_post375
+            event 208 release_post378
+            event 209 release_post381
+            event 210 release_post384
+          task jgfs_atmos_post_anl
+            trigger ./jgfs_atmos_post_manager:release_postanl
+            edit FHRGRP '000'
+            edit FHRLST 'anl'
+            edit HR 'anl'
+            edit FHR 'anl'
+          task jgfs_atmos_post_f000
+            trigger ./jgfs_atmos_post_manager:release_post000
+            edit FHRGRP '001'
+            edit FHRLST 'f000'
+            edit FHR 'f000'
+            edit HR '000'
+          task jgfs_atmos_post_f001
+            trigger ./jgfs_atmos_post_manager:release_post001
+            edit FHRGRP '002'
+            edit FHRLST 'f001'
+            edit FHR 'f001'
+            edit HR '001'
+          task jgfs_atmos_post_f002
+            trigger ./jgfs_atmos_post_manager:release_post002
+            edit FHRGRP '003'
+            edit FHRLST 'f002'
+            edit FHR 'f002'
+            edit HR '002'
+          task jgfs_atmos_post_f003
+            trigger ./jgfs_atmos_post_manager:release_post003
+            edit FHRGRP '004'
+            edit FHRLST 'f003'
+            edit FHR 'f003'
+            edit HR '003'
+          task jgfs_atmos_post_f004
+            trigger ./jgfs_atmos_post_manager:release_post004
+            edit FHRGRP '005'
+            edit FHRLST 'f004'
+            edit FHR 'f004'
+            edit HR '004'
+          task jgfs_atmos_post_f005
+            trigger ./jgfs_atmos_post_manager:release_post005
+            edit FHRGRP '006'
+            edit FHRLST 'f005'
+            edit FHR 'f005'
+            edit HR '005'
+          task jgfs_atmos_post_f006
+            trigger ./jgfs_atmos_post_manager:release_post006
+            edit FHRGRP '007'
+            edit FHRLST 'f006'
+            edit FHR 'f006'
+            edit HR '006'
+          task jgfs_atmos_post_f007
+            trigger ./jgfs_atmos_post_manager:release_post007
+            edit FHRGRP '008'
+            edit FHRLST 'f007'
+            edit FHR 'f007'
+            edit HR '007'
+          task jgfs_atmos_post_f008
+            trigger ./jgfs_atmos_post_manager:release_post008
+            edit FHRGRP '009'
+            edit FHRLST 'f008'
+            edit FHR 'f008'
+            edit HR '008'
+          task jgfs_atmos_post_f009
+            trigger ./jgfs_atmos_post_manager:release_post009
+            edit FHRGRP '010'
+            edit FHRLST 'f009'
+            edit FHR 'f009'
+            edit HR '009'
+          task jgfs_atmos_post_f010
+            trigger ./jgfs_atmos_post_manager:release_post010
+            edit FHRGRP '011'
+            edit FHRLST 'f010'
+            edit FHR 'f010'
+            edit HR '010'
+          task jgfs_atmos_post_f011
+            trigger ./jgfs_atmos_post_manager:release_post011
+            edit FHRGRP '012'
+            edit FHRLST 'f011'
+            edit FHR 'f011'
+            edit HR '011'
+          task jgfs_atmos_post_f012
+            trigger ./jgfs_atmos_post_manager:release_post012
+            edit FHRGRP '013'
+            edit FHRLST 'f012'
+            edit FHR 'f012'
+            edit HR '012'
+          task jgfs_atmos_post_f013
+            trigger ./jgfs_atmos_post_manager:release_post013
+            edit FHRGRP '014'
+            edit FHRLST 'f013'
+            edit FHR 'f013'
+            edit HR '013'
+          task jgfs_atmos_post_f014
+            trigger ./jgfs_atmos_post_manager:release_post014
+            edit FHRGRP '015'
+            edit FHRLST 'f014'
+            edit FHR 'f014'
+            edit HR '014'
+          task jgfs_atmos_post_f015
+            trigger ./jgfs_atmos_post_manager:release_post015
+            edit FHRGRP '016'
+            edit FHRLST 'f015'
+            edit FHR 'f015'
+            edit HR '015'
+          task jgfs_atmos_post_f016
+            trigger ./jgfs_atmos_post_manager:release_post016
+            edit FHRGRP '017'
+            edit FHRLST 'f016'
+            edit FHR 'f016'
+            edit HR '016'
+          task jgfs_atmos_post_f017
+            trigger ./jgfs_atmos_post_manager:release_post017
+            edit FHRGRP '018'
+            edit FHRLST 'f017'
+            edit FHR 'f017'
+            edit HR '017'
+          task jgfs_atmos_post_f018
+            trigger ./jgfs_atmos_post_manager:release_post018
+            edit FHRGRP '019'
+            edit FHRLST 'f018'
+            edit FHR 'f018'
+            edit HR '018'
+          task jgfs_atmos_post_f019
+            trigger ./jgfs_atmos_post_manager:release_post019
+            edit FHRGRP '020'
+            edit FHRLST 'f019'
+            edit FHR 'f019'
+            edit HR '019'
+          task jgfs_atmos_post_f020
+            trigger ./jgfs_atmos_post_manager:release_post020
+            edit FHRGRP '021'
+            edit FHRLST 'f020'
+            edit FHR 'f020'
+            edit HR '020'
+          task jgfs_atmos_post_f021
+            trigger ./jgfs_atmos_post_manager:release_post021
+            edit FHRGRP '022'
+            edit FHRLST 'f021'
+            edit FHR 'f021'
+            edit HR '021'
+          task jgfs_atmos_post_f022
+            trigger ./jgfs_atmos_post_manager:release_post022
+            edit FHRGRP '023'
+            edit FHRLST 'f022'
+            edit FHR 'f022'
+            edit HR '022'
+          task jgfs_atmos_post_f023
+            trigger ./jgfs_atmos_post_manager:release_post023
+            edit FHRGRP '024'
+            edit FHRLST 'f023'
+            edit FHR 'f023'
+            edit HR '023'
+          task jgfs_atmos_post_f024
+            trigger ./jgfs_atmos_post_manager:release_post024
+            edit FHRGRP '025'
+            edit FHRLST 'f024'
+            edit FHR 'f024'
+            edit HR '024'
+          task jgfs_atmos_post_f025
+            trigger ./jgfs_atmos_post_manager:release_post025
+            edit FHRGRP '026'
+            edit FHRLST 'f025'
+            edit FHR 'f025'
+            edit HR '025'
+          task jgfs_atmos_post_f026
+            trigger ./jgfs_atmos_post_manager:release_post026
+            edit FHRGRP '027'
+            edit FHRLST 'f026'
+            edit FHR 'f026'
+            edit HR '026'
+          task jgfs_atmos_post_f027
+            trigger ./jgfs_atmos_post_manager:release_post027
+            edit FHRGRP '028'
+            edit FHRLST 'f027'
+            edit FHR 'f027'
+            edit HR '027'
+          task jgfs_atmos_post_f028
+            trigger ./jgfs_atmos_post_manager:release_post028
+            edit FHRGRP '029'
+            edit FHRLST 'f028'
+            edit FHR 'f028'
+            edit HR '028'
+          task jgfs_atmos_post_f029
+            trigger ./jgfs_atmos_post_manager:release_post029
+            edit FHRGRP '030'
+            edit FHRLST 'f029'
+            edit FHR 'f029'
+            edit HR '029'
+          task jgfs_atmos_post_f030
+            trigger ./jgfs_atmos_post_manager:release_post030
+            edit FHRGRP '031'
+            edit FHRLST 'f030'
+            edit FHR 'f030'
+            edit HR '030'
+          task jgfs_atmos_post_f031
+            trigger ./jgfs_atmos_post_manager:release_post031
+            edit FHRGRP '032'
+            edit FHRLST 'f031'
+            edit FHR 'f031'
+            edit HR '031'
+          task jgfs_atmos_post_f032
+            trigger ./jgfs_atmos_post_manager:release_post032
+            edit FHRGRP '033'
+            edit FHRLST 'f032'
+            edit FHR 'f032'
+            edit HR '032'
+          task jgfs_atmos_post_f033
+            trigger ./jgfs_atmos_post_manager:release_post033
+            edit FHRGRP '034'
+            edit FHRLST 'f033'
+            edit FHR 'f033'
+            edit HR '033'
+          task jgfs_atmos_post_f034
+            trigger ./jgfs_atmos_post_manager:release_post034
+            edit FHRGRP '035'
+            edit FHRLST 'f034'
+            edit FHR 'f034'
+            edit HR '034'
+          task jgfs_atmos_post_f035
+            trigger ./jgfs_atmos_post_manager:release_post035
+            edit FHRGRP '036'
+            edit FHRLST 'f035'
+            edit FHR 'f035'
+            edit HR '035'
+          task jgfs_atmos_post_f036
+            trigger ./jgfs_atmos_post_manager:release_post036
+            edit FHRGRP '037'
+            edit FHRLST 'f036'
+            edit FHR 'f036'
+            edit HR '036'
+          task jgfs_atmos_post_f037
+            trigger ./jgfs_atmos_post_manager:release_post037
+            edit FHRGRP '038'
+            edit FHRLST 'f037'
+            edit FHR 'f037'
+            edit HR '037'
+          task jgfs_atmos_post_f038
+            trigger ./jgfs_atmos_post_manager:release_post038
+            edit FHRGRP '039'
+            edit FHRLST 'f038'
+            edit FHR 'f038'
+            edit HR '038'
+          task jgfs_atmos_post_f039
+            trigger ./jgfs_atmos_post_manager:release_post039
+            edit FHRGRP '040'
+            edit FHRLST 'f039'
+            edit FHR 'f039'
+            edit HR '039'
+          task jgfs_atmos_post_f040
+            trigger ./jgfs_atmos_post_manager:release_post040
+            edit FHRGRP '041'
+            edit FHRLST 'f040'
+            edit FHR 'f040'
+            edit HR '040'
+          task jgfs_atmos_post_f041
+            trigger ./jgfs_atmos_post_manager:release_post041
+            edit FHRGRP '042'
+            edit FHRLST 'f041'
+            edit FHR 'f041'
+            edit HR '041'
+          task jgfs_atmos_post_f042
+            trigger ./jgfs_atmos_post_manager:release_post042
+            edit FHRGRP '043'
+            edit FHRLST 'f042'
+            edit FHR 'f042'
+            edit HR '042'
+          task jgfs_atmos_post_f043
+            trigger ./jgfs_atmos_post_manager:release_post043
+            edit FHRGRP '044'
+            edit FHRLST 'f043'
+            edit FHR 'f043'
+            edit HR '043'
+          task jgfs_atmos_post_f044
+            trigger ./jgfs_atmos_post_manager:release_post044
+            edit FHRGRP '045'
+            edit FHRLST 'f044'
+            edit FHR 'f044'
+            edit HR '044'
+          task jgfs_atmos_post_f045
+            trigger ./jgfs_atmos_post_manager:release_post045
+            edit FHRGRP '046'
+            edit FHRLST 'f045'
+            edit FHR 'f045'
+            edit HR '045'
+          task jgfs_atmos_post_f046
+            trigger ./jgfs_atmos_post_manager:release_post046
+            edit FHRGRP '047'
+            edit FHRLST 'f046'
+            edit FHR 'f046'
+            edit HR '046'
+          task jgfs_atmos_post_f047
+            trigger ./jgfs_atmos_post_manager:release_post047
+            edit FHRGRP '048'
+            edit FHRLST 'f047'
+            edit FHR 'f047'
+            edit HR '047'
+          task jgfs_atmos_post_f048
+            trigger ./jgfs_atmos_post_manager:release_post048
+            edit FHRGRP '049'
+            edit FHRLST 'f048'
+            edit FHR 'f048'
+            edit HR '048'
+          task jgfs_atmos_post_f049
+            trigger ./jgfs_atmos_post_manager:release_post049
+            edit FHRGRP '050'
+            edit FHRLST 'f049'
+            edit FHR 'f049'
+            edit HR '049'
+          task jgfs_atmos_post_f050
+            trigger ./jgfs_atmos_post_manager:release_post050
+            edit FHRGRP '051'
+            edit FHRLST 'f050'
+            edit FHR 'f050'
+            edit HR '050'
+          task jgfs_atmos_post_f051
+            trigger ./jgfs_atmos_post_manager:release_post051
+            edit FHRGRP '052'
+            edit FHRLST 'f051'
+            edit FHR 'f051'
+            edit HR '051'
+          task jgfs_atmos_post_f052
+            trigger ./jgfs_atmos_post_manager:release_post052
+            edit FHRGRP '053'
+            edit FHRLST 'f052'
+            edit FHR 'f052'
+            edit HR '052'
+          task jgfs_atmos_post_f053
+            trigger ./jgfs_atmos_post_manager:release_post053
+            edit FHRGRP '054'
+            edit FHRLST 'f053'
+            edit FHR 'f053'
+            edit HR '053'
+          task jgfs_atmos_post_f054
+            trigger ./jgfs_atmos_post_manager:release_post054
+            edit FHRGRP '055'
+            edit FHRLST 'f054'
+            edit FHR 'f054'
+            edit HR '054'
+          task jgfs_atmos_post_f055
+            trigger ./jgfs_atmos_post_manager:release_post055
+            edit FHRGRP '056'
+            edit FHRLST 'f055'
+            edit FHR 'f055'
+            edit HR '055'
+          task jgfs_atmos_post_f056
+            trigger ./jgfs_atmos_post_manager:release_post056
+            edit FHRGRP '057'
+            edit FHRLST 'f056'
+            edit FHR 'f056'
+            edit HR '056'
+          task jgfs_atmos_post_f057
+            trigger ./jgfs_atmos_post_manager:release_post057
+            edit FHRGRP '058'
+            edit FHRLST 'f057'
+            edit FHR 'f057'
+            edit HR '057'
+          task jgfs_atmos_post_f058
+            trigger ./jgfs_atmos_post_manager:release_post058
+            edit FHRGRP '059'
+            edit FHRLST 'f058'
+            edit FHR 'f058'
+            edit HR '058'
+          task jgfs_atmos_post_f059
+            trigger ./jgfs_atmos_post_manager:release_post059
+            edit FHRGRP '060'
+            edit FHRLST 'f059'
+            edit FHR 'f059'
+            edit HR '059'
+          task jgfs_atmos_post_f060
+            trigger ./jgfs_atmos_post_manager:release_post060
+            edit FHRGRP '061'
+            edit FHRLST 'f060'
+            edit FHR 'f060'
+            edit HR '060'
+          task jgfs_atmos_post_f061
+            trigger ./jgfs_atmos_post_manager:release_post061
+            edit FHRGRP '062'
+            edit FHRLST 'f061'
+            edit FHR 'f061'
+            edit HR '061'
+          task jgfs_atmos_post_f062
+            trigger ./jgfs_atmos_post_manager:release_post062
+            edit FHRGRP '063'
+            edit FHRLST 'f062'
+            edit FHR 'f062'
+            edit HR '062'
+          task jgfs_atmos_post_f063
+            trigger ./jgfs_atmos_post_manager:release_post063
+            edit FHRGRP '064'
+            edit FHRLST 'f063'
+            edit FHR 'f063'
+            edit HR '063'
+          task jgfs_atmos_post_f064
+            trigger ./jgfs_atmos_post_manager:release_post064
+            edit FHRGRP '065'
+            edit FHRLST 'f064'
+            edit FHR 'f064'
+            edit HR '064'
+          task jgfs_atmos_post_f065
+            trigger ./jgfs_atmos_post_manager:release_post065
+            edit FHRGRP '066'
+            edit FHRLST 'f065'
+            edit FHR 'f065'
+            edit HR '065'
+          task jgfs_atmos_post_f066
+            trigger ./jgfs_atmos_post_manager:release_post066
+            edit FHRGRP '067'
+            edit FHRLST 'f066'
+            edit FHR 'f066'
+            edit HR '066'
+          task jgfs_atmos_post_f067
+            trigger ./jgfs_atmos_post_manager:release_post067
+            edit FHRGRP '068'
+            edit FHRLST 'f067'
+            edit FHR 'f067'
+            edit HR '067'
+          task jgfs_atmos_post_f068
+            trigger ./jgfs_atmos_post_manager:release_post068
+            edit FHRGRP '069'
+            edit FHRLST 'f068'
+            edit FHR 'f068'
+            edit HR '068'
+          task jgfs_atmos_post_f069
+            trigger ./jgfs_atmos_post_manager:release_post069
+            edit FHRGRP '070'
+            edit FHRLST 'f069'
+            edit FHR 'f069'
+            edit HR '069'
+          task jgfs_atmos_post_f070
+            trigger ./jgfs_atmos_post_manager:release_post070
+            edit FHRGRP '071'
+            edit FHRLST 'f070'
+            edit FHR 'f070'
+            edit HR '070'
+          task jgfs_atmos_post_f071
+            trigger ./jgfs_atmos_post_manager:release_post071
+            edit FHRGRP '072'
+            edit FHRLST 'f071'
+            edit FHR 'f071'
+            edit HR '071'
+          task jgfs_atmos_post_f072
+            trigger ./jgfs_atmos_post_manager:release_post072
+            edit FHRGRP '073'
+            edit FHRLST 'f072'
+            edit FHR 'f072'
+            edit HR '072'
+          task jgfs_atmos_post_f073
+            trigger ./jgfs_atmos_post_manager:release_post073
+            edit FHRGRP '074'
+            edit FHRLST 'f073'
+            edit FHR 'f073'
+            edit HR '073'
+          task jgfs_atmos_post_f074
+            trigger ./jgfs_atmos_post_manager:release_post074
+            edit FHRGRP '075'
+            edit FHRLST 'f074'
+            edit FHR 'f074'
+            edit HR '074'
+          task jgfs_atmos_post_f075
+            trigger ./jgfs_atmos_post_manager:release_post075
+            edit FHRGRP '076'
+            edit FHRLST 'f075'
+            edit FHR 'f075'
+            edit HR '075'
+          task jgfs_atmos_post_f076
+            trigger ./jgfs_atmos_post_manager:release_post076
+            edit FHRGRP '077'
+            edit FHRLST 'f076'
+            edit FHR 'f076'
+            edit HR '076'
+          task jgfs_atmos_post_f077
+            trigger ./jgfs_atmos_post_manager:release_post077
+            edit FHRGRP '078'
+            edit FHRLST 'f077'
+            edit FHR 'f077'
+            edit HR '077'
+          task jgfs_atmos_post_f078
+            trigger ./jgfs_atmos_post_manager:release_post078
+            edit FHRGRP '079'
+            edit FHRLST 'f078'
+            edit FHR 'f078'
+            edit HR '078'
+          task jgfs_atmos_post_f079
+            trigger ./jgfs_atmos_post_manager:release_post079
+            edit FHRGRP '080'
+            edit FHRLST 'f079'
+            edit FHR 'f079'
+            edit HR '079'
+          task jgfs_atmos_post_f080
+            trigger ./jgfs_atmos_post_manager:release_post080
+            edit FHRGRP '081'
+            edit FHRLST 'f080'
+            edit FHR 'f080'
+            edit HR '080'
+          task jgfs_atmos_post_f081
+            trigger ./jgfs_atmos_post_manager:release_post081
+            edit FHRGRP '082'
+            edit FHRLST 'f081'
+            edit FHR 'f081'
+            edit HR '081'
+          task jgfs_atmos_post_f082
+            trigger ./jgfs_atmos_post_manager:release_post082
+            edit FHRGRP '083'
+            edit FHRLST 'f082'
+            edit FHR 'f082'
+            edit HR '082'
+          task jgfs_atmos_post_f083
+            trigger ./jgfs_atmos_post_manager:release_post083
+            edit FHRGRP '084'
+            edit FHRLST 'f083'
+            edit FHR 'f083'
+            edit HR '083'
+          task jgfs_atmos_post_f084
+            trigger ./jgfs_atmos_post_manager:release_post084
+            edit FHRGRP '085'
+            edit FHRLST 'f084'
+            edit FHR 'f084'
+            edit HR '084'
+          task jgfs_atmos_post_f085
+            trigger ./jgfs_atmos_post_manager:release_post085
+            edit FHRGRP '086'
+            edit FHRLST 'f085'
+            edit FHR 'f085'
+            edit HR '085'
+          task jgfs_atmos_post_f086
+            trigger ./jgfs_atmos_post_manager:release_post086
+            edit FHRGRP '087'
+            edit FHRLST 'f086'
+            edit FHR 'f086'
+            edit HR '086'
+          task jgfs_atmos_post_f087
+            trigger ./jgfs_atmos_post_manager:release_post087
+            edit FHRGRP '088'
+            edit FHRLST 'f087'
+            edit FHR 'f087'
+            edit HR '087'
+          task jgfs_atmos_post_f088
+            trigger ./jgfs_atmos_post_manager:release_post088
+            edit FHRGRP '089'
+            edit FHRLST 'f088'
+            edit FHR 'f088'
+            edit HR '088'
+          task jgfs_atmos_post_f089
+            trigger ./jgfs_atmos_post_manager:release_post089
+            edit FHRGRP '090'
+            edit FHRLST 'f089'
+            edit FHR 'f089'
+            edit HR '089'
+          task jgfs_atmos_post_f090
+            trigger ./jgfs_atmos_post_manager:release_post090
+            edit FHRGRP '091'
+            edit FHRLST 'f090'
+            edit FHR 'f090'
+            edit HR '090'
+          task jgfs_atmos_post_f091
+            trigger ./jgfs_atmos_post_manager:release_post091
+            edit FHRGRP '092'
+            edit FHRLST 'f091'
+            edit FHR 'f091'
+            edit HR '091'
+          task jgfs_atmos_post_f092
+            trigger ./jgfs_atmos_post_manager:release_post092
+            edit FHRGRP '093'
+            edit FHRLST 'f092'
+            edit FHR 'f092'
+            edit HR '092'
+          task jgfs_atmos_post_f093
+            trigger ./jgfs_atmos_post_manager:release_post093
+            edit FHRGRP '094'
+            edit FHRLST 'f093'
+            edit FHR 'f093'
+            edit HR '093'
+          task jgfs_atmos_post_f094
+            trigger ./jgfs_atmos_post_manager:release_post094
+            edit FHRGRP '095'
+            edit FHRLST 'f094'
+            edit FHR 'f094'
+            edit HR '094'
+          task jgfs_atmos_post_f095
+            trigger ./jgfs_atmos_post_manager:release_post095
+            edit FHRGRP '096'
+            edit FHRLST 'f095'
+            edit FHR 'f095'
+            edit HR '095'
+          task jgfs_atmos_post_f096
+            trigger ./jgfs_atmos_post_manager:release_post096
+            edit FHRGRP '097'
+            edit FHRLST 'f096'
+            edit FHR 'f096'
+            edit HR '096'
+          task jgfs_atmos_post_f097
+            trigger ./jgfs_atmos_post_manager:release_post097
+            edit FHRGRP '098'
+            edit FHRLST 'f097'
+            edit FHR 'f097'
+            edit HR '097'
+          task jgfs_atmos_post_f098
+            trigger ./jgfs_atmos_post_manager:release_post098
+            edit FHRGRP '099'
+            edit FHRLST 'f098'
+            edit FHR 'f098'
+            edit HR '098'
+          task jgfs_atmos_post_f099
+            trigger ./jgfs_atmos_post_manager:release_post099
+            edit FHRGRP '100'
+            edit FHRLST 'f099'
+            edit FHR 'f099'
+            edit HR '099'
+          task jgfs_atmos_post_f100
+            trigger ./jgfs_atmos_post_manager:release_post100
+            edit FHRGRP '101'
+            edit FHRLST 'f100'
+            edit FHR 'f100'
+            edit HR '100'
+          task jgfs_atmos_post_f101
+            trigger ./jgfs_atmos_post_manager:release_post101
+            edit FHRGRP '102'
+            edit FHRLST 'f101'
+            edit FHR 'f101'
+            edit HR '101'
+          task jgfs_atmos_post_f102
+            trigger ./jgfs_atmos_post_manager:release_post102
+            edit FHRGRP '103'
+            edit FHRLST 'f102'
+            edit FHR 'f102'
+            edit HR '102'
+          task jgfs_atmos_post_f103
+            trigger ./jgfs_atmos_post_manager:release_post103
+            edit FHRGRP '104'
+            edit FHRLST 'f103'
+            edit FHR 'f103'
+            edit HR '103'
+          task jgfs_atmos_post_f104
+            trigger ./jgfs_atmos_post_manager:release_post104
+            edit FHRGRP '105'
+            edit FHRLST 'f104'
+            edit FHR 'f104'
+            edit HR '104'
+          task jgfs_atmos_post_f105
+            trigger ./jgfs_atmos_post_manager:release_post105
+            edit FHRGRP '106'
+            edit FHRLST 'f105'
+            edit FHR 'f105'
+            edit HR '105'
+          task jgfs_atmos_post_f106
+            trigger ./jgfs_atmos_post_manager:release_post106
+            edit FHRGRP '107'
+            edit FHRLST 'f106'
+            edit FHR 'f106'
+            edit HR '106'
+          task jgfs_atmos_post_f107
+            trigger ./jgfs_atmos_post_manager:release_post107
+            edit FHRGRP '108'
+            edit FHRLST 'f107'
+            edit FHR 'f107'
+            edit HR '107'
+          task jgfs_atmos_post_f108
+            trigger ./jgfs_atmos_post_manager:release_post108
+            edit FHRGRP '109'
+            edit FHRLST 'f108'
+            edit FHR 'f108'
+            edit HR '108'
+          task jgfs_atmos_post_f109
+            trigger ./jgfs_atmos_post_manager:release_post109
+            edit FHRGRP '110'
+            edit FHRLST 'f109'
+            edit FHR 'f109'
+            edit HR '109'
+          task jgfs_atmos_post_f110
+            trigger ./jgfs_atmos_post_manager:release_post110
+            edit FHRGRP '111'
+            edit FHRLST 'f110'
+            edit FHR 'f110'
+            edit HR '110'
+          task jgfs_atmos_post_f111
+            trigger ./jgfs_atmos_post_manager:release_post111
+            edit FHRGRP '112'
+            edit FHRLST 'f111'
+            edit FHR 'f111'
+            edit HR '111'
+          task jgfs_atmos_post_f112
+            trigger ./jgfs_atmos_post_manager:release_post112
+            edit FHRGRP '113'
+            edit FHRLST 'f112'
+            edit FHR 'f112'
+            edit HR '112'
+          task jgfs_atmos_post_f113
+            trigger ./jgfs_atmos_post_manager:release_post113
+            edit FHRGRP '114'
+            edit FHRLST 'f113'
+            edit FHR 'f113'
+            edit HR '113'
+          task jgfs_atmos_post_f114
+            trigger ./jgfs_atmos_post_manager:release_post114
+            edit FHRGRP '115'
+            edit FHRLST 'f114'
+            edit FHR 'f114'
+            edit HR '114'
+          task jgfs_atmos_post_f115
+            trigger ./jgfs_atmos_post_manager:release_post115
+            edit FHRGRP '116'
+            edit FHRLST 'f115'
+            edit FHR 'f115'
+            edit HR '115'
+          task jgfs_atmos_post_f116
+            trigger ./jgfs_atmos_post_manager:release_post116
+            edit FHRGRP '117'
+            edit FHRLST 'f116'
+            edit FHR 'f116'
+            edit HR '116'
+          task jgfs_atmos_post_f117
+            trigger ./jgfs_atmos_post_manager:release_post117
+            edit FHRGRP '118'
+            edit FHRLST 'f117'
+            edit FHR 'f117'
+            edit HR '117'
+          task jgfs_atmos_post_f118
+            trigger ./jgfs_atmos_post_manager:release_post118
+            edit FHRGRP '119'
+            edit FHRLST 'f118'
+            edit FHR 'f118'
+            edit HR '118'
+          task jgfs_atmos_post_f119
+            trigger ./jgfs_atmos_post_manager:release_post119
+            edit FHRGRP '120'
+            edit FHRLST 'f119'
+            edit FHR 'f119'
+            edit HR '119'
+          task jgfs_atmos_post_f120
+            trigger ./jgfs_atmos_post_manager:release_post120
+            edit FHRGRP '121'
+            edit FHRLST 'f120'
+            edit FHR 'f120'
+            edit HR '120'
+          task jgfs_atmos_post_f123
+            trigger ./jgfs_atmos_post_manager:release_post123
+            edit FHRGRP '122'
+            edit FHRLST 'f123'
+            edit FHR 'f123'
+            edit HR '123'
+          task jgfs_atmos_post_f126
+            trigger ./jgfs_atmos_post_manager:release_post126
+            edit FHRGRP '123'
+            edit FHRLST 'f126'
+            edit FHR 'f126'
+            edit HR '126'
+          task jgfs_atmos_post_f129
+            trigger ./jgfs_atmos_post_manager:release_post129
+            edit FHRGRP '124'
+            edit FHRLST 'f129'
+            edit FHR 'f129'
+            edit HR '129'
+          task jgfs_atmos_post_f132
+            trigger ./jgfs_atmos_post_manager:release_post132
+            edit FHRGRP '125'
+            edit FHRLST 'f132'
+            edit FHR 'f132'
+            edit HR '132'
+          task jgfs_atmos_post_f135
+            trigger ./jgfs_atmos_post_manager:release_post135
+            edit FHRGRP '126'
+            edit FHRLST 'f135'
+            edit FHR 'f135'
+            edit HR '135'
+          task jgfs_atmos_post_f138
+            trigger ./jgfs_atmos_post_manager:release_post138
+            edit FHRGRP '127'
+            edit FHRLST 'f138'
+            edit FHR 'f138'
+            edit HR '138'
+          task jgfs_atmos_post_f141
+            trigger ./jgfs_atmos_post_manager:release_post141
+            edit FHRGRP '128'
+            edit FHRLST 'f141'
+            edit FHR 'f141'
+            edit HR '141'
+          task jgfs_atmos_post_f144
+            trigger ./jgfs_atmos_post_manager:release_post144
+            edit FHRGRP '129'
+            edit FHRLST 'f144'
+            edit FHR 'f144'
+            edit HR '144'
+          task jgfs_atmos_post_f147
+            trigger ./jgfs_atmos_post_manager:release_post147
+            edit FHRGRP '130'
+            edit FHRLST 'f147'
+            edit FHR 'f147'
+            edit HR '147'
+          task jgfs_atmos_post_f150
+            trigger ./jgfs_atmos_post_manager:release_post150
+            edit FHRGRP '131'
+            edit FHRLST 'f150'
+            edit FHR 'f150'
+            edit HR '150'
+          task jgfs_atmos_post_f153
+            trigger ./jgfs_atmos_post_manager:release_post153
+            edit FHRGRP '132'
+            edit FHRLST 'f153'
+            edit FHR 'f153'
+            edit HR '153'
+          task jgfs_atmos_post_f156
+            trigger ./jgfs_atmos_post_manager:release_post156
+            edit FHRGRP '133'
+            edit FHRLST 'f156'
+            edit FHR 'f156'
+            edit HR '156'
+          task jgfs_atmos_post_f159
+            trigger ./jgfs_atmos_post_manager:release_post159
+            edit FHRGRP '134'
+            edit FHRLST 'f159'
+            edit FHR 'f159'
+            edit HR '159'
+          task jgfs_atmos_post_f162
+            trigger ./jgfs_atmos_post_manager:release_post162
+            edit FHRGRP '135'
+            edit FHRLST 'f162'
+            edit FHR 'f162'
+            edit HR '162'
+          task jgfs_atmos_post_f165
+            trigger ./jgfs_atmos_post_manager:release_post165
+            edit FHRGRP '136'
+            edit FHRLST 'f165'
+            edit FHR 'f165'
+            edit HR '165'
+          task jgfs_atmos_post_f168
+            trigger ./jgfs_atmos_post_manager:release_post168
+            edit FHRGRP '137'
+            edit FHRLST 'f168'
+            edit FHR 'f168'
+            edit HR '168'
+          task jgfs_atmos_post_f171
+            trigger ./jgfs_atmos_post_manager:release_post171
+            edit FHRGRP '138'
+            edit FHRLST 'f171'
+            edit FHR 'f171'
+            edit HR '171'
+          task jgfs_atmos_post_f174
+            trigger ./jgfs_atmos_post_manager:release_post174
+            edit FHRGRP '139'
+            edit FHRLST 'f174'
+            edit FHR 'f174'
+            edit HR '174'
+          task jgfs_atmos_post_f177
+            trigger ./jgfs_atmos_post_manager:release_post177
+            edit FHRGRP '140'
+            edit FHRLST 'f177'
+            edit FHR 'f177'
+            edit HR '177'
+          task jgfs_atmos_post_f180
+            trigger ./jgfs_atmos_post_manager:release_post180
+            edit FHRGRP '141'
+            edit FHRLST 'f180'
+            edit FHR 'f180'
+            edit HR '180'
+          task jgfs_atmos_post_f183
+            trigger ./jgfs_atmos_post_manager:release_post183
+            edit FHRGRP '142'
+            edit FHRLST 'f183'
+            edit FHR 'f183'
+            edit HR '183'
+          task jgfs_atmos_post_f186
+            trigger ./jgfs_atmos_post_manager:release_post186
+            edit FHRGRP '143'
+            edit FHRLST 'f186'
+            edit FHR 'f186'
+            edit HR '186'
+          task jgfs_atmos_post_f189
+            trigger ./jgfs_atmos_post_manager:release_post189
+            edit FHRGRP '144'
+            edit FHRLST 'f189'
+            edit FHR 'f189'
+            edit HR '189'
+          task jgfs_atmos_post_f192
+            trigger ./jgfs_atmos_post_manager:release_post192
+            edit FHRGRP '145'
+            edit FHRLST 'f192'
+            edit FHR 'f192'
+            edit HR '192'
+          task jgfs_atmos_post_f195
+            trigger ./jgfs_atmos_post_manager:release_post195
+            edit FHRGRP '146'
+            edit FHRLST 'f195'
+            edit FHR 'f195'
+            edit HR '195'
+          task jgfs_atmos_post_f198
+            trigger ./jgfs_atmos_post_manager:release_post198
+            edit FHRGRP '147'
+            edit FHRLST 'f198'
+            edit FHR 'f198'
+            edit HR '198'
+          task jgfs_atmos_post_f201
+            trigger ./jgfs_atmos_post_manager:release_post201
+            edit FHRGRP '148'
+            edit FHRLST 'f201'
+            edit FHR 'f201'
+            edit HR '201'
+          task jgfs_atmos_post_f204
+            trigger ./jgfs_atmos_post_manager:release_post204
+            edit FHRGRP '149'
+            edit FHRLST 'f204'
+            edit FHR 'f204'
+            edit HR '204'
+          task jgfs_atmos_post_f207
+            trigger ./jgfs_atmos_post_manager:release_post207
+            edit FHRGRP '150'
+            edit FHRLST 'f207'
+            edit FHR 'f207'
+            edit HR '207'
+          task jgfs_atmos_post_f210
+            trigger ./jgfs_atmos_post_manager:release_post210
+            edit FHRGRP '151'
+            edit FHRLST 'f210'
+            edit FHR 'f210'
+            edit HR '210'
+          task jgfs_atmos_post_f213
+            trigger ./jgfs_atmos_post_manager:release_post213
+            edit FHRGRP '152'
+            edit FHRLST 'f213'
+            edit FHR 'f213'
+            edit HR '213'
+          task jgfs_atmos_post_f216
+            trigger ./jgfs_atmos_post_manager:release_post216
+            edit FHRGRP '153'
+            edit FHRLST 'f216'
+            edit FHR 'f216'
+            edit HR '216'
+          task jgfs_atmos_post_f219
+            trigger ./jgfs_atmos_post_manager:release_post219
+            edit FHRGRP '154'
+            edit FHRLST 'f219'
+            edit FHR 'f219'
+            edit HR '219'
+          task jgfs_atmos_post_f222
+            trigger ./jgfs_atmos_post_manager:release_post222
+            edit FHRGRP '155'
+            edit FHRLST 'f222'
+            edit FHR 'f222'
+            edit HR '222'
+          task jgfs_atmos_post_f225
+            trigger ./jgfs_atmos_post_manager:release_post225
+            edit FHRGRP '156'
+            edit FHRLST 'f225'
+            edit FHR 'f225'
+            edit HR '225'
+          task jgfs_atmos_post_f228
+            trigger ./jgfs_atmos_post_manager:release_post228
+            edit FHRGRP '157'
+            edit FHRLST 'f228'
+            edit FHR 'f228'
+            edit HR '228'
+          task jgfs_atmos_post_f231
+            trigger ./jgfs_atmos_post_manager:release_post231
+            edit FHRGRP '158'
+            edit FHRLST 'f231'
+            edit FHR 'f231'
+            edit HR '231'
+          task jgfs_atmos_post_f234
+            trigger ./jgfs_atmos_post_manager:release_post234
+            edit FHRGRP '159'
+            edit FHRLST 'f234'
+            edit FHR 'f234'
+            edit HR '234'
+          task jgfs_atmos_post_f237
+            trigger ./jgfs_atmos_post_manager:release_post237
+            edit FHRGRP '160'
+            edit FHRLST 'f237'
+            edit FHR 'f237'
+            edit HR '237'
+          task jgfs_atmos_post_f240
+            trigger ./jgfs_atmos_post_manager:release_post240
+            edit FHRGRP '161'
+            edit FHRLST 'f240'
+            edit FHR 'f240'
+            edit HR '240'
+          task jgfs_atmos_post_f243
+            trigger ./jgfs_atmos_post_manager:release_post243
+            edit FHRGRP '162'
+            edit FHRLST 'f243'
+            edit FHR 'f243'
+            edit HR '243'
+          task jgfs_atmos_post_f246
+            trigger ./jgfs_atmos_post_manager:release_post246
+            edit FHRGRP '163'
+            edit FHRLST 'f246'
+            edit FHR 'f246'
+            edit HR '246'
+          task jgfs_atmos_post_f249
+            trigger ./jgfs_atmos_post_manager:release_post249
+            edit FHRGRP '164'
+            edit FHRLST 'f249'
+            edit FHR 'f249'
+            edit HR '249'
+          task jgfs_atmos_post_f252
+            trigger ./jgfs_atmos_post_manager:release_post252
+            edit FHRGRP '165'
+            edit FHRLST 'f252'
+            edit FHR 'f252'
+            edit HR '252'
+          task jgfs_atmos_post_f255
+            trigger ./jgfs_atmos_post_manager:release_post255
+            edit FHRGRP '166'
+            edit FHRLST 'f255'
+            edit FHR 'f255'
+            edit HR '255'
+          task jgfs_atmos_post_f258
+            trigger ./jgfs_atmos_post_manager:release_post258
+            edit FHRGRP '167'
+            edit FHRLST 'f258'
+            edit FHR 'f258'
+            edit HR '258'
+          task jgfs_atmos_post_f261
+            trigger ./jgfs_atmos_post_manager:release_post261
+            edit FHRGRP '168'
+            edit FHRLST 'f261'
+            edit FHR 'f261'
+            edit HR '261'
+          task jgfs_atmos_post_f264
+            trigger ./jgfs_atmos_post_manager:release_post264
+            edit FHRGRP '169'
+            edit FHRLST 'f264'
+            edit FHR 'f264'
+            edit HR '264'
+          task jgfs_atmos_post_f267
+            trigger ./jgfs_atmos_post_manager:release_post267
+            edit FHRGRP '170'
+            edit FHRLST 'f267'
+            edit FHR 'f267'
+            edit HR '267'
+          task jgfs_atmos_post_f270
+            trigger ./jgfs_atmos_post_manager:release_post270
+            edit FHRGRP '171'
+            edit FHRLST 'f270'
+            edit FHR 'f270'
+            edit HR '270'
+          task jgfs_atmos_post_f273
+            trigger ./jgfs_atmos_post_manager:release_post273
+            edit FHRGRP '172'
+            edit FHRLST 'f273'
+            edit FHR 'f273'
+            edit HR '273'
+          task jgfs_atmos_post_f276
+            trigger ./jgfs_atmos_post_manager:release_post276
+            edit FHRGRP '173'
+            edit FHRLST 'f276'
+            edit FHR 'f276'
+            edit HR '276'
+          task jgfs_atmos_post_f279
+            trigger ./jgfs_atmos_post_manager:release_post279
+            edit FHRGRP '174'
+            edit FHRLST 'f279'
+            edit FHR 'f279'
+            edit HR '279'
+          task jgfs_atmos_post_f282
+            trigger ./jgfs_atmos_post_manager:release_post282
+            edit FHRGRP '175'
+            edit FHRLST 'f282'
+            edit FHR 'f282'
+            edit HR '282'
+          task jgfs_atmos_post_f285
+            trigger ./jgfs_atmos_post_manager:release_post285
+            edit FHRGRP '176'
+            edit FHRLST 'f285'
+            edit FHR 'f285'
+            edit HR '285'
+          task jgfs_atmos_post_f288
+            trigger ./jgfs_atmos_post_manager:release_post288
+            edit FHRGRP '177'
+            edit FHRLST 'f288'
+            edit FHR 'f288'
+            edit HR '288'
+          task jgfs_atmos_post_f291
+            trigger ./jgfs_atmos_post_manager:release_post291
+            edit FHRGRP '178'
+            edit FHRLST 'f291'
+            edit FHR 'f291'
+            edit HR '291'
+          task jgfs_atmos_post_f294
+            trigger ./jgfs_atmos_post_manager:release_post294
+            edit FHRGRP '179'
+            edit FHRLST 'f294'
+            edit FHR 'f294'
+            edit HR '294'
+          task jgfs_atmos_post_f297
+            trigger ./jgfs_atmos_post_manager:release_post297
+            edit FHRGRP '180'
+            edit FHRLST 'f297'
+            edit FHR 'f297'
+            edit HR '297'
+          task jgfs_atmos_post_f300
+            trigger ./jgfs_atmos_post_manager:release_post300
+            edit FHRGRP '181'
+            edit FHRLST 'f300'
+            edit FHR 'f300'
+            edit HR '300'
+          task jgfs_atmos_post_f303
+            trigger ./jgfs_atmos_post_manager:release_post303
+            edit FHRGRP '182'
+            edit FHRLST 'f303'
+            edit FHR 'f303'
+            edit HR '303'
+          task jgfs_atmos_post_f306
+            trigger ./jgfs_atmos_post_manager:release_post306
+            edit FHRGRP '183'
+            edit FHRLST 'f306'
+            edit FHR 'f306'
+            edit HR '306'
+          task jgfs_atmos_post_f309
+            trigger ./jgfs_atmos_post_manager:release_post309
+            edit FHRGRP '184'
+            edit FHRLST 'f309'
+            edit FHR 'f309'
+            edit HR '309'
+          task jgfs_atmos_post_f312
+            trigger ./jgfs_atmos_post_manager:release_post312
+            edit FHRGRP '185'
+            edit FHRLST 'f312'
+            edit FHR 'f312'
+            edit HR '312'
+          task jgfs_atmos_post_f315
+            trigger ./jgfs_atmos_post_manager:release_post315
+            edit FHRGRP '186'
+            edit FHRLST 'f315'
+            edit FHR 'f315'
+            edit HR '315'
+          task jgfs_atmos_post_f318
+            trigger ./jgfs_atmos_post_manager:release_post318
+            edit FHRGRP '187'
+            edit FHRLST 'f318'
+            edit FHR 'f318'
+            edit HR '318'
+          task jgfs_atmos_post_f321
+            trigger ./jgfs_atmos_post_manager:release_post321
+            edit FHRGRP '188'
+            edit FHRLST 'f321'
+            edit FHR 'f321'
+            edit HR '321'
+          task jgfs_atmos_post_f324
+            trigger ./jgfs_atmos_post_manager:release_post324
+            edit FHRGRP '189'
+            edit FHRLST 'f324'
+            edit FHR 'f324'
+            edit HR '324'
+          task jgfs_atmos_post_f327
+            trigger ./jgfs_atmos_post_manager:release_post327
+            edit FHRGRP '190'
+            edit FHRLST 'f327'
+            edit FHR 'f327'
+            edit HR '327'
+          task jgfs_atmos_post_f330
+            trigger ./jgfs_atmos_post_manager:release_post330
+            edit FHRGRP '191'
+            edit FHRLST 'f330'
+            edit FHR 'f330'
+            edit HR '330'
+          task jgfs_atmos_post_f333
+            trigger ./jgfs_atmos_post_manager:release_post333
+            edit FHRGRP '192'
+            edit FHRLST 'f333'
+            edit FHR 'f333'
+            edit HR '333'
+          task jgfs_atmos_post_f336
+            trigger ./jgfs_atmos_post_manager:release_post336
+            edit FHRGRP '193'
+            edit FHRLST 'f336'
+            edit FHR 'f336'
+            edit HR '336'
+          task jgfs_atmos_post_f339
+            trigger ./jgfs_atmos_post_manager:release_post339
+            edit FHRGRP '194'
+            edit FHRLST 'f339'
+            edit FHR 'f339'
+            edit HR '339'
+          task jgfs_atmos_post_f342
+            trigger ./jgfs_atmos_post_manager:release_post342
+            edit FHRGRP '195'
+            edit FHRLST 'f342'
+            edit FHR 'f342'
+            edit HR '342'
+          task jgfs_atmos_post_f345
+            trigger ./jgfs_atmos_post_manager:release_post345
+            edit FHRGRP '196'
+            edit FHRLST 'f345'
+            edit FHR 'f345'
+            edit HR '345'
+          task jgfs_atmos_post_f348
+            trigger ./jgfs_atmos_post_manager:release_post348
+            edit FHRGRP '197'
+            edit FHRLST 'f348'
+            edit FHR 'f348'
+            edit HR '348'
+          task jgfs_atmos_post_f351
+            trigger ./jgfs_atmos_post_manager:release_post351
+            edit FHRGRP '198'
+            edit FHRLST 'f351'
+            edit FHR 'f351'
+            edit HR '351'
+          task jgfs_atmos_post_f354
+            trigger ./jgfs_atmos_post_manager:release_post354
+            edit FHRGRP '199'
+            edit FHRLST 'f354'
+            edit FHR 'f354'
+            edit HR '354'
+          task jgfs_atmos_post_f357
+            trigger ./jgfs_atmos_post_manager:release_post357
+            edit FHRGRP '200'
+            edit FHRLST 'f357'
+            edit FHR 'f357'
+            edit HR '357'
+          task jgfs_atmos_post_f360
+            trigger ./jgfs_atmos_post_manager:release_post360
+            edit FHRGRP '201'
+            edit FHRLST 'f360'
+            edit FHR 'f360'
+            edit HR '360'
+          task jgfs_atmos_post_f363
+            trigger ./jgfs_atmos_post_manager:release_post363
+            edit FHRGRP '202'
+            edit FHRLST 'f363'
+            edit FHR 'f363'
+            edit HR '363'
+          task jgfs_atmos_post_f366
+            trigger ./jgfs_atmos_post_manager:release_post366
+            edit FHRGRP '203'
+            edit FHRLST 'f366'
+            edit FHR 'f366'
+            edit HR '366'
+          task jgfs_atmos_post_f369
+            trigger ./jgfs_atmos_post_manager:release_post369
+            edit FHRGRP '204'
+            edit FHRLST 'f369'
+            edit FHR 'f369'
+            edit HR '369'
+          task jgfs_atmos_post_f372
+            trigger ./jgfs_atmos_post_manager:release_post372
+            edit FHRGRP '205'
+            edit FHRLST 'f372'
+            edit FHR 'f372'
+            edit HR '372'
+          task jgfs_atmos_post_f375
+            trigger ./jgfs_atmos_post_manager:release_post375
+            edit FHRGRP '206'
+            edit FHRLST 'f375'
+            edit FHR 'f375'
+            edit HR '375'
+          task jgfs_atmos_post_f378
+            trigger ./jgfs_atmos_post_manager:release_post378
+            edit FHRGRP '207'
+            edit FHRLST 'f378'
+            edit FHR 'f378'
+            edit HR '378'
+          task jgfs_atmos_post_f381
+            trigger ./jgfs_atmos_post_manager:release_post381
+            edit FHRGRP '208'
+            edit FHRLST 'f381'
+            edit FHR 'f381'
+            edit HR '381'
+          task jgfs_atmos_post_f384
+            trigger ./jgfs_atmos_post_manager:release_post384
+            edit FHRGRP '209'
+            edit FHRLST 'f384'
+            edit FHR 'f384'
+            edit HR '384'
+        endfamily
+        family post_processing
+          task jgfs_atmos_wafs_gcip
+            trigger ( :TIME >= 1040 and :TIME < 1640) and ../post/jgfs_atmos_post_f003 == complete
+          family grib_wafs
+            task jgfs_atmos_wafs_f000
+              trigger ../../post/jgfs_atmos_post_f000 == complete and ../../post/jgfs_atmos_post_f120 == complete and ../grib2_wafs/jgfs_atmos_wafs_grib2 == complete
+              edit FCSTHR '00'
+            task jgfs_atmos_wafs_f006
+              trigger ../../post/jgfs_atmos_post_f006 == complete and ./jgfs_atmos_wafs_f000 == complete
+              edit FCSTHR '06'
+            task jgfs_atmos_wafs_f012
+              trigger ../../post/jgfs_atmos_post_f012 == complete and ./jgfs_atmos_wafs_f006 == complete
+              edit FCSTHR '12'
+            task jgfs_atmos_wafs_f018
+              trigger ../../post/jgfs_atmos_post_f018 == complete and ./jgfs_atmos_wafs_f012 == complete
+              edit FCSTHR '18'
+            task jgfs_atmos_wafs_f024
+              trigger ../../post/jgfs_atmos_post_f024 == complete and ./jgfs_atmos_wafs_f018 == complete
+              edit FCSTHR '24'
+            task jgfs_atmos_wafs_f030
+              trigger ../../post/jgfs_atmos_post_f030 == complete and ./jgfs_atmos_wafs_f024 == complete
+              edit FCSTHR '30'
+            task jgfs_atmos_wafs_f036
+              trigger ../../post/jgfs_atmos_post_f036 == complete and ./jgfs_atmos_wafs_f030 == complete
+              edit FCSTHR '36'
+            task jgfs_atmos_wafs_f042
+              trigger ../../post/jgfs_atmos_post_f042 == complete and ./jgfs_atmos_wafs_f036 == complete
+              edit FCSTHR '42'
+            task jgfs_atmos_wafs_f048
+              trigger ../../post/jgfs_atmos_post_f048 == complete and ./jgfs_atmos_wafs_f042 == complete
+              edit FCSTHR '48'
+            task jgfs_atmos_wafs_f054
+              trigger ../../post/jgfs_atmos_post_f054 == complete and ./jgfs_atmos_wafs_f048 == complete
+              edit FCSTHR '54'
+            task jgfs_atmos_wafs_f060
+              trigger ../../post/jgfs_atmos_post_f060 == complete and ./jgfs_atmos_wafs_f054 == complete
+              edit FCSTHR '60'
+            task jgfs_atmos_wafs_f066
+              trigger ../../post/jgfs_atmos_post_f066 == complete and ./jgfs_atmos_wafs_f060 == complete
+              edit FCSTHR '66'
+            task jgfs_atmos_wafs_f072
+              trigger ../../post/jgfs_atmos_post_f072 == complete and ./jgfs_atmos_wafs_f066 == complete
+              edit FCSTHR '72'
+            task jgfs_atmos_wafs_f078
+              trigger ../../post/jgfs_atmos_post_f078 == complete and ./jgfs_atmos_wafs_f072 == complete
+              edit FCSTHR '78'
+            task jgfs_atmos_wafs_f084
+              trigger ../../post/jgfs_atmos_post_f084 == complete and ./jgfs_atmos_wafs_f078 == complete
+              edit FCSTHR '84'
+            task jgfs_atmos_wafs_f090
+              trigger ../../post/jgfs_atmos_post_f090 == complete and ./jgfs_atmos_wafs_f084 == complete
+              edit FCSTHR '90'
+            task jgfs_atmos_wafs_f096
+              trigger ../../post/jgfs_atmos_post_f096 == complete and ./jgfs_atmos_wafs_f090 == complete
+              edit FCSTHR '96'
+            task jgfs_atmos_wafs_f102
+              trigger ../../post/jgfs_atmos_post_f102 == complete and ./jgfs_atmos_wafs_f096 == complete
+              edit FCSTHR '102'
+            task jgfs_atmos_wafs_f108
+              trigger ../../post/jgfs_atmos_post_f108 == complete and ./jgfs_atmos_wafs_f102 == complete
+              edit FCSTHR '108'
+            task jgfs_atmos_wafs_f114
+              trigger ../../post/jgfs_atmos_post_f114 == complete and ./jgfs_atmos_wafs_f108 == complete
+              edit FCSTHR '114'
+            task jgfs_atmos_wafs_f120
+              trigger ../../post/jgfs_atmos_post_f120 == complete and ./jgfs_atmos_wafs_f114 == complete
+              edit FCSTHR '120'
+          endfamily
+          family grib2_wafs
+            task jgfs_atmos_wafs_grib2
+              trigger ../../post/jgfs_atmos_post_f000 == complete
+            task jgfs_atmos_wafs_grib2_0p25
+              trigger ../../post/jgfs_atmos_post_f036 == complete
+            task jgfs_atmos_wafs_blending
+              trigger ( :TIME >= 1033 and :TIME < 1633) and ./jgfs_atmos_wafs_grib2 == complete
+            task jgfs_atmos_wafs_blending_0p25
+              trigger ( :TIME >= 1025 and :TIME < 1625) and ./jgfs_atmos_wafs_grib2_0p25 == complete
+          endfamily
+          family bufr_sounding
+            task jgfs_atmos_postsnd
+              trigger ../../post/jgfs_atmos_post_manager:release_post000
+          endfamily
+          family bulletins
+            task jgfs_atmos_fbwind
+              trigger ../../post/jgfs_atmos_post_f006 == complete and ../../post/jgfs_atmos_post_f012 == complete and ../../post/jgfs_atmos_post_f024 == complete
+          endfamily
+          family awips_20km_1p0
+            task jgfs_atmos_awips_f000
+              trigger ../../post/jgfs_atmos_post_f000 == complete
+              edit FHRGRP '000'
+              edit FHRLST 'f000'
+              edit FCSTHR '000'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f003
+              trigger ../../post/jgfs_atmos_post_f003 == complete
+              edit FHRGRP '003'
+              edit FHRLST 'f003'
+              edit FCSTHR '003'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f006
+              trigger ../../post/jgfs_atmos_post_f006 == complete
+              edit FHRGRP '006'
+              edit FHRLST 'f006'
+              edit FCSTHR '006'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f009
+              trigger ../../post/jgfs_atmos_post_f009 == complete
+              edit FHRGRP '009'
+              edit FHRLST 'f009'
+              edit FCSTHR '009'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f012
+              trigger ../../post/jgfs_atmos_post_f012 == complete
+              edit FHRGRP '012'
+              edit FHRLST 'f012'
+              edit FCSTHR '012'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f015
+              trigger ../../post/jgfs_atmos_post_f015 == complete
+              edit FHRGRP '015'
+              edit FHRLST 'f015'
+              edit FCSTHR '015'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f018
+              trigger ../../post/jgfs_atmos_post_f018 == complete
+              edit FHRGRP '018'
+              edit FHRLST 'f018'
+              edit FCSTHR '018'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f021
+              trigger ../../post/jgfs_atmos_post_f021 == complete
+              edit FHRGRP '021'
+              edit FHRLST 'f021'
+              edit FCSTHR '021'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f024
+              trigger ../../post/jgfs_atmos_post_f024 == complete
+              edit FHRGRP '024'
+              edit FHRLST 'f024'
+              edit FCSTHR '024'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f027
+              trigger ../../post/jgfs_atmos_post_f027 == complete
+              edit FHRGRP '027'
+              edit FHRLST 'f027'
+              edit FCSTHR '027'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f030
+              trigger ../../post/jgfs_atmos_post_f030 == complete
+              edit FHRGRP '030'
+              edit FHRLST 'f030'
+              edit FCSTHR '030'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f033
+              trigger ../../post/jgfs_atmos_post_f033 == complete
+              edit FHRGRP '033'
+              edit FHRLST 'f033'
+              edit FCSTHR '033'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f036
+              trigger ../../post/jgfs_atmos_post_f036 == complete
+              edit FHRGRP '036'
+              edit FHRLST 'f036'
+              edit FCSTHR '036'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f039
+              trigger ../../post/jgfs_atmos_post_f039 == complete
+              edit FHRGRP '039'
+              edit FHRLST 'f039'
+              edit FCSTHR '039'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f042
+              trigger ../../post/jgfs_atmos_post_f042 == complete
+              edit FHRGRP '042'
+              edit FHRLST 'f042'
+              edit FCSTHR '042'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f045
+              trigger ../../post/jgfs_atmos_post_f045 == complete
+              edit FHRGRP '045'
+              edit FHRLST 'f045'
+              edit FCSTHR '045'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f048
+              trigger ../../post/jgfs_atmos_post_f048 == complete
+              edit FHRGRP '048'
+              edit FHRLST 'f048'
+              edit FCSTHR '048'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f051
+              trigger ../../post/jgfs_atmos_post_f051 == complete
+              edit FHRGRP '051'
+              edit FHRLST 'f051'
+              edit FCSTHR '051'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f054
+              trigger ../../post/jgfs_atmos_post_f054 == complete
+              edit FHRGRP '054'
+              edit FHRLST 'f054'
+              edit FCSTHR '054'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f057
+              trigger ../../post/jgfs_atmos_post_f057 == complete
+              edit FHRGRP '057'
+              edit FHRLST 'f057'
+              edit FCSTHR '057'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f060
+              trigger ../../post/jgfs_atmos_post_f060 == complete
+              edit FHRGRP '060'
+              edit FHRLST 'f060'
+              edit FCSTHR '060'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f063
+              trigger ../../post/jgfs_atmos_post_f063 == complete
+              edit FHRGRP '063'
+              edit FHRLST 'f063'
+              edit FCSTHR '063'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f066
+              trigger ../../post/jgfs_atmos_post_f066 == complete
+              edit FHRGRP '066'
+              edit FHRLST 'f066'
+              edit FCSTHR '066'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f069
+              trigger ../../post/jgfs_atmos_post_f069 == complete
+              edit FHRGRP '069'
+              edit FHRLST 'f069'
+              edit FCSTHR '069'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f072
+              trigger ../../post/jgfs_atmos_post_f072 == complete
+              edit FHRGRP '072'
+              edit FHRLST 'f072'
+              edit FCSTHR '072'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f075
+              trigger ../../post/jgfs_atmos_post_f075 == complete
+              edit FHRGRP '075'
+              edit FHRLST 'f075'
+              edit FCSTHR '075'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f078
+              trigger ../../post/jgfs_atmos_post_f078 == complete
+              edit FHRGRP '078'
+              edit FHRLST 'f078'
+              edit FCSTHR '078'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f081
+              trigger ../../post/jgfs_atmos_post_f081 == complete
+              edit FHRGRP '081'
+              edit FHRLST 'f081'
+              edit FCSTHR '081'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f084
+              trigger ../../post/jgfs_atmos_post_f084 == complete
+              edit FHRGRP '084'
+              edit FHRLST 'f084'
+              edit FCSTHR '084'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f090
+              trigger ../../post/jgfs_atmos_post_f090 == complete
+              edit FHRGRP '090'
+              edit FHRLST 'f090'
+              edit FCSTHR '090'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f096
+              trigger ../../post/jgfs_atmos_post_f096 == complete
+              edit FHRGRP '096'
+              edit FHRLST 'f096'
+              edit FCSTHR '096'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f102
+              trigger ../../post/jgfs_atmos_post_f102 == complete
+              edit FHRGRP '102'
+              edit FHRLST 'f102'
+              edit FCSTHR '102'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f108
+              trigger ../../post/jgfs_atmos_post_f108 == complete
+              edit FHRGRP '108'
+              edit FHRLST 'f108'
+              edit FCSTHR '108'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f114
+              trigger ../../post/jgfs_atmos_post_f114 == complete
+              edit FHRGRP '114'
+              edit FHRLST 'f114'
+              edit FCSTHR '114'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f120
+              trigger ../../post/jgfs_atmos_post_f120 == complete
+              edit FHRGRP '120'
+              edit FHRLST 'f120'
+              edit FCSTHR '120'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f126
+              trigger ../../post/jgfs_atmos_post_f126 == complete
+              edit FHRGRP '126'
+              edit FHRLST 'f126'
+              edit FCSTHR '126'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f132
+              trigger ../../post/jgfs_atmos_post_f132 == complete
+              edit FHRGRP '132'
+              edit FHRLST 'f132'
+              edit FCSTHR '132'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f138
+              trigger ../../post/jgfs_atmos_post_f138 == complete
+              edit FHRGRP '138'
+              edit FHRLST 'f138'
+              edit FCSTHR '138'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f144
+              trigger ../../post/jgfs_atmos_post_f144 == complete
+              edit FHRGRP '144'
+              edit FHRLST 'f144'
+              edit FCSTHR '144'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f150
+              trigger ../../post/jgfs_atmos_post_f150 == complete
+              edit FHRGRP '150'
+              edit FHRLST 'f150'
+              edit FCSTHR '150'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f156
+              trigger ../../post/jgfs_atmos_post_f156 == complete
+              edit FHRGRP '156'
+              edit FHRLST 'f156'
+              edit FCSTHR '156'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f162
+              trigger ../../post/jgfs_atmos_post_f162 == complete
+              edit FHRGRP '162'
+              edit FHRLST 'f162'
+              edit FCSTHR '162'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f168
+              trigger ../../post/jgfs_atmos_post_f168 == complete
+              edit FHRGRP '168'
+              edit FHRLST 'f168'
+              edit FCSTHR '168'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f174
+              trigger ../../post/jgfs_atmos_post_f174 == complete
+              edit FHRGRP '174'
+              edit FHRLST 'f174'
+              edit FCSTHR '174'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f180
+              trigger ../../post/jgfs_atmos_post_f180 == complete
+              edit FHRGRP '180'
+              edit FHRLST 'f180'
+              edit FCSTHR '180'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f186
+              trigger ../../post/jgfs_atmos_post_f186 == complete
+              edit FHRGRP '186'
+              edit FHRLST 'f186'
+              edit FCSTHR '186'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f192
+              trigger ../../post/jgfs_atmos_post_f192 == complete
+              edit FHRGRP '192'
+              edit FHRLST 'f192'
+              edit FCSTHR '192'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f198
+              trigger ../../post/jgfs_atmos_post_f198 == complete
+              edit FHRGRP '198'
+              edit FHRLST 'f198'
+              edit FCSTHR '198'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f204
+              trigger ../../post/jgfs_atmos_post_f204 == complete
+              edit FHRGRP '204'
+              edit FHRLST 'f204'
+              edit FCSTHR '204'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f210
+              trigger ../../post/jgfs_atmos_post_f210 == complete
+              edit FHRGRP '210'
+              edit FHRLST 'f210'
+              edit FCSTHR '210'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f216
+              trigger ../../post/jgfs_atmos_post_f216 == complete
+              edit FHRGRP '216'
+              edit FHRLST 'f216'
+              edit FCSTHR '216'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f222
+              trigger ../../post/jgfs_atmos_post_f222 == complete
+              edit FHRGRP '222'
+              edit FHRLST 'f222'
+              edit FCSTHR '222'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f228
+              trigger ../../post/jgfs_atmos_post_f228 == complete
+              edit FHRGRP '228'
+              edit FHRLST 'f228'
+              edit FCSTHR '228'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f234
+              trigger ../../post/jgfs_atmos_post_f234 == complete
+              edit FHRGRP '234'
+              edit FHRLST 'f234'
+              edit FCSTHR '234'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f240
+              trigger ../../post/jgfs_atmos_post_f240 == complete
+              edit FHRGRP '240'
+              edit FHRLST 'f240'
+              edit FCSTHR '240'
+              edit TRDRUN 'YES'
+          endfamily
+          family awips_g2
+            task jgfs_atmos_awips_g2_f000
+              trigger ../../post/jgfs_atmos_post_f000 == complete
+              edit FHRGRP '000'
+              edit FHRLST 'f000'
+              edit FCSTHR '000'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f006
+              trigger ../../post/jgfs_atmos_post_f006 == complete
+              edit FHRGRP '006'
+              edit FHRLST 'f006'
+              edit FCSTHR '006'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f012
+              trigger ../../post/jgfs_atmos_post_f012 == complete
+              edit FHRGRP '012'
+              edit FHRLST 'f012'
+              edit FCSTHR '012'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f018
+              trigger ../../post/jgfs_atmos_post_f018 == complete
+              edit FHRGRP '018'
+              edit FHRLST 'f018'
+              edit FCSTHR '018'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f024
+              trigger ../../post/jgfs_atmos_post_f024 == complete
+              edit FHRGRP '024'
+              edit FHRLST 'f024'
+              edit FCSTHR '024'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f030
+              trigger ../../post/jgfs_atmos_post_f030 == complete
+              edit FHRGRP '030'
+              edit FHRLST 'f030'
+              edit FCSTHR '030'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f036
+              trigger ../../post/jgfs_atmos_post_f036 == complete
+              edit FHRGRP '036'
+              edit FHRLST 'f036'
+              edit FCSTHR '036'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f042
+              trigger ../../post/jgfs_atmos_post_f042 == complete
+              edit FHRGRP '042'
+              edit FHRLST 'f042'
+              edit FCSTHR '042'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f048
+              trigger ../../post/jgfs_atmos_post_f048 == complete
+              edit FHRGRP '048'
+              edit FHRLST 'f048'
+              edit FCSTHR '048'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f054
+              trigger ../../post/jgfs_atmos_post_f054 == complete
+              edit FHRGRP '054'
+              edit FHRLST 'f054'
+              edit FCSTHR '054'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f060
+              trigger ../../post/jgfs_atmos_post_f060 == complete
+              edit FHRGRP '060'
+              edit FHRLST 'f060'
+              edit FCSTHR '060'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f066
+              trigger ../../post/jgfs_atmos_post_f066 == complete
+              edit FHRGRP '066'
+              edit FHRLST 'f066'
+              edit FCSTHR '066'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f072
+              trigger ../../post/jgfs_atmos_post_f072 == complete
+              edit FHRGRP '072'
+              edit FHRLST 'f072'
+              edit FCSTHR '072'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f078
+              trigger ../../post/jgfs_atmos_post_f078 == complete
+              edit FHRGRP '078'
+              edit FHRLST 'f078'
+              edit FCSTHR '078'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f084
+              trigger ../../post/jgfs_atmos_post_f084 == complete
+              edit FHRGRP '084'
+              edit FHRLST 'f084'
+              edit FCSTHR '084'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f090
+              trigger ../../post/jgfs_atmos_post_f090 == complete
+              edit FHRGRP '090'
+              edit FHRLST 'f090'
+              edit FCSTHR '090'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f096
+              trigger ../../post/jgfs_atmos_post_f096 == complete
+              edit FHRGRP '096'
+              edit FHRLST 'f096'
+              edit FCSTHR '096'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f102
+              trigger ../../post/jgfs_atmos_post_f102 == complete
+              edit FHRGRP '102'
+              edit FHRLST 'f102'
+              edit FCSTHR '102'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f108
+              trigger ../../post/jgfs_atmos_post_f108 == complete
+              edit FHRGRP '108'
+              edit FHRLST 'f108'
+              edit FCSTHR '108'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f114
+              trigger ../../post/jgfs_atmos_post_f114 == complete
+              edit FHRGRP '114'
+              edit FHRLST 'f114'
+              edit FCSTHR '114'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f120
+              trigger ../../post/jgfs_atmos_post_f120 == complete
+              edit FHRGRP '120'
+              edit FHRLST 'f120'
+              edit FCSTHR '120'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f126
+              trigger ../../post/jgfs_atmos_post_f126 == complete
+              edit FHRGRP '126'
+              edit FHRLST 'f126'
+              edit FCSTHR '126'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f132
+              trigger ../../post/jgfs_atmos_post_f132 == complete
+              edit FHRGRP '132'
+              edit FHRLST 'f132'
+              edit FCSTHR '132'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f138
+              trigger ../../post/jgfs_atmos_post_f138 == complete
+              edit FHRGRP '138'
+              edit FHRLST 'f138'
+              edit FCSTHR '138'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f144
+              trigger ../../post/jgfs_atmos_post_f144 == complete
+              edit FHRGRP '144'
+              edit FHRLST 'f144'
+              edit FCSTHR '144'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f150
+              trigger ../../post/jgfs_atmos_post_f150 == complete
+              edit FHRGRP '150'
+              edit FHRLST 'f150'
+              edit FCSTHR '150'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f156
+              trigger ../../post/jgfs_atmos_post_f156 == complete
+              edit FHRGRP '156'
+              edit FHRLST 'f156'
+              edit FCSTHR '156'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f162
+              trigger ../../post/jgfs_atmos_post_f162 == complete
+              edit FHRGRP '162'
+              edit FHRLST 'f162'
+              edit FCSTHR '162'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f168
+              trigger ../../post/jgfs_atmos_post_f168 == complete
+              edit FHRGRP '168'
+              edit FHRLST 'f168'
+              edit FCSTHR '168'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f174
+              trigger ../../post/jgfs_atmos_post_f174 == complete
+              edit FHRGRP '174'
+              edit FHRLST 'f174'
+              edit FCSTHR '174'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f180
+              trigger ../../post/jgfs_atmos_post_f180 == complete
+              edit FHRGRP '180'
+              edit FHRLST 'f180'
+              edit FCSTHR '180'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f186
+              trigger ../../post/jgfs_atmos_post_f186 == complete
+              edit FHRGRP '186'
+              edit FHRLST 'f186'
+              edit FCSTHR '186'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f192
+              trigger ../../post/jgfs_atmos_post_f192 == complete
+              edit FHRGRP '192'
+              edit FHRLST 'f192'
+              edit FCSTHR '192'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f198
+              trigger ../../post/jgfs_atmos_post_f198 == complete
+              edit FHRGRP '198'
+              edit FHRLST 'f198'
+              edit FCSTHR '198'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f204
+              trigger ../../post/jgfs_atmos_post_f204 == complete
+              edit FHRGRP '204'
+              edit FHRLST 'f204'
+              edit FCSTHR '204'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f210
+              trigger ../../post/jgfs_atmos_post_f210 == complete
+              edit FHRGRP '210'
+              edit FHRLST 'f210'
+              edit FCSTHR '210'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f216
+              trigger ../../post/jgfs_atmos_post_f216 == complete
+              edit FHRGRP '216'
+              edit FHRLST 'f216'
+              edit FCSTHR '216'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f222
+              trigger ../../post/jgfs_atmos_post_f222 == complete
+              edit FHRGRP '222'
+              edit FHRLST 'f222'
+              edit FCSTHR '222'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f228
+              trigger ../../post/jgfs_atmos_post_f228 == complete
+              edit FHRGRP '228'
+              edit FHRLST 'f228'
+              edit FCSTHR '228'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f234
+              trigger ../../post/jgfs_atmos_post_f234 == complete
+              edit FHRGRP '234'
+              edit FHRLST 'f234'
+              edit FCSTHR '234'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f240
+              trigger ../../post/jgfs_atmos_post_f240 == complete
+              edit FHRGRP '240'
+              edit FHRLST 'f240'
+              edit FCSTHR '240'
+              edit TRDRUN 'YES'
+          endfamily
+        endfamily
+        family gempak
+          task jgfs_atmos_gempak
+            trigger ../../atmos/analysis/jgfs_atmos_analysis == complete
+          task jgfs_atmos_gempak_meta
+            trigger ../../atmos/analysis/jgfs_atmos_analysis == complete
+          task jgfs_atmos_gempak_ncdc_upapgif
+            trigger ./jgfs_atmos_gempak == active or ./jgfs_atmos_gempak == complete
+          task jgfs_atmos_npoess_pgrb2_0p5deg
+            trigger ../post/jgfs_atmos_post_anl eq active or ../post/jgfs_atmos_post_anl == complete
+          task jgfs_atmos_pgrb2_spec_gempak
+            trigger ./jgfs_atmos_npoess_pgrb2_0p5deg == complete
+        endfamily
+        family verf
+          task jgfs_atmos_vminmon
+            trigger ../analysis/jgfs_atmos_analysis == complete
+        endfamily
+      endfamily
+      family wave
+        family init
+          task jgfs_wave_init
+            trigger /prod/primary/06/obsproc/v1.0/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete
+        endfamily
+        family prep
+          task jgfs_wave_prep
+            trigger ../init/jgfs_wave_init == complete
+        endfamily
+        family post
+          task jgfs_wave_postsbs
+            trigger ../../atmos/post/jgfs_atmos_post_manager:release_post000
+          task jgfs_wave_postpnt
+            trigger ../../jgfs_forecast == complete
+          task jgfs_wave_post_bndpnt
+            trigger ../../atmos/post/jgfs_atmos_post_manager:release_post180
+          task jgfs_wave_post_bndpntbll
+            trigger ../../atmos/post/jgfs_atmos_post_manager:release_post180
+          task jgfs_wave_prdgen_gridded
+            trigger ./jgfs_wave_postsbs == active or ./jgfs_wave_postsbs == complete
+          task jgfs_wave_prdgen_bulls
+            trigger ./jgfs_wave_postpnt == complete and ./jgfs_wave_postsbs == complete
+        endfamily
+        family gempak
+          task jgfs_wave_gempak
+            trigger ../post/jgfs_wave_postsbs == active or ../post/jgfs_wave_postsbs == complete
+        endfamily
+      endfamily
+      task jgfs_forecast
+        trigger ./atmos/analysis/jgfs_atmos_analysis:release_fcst and ./wave/prep/jgfs_wave_prep == complete
+    endfamily
+    family gdas
+      edit RUN 'gdas'
+      edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/gdas'
+      family atmos
+        family obsproc
+          family dump
+            task jgdas_atmos_tropcy_qc_reloc
+              trigger :TIME >= 1145 and :TIME < 1745
+          endfamily
+          family prep
+            task jgdas_atmos_emcsfc_sfc_prep
+              trigger /prod/primary/06/obsproc/v1.0/gdas/atmos/dump/jobsproc_gdas_atmos_dump:release_sfcprep
+          endfamily
+        endfamily
+        family init
+          task jgdas_atmos_gldas
+            trigger ../analysis/jgdas_atmos_analysis == complete
+        endfamily
+        family analysis
+          task jgdas_atmos_analysis
+            trigger /prod/primary/06/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../obsproc/prep/jgdas_atmos_emcsfc_sfc_prep == complete
+            event 1 release_fcst
+          task jgdas_atmos_analysis_calc
+            trigger ./jgdas_atmos_analysis == complete
+          task jgdas_atmos_analysis_diag
+            trigger ./jgdas_atmos_analysis == complete
+        endfamily
+        family post
+          task jgdas_atmos_post_manager
+            trigger ../../jgdas_forecast == active
+            event 1 release_postanl
+            event 2 release_post000
+            event 3 release_post001
+            event 4 release_post002
+            event 5 release_post003
+            event 6 release_post004
+            event 7 release_post005
+            event 8 release_post006
+            event 9 release_post007
+            event 10 release_post008
+            event 11 release_post009
+          task jgdas_atmos_post_anl
+            trigger ./jgdas_atmos_post_manager:release_postanl
+            edit FHRGRP '000'
+            edit FHRLST 'anl'
+            edit HR 'anl'
+            edit FHR 'anl'
+          task jgdas_atmos_post_f000
+            trigger ./jgdas_atmos_post_manager:release_post000
+            edit FHR 'f000'
+            edit HR '000'
+            edit FHRGRP '001'
+            edit FHRLST 'f000'
+          task jgdas_atmos_post_f001
+            trigger ./jgdas_atmos_post_manager:release_post001
+            edit FHR 'f001'
+            edit HR '001'
+            edit FHRGRP '002'
+            edit FHRLST 'f001'
+          task jgdas_atmos_post_f002
+            trigger ./jgdas_atmos_post_manager:release_post002
+            edit FHR 'f002'
+            edit HR '002'
+            edit FHRGRP '003'
+            edit FHRLST 'f002'
+          task jgdas_atmos_post_f003
+            trigger ./jgdas_atmos_post_manager:release_post003
+            edit FHR 'f003'
+            edit HR '003'
+            edit FHRGRP '004'
+            edit FHRLST 'f003'
+          task jgdas_atmos_post_f004
+            trigger ./jgdas_atmos_post_manager:release_post004
+            edit FHR 'f004'
+            edit HR '004'
+            edit FHRGRP '005'
+            edit FHRLST 'f004'
+          task jgdas_atmos_post_f005
+            trigger ./jgdas_atmos_post_manager:release_post005
+            edit FHR 'f005'
+            edit HR '005'
+            edit FHRGRP '006'
+            edit FHRLST 'f005'
+          task jgdas_atmos_post_f006
+            trigger ./jgdas_atmos_post_manager:release_post006
+            edit FHR 'f006'
+            edit HR '006'
+            edit FHRGRP '007'
+            edit FHRLST 'f006'
+          task jgdas_atmos_post_f007
+            trigger ./jgdas_atmos_post_manager:release_post007
+            edit FHR 'f007'
+            edit HR '007'
+            edit FHRGRP '008'
+            edit FHRLST 'f007'
+          task jgdas_atmos_post_f008
+            trigger ./jgdas_atmos_post_manager:release_post008
+            edit FHR 'f008'
+            edit HR '008'
+            edit FHRGRP '009'
+            edit FHRLST 'f008'
+          task jgdas_atmos_post_f009
+            trigger ./jgdas_atmos_post_manager:release_post009
+            edit FHR 'f009'
+            edit HR '009'
+            edit FHRGRP '010'
+            edit FHRLST 'f009'
+        endfamily
+        family post_processing
+          task jgdas_atmos_chgres_forenkf
+            trigger ../../jgdas_forecast == complete and ../../../enkfgdas/forecast == complete
+        endfamily
+        family gempak
+          task jgdas_atmos_gempak
+            trigger ../../jgdas_forecast == complete
+          task jgdas_atmos_gempak_meta_ncdc
+            trigger ./jgdas_atmos_gempak == complete
+        endfamily
+        family verf
+          task jgdas_atmos_vminmon
+            trigger ../analysis/jgdas_atmos_analysis == complete
+          task jgdas_atmos_verfrad
+            trigger ../analysis/jgdas_atmos_analysis_diag == complete
+          task jgdas_atmos_verfozn
+            trigger ../analysis/jgdas_atmos_analysis_diag == complete
+        endfamily
+      endfamily
+      family wave
+        family init
+          task jgdas_wave_init
+            trigger /prod/primary/06/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete
+        endfamily
+        family prep
+          task jgdas_wave_prep
+            trigger ../init/jgdas_wave_init == complete
+        endfamily
+        family post
+          task jgdas_wave_postsbs
+            trigger ../../atmos/post/jgdas_atmos_post_manager:release_post000
+          task jgdas_wave_postpnt
+            trigger ../../jgdas_forecast == complete
+        endfamily
+      endfamily
+      task jgdas_forecast
+        trigger ./atmos/analysis/jgdas_atmos_analysis:release_fcst and ./wave/prep/jgdas_wave_prep == complete and ./atmos/init/jgdas_atmos_gldas == complete
+    endfamily
+    family enkfgdas
+      edit RUN 'gdas'
+      edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/enkfgdas'
+      family analysis
+        family create
+          task jenkfgdas_select_obs
+            trigger /prod/primary/06/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and /prod/primary/00/gfs/v16.2/enkfgdas/post == complete
+          task jenkfgdas_diag
+            trigger ./jenkfgdas_select_obs == complete
+          task jenkfgdas_update
+            trigger ./jenkfgdas_diag == complete
+        endfamily
+        family recenter
+          family ecen
+            trigger ../create/jenkfgdas_update == complete and ../../../gdas/atmos/analysis/jgdas_atmos_analysis_calc == complete and /prod/primary/00/gfs/v16.2/gdas/atmos/post_processing/jgdas_atmos_chgres_forenkf == complete
+            edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/enkfgdas/analysis/recenter/ecen'
+            family grp1
+              edit FHRGRP '003'
+              task jenkfgdas_ecen
+            endfamily
+            family grp2
+              edit FHRGRP '006'
+              task jenkfgdas_ecen
+            endfamily
+            family grp3
+              edit FHRGRP '009'
+              task jenkfgdas_ecen
+            endfamily
+          endfamily
+          task jenkfgdas_sfc
+            trigger ../create/jenkfgdas_update == complete and ../../../gdas/atmos/analysis/jgdas_atmos_analysis_calc == complete
+        endfamily
+      endfamily
+      family forecast
+        trigger ./analysis/recenter/ecen == complete and ./analysis/recenter/jenkfgdas_sfc == complete
+        edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/enkfgdas/forecast'
+        family grp1
+          edit ENSGRP '01'
+          task jenkfgdas_fcst
+        endfamily
+        family grp2
+          edit ENSGRP '02'
+          task jenkfgdas_fcst
+        endfamily
+        family grp3
+          edit ENSGRP '03'
+          task jenkfgdas_fcst
+        endfamily
+        family grp4
+          edit ENSGRP '04'
+          task jenkfgdas_fcst
+        endfamily
+        family grp5
+          edit ENSGRP '05'
+          task jenkfgdas_fcst
+        endfamily
+        family grp6
+          edit ENSGRP '06'
+          task jenkfgdas_fcst
+        endfamily
+        family grp7
+          edit ENSGRP '07'
+          task jenkfgdas_fcst
+        endfamily
+        family grp8
+          edit ENSGRP '08'
+          task jenkfgdas_fcst
+        endfamily
+        family grp9
+          edit ENSGRP '09'
+          task jenkfgdas_fcst
+        endfamily
+        family grp10
+          edit ENSGRP '10'
+          task jenkfgdas_fcst
+        endfamily
+        family grp11
+          edit ENSGRP '11'
+          task jenkfgdas_fcst
+        endfamily
+        family grp12
+          edit ENSGRP '12'
+          task jenkfgdas_fcst
+        endfamily
+        family grp13
+          edit ENSGRP '13'
+          task jenkfgdas_fcst
+        endfamily
+        family grp14
+          edit ENSGRP '14'
+          task jenkfgdas_fcst
+        endfamily
+        family grp15
+          edit ENSGRP '15'
+          task jenkfgdas_fcst
+        endfamily
+        family grp16
+          edit ENSGRP '16'
+          task jenkfgdas_fcst
+        endfamily
+        family grp17
+          edit ENSGRP '17'
+          task jenkfgdas_fcst
+        endfamily
+        family grp18
+          edit ENSGRP '18'
+          task jenkfgdas_fcst
+        endfamily
+        family grp19
+          edit ENSGRP '19'
+          task jenkfgdas_fcst
+        endfamily
+        family grp20
+          edit ENSGRP '20'
+          task jenkfgdas_fcst
+        endfamily
+        family grp21
+          edit ENSGRP '21'
+          task jenkfgdas_fcst
+        endfamily
+        family grp22
+          edit ENSGRP '22'
+          task jenkfgdas_fcst
+        endfamily
+        family grp23
+          edit ENSGRP '23'
+          task jenkfgdas_fcst
+        endfamily
+        family grp24
+          edit ENSGRP '24'
+          task jenkfgdas_fcst
+        endfamily
+        family grp25
+          edit ENSGRP '25'
+          task jenkfgdas_fcst
+        endfamily
+        family grp26
+          edit ENSGRP '26'
+          task jenkfgdas_fcst
+        endfamily
+        family grp27
+          edit ENSGRP '27'
+          task jenkfgdas_fcst
+        endfamily
+        family grp28
+          edit ENSGRP '28'
+          task jenkfgdas_fcst
+        endfamily
+        family grp29
+          edit ENSGRP '29'
+          task jenkfgdas_fcst
+        endfamily
+        family grp30
+          edit ENSGRP '30'
+          task jenkfgdas_fcst
+        endfamily
+        family grp31
+          edit ENSGRP '31'
+          task jenkfgdas_fcst
+        endfamily
+        family grp32
+          edit ENSGRP '32'
+          task jenkfgdas_fcst
+        endfamily
+        family grp33
+          edit ENSGRP '33'
+          task jenkfgdas_fcst
+        endfamily
+        family grp34
+          edit ENSGRP '34'
+          task jenkfgdas_fcst
+        endfamily
+        family grp35
+          edit ENSGRP '35'
+          task jenkfgdas_fcst
+        endfamily
+        family grp36
+          edit ENSGRP '36'
+          task jenkfgdas_fcst
+        endfamily
+        family grp37
+          edit ENSGRP '37'
+          task jenkfgdas_fcst
+        endfamily
+        family grp38
+          edit ENSGRP '38'
+          task jenkfgdas_fcst
+        endfamily
+        family grp39
+          edit ENSGRP '39'
+          task jenkfgdas_fcst
+        endfamily
+        family grp40
+          edit ENSGRP '40'
+          task jenkfgdas_fcst
+        endfamily
+      endfamily
+      family post
+        trigger ./forecast == complete
+        task jenkfgdas_post_f003
+          edit FHMIN_EPOS '003'
+          edit FHMAX_EPOS '003'
+          edit FHOUT_EPOS '003'
+        task jenkfgdas_post_f004
+          edit FHMIN_EPOS '004'
+          edit FHMAX_EPOS '004'
+          edit FHOUT_EPOS '004'
+        task jenkfgdas_post_f005
+          edit FHMIN_EPOS '005'
+          edit FHMAX_EPOS '005'
+          edit FHOUT_EPOS '005'
+        task jenkfgdas_post_f006
+          edit FHMIN_EPOS '006'
+          edit FHMAX_EPOS '006'
+          edit FHOUT_EPOS '006'
+        task jenkfgdas_post_f007
+          edit FHMIN_EPOS '007'
+          edit FHMAX_EPOS '007'
+          edit FHOUT_EPOS '007'
+        task jenkfgdas_post_f008
+          edit FHMIN_EPOS '008'
+          edit FHMAX_EPOS '008'
+          edit FHOUT_EPOS '008'
+        task jenkfgdas_post_f009
+          edit FHMIN_EPOS '009'
+          edit FHMAX_EPOS '009'
+          edit FHOUT_EPOS '009'
+      endfamily
+    endfamily
+  endfamily
+

--- a/ecf/defs/gfs_12.def
+++ b/ecf/defs/gfs_12.def
@@ -1,0 +1,2590 @@
+  family v16.2
+    family gfs
+      edit RUN 'gfs'
+      edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/gfs'
+      family atmos
+        family obsproc
+          family dump
+            task jgfs_atmos_tropcy_qc_reloc
+              trigger :TIME >= 1441 and :TIME < 2041
+              event 1 jtwc_bull_email
+          endfamily
+          family prep
+            task jgfs_atmos_emcsfc_sfc_prep
+              trigger /prod/primary/12/obsproc/v1.0/gfs/atmos/dump/jobsproc_gfs_atmos_dump:release_sfcprep
+          endfamily
+        endfamily
+        family analysis
+          task jgfs_atmos_analysis
+            trigger /prod/primary/12/obsproc/v1.0/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete and ../obsproc/prep/jgfs_atmos_emcsfc_sfc_prep == complete
+            event 1 release_fcst
+          task jgfs_atmos_analysis_calc
+            trigger ./jgfs_atmos_analysis == complete
+        endfamily
+        family post
+          task jgfs_atmos_post_manager
+            trigger ../analysis/jgfs_atmos_analysis == complete
+            event 1 release_postanl
+            event 2 release_post000
+            event 3 release_post001
+            event 4 release_post002
+            event 5 release_post003
+            event 6 release_post004
+            event 7 release_post005
+            event 8 release_post006
+            event 9 release_post007
+            event 10 release_post008
+            event 11 release_post009
+            event 12 release_post010
+            event 13 release_post011
+            event 14 release_post012
+            event 15 release_post013
+            event 16 release_post014
+            event 17 release_post015
+            event 18 release_post016
+            event 19 release_post017
+            event 20 release_post018
+            event 21 release_post019
+            event 22 release_post020
+            event 23 release_post021
+            event 24 release_post022
+            event 25 release_post023
+            event 26 release_post024
+            event 27 release_post025
+            event 28 release_post026
+            event 29 release_post027
+            event 30 release_post028
+            event 31 release_post029
+            event 32 release_post030
+            event 33 release_post031
+            event 34 release_post032
+            event 35 release_post033
+            event 36 release_post034
+            event 37 release_post035
+            event 38 release_post036
+            event 39 release_post037
+            event 40 release_post038
+            event 41 release_post039
+            event 42 release_post040
+            event 43 release_post041
+            event 44 release_post042
+            event 45 release_post043
+            event 46 release_post044
+            event 47 release_post045
+            event 48 release_post046
+            event 49 release_post047
+            event 50 release_post048
+            event 51 release_post049
+            event 52 release_post050
+            event 53 release_post051
+            event 54 release_post052
+            event 55 release_post053
+            event 56 release_post054
+            event 57 release_post055
+            event 58 release_post056
+            event 59 release_post057
+            event 60 release_post058
+            event 61 release_post059
+            event 62 release_post060
+            event 63 release_post061
+            event 64 release_post062
+            event 65 release_post063
+            event 66 release_post064
+            event 67 release_post065
+            event 68 release_post066
+            event 69 release_post067
+            event 70 release_post068
+            event 71 release_post069
+            event 72 release_post070
+            event 73 release_post071
+            event 74 release_post072
+            event 75 release_post073
+            event 76 release_post074
+            event 77 release_post075
+            event 78 release_post076
+            event 79 release_post077
+            event 80 release_post078
+            event 81 release_post079
+            event 82 release_post080
+            event 83 release_post081
+            event 84 release_post082
+            event 85 release_post083
+            event 86 release_post084
+            event 87 release_post085
+            event 88 release_post086
+            event 89 release_post087
+            event 90 release_post088
+            event 91 release_post089
+            event 92 release_post090
+            event 93 release_post091
+            event 94 release_post092
+            event 95 release_post093
+            event 96 release_post094
+            event 97 release_post095
+            event 98 release_post096
+            event 99 release_post097
+            event 100 release_post098
+            event 101 release_post099
+            event 102 release_post100
+            event 103 release_post101
+            event 104 release_post102
+            event 105 release_post103
+            event 106 release_post104
+            event 107 release_post105
+            event 108 release_post106
+            event 109 release_post107
+            event 110 release_post108
+            event 111 release_post109
+            event 112 release_post110
+            event 113 release_post111
+            event 114 release_post112
+            event 115 release_post113
+            event 116 release_post114
+            event 117 release_post115
+            event 118 release_post116
+            event 119 release_post117
+            event 120 release_post118
+            event 121 release_post119
+            event 122 release_post120
+            event 123 release_post123
+            event 124 release_post126
+            event 125 release_post129
+            event 126 release_post132
+            event 127 release_post135
+            event 128 release_post138
+            event 129 release_post141
+            event 130 release_post144
+            event 131 release_post147
+            event 132 release_post150
+            event 133 release_post153
+            event 134 release_post156
+            event 135 release_post159
+            event 136 release_post162
+            event 137 release_post165
+            event 138 release_post168
+            event 139 release_post171
+            event 140 release_post174
+            event 141 release_post177
+            event 142 release_post180
+            event 143 release_post183
+            event 144 release_post186
+            event 145 release_post189
+            event 146 release_post192
+            event 147 release_post195
+            event 148 release_post198
+            event 149 release_post201
+            event 150 release_post204
+            event 151 release_post207
+            event 152 release_post210
+            event 153 release_post213
+            event 154 release_post216
+            event 155 release_post219
+            event 156 release_post222
+            event 157 release_post225
+            event 158 release_post228
+            event 159 release_post231
+            event 160 release_post234
+            event 161 release_post237
+            event 162 release_post240
+            event 163 release_post243
+            event 164 release_post246
+            event 165 release_post249
+            event 166 release_post252
+            event 167 release_post255
+            event 168 release_post258
+            event 169 release_post261
+            event 170 release_post264
+            event 171 release_post267
+            event 172 release_post270
+            event 173 release_post273
+            event 174 release_post276
+            event 175 release_post279
+            event 176 release_post282
+            event 177 release_post285
+            event 178 release_post288
+            event 179 release_post291
+            event 180 release_post294
+            event 181 release_post297
+            event 182 release_post300
+            event 183 release_post303
+            event 184 release_post306
+            event 185 release_post309
+            event 186 release_post312
+            event 187 release_post315
+            event 188 release_post318
+            event 189 release_post321
+            event 190 release_post324
+            event 191 release_post327
+            event 192 release_post330
+            event 193 release_post333
+            event 194 release_post336
+            event 195 release_post339
+            event 196 release_post342
+            event 197 release_post345
+            event 198 release_post348
+            event 199 release_post351
+            event 200 release_post354
+            event 201 release_post357
+            event 202 release_post360
+            event 203 release_post363
+            event 204 release_post366
+            event 205 release_post369
+            event 206 release_post372
+            event 207 release_post375
+            event 208 release_post378
+            event 209 release_post381
+            event 210 release_post384
+          task jgfs_atmos_post_anl
+            trigger ./jgfs_atmos_post_manager:release_postanl
+            edit FHRGRP '000'
+            edit FHRLST 'anl'
+            edit HR 'anl'
+            edit FHR 'anl'
+          task jgfs_atmos_post_f000
+            trigger ./jgfs_atmos_post_manager:release_post000
+            edit FHRGRP '001'
+            edit FHRLST 'f000'
+            edit FHR 'f000'
+            edit HR '000'
+          task jgfs_atmos_post_f001
+            trigger ./jgfs_atmos_post_manager:release_post001
+            edit FHRGRP '002'
+            edit FHRLST 'f001'
+            edit FHR 'f001'
+            edit HR '001'
+          task jgfs_atmos_post_f002
+            trigger ./jgfs_atmos_post_manager:release_post002
+            edit FHRGRP '003'
+            edit FHRLST 'f002'
+            edit FHR 'f002'
+            edit HR '002'
+          task jgfs_atmos_post_f003
+            trigger ./jgfs_atmos_post_manager:release_post003
+            edit FHRGRP '004'
+            edit FHRLST 'f003'
+            edit FHR 'f003'
+            edit HR '003'
+          task jgfs_atmos_post_f004
+            trigger ./jgfs_atmos_post_manager:release_post004
+            edit FHRGRP '005'
+            edit FHRLST 'f004'
+            edit FHR 'f004'
+            edit HR '004'
+          task jgfs_atmos_post_f005
+            trigger ./jgfs_atmos_post_manager:release_post005
+            edit FHRGRP '006'
+            edit FHRLST 'f005'
+            edit FHR 'f005'
+            edit HR '005'
+          task jgfs_atmos_post_f006
+            trigger ./jgfs_atmos_post_manager:release_post006
+            edit FHRGRP '007'
+            edit FHRLST 'f006'
+            edit FHR 'f006'
+            edit HR '006'
+          task jgfs_atmos_post_f007
+            trigger ./jgfs_atmos_post_manager:release_post007
+            edit FHRGRP '008'
+            edit FHRLST 'f007'
+            edit FHR 'f007'
+            edit HR '007'
+          task jgfs_atmos_post_f008
+            trigger ./jgfs_atmos_post_manager:release_post008
+            edit FHRGRP '009'
+            edit FHRLST 'f008'
+            edit FHR 'f008'
+            edit HR '008'
+          task jgfs_atmos_post_f009
+            trigger ./jgfs_atmos_post_manager:release_post009
+            edit FHRGRP '010'
+            edit FHRLST 'f009'
+            edit FHR 'f009'
+            edit HR '009'
+          task jgfs_atmos_post_f010
+            trigger ./jgfs_atmos_post_manager:release_post010
+            edit FHRGRP '011'
+            edit FHRLST 'f010'
+            edit FHR 'f010'
+            edit HR '010'
+          task jgfs_atmos_post_f011
+            trigger ./jgfs_atmos_post_manager:release_post011
+            edit FHRGRP '012'
+            edit FHRLST 'f011'
+            edit FHR 'f011'
+            edit HR '011'
+          task jgfs_atmos_post_f012
+            trigger ./jgfs_atmos_post_manager:release_post012
+            edit FHRGRP '013'
+            edit FHRLST 'f012'
+            edit FHR 'f012'
+            edit HR '012'
+          task jgfs_atmos_post_f013
+            trigger ./jgfs_atmos_post_manager:release_post013
+            edit FHRGRP '014'
+            edit FHRLST 'f013'
+            edit FHR 'f013'
+            edit HR '013'
+          task jgfs_atmos_post_f014
+            trigger ./jgfs_atmos_post_manager:release_post014
+            edit FHRGRP '015'
+            edit FHRLST 'f014'
+            edit FHR 'f014'
+            edit HR '014'
+          task jgfs_atmos_post_f015
+            trigger ./jgfs_atmos_post_manager:release_post015
+            edit FHRGRP '016'
+            edit FHRLST 'f015'
+            edit FHR 'f015'
+            edit HR '015'
+          task jgfs_atmos_post_f016
+            trigger ./jgfs_atmos_post_manager:release_post016
+            edit FHRGRP '017'
+            edit FHRLST 'f016'
+            edit FHR 'f016'
+            edit HR '016'
+          task jgfs_atmos_post_f017
+            trigger ./jgfs_atmos_post_manager:release_post017
+            edit FHRGRP '018'
+            edit FHRLST 'f017'
+            edit FHR 'f017'
+            edit HR '017'
+          task jgfs_atmos_post_f018
+            trigger ./jgfs_atmos_post_manager:release_post018
+            edit FHRGRP '019'
+            edit FHRLST 'f018'
+            edit FHR 'f018'
+            edit HR '018'
+          task jgfs_atmos_post_f019
+            trigger ./jgfs_atmos_post_manager:release_post019
+            edit FHRGRP '020'
+            edit FHRLST 'f019'
+            edit FHR 'f019'
+            edit HR '019'
+          task jgfs_atmos_post_f020
+            trigger ./jgfs_atmos_post_manager:release_post020
+            edit FHRGRP '021'
+            edit FHRLST 'f020'
+            edit FHR 'f020'
+            edit HR '020'
+          task jgfs_atmos_post_f021
+            trigger ./jgfs_atmos_post_manager:release_post021
+            edit FHRGRP '022'
+            edit FHRLST 'f021'
+            edit FHR 'f021'
+            edit HR '021'
+          task jgfs_atmos_post_f022
+            trigger ./jgfs_atmos_post_manager:release_post022
+            edit FHRGRP '023'
+            edit FHRLST 'f022'
+            edit FHR 'f022'
+            edit HR '022'
+          task jgfs_atmos_post_f023
+            trigger ./jgfs_atmos_post_manager:release_post023
+            edit FHRGRP '024'
+            edit FHRLST 'f023'
+            edit FHR 'f023'
+            edit HR '023'
+          task jgfs_atmos_post_f024
+            trigger ./jgfs_atmos_post_manager:release_post024
+            edit FHRGRP '025'
+            edit FHRLST 'f024'
+            edit FHR 'f024'
+            edit HR '024'
+          task jgfs_atmos_post_f025
+            trigger ./jgfs_atmos_post_manager:release_post025
+            edit FHRGRP '026'
+            edit FHRLST 'f025'
+            edit FHR 'f025'
+            edit HR '025'
+          task jgfs_atmos_post_f026
+            trigger ./jgfs_atmos_post_manager:release_post026
+            edit FHRGRP '027'
+            edit FHRLST 'f026'
+            edit FHR 'f026'
+            edit HR '026'
+          task jgfs_atmos_post_f027
+            trigger ./jgfs_atmos_post_manager:release_post027
+            edit FHRGRP '028'
+            edit FHRLST 'f027'
+            edit FHR 'f027'
+            edit HR '027'
+          task jgfs_atmos_post_f028
+            trigger ./jgfs_atmos_post_manager:release_post028
+            edit FHRGRP '029'
+            edit FHRLST 'f028'
+            edit FHR 'f028'
+            edit HR '028'
+          task jgfs_atmos_post_f029
+            trigger ./jgfs_atmos_post_manager:release_post029
+            edit FHRGRP '030'
+            edit FHRLST 'f029'
+            edit FHR 'f029'
+            edit HR '029'
+          task jgfs_atmos_post_f030
+            trigger ./jgfs_atmos_post_manager:release_post030
+            edit FHRGRP '031'
+            edit FHRLST 'f030'
+            edit FHR 'f030'
+            edit HR '030'
+          task jgfs_atmos_post_f031
+            trigger ./jgfs_atmos_post_manager:release_post031
+            edit FHRGRP '032'
+            edit FHRLST 'f031'
+            edit FHR 'f031'
+            edit HR '031'
+          task jgfs_atmos_post_f032
+            trigger ./jgfs_atmos_post_manager:release_post032
+            edit FHRGRP '033'
+            edit FHRLST 'f032'
+            edit FHR 'f032'
+            edit HR '032'
+          task jgfs_atmos_post_f033
+            trigger ./jgfs_atmos_post_manager:release_post033
+            edit FHRGRP '034'
+            edit FHRLST 'f033'
+            edit FHR 'f033'
+            edit HR '033'
+          task jgfs_atmos_post_f034
+            trigger ./jgfs_atmos_post_manager:release_post034
+            edit FHRGRP '035'
+            edit FHRLST 'f034'
+            edit FHR 'f034'
+            edit HR '034'
+          task jgfs_atmos_post_f035
+            trigger ./jgfs_atmos_post_manager:release_post035
+            edit FHRGRP '036'
+            edit FHRLST 'f035'
+            edit FHR 'f035'
+            edit HR '035'
+          task jgfs_atmos_post_f036
+            trigger ./jgfs_atmos_post_manager:release_post036
+            edit FHRGRP '037'
+            edit FHRLST 'f036'
+            edit FHR 'f036'
+            edit HR '036'
+          task jgfs_atmos_post_f037
+            trigger ./jgfs_atmos_post_manager:release_post037
+            edit FHRGRP '038'
+            edit FHRLST 'f037'
+            edit FHR 'f037'
+            edit HR '037'
+          task jgfs_atmos_post_f038
+            trigger ./jgfs_atmos_post_manager:release_post038
+            edit FHRGRP '039'
+            edit FHRLST 'f038'
+            edit FHR 'f038'
+            edit HR '038'
+          task jgfs_atmos_post_f039
+            trigger ./jgfs_atmos_post_manager:release_post039
+            edit FHRGRP '040'
+            edit FHRLST 'f039'
+            edit FHR 'f039'
+            edit HR '039'
+          task jgfs_atmos_post_f040
+            trigger ./jgfs_atmos_post_manager:release_post040
+            edit FHRGRP '041'
+            edit FHRLST 'f040'
+            edit FHR 'f040'
+            edit HR '040'
+          task jgfs_atmos_post_f041
+            trigger ./jgfs_atmos_post_manager:release_post041
+            edit FHRGRP '042'
+            edit FHRLST 'f041'
+            edit FHR 'f041'
+            edit HR '041'
+          task jgfs_atmos_post_f042
+            trigger ./jgfs_atmos_post_manager:release_post042
+            edit FHRGRP '043'
+            edit FHRLST 'f042'
+            edit FHR 'f042'
+            edit HR '042'
+          task jgfs_atmos_post_f043
+            trigger ./jgfs_atmos_post_manager:release_post043
+            edit FHRGRP '044'
+            edit FHRLST 'f043'
+            edit FHR 'f043'
+            edit HR '043'
+          task jgfs_atmos_post_f044
+            trigger ./jgfs_atmos_post_manager:release_post044
+            edit FHRGRP '045'
+            edit FHRLST 'f044'
+            edit FHR 'f044'
+            edit HR '044'
+          task jgfs_atmos_post_f045
+            trigger ./jgfs_atmos_post_manager:release_post045
+            edit FHRGRP '046'
+            edit FHRLST 'f045'
+            edit FHR 'f045'
+            edit HR '045'
+          task jgfs_atmos_post_f046
+            trigger ./jgfs_atmos_post_manager:release_post046
+            edit FHRGRP '047'
+            edit FHRLST 'f046'
+            edit FHR 'f046'
+            edit HR '046'
+          task jgfs_atmos_post_f047
+            trigger ./jgfs_atmos_post_manager:release_post047
+            edit FHRGRP '048'
+            edit FHRLST 'f047'
+            edit FHR 'f047'
+            edit HR '047'
+          task jgfs_atmos_post_f048
+            trigger ./jgfs_atmos_post_manager:release_post048
+            edit FHRGRP '049'
+            edit FHRLST 'f048'
+            edit FHR 'f048'
+            edit HR '048'
+          task jgfs_atmos_post_f049
+            trigger ./jgfs_atmos_post_manager:release_post049
+            edit FHRGRP '050'
+            edit FHRLST 'f049'
+            edit FHR 'f049'
+            edit HR '049'
+          task jgfs_atmos_post_f050
+            trigger ./jgfs_atmos_post_manager:release_post050
+            edit FHRGRP '051'
+            edit FHRLST 'f050'
+            edit FHR 'f050'
+            edit HR '050'
+          task jgfs_atmos_post_f051
+            trigger ./jgfs_atmos_post_manager:release_post051
+            edit FHRGRP '052'
+            edit FHRLST 'f051'
+            edit FHR 'f051'
+            edit HR '051'
+          task jgfs_atmos_post_f052
+            trigger ./jgfs_atmos_post_manager:release_post052
+            edit FHRGRP '053'
+            edit FHRLST 'f052'
+            edit FHR 'f052'
+            edit HR '052'
+          task jgfs_atmos_post_f053
+            trigger ./jgfs_atmos_post_manager:release_post053
+            edit FHRGRP '054'
+            edit FHRLST 'f053'
+            edit FHR 'f053'
+            edit HR '053'
+          task jgfs_atmos_post_f054
+            trigger ./jgfs_atmos_post_manager:release_post054
+            edit FHRGRP '055'
+            edit FHRLST 'f054'
+            edit FHR 'f054'
+            edit HR '054'
+          task jgfs_atmos_post_f055
+            trigger ./jgfs_atmos_post_manager:release_post055
+            edit FHRGRP '056'
+            edit FHRLST 'f055'
+            edit FHR 'f055'
+            edit HR '055'
+          task jgfs_atmos_post_f056
+            trigger ./jgfs_atmos_post_manager:release_post056
+            edit FHRGRP '057'
+            edit FHRLST 'f056'
+            edit FHR 'f056'
+            edit HR '056'
+          task jgfs_atmos_post_f057
+            trigger ./jgfs_atmos_post_manager:release_post057
+            edit FHRGRP '058'
+            edit FHRLST 'f057'
+            edit FHR 'f057'
+            edit HR '057'
+          task jgfs_atmos_post_f058
+            trigger ./jgfs_atmos_post_manager:release_post058
+            edit FHRGRP '059'
+            edit FHRLST 'f058'
+            edit FHR 'f058'
+            edit HR '058'
+          task jgfs_atmos_post_f059
+            trigger ./jgfs_atmos_post_manager:release_post059
+            edit FHRGRP '060'
+            edit FHRLST 'f059'
+            edit FHR 'f059'
+            edit HR '059'
+          task jgfs_atmos_post_f060
+            trigger ./jgfs_atmos_post_manager:release_post060
+            edit FHRGRP '061'
+            edit FHRLST 'f060'
+            edit FHR 'f060'
+            edit HR '060'
+          task jgfs_atmos_post_f061
+            trigger ./jgfs_atmos_post_manager:release_post061
+            edit FHRGRP '062'
+            edit FHRLST 'f061'
+            edit FHR 'f061'
+            edit HR '061'
+          task jgfs_atmos_post_f062
+            trigger ./jgfs_atmos_post_manager:release_post062
+            edit FHRGRP '063'
+            edit FHRLST 'f062'
+            edit FHR 'f062'
+            edit HR '062'
+          task jgfs_atmos_post_f063
+            trigger ./jgfs_atmos_post_manager:release_post063
+            edit FHRGRP '064'
+            edit FHRLST 'f063'
+            edit FHR 'f063'
+            edit HR '063'
+          task jgfs_atmos_post_f064
+            trigger ./jgfs_atmos_post_manager:release_post064
+            edit FHRGRP '065'
+            edit FHRLST 'f064'
+            edit FHR 'f064'
+            edit HR '064'
+          task jgfs_atmos_post_f065
+            trigger ./jgfs_atmos_post_manager:release_post065
+            edit FHRGRP '066'
+            edit FHRLST 'f065'
+            edit FHR 'f065'
+            edit HR '065'
+          task jgfs_atmos_post_f066
+            trigger ./jgfs_atmos_post_manager:release_post066
+            edit FHRGRP '067'
+            edit FHRLST 'f066'
+            edit FHR 'f066'
+            edit HR '066'
+          task jgfs_atmos_post_f067
+            trigger ./jgfs_atmos_post_manager:release_post067
+            edit FHRGRP '068'
+            edit FHRLST 'f067'
+            edit FHR 'f067'
+            edit HR '067'
+          task jgfs_atmos_post_f068
+            trigger ./jgfs_atmos_post_manager:release_post068
+            edit FHRGRP '069'
+            edit FHRLST 'f068'
+            edit FHR 'f068'
+            edit HR '068'
+          task jgfs_atmos_post_f069
+            trigger ./jgfs_atmos_post_manager:release_post069
+            edit FHRGRP '070'
+            edit FHRLST 'f069'
+            edit FHR 'f069'
+            edit HR '069'
+          task jgfs_atmos_post_f070
+            trigger ./jgfs_atmos_post_manager:release_post070
+            edit FHRGRP '071'
+            edit FHRLST 'f070'
+            edit FHR 'f070'
+            edit HR '070'
+          task jgfs_atmos_post_f071
+            trigger ./jgfs_atmos_post_manager:release_post071
+            edit FHRGRP '072'
+            edit FHRLST 'f071'
+            edit FHR 'f071'
+            edit HR '071'
+          task jgfs_atmos_post_f072
+            trigger ./jgfs_atmos_post_manager:release_post072
+            edit FHRGRP '073'
+            edit FHRLST 'f072'
+            edit FHR 'f072'
+            edit HR '072'
+          task jgfs_atmos_post_f073
+            trigger ./jgfs_atmos_post_manager:release_post073
+            edit FHRGRP '074'
+            edit FHRLST 'f073'
+            edit FHR 'f073'
+            edit HR '073'
+          task jgfs_atmos_post_f074
+            trigger ./jgfs_atmos_post_manager:release_post074
+            edit FHRGRP '075'
+            edit FHRLST 'f074'
+            edit FHR 'f074'
+            edit HR '074'
+          task jgfs_atmos_post_f075
+            trigger ./jgfs_atmos_post_manager:release_post075
+            edit FHRGRP '076'
+            edit FHRLST 'f075'
+            edit FHR 'f075'
+            edit HR '075'
+          task jgfs_atmos_post_f076
+            trigger ./jgfs_atmos_post_manager:release_post076
+            edit FHRGRP '077'
+            edit FHRLST 'f076'
+            edit FHR 'f076'
+            edit HR '076'
+          task jgfs_atmos_post_f077
+            trigger ./jgfs_atmos_post_manager:release_post077
+            edit FHRGRP '078'
+            edit FHRLST 'f077'
+            edit FHR 'f077'
+            edit HR '077'
+          task jgfs_atmos_post_f078
+            trigger ./jgfs_atmos_post_manager:release_post078
+            edit FHRGRP '079'
+            edit FHRLST 'f078'
+            edit FHR 'f078'
+            edit HR '078'
+          task jgfs_atmos_post_f079
+            trigger ./jgfs_atmos_post_manager:release_post079
+            edit FHRGRP '080'
+            edit FHRLST 'f079'
+            edit FHR 'f079'
+            edit HR '079'
+          task jgfs_atmos_post_f080
+            trigger ./jgfs_atmos_post_manager:release_post080
+            edit FHRGRP '081'
+            edit FHRLST 'f080'
+            edit FHR 'f080'
+            edit HR '080'
+          task jgfs_atmos_post_f081
+            trigger ./jgfs_atmos_post_manager:release_post081
+            edit FHRGRP '082'
+            edit FHRLST 'f081'
+            edit FHR 'f081'
+            edit HR '081'
+          task jgfs_atmos_post_f082
+            trigger ./jgfs_atmos_post_manager:release_post082
+            edit FHRGRP '083'
+            edit FHRLST 'f082'
+            edit FHR 'f082'
+            edit HR '082'
+          task jgfs_atmos_post_f083
+            trigger ./jgfs_atmos_post_manager:release_post083
+            edit FHRGRP '084'
+            edit FHRLST 'f083'
+            edit FHR 'f083'
+            edit HR '083'
+          task jgfs_atmos_post_f084
+            trigger ./jgfs_atmos_post_manager:release_post084
+            edit FHRGRP '085'
+            edit FHRLST 'f084'
+            edit FHR 'f084'
+            edit HR '084'
+          task jgfs_atmos_post_f085
+            trigger ./jgfs_atmos_post_manager:release_post085
+            edit FHRGRP '086'
+            edit FHRLST 'f085'
+            edit FHR 'f085'
+            edit HR '085'
+          task jgfs_atmos_post_f086
+            trigger ./jgfs_atmos_post_manager:release_post086
+            edit FHRGRP '087'
+            edit FHRLST 'f086'
+            edit FHR 'f086'
+            edit HR '086'
+          task jgfs_atmos_post_f087
+            trigger ./jgfs_atmos_post_manager:release_post087
+            edit FHRGRP '088'
+            edit FHRLST 'f087'
+            edit FHR 'f087'
+            edit HR '087'
+          task jgfs_atmos_post_f088
+            trigger ./jgfs_atmos_post_manager:release_post088
+            edit FHRGRP '089'
+            edit FHRLST 'f088'
+            edit FHR 'f088'
+            edit HR '088'
+          task jgfs_atmos_post_f089
+            trigger ./jgfs_atmos_post_manager:release_post089
+            edit FHRGRP '090'
+            edit FHRLST 'f089'
+            edit FHR 'f089'
+            edit HR '089'
+          task jgfs_atmos_post_f090
+            trigger ./jgfs_atmos_post_manager:release_post090
+            edit FHRGRP '091'
+            edit FHRLST 'f090'
+            edit FHR 'f090'
+            edit HR '090'
+          task jgfs_atmos_post_f091
+            trigger ./jgfs_atmos_post_manager:release_post091
+            edit FHRGRP '092'
+            edit FHRLST 'f091'
+            edit FHR 'f091'
+            edit HR '091'
+          task jgfs_atmos_post_f092
+            trigger ./jgfs_atmos_post_manager:release_post092
+            edit FHRGRP '093'
+            edit FHRLST 'f092'
+            edit FHR 'f092'
+            edit HR '092'
+          task jgfs_atmos_post_f093
+            trigger ./jgfs_atmos_post_manager:release_post093
+            edit FHRGRP '094'
+            edit FHRLST 'f093'
+            edit FHR 'f093'
+            edit HR '093'
+          task jgfs_atmos_post_f094
+            trigger ./jgfs_atmos_post_manager:release_post094
+            edit FHRGRP '095'
+            edit FHRLST 'f094'
+            edit FHR 'f094'
+            edit HR '094'
+          task jgfs_atmos_post_f095
+            trigger ./jgfs_atmos_post_manager:release_post095
+            edit FHRGRP '096'
+            edit FHRLST 'f095'
+            edit FHR 'f095'
+            edit HR '095'
+          task jgfs_atmos_post_f096
+            trigger ./jgfs_atmos_post_manager:release_post096
+            edit FHRGRP '097'
+            edit FHRLST 'f096'
+            edit FHR 'f096'
+            edit HR '096'
+          task jgfs_atmos_post_f097
+            trigger ./jgfs_atmos_post_manager:release_post097
+            edit FHRGRP '098'
+            edit FHRLST 'f097'
+            edit FHR 'f097'
+            edit HR '097'
+          task jgfs_atmos_post_f098
+            trigger ./jgfs_atmos_post_manager:release_post098
+            edit FHRGRP '099'
+            edit FHRLST 'f098'
+            edit FHR 'f098'
+            edit HR '098'
+          task jgfs_atmos_post_f099
+            trigger ./jgfs_atmos_post_manager:release_post099
+            edit FHRGRP '100'
+            edit FHRLST 'f099'
+            edit FHR 'f099'
+            edit HR '099'
+          task jgfs_atmos_post_f100
+            trigger ./jgfs_atmos_post_manager:release_post100
+            edit FHRGRP '101'
+            edit FHRLST 'f100'
+            edit FHR 'f100'
+            edit HR '100'
+          task jgfs_atmos_post_f101
+            trigger ./jgfs_atmos_post_manager:release_post101
+            edit FHRGRP '102'
+            edit FHRLST 'f101'
+            edit FHR 'f101'
+            edit HR '101'
+          task jgfs_atmos_post_f102
+            trigger ./jgfs_atmos_post_manager:release_post102
+            edit FHRGRP '103'
+            edit FHRLST 'f102'
+            edit FHR 'f102'
+            edit HR '102'
+          task jgfs_atmos_post_f103
+            trigger ./jgfs_atmos_post_manager:release_post103
+            edit FHRGRP '104'
+            edit FHRLST 'f103'
+            edit FHR 'f103'
+            edit HR '103'
+          task jgfs_atmos_post_f104
+            trigger ./jgfs_atmos_post_manager:release_post104
+            edit FHRGRP '105'
+            edit FHRLST 'f104'
+            edit FHR 'f104'
+            edit HR '104'
+          task jgfs_atmos_post_f105
+            trigger ./jgfs_atmos_post_manager:release_post105
+            edit FHRGRP '106'
+            edit FHRLST 'f105'
+            edit FHR 'f105'
+            edit HR '105'
+          task jgfs_atmos_post_f106
+            trigger ./jgfs_atmos_post_manager:release_post106
+            edit FHRGRP '107'
+            edit FHRLST 'f106'
+            edit FHR 'f106'
+            edit HR '106'
+          task jgfs_atmos_post_f107
+            trigger ./jgfs_atmos_post_manager:release_post107
+            edit FHRGRP '108'
+            edit FHRLST 'f107'
+            edit FHR 'f107'
+            edit HR '107'
+          task jgfs_atmos_post_f108
+            trigger ./jgfs_atmos_post_manager:release_post108
+            edit FHRGRP '109'
+            edit FHRLST 'f108'
+            edit FHR 'f108'
+            edit HR '108'
+          task jgfs_atmos_post_f109
+            trigger ./jgfs_atmos_post_manager:release_post109
+            edit FHRGRP '110'
+            edit FHRLST 'f109'
+            edit FHR 'f109'
+            edit HR '109'
+          task jgfs_atmos_post_f110
+            trigger ./jgfs_atmos_post_manager:release_post110
+            edit FHRGRP '111'
+            edit FHRLST 'f110'
+            edit FHR 'f110'
+            edit HR '110'
+          task jgfs_atmos_post_f111
+            trigger ./jgfs_atmos_post_manager:release_post111
+            edit FHRGRP '112'
+            edit FHRLST 'f111'
+            edit FHR 'f111'
+            edit HR '111'
+          task jgfs_atmos_post_f112
+            trigger ./jgfs_atmos_post_manager:release_post112
+            edit FHRGRP '113'
+            edit FHRLST 'f112'
+            edit FHR 'f112'
+            edit HR '112'
+          task jgfs_atmos_post_f113
+            trigger ./jgfs_atmos_post_manager:release_post113
+            edit FHRGRP '114'
+            edit FHRLST 'f113'
+            edit FHR 'f113'
+            edit HR '113'
+          task jgfs_atmos_post_f114
+            trigger ./jgfs_atmos_post_manager:release_post114
+            edit FHRGRP '115'
+            edit FHRLST 'f114'
+            edit FHR 'f114'
+            edit HR '114'
+          task jgfs_atmos_post_f115
+            trigger ./jgfs_atmos_post_manager:release_post115
+            edit FHRGRP '116'
+            edit FHRLST 'f115'
+            edit FHR 'f115'
+            edit HR '115'
+          task jgfs_atmos_post_f116
+            trigger ./jgfs_atmos_post_manager:release_post116
+            edit FHRGRP '117'
+            edit FHRLST 'f116'
+            edit FHR 'f116'
+            edit HR '116'
+          task jgfs_atmos_post_f117
+            trigger ./jgfs_atmos_post_manager:release_post117
+            edit FHRGRP '118'
+            edit FHRLST 'f117'
+            edit FHR 'f117'
+            edit HR '117'
+          task jgfs_atmos_post_f118
+            trigger ./jgfs_atmos_post_manager:release_post118
+            edit FHRGRP '119'
+            edit FHRLST 'f118'
+            edit FHR 'f118'
+            edit HR '118'
+          task jgfs_atmos_post_f119
+            trigger ./jgfs_atmos_post_manager:release_post119
+            edit FHRGRP '120'
+            edit FHRLST 'f119'
+            edit FHR 'f119'
+            edit HR '119'
+          task jgfs_atmos_post_f120
+            trigger ./jgfs_atmos_post_manager:release_post120
+            edit FHRGRP '121'
+            edit FHRLST 'f120'
+            edit FHR 'f120'
+            edit HR '120'
+          task jgfs_atmos_post_f123
+            trigger ./jgfs_atmos_post_manager:release_post123
+            edit FHRGRP '122'
+            edit FHRLST 'f123'
+            edit FHR 'f123'
+            edit HR '123'
+          task jgfs_atmos_post_f126
+            trigger ./jgfs_atmos_post_manager:release_post126
+            edit FHRGRP '123'
+            edit FHRLST 'f126'
+            edit FHR 'f126'
+            edit HR '126'
+          task jgfs_atmos_post_f129
+            trigger ./jgfs_atmos_post_manager:release_post129
+            edit FHRGRP '124'
+            edit FHRLST 'f129'
+            edit FHR 'f129'
+            edit HR '129'
+          task jgfs_atmos_post_f132
+            trigger ./jgfs_atmos_post_manager:release_post132
+            edit FHRGRP '125'
+            edit FHRLST 'f132'
+            edit FHR 'f132'
+            edit HR '132'
+          task jgfs_atmos_post_f135
+            trigger ./jgfs_atmos_post_manager:release_post135
+            edit FHRGRP '126'
+            edit FHRLST 'f135'
+            edit FHR 'f135'
+            edit HR '135'
+          task jgfs_atmos_post_f138
+            trigger ./jgfs_atmos_post_manager:release_post138
+            edit FHRGRP '127'
+            edit FHRLST 'f138'
+            edit FHR 'f138'
+            edit HR '138'
+          task jgfs_atmos_post_f141
+            trigger ./jgfs_atmos_post_manager:release_post141
+            edit FHRGRP '128'
+            edit FHRLST 'f141'
+            edit FHR 'f141'
+            edit HR '141'
+          task jgfs_atmos_post_f144
+            trigger ./jgfs_atmos_post_manager:release_post144
+            edit FHRGRP '129'
+            edit FHRLST 'f144'
+            edit FHR 'f144'
+            edit HR '144'
+          task jgfs_atmos_post_f147
+            trigger ./jgfs_atmos_post_manager:release_post147
+            edit FHRGRP '130'
+            edit FHRLST 'f147'
+            edit FHR 'f147'
+            edit HR '147'
+          task jgfs_atmos_post_f150
+            trigger ./jgfs_atmos_post_manager:release_post150
+            edit FHRGRP '131'
+            edit FHRLST 'f150'
+            edit FHR 'f150'
+            edit HR '150'
+          task jgfs_atmos_post_f153
+            trigger ./jgfs_atmos_post_manager:release_post153
+            edit FHRGRP '132'
+            edit FHRLST 'f153'
+            edit FHR 'f153'
+            edit HR '153'
+          task jgfs_atmos_post_f156
+            trigger ./jgfs_atmos_post_manager:release_post156
+            edit FHRGRP '133'
+            edit FHRLST 'f156'
+            edit FHR 'f156'
+            edit HR '156'
+          task jgfs_atmos_post_f159
+            trigger ./jgfs_atmos_post_manager:release_post159
+            edit FHRGRP '134'
+            edit FHRLST 'f159'
+            edit FHR 'f159'
+            edit HR '159'
+          task jgfs_atmos_post_f162
+            trigger ./jgfs_atmos_post_manager:release_post162
+            edit FHRGRP '135'
+            edit FHRLST 'f162'
+            edit FHR 'f162'
+            edit HR '162'
+          task jgfs_atmos_post_f165
+            trigger ./jgfs_atmos_post_manager:release_post165
+            edit FHRGRP '136'
+            edit FHRLST 'f165'
+            edit FHR 'f165'
+            edit HR '165'
+          task jgfs_atmos_post_f168
+            trigger ./jgfs_atmos_post_manager:release_post168
+            edit FHRGRP '137'
+            edit FHRLST 'f168'
+            edit FHR 'f168'
+            edit HR '168'
+          task jgfs_atmos_post_f171
+            trigger ./jgfs_atmos_post_manager:release_post171
+            edit FHRGRP '138'
+            edit FHRLST 'f171'
+            edit FHR 'f171'
+            edit HR '171'
+          task jgfs_atmos_post_f174
+            trigger ./jgfs_atmos_post_manager:release_post174
+            edit FHRGRP '139'
+            edit FHRLST 'f174'
+            edit FHR 'f174'
+            edit HR '174'
+          task jgfs_atmos_post_f177
+            trigger ./jgfs_atmos_post_manager:release_post177
+            edit FHRGRP '140'
+            edit FHRLST 'f177'
+            edit FHR 'f177'
+            edit HR '177'
+          task jgfs_atmos_post_f180
+            trigger ./jgfs_atmos_post_manager:release_post180
+            edit FHRGRP '141'
+            edit FHRLST 'f180'
+            edit FHR 'f180'
+            edit HR '180'
+          task jgfs_atmos_post_f183
+            trigger ./jgfs_atmos_post_manager:release_post183
+            edit FHRGRP '142'
+            edit FHRLST 'f183'
+            edit FHR 'f183'
+            edit HR '183'
+          task jgfs_atmos_post_f186
+            trigger ./jgfs_atmos_post_manager:release_post186
+            edit FHRGRP '143'
+            edit FHRLST 'f186'
+            edit FHR 'f186'
+            edit HR '186'
+          task jgfs_atmos_post_f189
+            trigger ./jgfs_atmos_post_manager:release_post189
+            edit FHRGRP '144'
+            edit FHRLST 'f189'
+            edit FHR 'f189'
+            edit HR '189'
+          task jgfs_atmos_post_f192
+            trigger ./jgfs_atmos_post_manager:release_post192
+            edit FHRGRP '145'
+            edit FHRLST 'f192'
+            edit FHR 'f192'
+            edit HR '192'
+          task jgfs_atmos_post_f195
+            trigger ./jgfs_atmos_post_manager:release_post195
+            edit FHRGRP '146'
+            edit FHRLST 'f195'
+            edit FHR 'f195'
+            edit HR '195'
+          task jgfs_atmos_post_f198
+            trigger ./jgfs_atmos_post_manager:release_post198
+            edit FHRGRP '147'
+            edit FHRLST 'f198'
+            edit FHR 'f198'
+            edit HR '198'
+          task jgfs_atmos_post_f201
+            trigger ./jgfs_atmos_post_manager:release_post201
+            edit FHRGRP '148'
+            edit FHRLST 'f201'
+            edit FHR 'f201'
+            edit HR '201'
+          task jgfs_atmos_post_f204
+            trigger ./jgfs_atmos_post_manager:release_post204
+            edit FHRGRP '149'
+            edit FHRLST 'f204'
+            edit FHR 'f204'
+            edit HR '204'
+          task jgfs_atmos_post_f207
+            trigger ./jgfs_atmos_post_manager:release_post207
+            edit FHRGRP '150'
+            edit FHRLST 'f207'
+            edit FHR 'f207'
+            edit HR '207'
+          task jgfs_atmos_post_f210
+            trigger ./jgfs_atmos_post_manager:release_post210
+            edit FHRGRP '151'
+            edit FHRLST 'f210'
+            edit FHR 'f210'
+            edit HR '210'
+          task jgfs_atmos_post_f213
+            trigger ./jgfs_atmos_post_manager:release_post213
+            edit FHRGRP '152'
+            edit FHRLST 'f213'
+            edit FHR 'f213'
+            edit HR '213'
+          task jgfs_atmos_post_f216
+            trigger ./jgfs_atmos_post_manager:release_post216
+            edit FHRGRP '153'
+            edit FHRLST 'f216'
+            edit FHR 'f216'
+            edit HR '216'
+          task jgfs_atmos_post_f219
+            trigger ./jgfs_atmos_post_manager:release_post219
+            edit FHRGRP '154'
+            edit FHRLST 'f219'
+            edit FHR 'f219'
+            edit HR '219'
+          task jgfs_atmos_post_f222
+            trigger ./jgfs_atmos_post_manager:release_post222
+            edit FHRGRP '155'
+            edit FHRLST 'f222'
+            edit FHR 'f222'
+            edit HR '222'
+          task jgfs_atmos_post_f225
+            trigger ./jgfs_atmos_post_manager:release_post225
+            edit FHRGRP '156'
+            edit FHRLST 'f225'
+            edit FHR 'f225'
+            edit HR '225'
+          task jgfs_atmos_post_f228
+            trigger ./jgfs_atmos_post_manager:release_post228
+            edit FHRGRP '157'
+            edit FHRLST 'f228'
+            edit FHR 'f228'
+            edit HR '228'
+          task jgfs_atmos_post_f231
+            trigger ./jgfs_atmos_post_manager:release_post231
+            edit FHRGRP '158'
+            edit FHRLST 'f231'
+            edit FHR 'f231'
+            edit HR '231'
+          task jgfs_atmos_post_f234
+            trigger ./jgfs_atmos_post_manager:release_post234
+            edit FHRGRP '159'
+            edit FHRLST 'f234'
+            edit FHR 'f234'
+            edit HR '234'
+          task jgfs_atmos_post_f237
+            trigger ./jgfs_atmos_post_manager:release_post237
+            edit FHRGRP '160'
+            edit FHRLST 'f237'
+            edit FHR 'f237'
+            edit HR '237'
+          task jgfs_atmos_post_f240
+            trigger ./jgfs_atmos_post_manager:release_post240
+            edit FHRGRP '161'
+            edit FHRLST 'f240'
+            edit FHR 'f240'
+            edit HR '240'
+          task jgfs_atmos_post_f243
+            trigger ./jgfs_atmos_post_manager:release_post243
+            edit FHRGRP '162'
+            edit FHRLST 'f243'
+            edit FHR 'f243'
+            edit HR '243'
+          task jgfs_atmos_post_f246
+            trigger ./jgfs_atmos_post_manager:release_post246
+            edit FHRGRP '163'
+            edit FHRLST 'f246'
+            edit FHR 'f246'
+            edit HR '246'
+          task jgfs_atmos_post_f249
+            trigger ./jgfs_atmos_post_manager:release_post249
+            edit FHRGRP '164'
+            edit FHRLST 'f249'
+            edit FHR 'f249'
+            edit HR '249'
+          task jgfs_atmos_post_f252
+            trigger ./jgfs_atmos_post_manager:release_post252
+            edit FHRGRP '165'
+            edit FHRLST 'f252'
+            edit FHR 'f252'
+            edit HR '252'
+          task jgfs_atmos_post_f255
+            trigger ./jgfs_atmos_post_manager:release_post255
+            edit FHRGRP '166'
+            edit FHRLST 'f255'
+            edit FHR 'f255'
+            edit HR '255'
+          task jgfs_atmos_post_f258
+            trigger ./jgfs_atmos_post_manager:release_post258
+            edit FHRGRP '167'
+            edit FHRLST 'f258'
+            edit FHR 'f258'
+            edit HR '258'
+          task jgfs_atmos_post_f261
+            trigger ./jgfs_atmos_post_manager:release_post261
+            edit FHRGRP '168'
+            edit FHRLST 'f261'
+            edit FHR 'f261'
+            edit HR '261'
+          task jgfs_atmos_post_f264
+            trigger ./jgfs_atmos_post_manager:release_post264
+            edit FHRGRP '169'
+            edit FHRLST 'f264'
+            edit FHR 'f264'
+            edit HR '264'
+          task jgfs_atmos_post_f267
+            trigger ./jgfs_atmos_post_manager:release_post267
+            edit FHRGRP '170'
+            edit FHRLST 'f267'
+            edit FHR 'f267'
+            edit HR '267'
+          task jgfs_atmos_post_f270
+            trigger ./jgfs_atmos_post_manager:release_post270
+            edit FHRGRP '171'
+            edit FHRLST 'f270'
+            edit FHR 'f270'
+            edit HR '270'
+          task jgfs_atmos_post_f273
+            trigger ./jgfs_atmos_post_manager:release_post273
+            edit FHRGRP '172'
+            edit FHRLST 'f273'
+            edit FHR 'f273'
+            edit HR '273'
+          task jgfs_atmos_post_f276
+            trigger ./jgfs_atmos_post_manager:release_post276
+            edit FHRGRP '173'
+            edit FHRLST 'f276'
+            edit FHR 'f276'
+            edit HR '276'
+          task jgfs_atmos_post_f279
+            trigger ./jgfs_atmos_post_manager:release_post279
+            edit FHRGRP '174'
+            edit FHRLST 'f279'
+            edit FHR 'f279'
+            edit HR '279'
+          task jgfs_atmos_post_f282
+            trigger ./jgfs_atmos_post_manager:release_post282
+            edit FHRGRP '175'
+            edit FHRLST 'f282'
+            edit FHR 'f282'
+            edit HR '282'
+          task jgfs_atmos_post_f285
+            trigger ./jgfs_atmos_post_manager:release_post285
+            edit FHRGRP '176'
+            edit FHRLST 'f285'
+            edit FHR 'f285'
+            edit HR '285'
+          task jgfs_atmos_post_f288
+            trigger ./jgfs_atmos_post_manager:release_post288
+            edit FHRGRP '177'
+            edit FHRLST 'f288'
+            edit FHR 'f288'
+            edit HR '288'
+          task jgfs_atmos_post_f291
+            trigger ./jgfs_atmos_post_manager:release_post291
+            edit FHRGRP '178'
+            edit FHRLST 'f291'
+            edit FHR 'f291'
+            edit HR '291'
+          task jgfs_atmos_post_f294
+            trigger ./jgfs_atmos_post_manager:release_post294
+            edit FHRGRP '179'
+            edit FHRLST 'f294'
+            edit FHR 'f294'
+            edit HR '294'
+          task jgfs_atmos_post_f297
+            trigger ./jgfs_atmos_post_manager:release_post297
+            edit FHRGRP '180'
+            edit FHRLST 'f297'
+            edit FHR 'f297'
+            edit HR '297'
+          task jgfs_atmos_post_f300
+            trigger ./jgfs_atmos_post_manager:release_post300
+            edit FHRGRP '181'
+            edit FHRLST 'f300'
+            edit FHR 'f300'
+            edit HR '300'
+          task jgfs_atmos_post_f303
+            trigger ./jgfs_atmos_post_manager:release_post303
+            edit FHRGRP '182'
+            edit FHRLST 'f303'
+            edit FHR 'f303'
+            edit HR '303'
+          task jgfs_atmos_post_f306
+            trigger ./jgfs_atmos_post_manager:release_post306
+            edit FHRGRP '183'
+            edit FHRLST 'f306'
+            edit FHR 'f306'
+            edit HR '306'
+          task jgfs_atmos_post_f309
+            trigger ./jgfs_atmos_post_manager:release_post309
+            edit FHRGRP '184'
+            edit FHRLST 'f309'
+            edit FHR 'f309'
+            edit HR '309'
+          task jgfs_atmos_post_f312
+            trigger ./jgfs_atmos_post_manager:release_post312
+            edit FHRGRP '185'
+            edit FHRLST 'f312'
+            edit FHR 'f312'
+            edit HR '312'
+          task jgfs_atmos_post_f315
+            trigger ./jgfs_atmos_post_manager:release_post315
+            edit FHRGRP '186'
+            edit FHRLST 'f315'
+            edit FHR 'f315'
+            edit HR '315'
+          task jgfs_atmos_post_f318
+            trigger ./jgfs_atmos_post_manager:release_post318
+            edit FHRGRP '187'
+            edit FHRLST 'f318'
+            edit FHR 'f318'
+            edit HR '318'
+          task jgfs_atmos_post_f321
+            trigger ./jgfs_atmos_post_manager:release_post321
+            edit FHRGRP '188'
+            edit FHRLST 'f321'
+            edit FHR 'f321'
+            edit HR '321'
+          task jgfs_atmos_post_f324
+            trigger ./jgfs_atmos_post_manager:release_post324
+            edit FHRGRP '189'
+            edit FHRLST 'f324'
+            edit FHR 'f324'
+            edit HR '324'
+          task jgfs_atmos_post_f327
+            trigger ./jgfs_atmos_post_manager:release_post327
+            edit FHRGRP '190'
+            edit FHRLST 'f327'
+            edit FHR 'f327'
+            edit HR '327'
+          task jgfs_atmos_post_f330
+            trigger ./jgfs_atmos_post_manager:release_post330
+            edit FHRGRP '191'
+            edit FHRLST 'f330'
+            edit FHR 'f330'
+            edit HR '330'
+          task jgfs_atmos_post_f333
+            trigger ./jgfs_atmos_post_manager:release_post333
+            edit FHRGRP '192'
+            edit FHRLST 'f333'
+            edit FHR 'f333'
+            edit HR '333'
+          task jgfs_atmos_post_f336
+            trigger ./jgfs_atmos_post_manager:release_post336
+            edit FHRGRP '193'
+            edit FHRLST 'f336'
+            edit FHR 'f336'
+            edit HR '336'
+          task jgfs_atmos_post_f339
+            trigger ./jgfs_atmos_post_manager:release_post339
+            edit FHRGRP '194'
+            edit FHRLST 'f339'
+            edit FHR 'f339'
+            edit HR '339'
+          task jgfs_atmos_post_f342
+            trigger ./jgfs_atmos_post_manager:release_post342
+            edit FHRGRP '195'
+            edit FHRLST 'f342'
+            edit FHR 'f342'
+            edit HR '342'
+          task jgfs_atmos_post_f345
+            trigger ./jgfs_atmos_post_manager:release_post345
+            edit FHRGRP '196'
+            edit FHRLST 'f345'
+            edit FHR 'f345'
+            edit HR '345'
+          task jgfs_atmos_post_f348
+            trigger ./jgfs_atmos_post_manager:release_post348
+            edit FHRGRP '197'
+            edit FHRLST 'f348'
+            edit FHR 'f348'
+            edit HR '348'
+          task jgfs_atmos_post_f351
+            trigger ./jgfs_atmos_post_manager:release_post351
+            edit FHRGRP '198'
+            edit FHRLST 'f351'
+            edit FHR 'f351'
+            edit HR '351'
+          task jgfs_atmos_post_f354
+            trigger ./jgfs_atmos_post_manager:release_post354
+            edit FHRGRP '199'
+            edit FHRLST 'f354'
+            edit FHR 'f354'
+            edit HR '354'
+          task jgfs_atmos_post_f357
+            trigger ./jgfs_atmos_post_manager:release_post357
+            edit FHRGRP '200'
+            edit FHRLST 'f357'
+            edit FHR 'f357'
+            edit HR '357'
+          task jgfs_atmos_post_f360
+            trigger ./jgfs_atmos_post_manager:release_post360
+            edit FHRGRP '201'
+            edit FHRLST 'f360'
+            edit FHR 'f360'
+            edit HR '360'
+          task jgfs_atmos_post_f363
+            trigger ./jgfs_atmos_post_manager:release_post363
+            edit FHRGRP '202'
+            edit FHRLST 'f363'
+            edit FHR 'f363'
+            edit HR '363'
+          task jgfs_atmos_post_f366
+            trigger ./jgfs_atmos_post_manager:release_post366
+            edit FHRGRP '203'
+            edit FHRLST 'f366'
+            edit FHR 'f366'
+            edit HR '366'
+          task jgfs_atmos_post_f369
+            trigger ./jgfs_atmos_post_manager:release_post369
+            edit FHRGRP '204'
+            edit FHRLST 'f369'
+            edit FHR 'f369'
+            edit HR '369'
+          task jgfs_atmos_post_f372
+            trigger ./jgfs_atmos_post_manager:release_post372
+            edit FHRGRP '205'
+            edit FHRLST 'f372'
+            edit FHR 'f372'
+            edit HR '372'
+          task jgfs_atmos_post_f375
+            trigger ./jgfs_atmos_post_manager:release_post375
+            edit FHRGRP '206'
+            edit FHRLST 'f375'
+            edit FHR 'f375'
+            edit HR '375'
+          task jgfs_atmos_post_f378
+            trigger ./jgfs_atmos_post_manager:release_post378
+            edit FHRGRP '207'
+            edit FHRLST 'f378'
+            edit FHR 'f378'
+            edit HR '378'
+          task jgfs_atmos_post_f381
+            trigger ./jgfs_atmos_post_manager:release_post381
+            edit FHRGRP '208'
+            edit FHRLST 'f381'
+            edit FHR 'f381'
+            edit HR '381'
+          task jgfs_atmos_post_f384
+            trigger ./jgfs_atmos_post_manager:release_post384
+            edit FHRGRP '209'
+            edit FHRLST 'f384'
+            edit FHR 'f384'
+            edit HR '384'
+        endfamily
+        family post_processing
+          task jgfs_atmos_wafs_gcip
+            trigger ( :TIME >= 1640 and :TIME < 2240) and ../post/jgfs_atmos_post_f003 == complete
+          family grib_wafs
+            task jgfs_atmos_wafs_f000
+              trigger ../../post/jgfs_atmos_post_f000 == complete and ../../post/jgfs_atmos_post_f120 == complete and ../grib2_wafs/jgfs_atmos_wafs_grib2 == complete
+              edit FCSTHR '00'
+            task jgfs_atmos_wafs_f006
+              trigger ../../post/jgfs_atmos_post_f006 == complete and ./jgfs_atmos_wafs_f000 == complete
+              edit FCSTHR '06'
+            task jgfs_atmos_wafs_f012
+              trigger ../../post/jgfs_atmos_post_f012 == complete and ./jgfs_atmos_wafs_f006 == complete
+              edit FCSTHR '12'
+            task jgfs_atmos_wafs_f018
+              trigger ../../post/jgfs_atmos_post_f018 == complete and ./jgfs_atmos_wafs_f012 == complete
+              edit FCSTHR '18'
+            task jgfs_atmos_wafs_f024
+              trigger ../../post/jgfs_atmos_post_f024 == complete and ./jgfs_atmos_wafs_f018 == complete
+              edit FCSTHR '24'
+            task jgfs_atmos_wafs_f030
+              trigger ../../post/jgfs_atmos_post_f030 == complete and ./jgfs_atmos_wafs_f024 == complete
+              edit FCSTHR '30'
+            task jgfs_atmos_wafs_f036
+              trigger ../../post/jgfs_atmos_post_f036 == complete and ./jgfs_atmos_wafs_f030 == complete
+              edit FCSTHR '36'
+            task jgfs_atmos_wafs_f042
+              trigger ../../post/jgfs_atmos_post_f042 == complete and ./jgfs_atmos_wafs_f036 == complete
+              edit FCSTHR '42'
+            task jgfs_atmos_wafs_f048
+              trigger ../../post/jgfs_atmos_post_f048 == complete and ./jgfs_atmos_wafs_f042 == complete
+              edit FCSTHR '48'
+            task jgfs_atmos_wafs_f054
+              trigger ../../post/jgfs_atmos_post_f054 == complete and ./jgfs_atmos_wafs_f048 == complete
+              edit FCSTHR '54'
+            task jgfs_atmos_wafs_f060
+              trigger ../../post/jgfs_atmos_post_f060 == complete and ./jgfs_atmos_wafs_f054 == complete
+              edit FCSTHR '60'
+            task jgfs_atmos_wafs_f066
+              trigger ../../post/jgfs_atmos_post_f066 == complete and ./jgfs_atmos_wafs_f060 == complete
+              edit FCSTHR '66'
+            task jgfs_atmos_wafs_f072
+              trigger ../../post/jgfs_atmos_post_f072 == complete and ./jgfs_atmos_wafs_f066 == complete
+              edit FCSTHR '72'
+            task jgfs_atmos_wafs_f078
+              trigger ../../post/jgfs_atmos_post_f078 == complete and ./jgfs_atmos_wafs_f072 == complete
+              edit FCSTHR '78'
+            task jgfs_atmos_wafs_f084
+              trigger ../../post/jgfs_atmos_post_f084 == complete and ./jgfs_atmos_wafs_f078 == complete
+              edit FCSTHR '84'
+            task jgfs_atmos_wafs_f090
+              trigger ../../post/jgfs_atmos_post_f090 == complete and ./jgfs_atmos_wafs_f084 == complete
+              edit FCSTHR '90'
+            task jgfs_atmos_wafs_f096
+              trigger ../../post/jgfs_atmos_post_f096 == complete and ./jgfs_atmos_wafs_f090 == complete
+              edit FCSTHR '96'
+            task jgfs_atmos_wafs_f102
+              trigger ../../post/jgfs_atmos_post_f102 == complete and ./jgfs_atmos_wafs_f096 == complete
+              edit FCSTHR '102'
+            task jgfs_atmos_wafs_f108
+              trigger ../../post/jgfs_atmos_post_f108 == complete and ./jgfs_atmos_wafs_f102 == complete
+              edit FCSTHR '108'
+            task jgfs_atmos_wafs_f114
+              trigger ../../post/jgfs_atmos_post_f114 == complete and ./jgfs_atmos_wafs_f108 == complete
+              edit FCSTHR '114'
+            task jgfs_atmos_wafs_f120
+              trigger ../../post/jgfs_atmos_post_f120 == complete and ./jgfs_atmos_wafs_f114 == complete
+              edit FCSTHR '120'
+          endfamily
+          family grib2_wafs
+            task jgfs_atmos_wafs_grib2
+              trigger ../../post/jgfs_atmos_post_f000 == complete
+            task jgfs_atmos_wafs_grib2_0p25
+              trigger ../../post/jgfs_atmos_post_f036 == complete
+            task jgfs_atmos_wafs_blending
+              trigger ( :TIME >= 1633 and :TIME < 2233) and ./jgfs_atmos_wafs_grib2 == complete
+            task jgfs_atmos_wafs_blending_0p25
+              trigger ( :TIME >= 1625 and :TIME < 2225) and ./jgfs_atmos_wafs_grib2_0p25 == complete
+          endfamily
+          family bufr_sounding
+            task jgfs_atmos_postsnd
+              trigger ../../post/jgfs_atmos_post_manager:release_post000
+          endfamily
+          family bulletins
+            task jgfs_atmos_fbwind
+              trigger ../../post/jgfs_atmos_post_f006 == complete and ../../post/jgfs_atmos_post_f012 == complete and ../../post/jgfs_atmos_post_f024 == complete
+          endfamily
+          family awips_20km_1p0
+            task jgfs_atmos_awips_f000
+              trigger ../../post/jgfs_atmos_post_f000 == complete
+              edit FHRGRP '000'
+              edit FHRLST 'f000'
+              edit FCSTHR '000'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f003
+              trigger ../../post/jgfs_atmos_post_f003 == complete
+              edit FHRGRP '003'
+              edit FHRLST 'f003'
+              edit FCSTHR '003'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f006
+              trigger ../../post/jgfs_atmos_post_f006 == complete
+              edit FHRGRP '006'
+              edit FHRLST 'f006'
+              edit FCSTHR '006'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f009
+              trigger ../../post/jgfs_atmos_post_f009 == complete
+              edit FHRGRP '009'
+              edit FHRLST 'f009'
+              edit FCSTHR '009'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f012
+              trigger ../../post/jgfs_atmos_post_f012 == complete
+              edit FHRGRP '012'
+              edit FHRLST 'f012'
+              edit FCSTHR '012'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f015
+              trigger ../../post/jgfs_atmos_post_f015 == complete
+              edit FHRGRP '015'
+              edit FHRLST 'f015'
+              edit FCSTHR '015'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f018
+              trigger ../../post/jgfs_atmos_post_f018 == complete
+              edit FHRGRP '018'
+              edit FHRLST 'f018'
+              edit FCSTHR '018'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f021
+              trigger ../../post/jgfs_atmos_post_f021 == complete
+              edit FHRGRP '021'
+              edit FHRLST 'f021'
+              edit FCSTHR '021'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f024
+              trigger ../../post/jgfs_atmos_post_f024 == complete
+              edit FHRGRP '024'
+              edit FHRLST 'f024'
+              edit FCSTHR '024'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f027
+              trigger ../../post/jgfs_atmos_post_f027 == complete
+              edit FHRGRP '027'
+              edit FHRLST 'f027'
+              edit FCSTHR '027'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f030
+              trigger ../../post/jgfs_atmos_post_f030 == complete
+              edit FHRGRP '030'
+              edit FHRLST 'f030'
+              edit FCSTHR '030'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f033
+              trigger ../../post/jgfs_atmos_post_f033 == complete
+              edit FHRGRP '033'
+              edit FHRLST 'f033'
+              edit FCSTHR '033'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f036
+              trigger ../../post/jgfs_atmos_post_f036 == complete
+              edit FHRGRP '036'
+              edit FHRLST 'f036'
+              edit FCSTHR '036'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f039
+              trigger ../../post/jgfs_atmos_post_f039 == complete
+              edit FHRGRP '039'
+              edit FHRLST 'f039'
+              edit FCSTHR '039'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f042
+              trigger ../../post/jgfs_atmos_post_f042 == complete
+              edit FHRGRP '042'
+              edit FHRLST 'f042'
+              edit FCSTHR '042'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f045
+              trigger ../../post/jgfs_atmos_post_f045 == complete
+              edit FHRGRP '045'
+              edit FHRLST 'f045'
+              edit FCSTHR '045'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f048
+              trigger ../../post/jgfs_atmos_post_f048 == complete
+              edit FHRGRP '048'
+              edit FHRLST 'f048'
+              edit FCSTHR '048'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f051
+              trigger ../../post/jgfs_atmos_post_f051 == complete
+              edit FHRGRP '051'
+              edit FHRLST 'f051'
+              edit FCSTHR '051'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f054
+              trigger ../../post/jgfs_atmos_post_f054 == complete
+              edit FHRGRP '054'
+              edit FHRLST 'f054'
+              edit FCSTHR '054'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f057
+              trigger ../../post/jgfs_atmos_post_f057 == complete
+              edit FHRGRP '057'
+              edit FHRLST 'f057'
+              edit FCSTHR '057'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f060
+              trigger ../../post/jgfs_atmos_post_f060 == complete
+              edit FHRGRP '060'
+              edit FHRLST 'f060'
+              edit FCSTHR '060'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f063
+              trigger ../../post/jgfs_atmos_post_f063 == complete
+              edit FHRGRP '063'
+              edit FHRLST 'f063'
+              edit FCSTHR '063'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f066
+              trigger ../../post/jgfs_atmos_post_f066 == complete
+              edit FHRGRP '066'
+              edit FHRLST 'f066'
+              edit FCSTHR '066'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f069
+              trigger ../../post/jgfs_atmos_post_f069 == complete
+              edit FHRGRP '069'
+              edit FHRLST 'f069'
+              edit FCSTHR '069'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f072
+              trigger ../../post/jgfs_atmos_post_f072 == complete
+              edit FHRGRP '072'
+              edit FHRLST 'f072'
+              edit FCSTHR '072'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f075
+              trigger ../../post/jgfs_atmos_post_f075 == complete
+              edit FHRGRP '075'
+              edit FHRLST 'f075'
+              edit FCSTHR '075'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f078
+              trigger ../../post/jgfs_atmos_post_f078 == complete
+              edit FHRGRP '078'
+              edit FHRLST 'f078'
+              edit FCSTHR '078'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f081
+              trigger ../../post/jgfs_atmos_post_f081 == complete
+              edit FHRGRP '081'
+              edit FHRLST 'f081'
+              edit FCSTHR '081'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f084
+              trigger ../../post/jgfs_atmos_post_f084 == complete
+              edit FHRGRP '084'
+              edit FHRLST 'f084'
+              edit FCSTHR '084'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f090
+              trigger ../../post/jgfs_atmos_post_f090 == complete
+              edit FHRGRP '090'
+              edit FHRLST 'f090'
+              edit FCSTHR '090'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f096
+              trigger ../../post/jgfs_atmos_post_f096 == complete
+              edit FHRGRP '096'
+              edit FHRLST 'f096'
+              edit FCSTHR '096'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f102
+              trigger ../../post/jgfs_atmos_post_f102 == complete
+              edit FHRGRP '102'
+              edit FHRLST 'f102'
+              edit FCSTHR '102'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f108
+              trigger ../../post/jgfs_atmos_post_f108 == complete
+              edit FHRGRP '108'
+              edit FHRLST 'f108'
+              edit FCSTHR '108'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f114
+              trigger ../../post/jgfs_atmos_post_f114 == complete
+              edit FHRGRP '114'
+              edit FHRLST 'f114'
+              edit FCSTHR '114'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f120
+              trigger ../../post/jgfs_atmos_post_f120 == complete
+              edit FHRGRP '120'
+              edit FHRLST 'f120'
+              edit FCSTHR '120'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f126
+              trigger ../../post/jgfs_atmos_post_f126 == complete
+              edit FHRGRP '126'
+              edit FHRLST 'f126'
+              edit FCSTHR '126'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f132
+              trigger ../../post/jgfs_atmos_post_f132 == complete
+              edit FHRGRP '132'
+              edit FHRLST 'f132'
+              edit FCSTHR '132'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f138
+              trigger ../../post/jgfs_atmos_post_f138 == complete
+              edit FHRGRP '138'
+              edit FHRLST 'f138'
+              edit FCSTHR '138'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f144
+              trigger ../../post/jgfs_atmos_post_f144 == complete
+              edit FHRGRP '144'
+              edit FHRLST 'f144'
+              edit FCSTHR '144'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f150
+              trigger ../../post/jgfs_atmos_post_f150 == complete
+              edit FHRGRP '150'
+              edit FHRLST 'f150'
+              edit FCSTHR '150'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f156
+              trigger ../../post/jgfs_atmos_post_f156 == complete
+              edit FHRGRP '156'
+              edit FHRLST 'f156'
+              edit FCSTHR '156'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f162
+              trigger ../../post/jgfs_atmos_post_f162 == complete
+              edit FHRGRP '162'
+              edit FHRLST 'f162'
+              edit FCSTHR '162'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f168
+              trigger ../../post/jgfs_atmos_post_f168 == complete
+              edit FHRGRP '168'
+              edit FHRLST 'f168'
+              edit FCSTHR '168'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f174
+              trigger ../../post/jgfs_atmos_post_f174 == complete
+              edit FHRGRP '174'
+              edit FHRLST 'f174'
+              edit FCSTHR '174'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f180
+              trigger ../../post/jgfs_atmos_post_f180 == complete
+              edit FHRGRP '180'
+              edit FHRLST 'f180'
+              edit FCSTHR '180'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f186
+              trigger ../../post/jgfs_atmos_post_f186 == complete
+              edit FHRGRP '186'
+              edit FHRLST 'f186'
+              edit FCSTHR '186'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f192
+              trigger ../../post/jgfs_atmos_post_f192 == complete
+              edit FHRGRP '192'
+              edit FHRLST 'f192'
+              edit FCSTHR '192'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f198
+              trigger ../../post/jgfs_atmos_post_f198 == complete
+              edit FHRGRP '198'
+              edit FHRLST 'f198'
+              edit FCSTHR '198'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f204
+              trigger ../../post/jgfs_atmos_post_f204 == complete
+              edit FHRGRP '204'
+              edit FHRLST 'f204'
+              edit FCSTHR '204'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f210
+              trigger ../../post/jgfs_atmos_post_f210 == complete
+              edit FHRGRP '210'
+              edit FHRLST 'f210'
+              edit FCSTHR '210'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f216
+              trigger ../../post/jgfs_atmos_post_f216 == complete
+              edit FHRGRP '216'
+              edit FHRLST 'f216'
+              edit FCSTHR '216'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f222
+              trigger ../../post/jgfs_atmos_post_f222 == complete
+              edit FHRGRP '222'
+              edit FHRLST 'f222'
+              edit FCSTHR '222'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f228
+              trigger ../../post/jgfs_atmos_post_f228 == complete
+              edit FHRGRP '228'
+              edit FHRLST 'f228'
+              edit FCSTHR '228'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f234
+              trigger ../../post/jgfs_atmos_post_f234 == complete
+              edit FHRGRP '234'
+              edit FHRLST 'f234'
+              edit FCSTHR '234'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f240
+              trigger ../../post/jgfs_atmos_post_f240 == complete
+              edit FHRGRP '240'
+              edit FHRLST 'f240'
+              edit FCSTHR '240'
+              edit TRDRUN 'YES'
+          endfamily
+          family awips_g2
+            task jgfs_atmos_awips_g2_f000
+              trigger ../../post/jgfs_atmos_post_f000 == complete
+              edit FHRGRP '000'
+              edit FHRLST 'f000'
+              edit FCSTHR '000'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f006
+              trigger ../../post/jgfs_atmos_post_f006 == complete
+              edit FHRGRP '006'
+              edit FHRLST 'f006'
+              edit FCSTHR '006'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f012
+              trigger ../../post/jgfs_atmos_post_f012 == complete
+              edit FHRGRP '012'
+              edit FHRLST 'f012'
+              edit FCSTHR '012'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f018
+              trigger ../../post/jgfs_atmos_post_f018 == complete
+              edit FHRGRP '018'
+              edit FHRLST 'f018'
+              edit FCSTHR '018'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f024
+              trigger ../../post/jgfs_atmos_post_f024 == complete
+              edit FHRGRP '024'
+              edit FHRLST 'f024'
+              edit FCSTHR '024'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f030
+              trigger ../../post/jgfs_atmos_post_f030 == complete
+              edit FHRGRP '030'
+              edit FHRLST 'f030'
+              edit FCSTHR '030'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f036
+              trigger ../../post/jgfs_atmos_post_f036 == complete
+              edit FHRGRP '036'
+              edit FHRLST 'f036'
+              edit FCSTHR '036'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f042
+              trigger ../../post/jgfs_atmos_post_f042 == complete
+              edit FHRGRP '042'
+              edit FHRLST 'f042'
+              edit FCSTHR '042'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f048
+              trigger ../../post/jgfs_atmos_post_f048 == complete
+              edit FHRGRP '048'
+              edit FHRLST 'f048'
+              edit FCSTHR '048'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f054
+              trigger ../../post/jgfs_atmos_post_f054 == complete
+              edit FHRGRP '054'
+              edit FHRLST 'f054'
+              edit FCSTHR '054'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f060
+              trigger ../../post/jgfs_atmos_post_f060 == complete
+              edit FHRGRP '060'
+              edit FHRLST 'f060'
+              edit FCSTHR '060'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f066
+              trigger ../../post/jgfs_atmos_post_f066 == complete
+              edit FHRGRP '066'
+              edit FHRLST 'f066'
+              edit FCSTHR '066'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f072
+              trigger ../../post/jgfs_atmos_post_f072 == complete
+              edit FHRGRP '072'
+              edit FHRLST 'f072'
+              edit FCSTHR '072'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f078
+              trigger ../../post/jgfs_atmos_post_f078 == complete
+              edit FHRGRP '078'
+              edit FHRLST 'f078'
+              edit FCSTHR '078'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f084
+              trigger ../../post/jgfs_atmos_post_f084 == complete
+              edit FHRGRP '084'
+              edit FHRLST 'f084'
+              edit FCSTHR '084'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f090
+              trigger ../../post/jgfs_atmos_post_f090 == complete
+              edit FHRGRP '090'
+              edit FHRLST 'f090'
+              edit FCSTHR '090'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f096
+              trigger ../../post/jgfs_atmos_post_f096 == complete
+              edit FHRGRP '096'
+              edit FHRLST 'f096'
+              edit FCSTHR '096'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f102
+              trigger ../../post/jgfs_atmos_post_f102 == complete
+              edit FHRGRP '102'
+              edit FHRLST 'f102'
+              edit FCSTHR '102'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f108
+              trigger ../../post/jgfs_atmos_post_f108 == complete
+              edit FHRGRP '108'
+              edit FHRLST 'f108'
+              edit FCSTHR '108'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f114
+              trigger ../../post/jgfs_atmos_post_f114 == complete
+              edit FHRGRP '114'
+              edit FHRLST 'f114'
+              edit FCSTHR '114'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f120
+              trigger ../../post/jgfs_atmos_post_f120 == complete
+              edit FHRGRP '120'
+              edit FHRLST 'f120'
+              edit FCSTHR '120'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f126
+              trigger ../../post/jgfs_atmos_post_f126 == complete
+              edit FHRGRP '126'
+              edit FHRLST 'f126'
+              edit FCSTHR '126'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f132
+              trigger ../../post/jgfs_atmos_post_f132 == complete
+              edit FHRGRP '132'
+              edit FHRLST 'f132'
+              edit FCSTHR '132'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f138
+              trigger ../../post/jgfs_atmos_post_f138 == complete
+              edit FHRGRP '138'
+              edit FHRLST 'f138'
+              edit FCSTHR '138'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f144
+              trigger ../../post/jgfs_atmos_post_f144 == complete
+              edit FHRGRP '144'
+              edit FHRLST 'f144'
+              edit FCSTHR '144'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f150
+              trigger ../../post/jgfs_atmos_post_f150 == complete
+              edit FHRGRP '150'
+              edit FHRLST 'f150'
+              edit FCSTHR '150'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f156
+              trigger ../../post/jgfs_atmos_post_f156 == complete
+              edit FHRGRP '156'
+              edit FHRLST 'f156'
+              edit FCSTHR '156'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f162
+              trigger ../../post/jgfs_atmos_post_f162 == complete
+              edit FHRGRP '162'
+              edit FHRLST 'f162'
+              edit FCSTHR '162'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f168
+              trigger ../../post/jgfs_atmos_post_f168 == complete
+              edit FHRGRP '168'
+              edit FHRLST 'f168'
+              edit FCSTHR '168'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f174
+              trigger ../../post/jgfs_atmos_post_f174 == complete
+              edit FHRGRP '174'
+              edit FHRLST 'f174'
+              edit FCSTHR '174'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f180
+              trigger ../../post/jgfs_atmos_post_f180 == complete
+              edit FHRGRP '180'
+              edit FHRLST 'f180'
+              edit FCSTHR '180'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f186
+              trigger ../../post/jgfs_atmos_post_f186 == complete
+              edit FHRGRP '186'
+              edit FHRLST 'f186'
+              edit FCSTHR '186'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f192
+              trigger ../../post/jgfs_atmos_post_f192 == complete
+              edit FHRGRP '192'
+              edit FHRLST 'f192'
+              edit FCSTHR '192'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f198
+              trigger ../../post/jgfs_atmos_post_f198 == complete
+              edit FHRGRP '198'
+              edit FHRLST 'f198'
+              edit FCSTHR '198'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f204
+              trigger ../../post/jgfs_atmos_post_f204 == complete
+              edit FHRGRP '204'
+              edit FHRLST 'f204'
+              edit FCSTHR '204'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f210
+              trigger ../../post/jgfs_atmos_post_f210 == complete
+              edit FHRGRP '210'
+              edit FHRLST 'f210'
+              edit FCSTHR '210'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f216
+              trigger ../../post/jgfs_atmos_post_f216 == complete
+              edit FHRGRP '216'
+              edit FHRLST 'f216'
+              edit FCSTHR '216'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f222
+              trigger ../../post/jgfs_atmos_post_f222 == complete
+              edit FHRGRP '222'
+              edit FHRLST 'f222'
+              edit FCSTHR '222'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f228
+              trigger ../../post/jgfs_atmos_post_f228 == complete
+              edit FHRGRP '228'
+              edit FHRLST 'f228'
+              edit FCSTHR '228'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f234
+              trigger ../../post/jgfs_atmos_post_f234 == complete
+              edit FHRGRP '234'
+              edit FHRLST 'f234'
+              edit FCSTHR '234'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f240
+              trigger ../../post/jgfs_atmos_post_f240 == complete
+              edit FHRGRP '240'
+              edit FHRLST 'f240'
+              edit FCSTHR '240'
+              edit TRDRUN 'YES'
+          endfamily
+        endfamily
+        family gempak
+          task jgfs_atmos_gempak
+            trigger ../../atmos/analysis/jgfs_atmos_analysis == complete
+          task jgfs_atmos_gempak_meta
+            trigger ../../atmos/analysis/jgfs_atmos_analysis == complete
+          task jgfs_atmos_gempak_ncdc_upapgif
+            trigger ./jgfs_atmos_gempak == active or ./jgfs_atmos_gempak == complete
+          task jgfs_atmos_npoess_pgrb2_0p5deg
+            trigger ../post/jgfs_atmos_post_anl eq active or ../post/jgfs_atmos_post_anl == complete
+          task jgfs_atmos_pgrb2_spec_gempak
+            trigger ./jgfs_atmos_npoess_pgrb2_0p5deg == complete
+        endfamily
+        family verf
+          task jgfs_atmos_vminmon
+            trigger ../analysis/jgfs_atmos_analysis == complete
+        endfamily
+      endfamily
+      family wave
+        family init
+          task jgfs_wave_init
+            trigger /prod/primary/12/obsproc/v1.0/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete
+        endfamily
+        family prep
+          task jgfs_wave_prep
+            trigger ../init/jgfs_wave_init == complete
+        endfamily
+        family post
+          task jgfs_wave_postsbs
+            trigger ../../atmos/post/jgfs_atmos_post_manager:release_post000
+          task jgfs_wave_postpnt
+            trigger ../../jgfs_forecast == complete
+          task jgfs_wave_post_bndpnt
+            trigger ../../atmos/post/jgfs_atmos_post_manager:release_post180
+          task jgfs_wave_post_bndpntbll
+            trigger ../../atmos/post/jgfs_atmos_post_manager:release_post180
+          task jgfs_wave_prdgen_gridded
+            trigger ./jgfs_wave_postsbs == active or ./jgfs_wave_postsbs == complete
+          task jgfs_wave_prdgen_bulls
+            trigger ./jgfs_wave_postpnt == complete and ./jgfs_wave_postsbs == complete
+        endfamily
+        family gempak
+          task jgfs_wave_gempak
+            trigger ../post/jgfs_wave_postsbs == active or ../post/jgfs_wave_postsbs == complete
+        endfamily
+      endfamily
+      task jgfs_forecast
+        trigger ./atmos/analysis/jgfs_atmos_analysis:release_fcst and ./wave/prep/jgfs_wave_prep == complete
+        edit KEEPDATA 'YES'
+    endfamily
+    family gdas
+      edit RUN 'gdas'
+      edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/gdas'
+      family atmos
+        family obsproc
+          family dump
+            task jgdas_atmos_tropcy_qc_reloc
+              trigger :TIME >= 1745 and :TIME < 2345
+          endfamily
+          family prep
+            task jgdas_atmos_emcsfc_sfc_prep
+              trigger /prod/primary/12/obsproc/v1.0/gdas/atmos/dump/jobsproc_gdas_atmos_dump:release_sfcprep
+          endfamily
+        endfamily
+        family init
+          task jgdas_atmos_gldas
+            trigger ../analysis/jgdas_atmos_analysis == complete
+        endfamily
+        family analysis
+          task jgdas_atmos_analysis
+            trigger /prod/primary/12/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../obsproc/prep/jgdas_atmos_emcsfc_sfc_prep == complete
+            event 1 release_fcst
+          task jgdas_atmos_analysis_calc
+            trigger ./jgdas_atmos_analysis == complete
+          task jgdas_atmos_analysis_diag
+            trigger ./jgdas_atmos_analysis == complete
+        endfamily
+        family post
+          task jgdas_atmos_post_manager
+            trigger ../../jgdas_forecast == active
+            event 1 release_postanl
+            event 2 release_post000
+            event 3 release_post001
+            event 4 release_post002
+            event 5 release_post003
+            event 6 release_post004
+            event 7 release_post005
+            event 8 release_post006
+            event 9 release_post007
+            event 10 release_post008
+            event 11 release_post009
+          task jgdas_atmos_post_anl
+            trigger ./jgdas_atmos_post_manager:release_postanl
+            edit FHRGRP '000'
+            edit FHRLST 'anl'
+            edit HR 'anl'
+            edit FHR 'anl'
+          task jgdas_atmos_post_f000
+            trigger ./jgdas_atmos_post_manager:release_post000
+            edit FHR 'f000'
+            edit HR '000'
+            edit FHRGRP '001'
+            edit FHRLST 'f000'
+          task jgdas_atmos_post_f001
+            trigger ./jgdas_atmos_post_manager:release_post001
+            edit FHR 'f001'
+            edit HR '001'
+            edit FHRGRP '002'
+            edit FHRLST 'f001'
+          task jgdas_atmos_post_f002
+            trigger ./jgdas_atmos_post_manager:release_post002
+            edit FHR 'f002'
+            edit HR '002'
+            edit FHRGRP '003'
+            edit FHRLST 'f002'
+          task jgdas_atmos_post_f003
+            trigger ./jgdas_atmos_post_manager:release_post003
+            edit FHR 'f003'
+            edit HR '003'
+            edit FHRGRP '004'
+            edit FHRLST 'f003'
+          task jgdas_atmos_post_f004
+            trigger ./jgdas_atmos_post_manager:release_post004
+            edit FHR 'f004'
+            edit HR '004'
+            edit FHRGRP '005'
+            edit FHRLST 'f004'
+          task jgdas_atmos_post_f005
+            trigger ./jgdas_atmos_post_manager:release_post005
+            edit FHR 'f005'
+            edit HR '005'
+            edit FHRGRP '006'
+            edit FHRLST 'f005'
+          task jgdas_atmos_post_f006
+            trigger ./jgdas_atmos_post_manager:release_post006
+            edit FHR 'f006'
+            edit HR '006'
+            edit FHRGRP '007'
+            edit FHRLST 'f006'
+          task jgdas_atmos_post_f007
+            trigger ./jgdas_atmos_post_manager:release_post007
+            edit FHR 'f007'
+            edit HR '007'
+            edit FHRGRP '008'
+            edit FHRLST 'f007'
+          task jgdas_atmos_post_f008
+            trigger ./jgdas_atmos_post_manager:release_post008
+            edit FHR 'f008'
+            edit HR '008'
+            edit FHRGRP '009'
+            edit FHRLST 'f008'
+          task jgdas_atmos_post_f009
+            trigger ./jgdas_atmos_post_manager:release_post009
+            edit FHR 'f009'
+            edit HR '009'
+            edit FHRGRP '010'
+            edit FHRLST 'f009'
+        endfamily
+        family post_processing
+          task jgdas_atmos_chgres_forenkf
+            trigger ../../jgdas_forecast == complete and ../../../enkfgdas/forecast == complete
+        endfamily
+        family gempak
+          task jgdas_atmos_gempak
+            trigger ../../jgdas_forecast == complete
+          task jgdas_atmos_gempak_meta_ncdc
+            trigger ./jgdas_atmos_gempak == complete
+        endfamily
+        family verf
+          task jgdas_atmos_vminmon
+            trigger ../analysis/jgdas_atmos_analysis == complete
+          task jgdas_atmos_verfrad
+            trigger ../analysis/jgdas_atmos_analysis_diag == complete
+          task jgdas_atmos_verfozn
+            trigger ../analysis/jgdas_atmos_analysis_diag == complete
+        endfamily
+      endfamily
+      family wave
+        family init
+          task jgdas_wave_init
+            trigger /prod/primary/12/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete
+        endfamily
+        family prep
+          task jgdas_wave_prep
+            trigger ../init/jgdas_wave_init == complete
+        endfamily
+        family post
+          task jgdas_wave_postsbs
+            trigger ../../atmos/post/jgdas_atmos_post_manager:release_post000
+          task jgdas_wave_postpnt
+            trigger ../../jgdas_forecast == complete
+        endfamily
+      endfamily
+      task jgdas_forecast
+        trigger ./atmos/analysis/jgdas_atmos_analysis:release_fcst and ./wave/prep/jgdas_wave_prep == complete and ./atmos/init/jgdas_atmos_gldas == complete
+    endfamily
+    family enkfgdas
+      edit RUN 'gdas'
+      edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/enkfgdas'
+      family analysis
+        family create
+          task jenkfgdas_select_obs
+            trigger /prod/primary/12/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and /prod/primary/06/gfs/v16.2/enkfgdas/post == complete
+          task jenkfgdas_diag
+            trigger ./jenkfgdas_select_obs == complete
+          task jenkfgdas_update
+            trigger ./jenkfgdas_diag == complete
+        endfamily
+        family recenter
+          family ecen
+            trigger ../create/jenkfgdas_update == complete and ../../../gdas/atmos/analysis/jgdas_atmos_analysis_calc == complete and /prod/primary/06/gfs/v16.2/gdas/atmos/post_processing/jgdas_atmos_chgres_forenkf == complete
+            edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/enkfgdas/analysis/recenter/ecen'
+            family grp1
+              edit FHRGRP '003'
+              task jenkfgdas_ecen
+            endfamily
+            family grp2
+              edit FHRGRP '006'
+              task jenkfgdas_ecen
+            endfamily
+            family grp3
+              edit FHRGRP '009'
+              task jenkfgdas_ecen
+            endfamily
+          endfamily
+          task jenkfgdas_sfc
+            trigger ../create/jenkfgdas_update == complete and ../../../gdas/atmos/analysis/jgdas_atmos_analysis_calc == complete
+        endfamily
+      endfamily
+      family forecast
+        trigger ./analysis/recenter/ecen == complete and ./analysis/recenter/jenkfgdas_sfc == complete
+        edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/enkfgdas/forecast'
+        family grp1
+          edit ENSGRP '01'
+          task jenkfgdas_fcst
+        endfamily
+        family grp2
+          edit ENSGRP '02'
+          task jenkfgdas_fcst
+        endfamily
+        family grp3
+          edit ENSGRP '03'
+          task jenkfgdas_fcst
+        endfamily
+        family grp4
+          edit ENSGRP '04'
+          task jenkfgdas_fcst
+        endfamily
+        family grp5
+          edit ENSGRP '05'
+          task jenkfgdas_fcst
+        endfamily
+        family grp6
+          edit ENSGRP '06'
+          task jenkfgdas_fcst
+        endfamily
+        family grp7
+          edit ENSGRP '07'
+          task jenkfgdas_fcst
+        endfamily
+        family grp8
+          edit ENSGRP '08'
+          task jenkfgdas_fcst
+        endfamily
+        family grp9
+          edit ENSGRP '09'
+          task jenkfgdas_fcst
+        endfamily
+        family grp10
+          edit ENSGRP '10'
+          task jenkfgdas_fcst
+        endfamily
+        family grp11
+          edit ENSGRP '11'
+          task jenkfgdas_fcst
+        endfamily
+        family grp12
+          edit ENSGRP '12'
+          task jenkfgdas_fcst
+        endfamily
+        family grp13
+          edit ENSGRP '13'
+          task jenkfgdas_fcst
+        endfamily
+        family grp14
+          edit ENSGRP '14'
+          task jenkfgdas_fcst
+        endfamily
+        family grp15
+          edit ENSGRP '15'
+          task jenkfgdas_fcst
+        endfamily
+        family grp16
+          edit ENSGRP '16'
+          task jenkfgdas_fcst
+        endfamily
+        family grp17
+          edit ENSGRP '17'
+          task jenkfgdas_fcst
+        endfamily
+        family grp18
+          edit ENSGRP '18'
+          task jenkfgdas_fcst
+        endfamily
+        family grp19
+          edit ENSGRP '19'
+          task jenkfgdas_fcst
+        endfamily
+        family grp20
+          edit ENSGRP '20'
+          task jenkfgdas_fcst
+        endfamily
+        family grp21
+          edit ENSGRP '21'
+          task jenkfgdas_fcst
+        endfamily
+        family grp22
+          edit ENSGRP '22'
+          task jenkfgdas_fcst
+        endfamily
+        family grp23
+          edit ENSGRP '23'
+          task jenkfgdas_fcst
+        endfamily
+        family grp24
+          edit ENSGRP '24'
+          task jenkfgdas_fcst
+        endfamily
+        family grp25
+          edit ENSGRP '25'
+          task jenkfgdas_fcst
+        endfamily
+        family grp26
+          edit ENSGRP '26'
+          task jenkfgdas_fcst
+        endfamily
+        family grp27
+          edit ENSGRP '27'
+          task jenkfgdas_fcst
+        endfamily
+        family grp28
+          edit ENSGRP '28'
+          task jenkfgdas_fcst
+        endfamily
+        family grp29
+          edit ENSGRP '29'
+          task jenkfgdas_fcst
+        endfamily
+        family grp30
+          edit ENSGRP '30'
+          task jenkfgdas_fcst
+        endfamily
+        family grp31
+          edit ENSGRP '31'
+          task jenkfgdas_fcst
+        endfamily
+        family grp32
+          edit ENSGRP '32'
+          task jenkfgdas_fcst
+        endfamily
+        family grp33
+          edit ENSGRP '33'
+          task jenkfgdas_fcst
+        endfamily
+        family grp34
+          edit ENSGRP '34'
+          task jenkfgdas_fcst
+        endfamily
+        family grp35
+          edit ENSGRP '35'
+          task jenkfgdas_fcst
+        endfamily
+        family grp36
+          edit ENSGRP '36'
+          task jenkfgdas_fcst
+        endfamily
+        family grp37
+          edit ENSGRP '37'
+          task jenkfgdas_fcst
+        endfamily
+        family grp38
+          edit ENSGRP '38'
+          task jenkfgdas_fcst
+        endfamily
+        family grp39
+          edit ENSGRP '39'
+          task jenkfgdas_fcst
+        endfamily
+        family grp40
+          edit ENSGRP '40'
+          task jenkfgdas_fcst
+        endfamily
+      endfamily
+      family post
+        trigger ./forecast == complete
+        task jenkfgdas_post_f003
+          edit FHMIN_EPOS '003'
+          edit FHMAX_EPOS '003'
+          edit FHOUT_EPOS '003'
+        task jenkfgdas_post_f004
+          edit FHMIN_EPOS '004'
+          edit FHMAX_EPOS '004'
+          edit FHOUT_EPOS '004'
+        task jenkfgdas_post_f005
+          edit FHMIN_EPOS '005'
+          edit FHMAX_EPOS '005'
+          edit FHOUT_EPOS '005'
+        task jenkfgdas_post_f006
+          edit FHMIN_EPOS '006'
+          edit FHMAX_EPOS '006'
+          edit FHOUT_EPOS '006'
+        task jenkfgdas_post_f007
+          edit FHMIN_EPOS '007'
+          edit FHMAX_EPOS '007'
+          edit FHOUT_EPOS '007'
+        task jenkfgdas_post_f008
+          edit FHMIN_EPOS '008'
+          edit FHMAX_EPOS '008'
+          edit FHOUT_EPOS '008'
+        task jenkfgdas_post_f009
+          edit FHMIN_EPOS '009'
+          edit FHMAX_EPOS '009'
+          edit FHOUT_EPOS '009'
+      endfamily
+    endfamily
+  endfamily
+

--- a/ecf/defs/gfs_18.def
+++ b/ecf/defs/gfs_18.def
@@ -1,0 +1,2589 @@
+  family v16.2
+    family gfs
+      edit RUN 'gfs'
+      edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/gfs'
+      family atmos
+        family obsproc
+          family dump
+            task jgfs_atmos_tropcy_qc_reloc
+              trigger :TIME >= 2041 or :TIME < 0241
+              event 1 jtwc_bull_email
+          endfamily
+          family prep
+            task jgfs_atmos_emcsfc_sfc_prep
+              trigger /prod/primary/18/obsproc/v1.0/gfs/atmos/dump/jobsproc_gfs_atmos_dump:release_sfcprep
+          endfamily
+        endfamily
+        family analysis
+          task jgfs_atmos_analysis
+            trigger /prod/primary/18/obsproc/v1.0/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete and ../obsproc/prep/jgfs_atmos_emcsfc_sfc_prep == complete
+            event 1 release_fcst
+          task jgfs_atmos_analysis_calc
+            trigger ./jgfs_atmos_analysis == complete
+        endfamily
+        family post
+          task jgfs_atmos_post_manager
+            trigger ../analysis/jgfs_atmos_analysis == complete
+            event 1 release_postanl
+            event 2 release_post000
+            event 3 release_post001
+            event 4 release_post002
+            event 5 release_post003
+            event 6 release_post004
+            event 7 release_post005
+            event 8 release_post006
+            event 9 release_post007
+            event 10 release_post008
+            event 11 release_post009
+            event 12 release_post010
+            event 13 release_post011
+            event 14 release_post012
+            event 15 release_post013
+            event 16 release_post014
+            event 17 release_post015
+            event 18 release_post016
+            event 19 release_post017
+            event 20 release_post018
+            event 21 release_post019
+            event 22 release_post020
+            event 23 release_post021
+            event 24 release_post022
+            event 25 release_post023
+            event 26 release_post024
+            event 27 release_post025
+            event 28 release_post026
+            event 29 release_post027
+            event 30 release_post028
+            event 31 release_post029
+            event 32 release_post030
+            event 33 release_post031
+            event 34 release_post032
+            event 35 release_post033
+            event 36 release_post034
+            event 37 release_post035
+            event 38 release_post036
+            event 39 release_post037
+            event 40 release_post038
+            event 41 release_post039
+            event 42 release_post040
+            event 43 release_post041
+            event 44 release_post042
+            event 45 release_post043
+            event 46 release_post044
+            event 47 release_post045
+            event 48 release_post046
+            event 49 release_post047
+            event 50 release_post048
+            event 51 release_post049
+            event 52 release_post050
+            event 53 release_post051
+            event 54 release_post052
+            event 55 release_post053
+            event 56 release_post054
+            event 57 release_post055
+            event 58 release_post056
+            event 59 release_post057
+            event 60 release_post058
+            event 61 release_post059
+            event 62 release_post060
+            event 63 release_post061
+            event 64 release_post062
+            event 65 release_post063
+            event 66 release_post064
+            event 67 release_post065
+            event 68 release_post066
+            event 69 release_post067
+            event 70 release_post068
+            event 71 release_post069
+            event 72 release_post070
+            event 73 release_post071
+            event 74 release_post072
+            event 75 release_post073
+            event 76 release_post074
+            event 77 release_post075
+            event 78 release_post076
+            event 79 release_post077
+            event 80 release_post078
+            event 81 release_post079
+            event 82 release_post080
+            event 83 release_post081
+            event 84 release_post082
+            event 85 release_post083
+            event 86 release_post084
+            event 87 release_post085
+            event 88 release_post086
+            event 89 release_post087
+            event 90 release_post088
+            event 91 release_post089
+            event 92 release_post090
+            event 93 release_post091
+            event 94 release_post092
+            event 95 release_post093
+            event 96 release_post094
+            event 97 release_post095
+            event 98 release_post096
+            event 99 release_post097
+            event 100 release_post098
+            event 101 release_post099
+            event 102 release_post100
+            event 103 release_post101
+            event 104 release_post102
+            event 105 release_post103
+            event 106 release_post104
+            event 107 release_post105
+            event 108 release_post106
+            event 109 release_post107
+            event 110 release_post108
+            event 111 release_post109
+            event 112 release_post110
+            event 113 release_post111
+            event 114 release_post112
+            event 115 release_post113
+            event 116 release_post114
+            event 117 release_post115
+            event 118 release_post116
+            event 119 release_post117
+            event 120 release_post118
+            event 121 release_post119
+            event 122 release_post120
+            event 123 release_post123
+            event 124 release_post126
+            event 125 release_post129
+            event 126 release_post132
+            event 127 release_post135
+            event 128 release_post138
+            event 129 release_post141
+            event 130 release_post144
+            event 131 release_post147
+            event 132 release_post150
+            event 133 release_post153
+            event 134 release_post156
+            event 135 release_post159
+            event 136 release_post162
+            event 137 release_post165
+            event 138 release_post168
+            event 139 release_post171
+            event 140 release_post174
+            event 141 release_post177
+            event 142 release_post180
+            event 143 release_post183
+            event 144 release_post186
+            event 145 release_post189
+            event 146 release_post192
+            event 147 release_post195
+            event 148 release_post198
+            event 149 release_post201
+            event 150 release_post204
+            event 151 release_post207
+            event 152 release_post210
+            event 153 release_post213
+            event 154 release_post216
+            event 155 release_post219
+            event 156 release_post222
+            event 157 release_post225
+            event 158 release_post228
+            event 159 release_post231
+            event 160 release_post234
+            event 161 release_post237
+            event 162 release_post240
+            event 163 release_post243
+            event 164 release_post246
+            event 165 release_post249
+            event 166 release_post252
+            event 167 release_post255
+            event 168 release_post258
+            event 169 release_post261
+            event 170 release_post264
+            event 171 release_post267
+            event 172 release_post270
+            event 173 release_post273
+            event 174 release_post276
+            event 175 release_post279
+            event 176 release_post282
+            event 177 release_post285
+            event 178 release_post288
+            event 179 release_post291
+            event 180 release_post294
+            event 181 release_post297
+            event 182 release_post300
+            event 183 release_post303
+            event 184 release_post306
+            event 185 release_post309
+            event 186 release_post312
+            event 187 release_post315
+            event 188 release_post318
+            event 189 release_post321
+            event 190 release_post324
+            event 191 release_post327
+            event 192 release_post330
+            event 193 release_post333
+            event 194 release_post336
+            event 195 release_post339
+            event 196 release_post342
+            event 197 release_post345
+            event 198 release_post348
+            event 199 release_post351
+            event 200 release_post354
+            event 201 release_post357
+            event 202 release_post360
+            event 203 release_post363
+            event 204 release_post366
+            event 205 release_post369
+            event 206 release_post372
+            event 207 release_post375
+            event 208 release_post378
+            event 209 release_post381
+            event 210 release_post384
+          task jgfs_atmos_post_anl
+            trigger ./jgfs_atmos_post_manager:release_postanl
+            edit FHRGRP '000'
+            edit FHRLST 'anl'
+            edit HR 'anl'
+            edit FHR 'anl'
+          task jgfs_atmos_post_f000
+            trigger ./jgfs_atmos_post_manager:release_post000
+            edit FHRGRP '001'
+            edit FHRLST 'f000'
+            edit FHR 'f000'
+            edit HR '000'
+          task jgfs_atmos_post_f001
+            trigger ./jgfs_atmos_post_manager:release_post001
+            edit FHRGRP '002'
+            edit FHRLST 'f001'
+            edit FHR 'f001'
+            edit HR '001'
+          task jgfs_atmos_post_f002
+            trigger ./jgfs_atmos_post_manager:release_post002
+            edit FHRGRP '003'
+            edit FHRLST 'f002'
+            edit FHR 'f002'
+            edit HR '002'
+          task jgfs_atmos_post_f003
+            trigger ./jgfs_atmos_post_manager:release_post003
+            edit FHRGRP '004'
+            edit FHRLST 'f003'
+            edit FHR 'f003'
+            edit HR '003'
+          task jgfs_atmos_post_f004
+            trigger ./jgfs_atmos_post_manager:release_post004
+            edit FHRGRP '005'
+            edit FHRLST 'f004'
+            edit FHR 'f004'
+            edit HR '004'
+          task jgfs_atmos_post_f005
+            trigger ./jgfs_atmos_post_manager:release_post005
+            edit FHRGRP '006'
+            edit FHRLST 'f005'
+            edit FHR 'f005'
+            edit HR '005'
+          task jgfs_atmos_post_f006
+            trigger ./jgfs_atmos_post_manager:release_post006
+            edit FHRGRP '007'
+            edit FHRLST 'f006'
+            edit FHR 'f006'
+            edit HR '006'
+          task jgfs_atmos_post_f007
+            trigger ./jgfs_atmos_post_manager:release_post007
+            edit FHRGRP '008'
+            edit FHRLST 'f007'
+            edit FHR 'f007'
+            edit HR '007'
+          task jgfs_atmos_post_f008
+            trigger ./jgfs_atmos_post_manager:release_post008
+            edit FHRGRP '009'
+            edit FHRLST 'f008'
+            edit FHR 'f008'
+            edit HR '008'
+          task jgfs_atmos_post_f009
+            trigger ./jgfs_atmos_post_manager:release_post009
+            edit FHRGRP '010'
+            edit FHRLST 'f009'
+            edit FHR 'f009'
+            edit HR '009'
+          task jgfs_atmos_post_f010
+            trigger ./jgfs_atmos_post_manager:release_post010
+            edit FHRGRP '011'
+            edit FHRLST 'f010'
+            edit FHR 'f010'
+            edit HR '010'
+          task jgfs_atmos_post_f011
+            trigger ./jgfs_atmos_post_manager:release_post011
+            edit FHRGRP '012'
+            edit FHRLST 'f011'
+            edit FHR 'f011'
+            edit HR '011'
+          task jgfs_atmos_post_f012
+            trigger ./jgfs_atmos_post_manager:release_post012
+            edit FHRGRP '013'
+            edit FHRLST 'f012'
+            edit FHR 'f012'
+            edit HR '012'
+          task jgfs_atmos_post_f013
+            trigger ./jgfs_atmos_post_manager:release_post013
+            edit FHRGRP '014'
+            edit FHRLST 'f013'
+            edit FHR 'f013'
+            edit HR '013'
+          task jgfs_atmos_post_f014
+            trigger ./jgfs_atmos_post_manager:release_post014
+            edit FHRGRP '015'
+            edit FHRLST 'f014'
+            edit FHR 'f014'
+            edit HR '014'
+          task jgfs_atmos_post_f015
+            trigger ./jgfs_atmos_post_manager:release_post015
+            edit FHRGRP '016'
+            edit FHRLST 'f015'
+            edit FHR 'f015'
+            edit HR '015'
+          task jgfs_atmos_post_f016
+            trigger ./jgfs_atmos_post_manager:release_post016
+            edit FHRGRP '017'
+            edit FHRLST 'f016'
+            edit FHR 'f016'
+            edit HR '016'
+          task jgfs_atmos_post_f017
+            trigger ./jgfs_atmos_post_manager:release_post017
+            edit FHRGRP '018'
+            edit FHRLST 'f017'
+            edit FHR 'f017'
+            edit HR '017'
+          task jgfs_atmos_post_f018
+            trigger ./jgfs_atmos_post_manager:release_post018
+            edit FHRGRP '019'
+            edit FHRLST 'f018'
+            edit FHR 'f018'
+            edit HR '018'
+          task jgfs_atmos_post_f019
+            trigger ./jgfs_atmos_post_manager:release_post019
+            edit FHRGRP '020'
+            edit FHRLST 'f019'
+            edit FHR 'f019'
+            edit HR '019'
+          task jgfs_atmos_post_f020
+            trigger ./jgfs_atmos_post_manager:release_post020
+            edit FHRGRP '021'
+            edit FHRLST 'f020'
+            edit FHR 'f020'
+            edit HR '020'
+          task jgfs_atmos_post_f021
+            trigger ./jgfs_atmos_post_manager:release_post021
+            edit FHRGRP '022'
+            edit FHRLST 'f021'
+            edit FHR 'f021'
+            edit HR '021'
+          task jgfs_atmos_post_f022
+            trigger ./jgfs_atmos_post_manager:release_post022
+            edit FHRGRP '023'
+            edit FHRLST 'f022'
+            edit FHR 'f022'
+            edit HR '022'
+          task jgfs_atmos_post_f023
+            trigger ./jgfs_atmos_post_manager:release_post023
+            edit FHRGRP '024'
+            edit FHRLST 'f023'
+            edit FHR 'f023'
+            edit HR '023'
+          task jgfs_atmos_post_f024
+            trigger ./jgfs_atmos_post_manager:release_post024
+            edit FHRGRP '025'
+            edit FHRLST 'f024'
+            edit FHR 'f024'
+            edit HR '024'
+          task jgfs_atmos_post_f025
+            trigger ./jgfs_atmos_post_manager:release_post025
+            edit FHRGRP '026'
+            edit FHRLST 'f025'
+            edit FHR 'f025'
+            edit HR '025'
+          task jgfs_atmos_post_f026
+            trigger ./jgfs_atmos_post_manager:release_post026
+            edit FHRGRP '027'
+            edit FHRLST 'f026'
+            edit FHR 'f026'
+            edit HR '026'
+          task jgfs_atmos_post_f027
+            trigger ./jgfs_atmos_post_manager:release_post027
+            edit FHRGRP '028'
+            edit FHRLST 'f027'
+            edit FHR 'f027'
+            edit HR '027'
+          task jgfs_atmos_post_f028
+            trigger ./jgfs_atmos_post_manager:release_post028
+            edit FHRGRP '029'
+            edit FHRLST 'f028'
+            edit FHR 'f028'
+            edit HR '028'
+          task jgfs_atmos_post_f029
+            trigger ./jgfs_atmos_post_manager:release_post029
+            edit FHRGRP '030'
+            edit FHRLST 'f029'
+            edit FHR 'f029'
+            edit HR '029'
+          task jgfs_atmos_post_f030
+            trigger ./jgfs_atmos_post_manager:release_post030
+            edit FHRGRP '031'
+            edit FHRLST 'f030'
+            edit FHR 'f030'
+            edit HR '030'
+          task jgfs_atmos_post_f031
+            trigger ./jgfs_atmos_post_manager:release_post031
+            edit FHRGRP '032'
+            edit FHRLST 'f031'
+            edit FHR 'f031'
+            edit HR '031'
+          task jgfs_atmos_post_f032
+            trigger ./jgfs_atmos_post_manager:release_post032
+            edit FHRGRP '033'
+            edit FHRLST 'f032'
+            edit FHR 'f032'
+            edit HR '032'
+          task jgfs_atmos_post_f033
+            trigger ./jgfs_atmos_post_manager:release_post033
+            edit FHRGRP '034'
+            edit FHRLST 'f033'
+            edit FHR 'f033'
+            edit HR '033'
+          task jgfs_atmos_post_f034
+            trigger ./jgfs_atmos_post_manager:release_post034
+            edit FHRGRP '035'
+            edit FHRLST 'f034'
+            edit FHR 'f034'
+            edit HR '034'
+          task jgfs_atmos_post_f035
+            trigger ./jgfs_atmos_post_manager:release_post035
+            edit FHRGRP '036'
+            edit FHRLST 'f035'
+            edit FHR 'f035'
+            edit HR '035'
+          task jgfs_atmos_post_f036
+            trigger ./jgfs_atmos_post_manager:release_post036
+            edit FHRGRP '037'
+            edit FHRLST 'f036'
+            edit FHR 'f036'
+            edit HR '036'
+          task jgfs_atmos_post_f037
+            trigger ./jgfs_atmos_post_manager:release_post037
+            edit FHRGRP '038'
+            edit FHRLST 'f037'
+            edit FHR 'f037'
+            edit HR '037'
+          task jgfs_atmos_post_f038
+            trigger ./jgfs_atmos_post_manager:release_post038
+            edit FHRGRP '039'
+            edit FHRLST 'f038'
+            edit FHR 'f038'
+            edit HR '038'
+          task jgfs_atmos_post_f039
+            trigger ./jgfs_atmos_post_manager:release_post039
+            edit FHRGRP '040'
+            edit FHRLST 'f039'
+            edit FHR 'f039'
+            edit HR '039'
+          task jgfs_atmos_post_f040
+            trigger ./jgfs_atmos_post_manager:release_post040
+            edit FHRGRP '041'
+            edit FHRLST 'f040'
+            edit FHR 'f040'
+            edit HR '040'
+          task jgfs_atmos_post_f041
+            trigger ./jgfs_atmos_post_manager:release_post041
+            edit FHRGRP '042'
+            edit FHRLST 'f041'
+            edit FHR 'f041'
+            edit HR '041'
+          task jgfs_atmos_post_f042
+            trigger ./jgfs_atmos_post_manager:release_post042
+            edit FHRGRP '043'
+            edit FHRLST 'f042'
+            edit FHR 'f042'
+            edit HR '042'
+          task jgfs_atmos_post_f043
+            trigger ./jgfs_atmos_post_manager:release_post043
+            edit FHRGRP '044'
+            edit FHRLST 'f043'
+            edit FHR 'f043'
+            edit HR '043'
+          task jgfs_atmos_post_f044
+            trigger ./jgfs_atmos_post_manager:release_post044
+            edit FHRGRP '045'
+            edit FHRLST 'f044'
+            edit FHR 'f044'
+            edit HR '044'
+          task jgfs_atmos_post_f045
+            trigger ./jgfs_atmos_post_manager:release_post045
+            edit FHRGRP '046'
+            edit FHRLST 'f045'
+            edit FHR 'f045'
+            edit HR '045'
+          task jgfs_atmos_post_f046
+            trigger ./jgfs_atmos_post_manager:release_post046
+            edit FHRGRP '047'
+            edit FHRLST 'f046'
+            edit FHR 'f046'
+            edit HR '046'
+          task jgfs_atmos_post_f047
+            trigger ./jgfs_atmos_post_manager:release_post047
+            edit FHRGRP '048'
+            edit FHRLST 'f047'
+            edit FHR 'f047'
+            edit HR '047'
+          task jgfs_atmos_post_f048
+            trigger ./jgfs_atmos_post_manager:release_post048
+            edit FHRGRP '049'
+            edit FHRLST 'f048'
+            edit FHR 'f048'
+            edit HR '048'
+          task jgfs_atmos_post_f049
+            trigger ./jgfs_atmos_post_manager:release_post049
+            edit FHRGRP '050'
+            edit FHRLST 'f049'
+            edit FHR 'f049'
+            edit HR '049'
+          task jgfs_atmos_post_f050
+            trigger ./jgfs_atmos_post_manager:release_post050
+            edit FHRGRP '051'
+            edit FHRLST 'f050'
+            edit FHR 'f050'
+            edit HR '050'
+          task jgfs_atmos_post_f051
+            trigger ./jgfs_atmos_post_manager:release_post051
+            edit FHRGRP '052'
+            edit FHRLST 'f051'
+            edit FHR 'f051'
+            edit HR '051'
+          task jgfs_atmos_post_f052
+            trigger ./jgfs_atmos_post_manager:release_post052
+            edit FHRGRP '053'
+            edit FHRLST 'f052'
+            edit FHR 'f052'
+            edit HR '052'
+          task jgfs_atmos_post_f053
+            trigger ./jgfs_atmos_post_manager:release_post053
+            edit FHRGRP '054'
+            edit FHRLST 'f053'
+            edit FHR 'f053'
+            edit HR '053'
+          task jgfs_atmos_post_f054
+            trigger ./jgfs_atmos_post_manager:release_post054
+            edit FHRGRP '055'
+            edit FHRLST 'f054'
+            edit FHR 'f054'
+            edit HR '054'
+          task jgfs_atmos_post_f055
+            trigger ./jgfs_atmos_post_manager:release_post055
+            edit FHRGRP '056'
+            edit FHRLST 'f055'
+            edit FHR 'f055'
+            edit HR '055'
+          task jgfs_atmos_post_f056
+            trigger ./jgfs_atmos_post_manager:release_post056
+            edit FHRGRP '057'
+            edit FHRLST 'f056'
+            edit FHR 'f056'
+            edit HR '056'
+          task jgfs_atmos_post_f057
+            trigger ./jgfs_atmos_post_manager:release_post057
+            edit FHRGRP '058'
+            edit FHRLST 'f057'
+            edit FHR 'f057'
+            edit HR '057'
+          task jgfs_atmos_post_f058
+            trigger ./jgfs_atmos_post_manager:release_post058
+            edit FHRGRP '059'
+            edit FHRLST 'f058'
+            edit FHR 'f058'
+            edit HR '058'
+          task jgfs_atmos_post_f059
+            trigger ./jgfs_atmos_post_manager:release_post059
+            edit FHRGRP '060'
+            edit FHRLST 'f059'
+            edit FHR 'f059'
+            edit HR '059'
+          task jgfs_atmos_post_f060
+            trigger ./jgfs_atmos_post_manager:release_post060
+            edit FHRGRP '061'
+            edit FHRLST 'f060'
+            edit FHR 'f060'
+            edit HR '060'
+          task jgfs_atmos_post_f061
+            trigger ./jgfs_atmos_post_manager:release_post061
+            edit FHRGRP '062'
+            edit FHRLST 'f061'
+            edit FHR 'f061'
+            edit HR '061'
+          task jgfs_atmos_post_f062
+            trigger ./jgfs_atmos_post_manager:release_post062
+            edit FHRGRP '063'
+            edit FHRLST 'f062'
+            edit FHR 'f062'
+            edit HR '062'
+          task jgfs_atmos_post_f063
+            trigger ./jgfs_atmos_post_manager:release_post063
+            edit FHRGRP '064'
+            edit FHRLST 'f063'
+            edit FHR 'f063'
+            edit HR '063'
+          task jgfs_atmos_post_f064
+            trigger ./jgfs_atmos_post_manager:release_post064
+            edit FHRGRP '065'
+            edit FHRLST 'f064'
+            edit FHR 'f064'
+            edit HR '064'
+          task jgfs_atmos_post_f065
+            trigger ./jgfs_atmos_post_manager:release_post065
+            edit FHRGRP '066'
+            edit FHRLST 'f065'
+            edit FHR 'f065'
+            edit HR '065'
+          task jgfs_atmos_post_f066
+            trigger ./jgfs_atmos_post_manager:release_post066
+            edit FHRGRP '067'
+            edit FHRLST 'f066'
+            edit FHR 'f066'
+            edit HR '066'
+          task jgfs_atmos_post_f067
+            trigger ./jgfs_atmos_post_manager:release_post067
+            edit FHRGRP '068'
+            edit FHRLST 'f067'
+            edit FHR 'f067'
+            edit HR '067'
+          task jgfs_atmos_post_f068
+            trigger ./jgfs_atmos_post_manager:release_post068
+            edit FHRGRP '069'
+            edit FHRLST 'f068'
+            edit FHR 'f068'
+            edit HR '068'
+          task jgfs_atmos_post_f069
+            trigger ./jgfs_atmos_post_manager:release_post069
+            edit FHRGRP '070'
+            edit FHRLST 'f069'
+            edit FHR 'f069'
+            edit HR '069'
+          task jgfs_atmos_post_f070
+            trigger ./jgfs_atmos_post_manager:release_post070
+            edit FHRGRP '071'
+            edit FHRLST 'f070'
+            edit FHR 'f070'
+            edit HR '070'
+          task jgfs_atmos_post_f071
+            trigger ./jgfs_atmos_post_manager:release_post071
+            edit FHRGRP '072'
+            edit FHRLST 'f071'
+            edit FHR 'f071'
+            edit HR '071'
+          task jgfs_atmos_post_f072
+            trigger ./jgfs_atmos_post_manager:release_post072
+            edit FHRGRP '073'
+            edit FHRLST 'f072'
+            edit FHR 'f072'
+            edit HR '072'
+          task jgfs_atmos_post_f073
+            trigger ./jgfs_atmos_post_manager:release_post073
+            edit FHRGRP '074'
+            edit FHRLST 'f073'
+            edit FHR 'f073'
+            edit HR '073'
+          task jgfs_atmos_post_f074
+            trigger ./jgfs_atmos_post_manager:release_post074
+            edit FHRGRP '075'
+            edit FHRLST 'f074'
+            edit FHR 'f074'
+            edit HR '074'
+          task jgfs_atmos_post_f075
+            trigger ./jgfs_atmos_post_manager:release_post075
+            edit FHRGRP '076'
+            edit FHRLST 'f075'
+            edit FHR 'f075'
+            edit HR '075'
+          task jgfs_atmos_post_f076
+            trigger ./jgfs_atmos_post_manager:release_post076
+            edit FHRGRP '077'
+            edit FHRLST 'f076'
+            edit FHR 'f076'
+            edit HR '076'
+          task jgfs_atmos_post_f077
+            trigger ./jgfs_atmos_post_manager:release_post077
+            edit FHRGRP '078'
+            edit FHRLST 'f077'
+            edit FHR 'f077'
+            edit HR '077'
+          task jgfs_atmos_post_f078
+            trigger ./jgfs_atmos_post_manager:release_post078
+            edit FHRGRP '079'
+            edit FHRLST 'f078'
+            edit FHR 'f078'
+            edit HR '078'
+          task jgfs_atmos_post_f079
+            trigger ./jgfs_atmos_post_manager:release_post079
+            edit FHRGRP '080'
+            edit FHRLST 'f079'
+            edit FHR 'f079'
+            edit HR '079'
+          task jgfs_atmos_post_f080
+            trigger ./jgfs_atmos_post_manager:release_post080
+            edit FHRGRP '081'
+            edit FHRLST 'f080'
+            edit FHR 'f080'
+            edit HR '080'
+          task jgfs_atmos_post_f081
+            trigger ./jgfs_atmos_post_manager:release_post081
+            edit FHRGRP '082'
+            edit FHRLST 'f081'
+            edit FHR 'f081'
+            edit HR '081'
+          task jgfs_atmos_post_f082
+            trigger ./jgfs_atmos_post_manager:release_post082
+            edit FHRGRP '083'
+            edit FHRLST 'f082'
+            edit FHR 'f082'
+            edit HR '082'
+          task jgfs_atmos_post_f083
+            trigger ./jgfs_atmos_post_manager:release_post083
+            edit FHRGRP '084'
+            edit FHRLST 'f083'
+            edit FHR 'f083'
+            edit HR '083'
+          task jgfs_atmos_post_f084
+            trigger ./jgfs_atmos_post_manager:release_post084
+            edit FHRGRP '085'
+            edit FHRLST 'f084'
+            edit FHR 'f084'
+            edit HR '084'
+          task jgfs_atmos_post_f085
+            trigger ./jgfs_atmos_post_manager:release_post085
+            edit FHRGRP '086'
+            edit FHRLST 'f085'
+            edit FHR 'f085'
+            edit HR '085'
+          task jgfs_atmos_post_f086
+            trigger ./jgfs_atmos_post_manager:release_post086
+            edit FHRGRP '087'
+            edit FHRLST 'f086'
+            edit FHR 'f086'
+            edit HR '086'
+          task jgfs_atmos_post_f087
+            trigger ./jgfs_atmos_post_manager:release_post087
+            edit FHRGRP '088'
+            edit FHRLST 'f087'
+            edit FHR 'f087'
+            edit HR '087'
+          task jgfs_atmos_post_f088
+            trigger ./jgfs_atmos_post_manager:release_post088
+            edit FHRGRP '089'
+            edit FHRLST 'f088'
+            edit FHR 'f088'
+            edit HR '088'
+          task jgfs_atmos_post_f089
+            trigger ./jgfs_atmos_post_manager:release_post089
+            edit FHRGRP '090'
+            edit FHRLST 'f089'
+            edit FHR 'f089'
+            edit HR '089'
+          task jgfs_atmos_post_f090
+            trigger ./jgfs_atmos_post_manager:release_post090
+            edit FHRGRP '091'
+            edit FHRLST 'f090'
+            edit FHR 'f090'
+            edit HR '090'
+          task jgfs_atmos_post_f091
+            trigger ./jgfs_atmos_post_manager:release_post091
+            edit FHRGRP '092'
+            edit FHRLST 'f091'
+            edit FHR 'f091'
+            edit HR '091'
+          task jgfs_atmos_post_f092
+            trigger ./jgfs_atmos_post_manager:release_post092
+            edit FHRGRP '093'
+            edit FHRLST 'f092'
+            edit FHR 'f092'
+            edit HR '092'
+          task jgfs_atmos_post_f093
+            trigger ./jgfs_atmos_post_manager:release_post093
+            edit FHRGRP '094'
+            edit FHRLST 'f093'
+            edit FHR 'f093'
+            edit HR '093'
+          task jgfs_atmos_post_f094
+            trigger ./jgfs_atmos_post_manager:release_post094
+            edit FHRGRP '095'
+            edit FHRLST 'f094'
+            edit FHR 'f094'
+            edit HR '094'
+          task jgfs_atmos_post_f095
+            trigger ./jgfs_atmos_post_manager:release_post095
+            edit FHRGRP '096'
+            edit FHRLST 'f095'
+            edit FHR 'f095'
+            edit HR '095'
+          task jgfs_atmos_post_f096
+            trigger ./jgfs_atmos_post_manager:release_post096
+            edit FHRGRP '097'
+            edit FHRLST 'f096'
+            edit FHR 'f096'
+            edit HR '096'
+          task jgfs_atmos_post_f097
+            trigger ./jgfs_atmos_post_manager:release_post097
+            edit FHRGRP '098'
+            edit FHRLST 'f097'
+            edit FHR 'f097'
+            edit HR '097'
+          task jgfs_atmos_post_f098
+            trigger ./jgfs_atmos_post_manager:release_post098
+            edit FHRGRP '099'
+            edit FHRLST 'f098'
+            edit FHR 'f098'
+            edit HR '098'
+          task jgfs_atmos_post_f099
+            trigger ./jgfs_atmos_post_manager:release_post099
+            edit FHRGRP '100'
+            edit FHRLST 'f099'
+            edit FHR 'f099'
+            edit HR '099'
+          task jgfs_atmos_post_f100
+            trigger ./jgfs_atmos_post_manager:release_post100
+            edit FHRGRP '101'
+            edit FHRLST 'f100'
+            edit FHR 'f100'
+            edit HR '100'
+          task jgfs_atmos_post_f101
+            trigger ./jgfs_atmos_post_manager:release_post101
+            edit FHRGRP '102'
+            edit FHRLST 'f101'
+            edit FHR 'f101'
+            edit HR '101'
+          task jgfs_atmos_post_f102
+            trigger ./jgfs_atmos_post_manager:release_post102
+            edit FHRGRP '103'
+            edit FHRLST 'f102'
+            edit FHR 'f102'
+            edit HR '102'
+          task jgfs_atmos_post_f103
+            trigger ./jgfs_atmos_post_manager:release_post103
+            edit FHRGRP '104'
+            edit FHRLST 'f103'
+            edit FHR 'f103'
+            edit HR '103'
+          task jgfs_atmos_post_f104
+            trigger ./jgfs_atmos_post_manager:release_post104
+            edit FHRGRP '105'
+            edit FHRLST 'f104'
+            edit FHR 'f104'
+            edit HR '104'
+          task jgfs_atmos_post_f105
+            trigger ./jgfs_atmos_post_manager:release_post105
+            edit FHRGRP '106'
+            edit FHRLST 'f105'
+            edit FHR 'f105'
+            edit HR '105'
+          task jgfs_atmos_post_f106
+            trigger ./jgfs_atmos_post_manager:release_post106
+            edit FHRGRP '107'
+            edit FHRLST 'f106'
+            edit FHR 'f106'
+            edit HR '106'
+          task jgfs_atmos_post_f107
+            trigger ./jgfs_atmos_post_manager:release_post107
+            edit FHRGRP '108'
+            edit FHRLST 'f107'
+            edit FHR 'f107'
+            edit HR '107'
+          task jgfs_atmos_post_f108
+            trigger ./jgfs_atmos_post_manager:release_post108
+            edit FHRGRP '109'
+            edit FHRLST 'f108'
+            edit FHR 'f108'
+            edit HR '108'
+          task jgfs_atmos_post_f109
+            trigger ./jgfs_atmos_post_manager:release_post109
+            edit FHRGRP '110'
+            edit FHRLST 'f109'
+            edit FHR 'f109'
+            edit HR '109'
+          task jgfs_atmos_post_f110
+            trigger ./jgfs_atmos_post_manager:release_post110
+            edit FHRGRP '111'
+            edit FHRLST 'f110'
+            edit FHR 'f110'
+            edit HR '110'
+          task jgfs_atmos_post_f111
+            trigger ./jgfs_atmos_post_manager:release_post111
+            edit FHRGRP '112'
+            edit FHRLST 'f111'
+            edit FHR 'f111'
+            edit HR '111'
+          task jgfs_atmos_post_f112
+            trigger ./jgfs_atmos_post_manager:release_post112
+            edit FHRGRP '113'
+            edit FHRLST 'f112'
+            edit FHR 'f112'
+            edit HR '112'
+          task jgfs_atmos_post_f113
+            trigger ./jgfs_atmos_post_manager:release_post113
+            edit FHRGRP '114'
+            edit FHRLST 'f113'
+            edit FHR 'f113'
+            edit HR '113'
+          task jgfs_atmos_post_f114
+            trigger ./jgfs_atmos_post_manager:release_post114
+            edit FHRGRP '115'
+            edit FHRLST 'f114'
+            edit FHR 'f114'
+            edit HR '114'
+          task jgfs_atmos_post_f115
+            trigger ./jgfs_atmos_post_manager:release_post115
+            edit FHRGRP '116'
+            edit FHRLST 'f115'
+            edit FHR 'f115'
+            edit HR '115'
+          task jgfs_atmos_post_f116
+            trigger ./jgfs_atmos_post_manager:release_post116
+            edit FHRGRP '117'
+            edit FHRLST 'f116'
+            edit FHR 'f116'
+            edit HR '116'
+          task jgfs_atmos_post_f117
+            trigger ./jgfs_atmos_post_manager:release_post117
+            edit FHRGRP '118'
+            edit FHRLST 'f117'
+            edit FHR 'f117'
+            edit HR '117'
+          task jgfs_atmos_post_f118
+            trigger ./jgfs_atmos_post_manager:release_post118
+            edit FHRGRP '119'
+            edit FHRLST 'f118'
+            edit FHR 'f118'
+            edit HR '118'
+          task jgfs_atmos_post_f119
+            trigger ./jgfs_atmos_post_manager:release_post119
+            edit FHRGRP '120'
+            edit FHRLST 'f119'
+            edit FHR 'f119'
+            edit HR '119'
+          task jgfs_atmos_post_f120
+            trigger ./jgfs_atmos_post_manager:release_post120
+            edit FHRGRP '121'
+            edit FHRLST 'f120'
+            edit FHR 'f120'
+            edit HR '120'
+          task jgfs_atmos_post_f123
+            trigger ./jgfs_atmos_post_manager:release_post123
+            edit FHRGRP '122'
+            edit FHRLST 'f123'
+            edit FHR 'f123'
+            edit HR '123'
+          task jgfs_atmos_post_f126
+            trigger ./jgfs_atmos_post_manager:release_post126
+            edit FHRGRP '123'
+            edit FHRLST 'f126'
+            edit FHR 'f126'
+            edit HR '126'
+          task jgfs_atmos_post_f129
+            trigger ./jgfs_atmos_post_manager:release_post129
+            edit FHRGRP '124'
+            edit FHRLST 'f129'
+            edit FHR 'f129'
+            edit HR '129'
+          task jgfs_atmos_post_f132
+            trigger ./jgfs_atmos_post_manager:release_post132
+            edit FHRGRP '125'
+            edit FHRLST 'f132'
+            edit FHR 'f132'
+            edit HR '132'
+          task jgfs_atmos_post_f135
+            trigger ./jgfs_atmos_post_manager:release_post135
+            edit FHRGRP '126'
+            edit FHRLST 'f135'
+            edit FHR 'f135'
+            edit HR '135'
+          task jgfs_atmos_post_f138
+            trigger ./jgfs_atmos_post_manager:release_post138
+            edit FHRGRP '127'
+            edit FHRLST 'f138'
+            edit FHR 'f138'
+            edit HR '138'
+          task jgfs_atmos_post_f141
+            trigger ./jgfs_atmos_post_manager:release_post141
+            edit FHRGRP '128'
+            edit FHRLST 'f141'
+            edit FHR 'f141'
+            edit HR '141'
+          task jgfs_atmos_post_f144
+            trigger ./jgfs_atmos_post_manager:release_post144
+            edit FHRGRP '129'
+            edit FHRLST 'f144'
+            edit FHR 'f144'
+            edit HR '144'
+          task jgfs_atmos_post_f147
+            trigger ./jgfs_atmos_post_manager:release_post147
+            edit FHRGRP '130'
+            edit FHRLST 'f147'
+            edit FHR 'f147'
+            edit HR '147'
+          task jgfs_atmos_post_f150
+            trigger ./jgfs_atmos_post_manager:release_post150
+            edit FHRGRP '131'
+            edit FHRLST 'f150'
+            edit FHR 'f150'
+            edit HR '150'
+          task jgfs_atmos_post_f153
+            trigger ./jgfs_atmos_post_manager:release_post153
+            edit FHRGRP '132'
+            edit FHRLST 'f153'
+            edit FHR 'f153'
+            edit HR '153'
+          task jgfs_atmos_post_f156
+            trigger ./jgfs_atmos_post_manager:release_post156
+            edit FHRGRP '133'
+            edit FHRLST 'f156'
+            edit FHR 'f156'
+            edit HR '156'
+          task jgfs_atmos_post_f159
+            trigger ./jgfs_atmos_post_manager:release_post159
+            edit FHRGRP '134'
+            edit FHRLST 'f159'
+            edit FHR 'f159'
+            edit HR '159'
+          task jgfs_atmos_post_f162
+            trigger ./jgfs_atmos_post_manager:release_post162
+            edit FHRGRP '135'
+            edit FHRLST 'f162'
+            edit FHR 'f162'
+            edit HR '162'
+          task jgfs_atmos_post_f165
+            trigger ./jgfs_atmos_post_manager:release_post165
+            edit FHRGRP '136'
+            edit FHRLST 'f165'
+            edit FHR 'f165'
+            edit HR '165'
+          task jgfs_atmos_post_f168
+            trigger ./jgfs_atmos_post_manager:release_post168
+            edit FHRGRP '137'
+            edit FHRLST 'f168'
+            edit FHR 'f168'
+            edit HR '168'
+          task jgfs_atmos_post_f171
+            trigger ./jgfs_atmos_post_manager:release_post171
+            edit FHRGRP '138'
+            edit FHRLST 'f171'
+            edit FHR 'f171'
+            edit HR '171'
+          task jgfs_atmos_post_f174
+            trigger ./jgfs_atmos_post_manager:release_post174
+            edit FHRGRP '139'
+            edit FHRLST 'f174'
+            edit FHR 'f174'
+            edit HR '174'
+          task jgfs_atmos_post_f177
+            trigger ./jgfs_atmos_post_manager:release_post177
+            edit FHRGRP '140'
+            edit FHRLST 'f177'
+            edit FHR 'f177'
+            edit HR '177'
+          task jgfs_atmos_post_f180
+            trigger ./jgfs_atmos_post_manager:release_post180
+            edit FHRGRP '141'
+            edit FHRLST 'f180'
+            edit FHR 'f180'
+            edit HR '180'
+          task jgfs_atmos_post_f183
+            trigger ./jgfs_atmos_post_manager:release_post183
+            edit FHRGRP '142'
+            edit FHRLST 'f183'
+            edit FHR 'f183'
+            edit HR '183'
+          task jgfs_atmos_post_f186
+            trigger ./jgfs_atmos_post_manager:release_post186
+            edit FHRGRP '143'
+            edit FHRLST 'f186'
+            edit FHR 'f186'
+            edit HR '186'
+          task jgfs_atmos_post_f189
+            trigger ./jgfs_atmos_post_manager:release_post189
+            edit FHRGRP '144'
+            edit FHRLST 'f189'
+            edit FHR 'f189'
+            edit HR '189'
+          task jgfs_atmos_post_f192
+            trigger ./jgfs_atmos_post_manager:release_post192
+            edit FHRGRP '145'
+            edit FHRLST 'f192'
+            edit FHR 'f192'
+            edit HR '192'
+          task jgfs_atmos_post_f195
+            trigger ./jgfs_atmos_post_manager:release_post195
+            edit FHRGRP '146'
+            edit FHRLST 'f195'
+            edit FHR 'f195'
+            edit HR '195'
+          task jgfs_atmos_post_f198
+            trigger ./jgfs_atmos_post_manager:release_post198
+            edit FHRGRP '147'
+            edit FHRLST 'f198'
+            edit FHR 'f198'
+            edit HR '198'
+          task jgfs_atmos_post_f201
+            trigger ./jgfs_atmos_post_manager:release_post201
+            edit FHRGRP '148'
+            edit FHRLST 'f201'
+            edit FHR 'f201'
+            edit HR '201'
+          task jgfs_atmos_post_f204
+            trigger ./jgfs_atmos_post_manager:release_post204
+            edit FHRGRP '149'
+            edit FHRLST 'f204'
+            edit FHR 'f204'
+            edit HR '204'
+          task jgfs_atmos_post_f207
+            trigger ./jgfs_atmos_post_manager:release_post207
+            edit FHRGRP '150'
+            edit FHRLST 'f207'
+            edit FHR 'f207'
+            edit HR '207'
+          task jgfs_atmos_post_f210
+            trigger ./jgfs_atmos_post_manager:release_post210
+            edit FHRGRP '151'
+            edit FHRLST 'f210'
+            edit FHR 'f210'
+            edit HR '210'
+          task jgfs_atmos_post_f213
+            trigger ./jgfs_atmos_post_manager:release_post213
+            edit FHRGRP '152'
+            edit FHRLST 'f213'
+            edit FHR 'f213'
+            edit HR '213'
+          task jgfs_atmos_post_f216
+            trigger ./jgfs_atmos_post_manager:release_post216
+            edit FHRGRP '153'
+            edit FHRLST 'f216'
+            edit FHR 'f216'
+            edit HR '216'
+          task jgfs_atmos_post_f219
+            trigger ./jgfs_atmos_post_manager:release_post219
+            edit FHRGRP '154'
+            edit FHRLST 'f219'
+            edit FHR 'f219'
+            edit HR '219'
+          task jgfs_atmos_post_f222
+            trigger ./jgfs_atmos_post_manager:release_post222
+            edit FHRGRP '155'
+            edit FHRLST 'f222'
+            edit FHR 'f222'
+            edit HR '222'
+          task jgfs_atmos_post_f225
+            trigger ./jgfs_atmos_post_manager:release_post225
+            edit FHRGRP '156'
+            edit FHRLST 'f225'
+            edit FHR 'f225'
+            edit HR '225'
+          task jgfs_atmos_post_f228
+            trigger ./jgfs_atmos_post_manager:release_post228
+            edit FHRGRP '157'
+            edit FHRLST 'f228'
+            edit FHR 'f228'
+            edit HR '228'
+          task jgfs_atmos_post_f231
+            trigger ./jgfs_atmos_post_manager:release_post231
+            edit FHRGRP '158'
+            edit FHRLST 'f231'
+            edit FHR 'f231'
+            edit HR '231'
+          task jgfs_atmos_post_f234
+            trigger ./jgfs_atmos_post_manager:release_post234
+            edit FHRGRP '159'
+            edit FHRLST 'f234'
+            edit FHR 'f234'
+            edit HR '234'
+          task jgfs_atmos_post_f237
+            trigger ./jgfs_atmos_post_manager:release_post237
+            edit FHRGRP '160'
+            edit FHRLST 'f237'
+            edit FHR 'f237'
+            edit HR '237'
+          task jgfs_atmos_post_f240
+            trigger ./jgfs_atmos_post_manager:release_post240
+            edit FHRGRP '161'
+            edit FHRLST 'f240'
+            edit FHR 'f240'
+            edit HR '240'
+          task jgfs_atmos_post_f243
+            trigger ./jgfs_atmos_post_manager:release_post243
+            edit FHRGRP '162'
+            edit FHRLST 'f243'
+            edit FHR 'f243'
+            edit HR '243'
+          task jgfs_atmos_post_f246
+            trigger ./jgfs_atmos_post_manager:release_post246
+            edit FHRGRP '163'
+            edit FHRLST 'f246'
+            edit FHR 'f246'
+            edit HR '246'
+          task jgfs_atmos_post_f249
+            trigger ./jgfs_atmos_post_manager:release_post249
+            edit FHRGRP '164'
+            edit FHRLST 'f249'
+            edit FHR 'f249'
+            edit HR '249'
+          task jgfs_atmos_post_f252
+            trigger ./jgfs_atmos_post_manager:release_post252
+            edit FHRGRP '165'
+            edit FHRLST 'f252'
+            edit FHR 'f252'
+            edit HR '252'
+          task jgfs_atmos_post_f255
+            trigger ./jgfs_atmos_post_manager:release_post255
+            edit FHRGRP '166'
+            edit FHRLST 'f255'
+            edit FHR 'f255'
+            edit HR '255'
+          task jgfs_atmos_post_f258
+            trigger ./jgfs_atmos_post_manager:release_post258
+            edit FHRGRP '167'
+            edit FHRLST 'f258'
+            edit FHR 'f258'
+            edit HR '258'
+          task jgfs_atmos_post_f261
+            trigger ./jgfs_atmos_post_manager:release_post261
+            edit FHRGRP '168'
+            edit FHRLST 'f261'
+            edit FHR 'f261'
+            edit HR '261'
+          task jgfs_atmos_post_f264
+            trigger ./jgfs_atmos_post_manager:release_post264
+            edit FHRGRP '169'
+            edit FHRLST 'f264'
+            edit FHR 'f264'
+            edit HR '264'
+          task jgfs_atmos_post_f267
+            trigger ./jgfs_atmos_post_manager:release_post267
+            edit FHRGRP '170'
+            edit FHRLST 'f267'
+            edit FHR 'f267'
+            edit HR '267'
+          task jgfs_atmos_post_f270
+            trigger ./jgfs_atmos_post_manager:release_post270
+            edit FHRGRP '171'
+            edit FHRLST 'f270'
+            edit FHR 'f270'
+            edit HR '270'
+          task jgfs_atmos_post_f273
+            trigger ./jgfs_atmos_post_manager:release_post273
+            edit FHRGRP '172'
+            edit FHRLST 'f273'
+            edit FHR 'f273'
+            edit HR '273'
+          task jgfs_atmos_post_f276
+            trigger ./jgfs_atmos_post_manager:release_post276
+            edit FHRGRP '173'
+            edit FHRLST 'f276'
+            edit FHR 'f276'
+            edit HR '276'
+          task jgfs_atmos_post_f279
+            trigger ./jgfs_atmos_post_manager:release_post279
+            edit FHRGRP '174'
+            edit FHRLST 'f279'
+            edit FHR 'f279'
+            edit HR '279'
+          task jgfs_atmos_post_f282
+            trigger ./jgfs_atmos_post_manager:release_post282
+            edit FHRGRP '175'
+            edit FHRLST 'f282'
+            edit FHR 'f282'
+            edit HR '282'
+          task jgfs_atmos_post_f285
+            trigger ./jgfs_atmos_post_manager:release_post285
+            edit FHRGRP '176'
+            edit FHRLST 'f285'
+            edit FHR 'f285'
+            edit HR '285'
+          task jgfs_atmos_post_f288
+            trigger ./jgfs_atmos_post_manager:release_post288
+            edit FHRGRP '177'
+            edit FHRLST 'f288'
+            edit FHR 'f288'
+            edit HR '288'
+          task jgfs_atmos_post_f291
+            trigger ./jgfs_atmos_post_manager:release_post291
+            edit FHRGRP '178'
+            edit FHRLST 'f291'
+            edit FHR 'f291'
+            edit HR '291'
+          task jgfs_atmos_post_f294
+            trigger ./jgfs_atmos_post_manager:release_post294
+            edit FHRGRP '179'
+            edit FHRLST 'f294'
+            edit FHR 'f294'
+            edit HR '294'
+          task jgfs_atmos_post_f297
+            trigger ./jgfs_atmos_post_manager:release_post297
+            edit FHRGRP '180'
+            edit FHRLST 'f297'
+            edit FHR 'f297'
+            edit HR '297'
+          task jgfs_atmos_post_f300
+            trigger ./jgfs_atmos_post_manager:release_post300
+            edit FHRGRP '181'
+            edit FHRLST 'f300'
+            edit FHR 'f300'
+            edit HR '300'
+          task jgfs_atmos_post_f303
+            trigger ./jgfs_atmos_post_manager:release_post303
+            edit FHRGRP '182'
+            edit FHRLST 'f303'
+            edit FHR 'f303'
+            edit HR '303'
+          task jgfs_atmos_post_f306
+            trigger ./jgfs_atmos_post_manager:release_post306
+            edit FHRGRP '183'
+            edit FHRLST 'f306'
+            edit FHR 'f306'
+            edit HR '306'
+          task jgfs_atmos_post_f309
+            trigger ./jgfs_atmos_post_manager:release_post309
+            edit FHRGRP '184'
+            edit FHRLST 'f309'
+            edit FHR 'f309'
+            edit HR '309'
+          task jgfs_atmos_post_f312
+            trigger ./jgfs_atmos_post_manager:release_post312
+            edit FHRGRP '185'
+            edit FHRLST 'f312'
+            edit FHR 'f312'
+            edit HR '312'
+          task jgfs_atmos_post_f315
+            trigger ./jgfs_atmos_post_manager:release_post315
+            edit FHRGRP '186'
+            edit FHRLST 'f315'
+            edit FHR 'f315'
+            edit HR '315'
+          task jgfs_atmos_post_f318
+            trigger ./jgfs_atmos_post_manager:release_post318
+            edit FHRGRP '187'
+            edit FHRLST 'f318'
+            edit FHR 'f318'
+            edit HR '318'
+          task jgfs_atmos_post_f321
+            trigger ./jgfs_atmos_post_manager:release_post321
+            edit FHRGRP '188'
+            edit FHRLST 'f321'
+            edit FHR 'f321'
+            edit HR '321'
+          task jgfs_atmos_post_f324
+            trigger ./jgfs_atmos_post_manager:release_post324
+            edit FHRGRP '189'
+            edit FHRLST 'f324'
+            edit FHR 'f324'
+            edit HR '324'
+          task jgfs_atmos_post_f327
+            trigger ./jgfs_atmos_post_manager:release_post327
+            edit FHRGRP '190'
+            edit FHRLST 'f327'
+            edit FHR 'f327'
+            edit HR '327'
+          task jgfs_atmos_post_f330
+            trigger ./jgfs_atmos_post_manager:release_post330
+            edit FHRGRP '191'
+            edit FHRLST 'f330'
+            edit FHR 'f330'
+            edit HR '330'
+          task jgfs_atmos_post_f333
+            trigger ./jgfs_atmos_post_manager:release_post333
+            edit FHRGRP '192'
+            edit FHRLST 'f333'
+            edit FHR 'f333'
+            edit HR '333'
+          task jgfs_atmos_post_f336
+            trigger ./jgfs_atmos_post_manager:release_post336
+            edit FHRGRP '193'
+            edit FHRLST 'f336'
+            edit FHR 'f336'
+            edit HR '336'
+          task jgfs_atmos_post_f339
+            trigger ./jgfs_atmos_post_manager:release_post339
+            edit FHRGRP '194'
+            edit FHRLST 'f339'
+            edit FHR 'f339'
+            edit HR '339'
+          task jgfs_atmos_post_f342
+            trigger ./jgfs_atmos_post_manager:release_post342
+            edit FHRGRP '195'
+            edit FHRLST 'f342'
+            edit FHR 'f342'
+            edit HR '342'
+          task jgfs_atmos_post_f345
+            trigger ./jgfs_atmos_post_manager:release_post345
+            edit FHRGRP '196'
+            edit FHRLST 'f345'
+            edit FHR 'f345'
+            edit HR '345'
+          task jgfs_atmos_post_f348
+            trigger ./jgfs_atmos_post_manager:release_post348
+            edit FHRGRP '197'
+            edit FHRLST 'f348'
+            edit FHR 'f348'
+            edit HR '348'
+          task jgfs_atmos_post_f351
+            trigger ./jgfs_atmos_post_manager:release_post351
+            edit FHRGRP '198'
+            edit FHRLST 'f351'
+            edit FHR 'f351'
+            edit HR '351'
+          task jgfs_atmos_post_f354
+            trigger ./jgfs_atmos_post_manager:release_post354
+            edit FHRGRP '199'
+            edit FHRLST 'f354'
+            edit FHR 'f354'
+            edit HR '354'
+          task jgfs_atmos_post_f357
+            trigger ./jgfs_atmos_post_manager:release_post357
+            edit FHRGRP '200'
+            edit FHRLST 'f357'
+            edit FHR 'f357'
+            edit HR '357'
+          task jgfs_atmos_post_f360
+            trigger ./jgfs_atmos_post_manager:release_post360
+            edit FHRGRP '201'
+            edit FHRLST 'f360'
+            edit FHR 'f360'
+            edit HR '360'
+          task jgfs_atmos_post_f363
+            trigger ./jgfs_atmos_post_manager:release_post363
+            edit FHRGRP '202'
+            edit FHRLST 'f363'
+            edit FHR 'f363'
+            edit HR '363'
+          task jgfs_atmos_post_f366
+            trigger ./jgfs_atmos_post_manager:release_post366
+            edit FHRGRP '203'
+            edit FHRLST 'f366'
+            edit FHR 'f366'
+            edit HR '366'
+          task jgfs_atmos_post_f369
+            trigger ./jgfs_atmos_post_manager:release_post369
+            edit FHRGRP '204'
+            edit FHRLST 'f369'
+            edit FHR 'f369'
+            edit HR '369'
+          task jgfs_atmos_post_f372
+            trigger ./jgfs_atmos_post_manager:release_post372
+            edit FHRGRP '205'
+            edit FHRLST 'f372'
+            edit FHR 'f372'
+            edit HR '372'
+          task jgfs_atmos_post_f375
+            trigger ./jgfs_atmos_post_manager:release_post375
+            edit FHRGRP '206'
+            edit FHRLST 'f375'
+            edit FHR 'f375'
+            edit HR '375'
+          task jgfs_atmos_post_f378
+            trigger ./jgfs_atmos_post_manager:release_post378
+            edit FHRGRP '207'
+            edit FHRLST 'f378'
+            edit FHR 'f378'
+            edit HR '378'
+          task jgfs_atmos_post_f381
+            trigger ./jgfs_atmos_post_manager:release_post381
+            edit FHRGRP '208'
+            edit FHRLST 'f381'
+            edit FHR 'f381'
+            edit HR '381'
+          task jgfs_atmos_post_f384
+            trigger ./jgfs_atmos_post_manager:release_post384
+            edit FHRGRP '209'
+            edit FHRLST 'f384'
+            edit FHR 'f384'
+            edit HR '384'
+        endfamily
+        family post_processing
+          task jgfs_atmos_wafs_gcip
+            trigger ( :TIME >= 2240 or :TIME < 0240) and ../post/jgfs_atmos_post_f003 == complete
+          family grib_wafs
+            task jgfs_atmos_wafs_f000
+              trigger ../../post/jgfs_atmos_post_f000 == complete and ../../post/jgfs_atmos_post_f120 == complete and ../grib2_wafs/jgfs_atmos_wafs_grib2 == complete
+              edit FCSTHR '00'
+            task jgfs_atmos_wafs_f006
+              trigger ../../post/jgfs_atmos_post_f006 == complete and ./jgfs_atmos_wafs_f000 == complete
+              edit FCSTHR '06'
+            task jgfs_atmos_wafs_f012
+              trigger ../../post/jgfs_atmos_post_f012 == complete and ./jgfs_atmos_wafs_f006 == complete
+              edit FCSTHR '12'
+            task jgfs_atmos_wafs_f018
+              trigger ../../post/jgfs_atmos_post_f018 == complete and ./jgfs_atmos_wafs_f012 == complete
+              edit FCSTHR '18'
+            task jgfs_atmos_wafs_f024
+              trigger ../../post/jgfs_atmos_post_f024 == complete and ./jgfs_atmos_wafs_f018 == complete
+              edit FCSTHR '24'
+            task jgfs_atmos_wafs_f030
+              trigger ../../post/jgfs_atmos_post_f030 == complete and ./jgfs_atmos_wafs_f024 == complete
+              edit FCSTHR '30'
+            task jgfs_atmos_wafs_f036
+              trigger ../../post/jgfs_atmos_post_f036 == complete and ./jgfs_atmos_wafs_f030 == complete
+              edit FCSTHR '36'
+            task jgfs_atmos_wafs_f042
+              trigger ../../post/jgfs_atmos_post_f042 == complete and ./jgfs_atmos_wafs_f036 == complete
+              edit FCSTHR '42'
+            task jgfs_atmos_wafs_f048
+              trigger ../../post/jgfs_atmos_post_f048 == complete and ./jgfs_atmos_wafs_f042 == complete
+              edit FCSTHR '48'
+            task jgfs_atmos_wafs_f054
+              trigger ../../post/jgfs_atmos_post_f054 == complete and ./jgfs_atmos_wafs_f048 == complete
+              edit FCSTHR '54'
+            task jgfs_atmos_wafs_f060
+              trigger ../../post/jgfs_atmos_post_f060 == complete and ./jgfs_atmos_wafs_f054 == complete
+              edit FCSTHR '60'
+            task jgfs_atmos_wafs_f066
+              trigger ../../post/jgfs_atmos_post_f066 == complete and ./jgfs_atmos_wafs_f060 == complete
+              edit FCSTHR '66'
+            task jgfs_atmos_wafs_f072
+              trigger ../../post/jgfs_atmos_post_f072 == complete and ./jgfs_atmos_wafs_f066 == complete
+              edit FCSTHR '72'
+            task jgfs_atmos_wafs_f078
+              trigger ../../post/jgfs_atmos_post_f078 == complete and ./jgfs_atmos_wafs_f072 == complete
+              edit FCSTHR '78'
+            task jgfs_atmos_wafs_f084
+              trigger ../../post/jgfs_atmos_post_f084 == complete and ./jgfs_atmos_wafs_f078 == complete
+              edit FCSTHR '84'
+            task jgfs_atmos_wafs_f090
+              trigger ../../post/jgfs_atmos_post_f090 == complete and ./jgfs_atmos_wafs_f084 == complete
+              edit FCSTHR '90'
+            task jgfs_atmos_wafs_f096
+              trigger ../../post/jgfs_atmos_post_f096 == complete and ./jgfs_atmos_wafs_f090 == complete
+              edit FCSTHR '96'
+            task jgfs_atmos_wafs_f102
+              trigger ../../post/jgfs_atmos_post_f102 == complete and ./jgfs_atmos_wafs_f096 == complete
+              edit FCSTHR '102'
+            task jgfs_atmos_wafs_f108
+              trigger ../../post/jgfs_atmos_post_f108 == complete and ./jgfs_atmos_wafs_f102 == complete
+              edit FCSTHR '108'
+            task jgfs_atmos_wafs_f114
+              trigger ../../post/jgfs_atmos_post_f114 == complete and ./jgfs_atmos_wafs_f108 == complete
+              edit FCSTHR '114'
+            task jgfs_atmos_wafs_f120
+              trigger ../../post/jgfs_atmos_post_f120 == complete and ./jgfs_atmos_wafs_f114 == complete
+              edit FCSTHR '120'
+          endfamily
+          family grib2_wafs
+            task jgfs_atmos_wafs_grib2
+              trigger ../../post/jgfs_atmos_post_f000 == complete
+            task jgfs_atmos_wafs_grib2_0p25
+              trigger ../../post/jgfs_atmos_post_f036 == complete
+            task jgfs_atmos_wafs_blending
+              trigger ( :TIME >= 2233 or :TIME < 0233 ) and ./jgfs_atmos_wafs_grib2 == complete
+            task jgfs_atmos_wafs_blending_0p25
+              trigger ( :TIME >= 2225 or :TIME < 0225) and ./jgfs_atmos_wafs_grib2_0p25 == complete
+          endfamily
+          family bufr_sounding
+            task jgfs_atmos_postsnd
+              trigger ../../post/jgfs_atmos_post_manager:release_post000
+          endfamily
+          family bulletins
+            task jgfs_atmos_fbwind
+              trigger ../../post/jgfs_atmos_post_f006 == complete and ../../post/jgfs_atmos_post_f012 == complete and ../../post/jgfs_atmos_post_f024 == complete
+          endfamily
+          family awips_20km_1p0
+            task jgfs_atmos_awips_f000
+              trigger ../../post/jgfs_atmos_post_f000 == complete
+              edit FHRGRP '000'
+              edit FHRLST 'f000'
+              edit FCSTHR '000'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f003
+              trigger ../../post/jgfs_atmos_post_f003 == complete
+              edit FHRGRP '003'
+              edit FHRLST 'f003'
+              edit FCSTHR '003'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f006
+              trigger ../../post/jgfs_atmos_post_f006 == complete
+              edit FHRGRP '006'
+              edit FHRLST 'f006'
+              edit FCSTHR '006'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f009
+              trigger ../../post/jgfs_atmos_post_f009 == complete
+              edit FHRGRP '009'
+              edit FHRLST 'f009'
+              edit FCSTHR '009'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f012
+              trigger ../../post/jgfs_atmos_post_f012 == complete
+              edit FHRGRP '012'
+              edit FHRLST 'f012'
+              edit FCSTHR '012'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f015
+              trigger ../../post/jgfs_atmos_post_f015 == complete
+              edit FHRGRP '015'
+              edit FHRLST 'f015'
+              edit FCSTHR '015'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f018
+              trigger ../../post/jgfs_atmos_post_f018 == complete
+              edit FHRGRP '018'
+              edit FHRLST 'f018'
+              edit FCSTHR '018'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f021
+              trigger ../../post/jgfs_atmos_post_f021 == complete
+              edit FHRGRP '021'
+              edit FHRLST 'f021'
+              edit FCSTHR '021'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f024
+              trigger ../../post/jgfs_atmos_post_f024 == complete
+              edit FHRGRP '024'
+              edit FHRLST 'f024'
+              edit FCSTHR '024'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f027
+              trigger ../../post/jgfs_atmos_post_f027 == complete
+              edit FHRGRP '027'
+              edit FHRLST 'f027'
+              edit FCSTHR '027'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f030
+              trigger ../../post/jgfs_atmos_post_f030 == complete
+              edit FHRGRP '030'
+              edit FHRLST 'f030'
+              edit FCSTHR '030'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f033
+              trigger ../../post/jgfs_atmos_post_f033 == complete
+              edit FHRGRP '033'
+              edit FHRLST 'f033'
+              edit FCSTHR '033'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f036
+              trigger ../../post/jgfs_atmos_post_f036 == complete
+              edit FHRGRP '036'
+              edit FHRLST 'f036'
+              edit FCSTHR '036'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f039
+              trigger ../../post/jgfs_atmos_post_f039 == complete
+              edit FHRGRP '039'
+              edit FHRLST 'f039'
+              edit FCSTHR '039'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f042
+              trigger ../../post/jgfs_atmos_post_f042 == complete
+              edit FHRGRP '042'
+              edit FHRLST 'f042'
+              edit FCSTHR '042'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f045
+              trigger ../../post/jgfs_atmos_post_f045 == complete
+              edit FHRGRP '045'
+              edit FHRLST 'f045'
+              edit FCSTHR '045'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f048
+              trigger ../../post/jgfs_atmos_post_f048 == complete
+              edit FHRGRP '048'
+              edit FHRLST 'f048'
+              edit FCSTHR '048'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f051
+              trigger ../../post/jgfs_atmos_post_f051 == complete
+              edit FHRGRP '051'
+              edit FHRLST 'f051'
+              edit FCSTHR '051'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f054
+              trigger ../../post/jgfs_atmos_post_f054 == complete
+              edit FHRGRP '054'
+              edit FHRLST 'f054'
+              edit FCSTHR '054'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f057
+              trigger ../../post/jgfs_atmos_post_f057 == complete
+              edit FHRGRP '057'
+              edit FHRLST 'f057'
+              edit FCSTHR '057'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f060
+              trigger ../../post/jgfs_atmos_post_f060 == complete
+              edit FHRGRP '060'
+              edit FHRLST 'f060'
+              edit FCSTHR '060'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f063
+              trigger ../../post/jgfs_atmos_post_f063 == complete
+              edit FHRGRP '063'
+              edit FHRLST 'f063'
+              edit FCSTHR '063'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f066
+              trigger ../../post/jgfs_atmos_post_f066 == complete
+              edit FHRGRP '066'
+              edit FHRLST 'f066'
+              edit FCSTHR '066'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f069
+              trigger ../../post/jgfs_atmos_post_f069 == complete
+              edit FHRGRP '069'
+              edit FHRLST 'f069'
+              edit FCSTHR '069'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f072
+              trigger ../../post/jgfs_atmos_post_f072 == complete
+              edit FHRGRP '072'
+              edit FHRLST 'f072'
+              edit FCSTHR '072'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f075
+              trigger ../../post/jgfs_atmos_post_f075 == complete
+              edit FHRGRP '075'
+              edit FHRLST 'f075'
+              edit FCSTHR '075'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f078
+              trigger ../../post/jgfs_atmos_post_f078 == complete
+              edit FHRGRP '078'
+              edit FHRLST 'f078'
+              edit FCSTHR '078'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f081
+              trigger ../../post/jgfs_atmos_post_f081 == complete
+              edit FHRGRP '081'
+              edit FHRLST 'f081'
+              edit FCSTHR '081'
+              edit TRDRUN 'NO'
+            task jgfs_atmos_awips_f084
+              trigger ../../post/jgfs_atmos_post_f084 == complete
+              edit FHRGRP '084'
+              edit FHRLST 'f084'
+              edit FCSTHR '084'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f090
+              trigger ../../post/jgfs_atmos_post_f090 == complete
+              edit FHRGRP '090'
+              edit FHRLST 'f090'
+              edit FCSTHR '090'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f096
+              trigger ../../post/jgfs_atmos_post_f096 == complete
+              edit FHRGRP '096'
+              edit FHRLST 'f096'
+              edit FCSTHR '096'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f102
+              trigger ../../post/jgfs_atmos_post_f102 == complete
+              edit FHRGRP '102'
+              edit FHRLST 'f102'
+              edit FCSTHR '102'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f108
+              trigger ../../post/jgfs_atmos_post_f108 == complete
+              edit FHRGRP '108'
+              edit FHRLST 'f108'
+              edit FCSTHR '108'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f114
+              trigger ../../post/jgfs_atmos_post_f114 == complete
+              edit FHRGRP '114'
+              edit FHRLST 'f114'
+              edit FCSTHR '114'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f120
+              trigger ../../post/jgfs_atmos_post_f120 == complete
+              edit FHRGRP '120'
+              edit FHRLST 'f120'
+              edit FCSTHR '120'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f126
+              trigger ../../post/jgfs_atmos_post_f126 == complete
+              edit FHRGRP '126'
+              edit FHRLST 'f126'
+              edit FCSTHR '126'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f132
+              trigger ../../post/jgfs_atmos_post_f132 == complete
+              edit FHRGRP '132'
+              edit FHRLST 'f132'
+              edit FCSTHR '132'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f138
+              trigger ../../post/jgfs_atmos_post_f138 == complete
+              edit FHRGRP '138'
+              edit FHRLST 'f138'
+              edit FCSTHR '138'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f144
+              trigger ../../post/jgfs_atmos_post_f144 == complete
+              edit FHRGRP '144'
+              edit FHRLST 'f144'
+              edit FCSTHR '144'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f150
+              trigger ../../post/jgfs_atmos_post_f150 == complete
+              edit FHRGRP '150'
+              edit FHRLST 'f150'
+              edit FCSTHR '150'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f156
+              trigger ../../post/jgfs_atmos_post_f156 == complete
+              edit FHRGRP '156'
+              edit FHRLST 'f156'
+              edit FCSTHR '156'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f162
+              trigger ../../post/jgfs_atmos_post_f162 == complete
+              edit FHRGRP '162'
+              edit FHRLST 'f162'
+              edit FCSTHR '162'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f168
+              trigger ../../post/jgfs_atmos_post_f168 == complete
+              edit FHRGRP '168'
+              edit FHRLST 'f168'
+              edit FCSTHR '168'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f174
+              trigger ../../post/jgfs_atmos_post_f174 == complete
+              edit FHRGRP '174'
+              edit FHRLST 'f174'
+              edit FCSTHR '174'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f180
+              trigger ../../post/jgfs_atmos_post_f180 == complete
+              edit FHRGRP '180'
+              edit FHRLST 'f180'
+              edit FCSTHR '180'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f186
+              trigger ../../post/jgfs_atmos_post_f186 == complete
+              edit FHRGRP '186'
+              edit FHRLST 'f186'
+              edit FCSTHR '186'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f192
+              trigger ../../post/jgfs_atmos_post_f192 == complete
+              edit FHRGRP '192'
+              edit FHRLST 'f192'
+              edit FCSTHR '192'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f198
+              trigger ../../post/jgfs_atmos_post_f198 == complete
+              edit FHRGRP '198'
+              edit FHRLST 'f198'
+              edit FCSTHR '198'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f204
+              trigger ../../post/jgfs_atmos_post_f204 == complete
+              edit FHRGRP '204'
+              edit FHRLST 'f204'
+              edit FCSTHR '204'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f210
+              trigger ../../post/jgfs_atmos_post_f210 == complete
+              edit FHRGRP '210'
+              edit FHRLST 'f210'
+              edit FCSTHR '210'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f216
+              trigger ../../post/jgfs_atmos_post_f216 == complete
+              edit FHRGRP '216'
+              edit FHRLST 'f216'
+              edit FCSTHR '216'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f222
+              trigger ../../post/jgfs_atmos_post_f222 == complete
+              edit FHRGRP '222'
+              edit FHRLST 'f222'
+              edit FCSTHR '222'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f228
+              trigger ../../post/jgfs_atmos_post_f228 == complete
+              edit FHRGRP '228'
+              edit FHRLST 'f228'
+              edit FCSTHR '228'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f234
+              trigger ../../post/jgfs_atmos_post_f234 == complete
+              edit FHRGRP '234'
+              edit FHRLST 'f234'
+              edit FCSTHR '234'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_f240
+              trigger ../../post/jgfs_atmos_post_f240 == complete
+              edit FHRGRP '240'
+              edit FHRLST 'f240'
+              edit FCSTHR '240'
+              edit TRDRUN 'YES'
+          endfamily
+          family awips_g2
+            task jgfs_atmos_awips_g2_f000
+              trigger ../../post/jgfs_atmos_post_f000 == complete
+              edit FHRGRP '000'
+              edit FHRLST 'f000'
+              edit FCSTHR '000'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f006
+              trigger ../../post/jgfs_atmos_post_f006 == complete
+              edit FHRGRP '006'
+              edit FHRLST 'f006'
+              edit FCSTHR '006'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f012
+              trigger ../../post/jgfs_atmos_post_f012 == complete
+              edit FHRGRP '012'
+              edit FHRLST 'f012'
+              edit FCSTHR '012'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f018
+              trigger ../../post/jgfs_atmos_post_f018 == complete
+              edit FHRGRP '018'
+              edit FHRLST 'f018'
+              edit FCSTHR '018'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f024
+              trigger ../../post/jgfs_atmos_post_f024 == complete
+              edit FHRGRP '024'
+              edit FHRLST 'f024'
+              edit FCSTHR '024'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f030
+              trigger ../../post/jgfs_atmos_post_f030 == complete
+              edit FHRGRP '030'
+              edit FHRLST 'f030'
+              edit FCSTHR '030'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f036
+              trigger ../../post/jgfs_atmos_post_f036 == complete
+              edit FHRGRP '036'
+              edit FHRLST 'f036'
+              edit FCSTHR '036'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f042
+              trigger ../../post/jgfs_atmos_post_f042 == complete
+              edit FHRGRP '042'
+              edit FHRLST 'f042'
+              edit FCSTHR '042'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f048
+              trigger ../../post/jgfs_atmos_post_f048 == complete
+              edit FHRGRP '048'
+              edit FHRLST 'f048'
+              edit FCSTHR '048'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f054
+              trigger ../../post/jgfs_atmos_post_f054 == complete
+              edit FHRGRP '054'
+              edit FHRLST 'f054'
+              edit FCSTHR '054'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f060
+              trigger ../../post/jgfs_atmos_post_f060 == complete
+              edit FHRGRP '060'
+              edit FHRLST 'f060'
+              edit FCSTHR '060'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f066
+              trigger ../../post/jgfs_atmos_post_f066 == complete
+              edit FHRGRP '066'
+              edit FHRLST 'f066'
+              edit FCSTHR '066'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f072
+              trigger ../../post/jgfs_atmos_post_f072 == complete
+              edit FHRGRP '072'
+              edit FHRLST 'f072'
+              edit FCSTHR '072'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f078
+              trigger ../../post/jgfs_atmos_post_f078 == complete
+              edit FHRGRP '078'
+              edit FHRLST 'f078'
+              edit FCSTHR '078'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f084
+              trigger ../../post/jgfs_atmos_post_f084 == complete
+              edit FHRGRP '084'
+              edit FHRLST 'f084'
+              edit FCSTHR '084'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f090
+              trigger ../../post/jgfs_atmos_post_f090 == complete
+              edit FHRGRP '090'
+              edit FHRLST 'f090'
+              edit FCSTHR '090'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f096
+              trigger ../../post/jgfs_atmos_post_f096 == complete
+              edit FHRGRP '096'
+              edit FHRLST 'f096'
+              edit FCSTHR '096'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f102
+              trigger ../../post/jgfs_atmos_post_f102 == complete
+              edit FHRGRP '102'
+              edit FHRLST 'f102'
+              edit FCSTHR '102'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f108
+              trigger ../../post/jgfs_atmos_post_f108 == complete
+              edit FHRGRP '108'
+              edit FHRLST 'f108'
+              edit FCSTHR '108'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f114
+              trigger ../../post/jgfs_atmos_post_f114 == complete
+              edit FHRGRP '114'
+              edit FHRLST 'f114'
+              edit FCSTHR '114'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f120
+              trigger ../../post/jgfs_atmos_post_f120 == complete
+              edit FHRGRP '120'
+              edit FHRLST 'f120'
+              edit FCSTHR '120'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f126
+              trigger ../../post/jgfs_atmos_post_f126 == complete
+              edit FHRGRP '126'
+              edit FHRLST 'f126'
+              edit FCSTHR '126'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f132
+              trigger ../../post/jgfs_atmos_post_f132 == complete
+              edit FHRGRP '132'
+              edit FHRLST 'f132'
+              edit FCSTHR '132'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f138
+              trigger ../../post/jgfs_atmos_post_f138 == complete
+              edit FHRGRP '138'
+              edit FHRLST 'f138'
+              edit FCSTHR '138'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f144
+              trigger ../../post/jgfs_atmos_post_f144 == complete
+              edit FHRGRP '144'
+              edit FHRLST 'f144'
+              edit FCSTHR '144'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f150
+              trigger ../../post/jgfs_atmos_post_f150 == complete
+              edit FHRGRP '150'
+              edit FHRLST 'f150'
+              edit FCSTHR '150'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f156
+              trigger ../../post/jgfs_atmos_post_f156 == complete
+              edit FHRGRP '156'
+              edit FHRLST 'f156'
+              edit FCSTHR '156'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f162
+              trigger ../../post/jgfs_atmos_post_f162 == complete
+              edit FHRGRP '162'
+              edit FHRLST 'f162'
+              edit FCSTHR '162'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f168
+              trigger ../../post/jgfs_atmos_post_f168 == complete
+              edit FHRGRP '168'
+              edit FHRLST 'f168'
+              edit FCSTHR '168'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f174
+              trigger ../../post/jgfs_atmos_post_f174 == complete
+              edit FHRGRP '174'
+              edit FHRLST 'f174'
+              edit FCSTHR '174'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f180
+              trigger ../../post/jgfs_atmos_post_f180 == complete
+              edit FHRGRP '180'
+              edit FHRLST 'f180'
+              edit FCSTHR '180'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f186
+              trigger ../../post/jgfs_atmos_post_f186 == complete
+              edit FHRGRP '186'
+              edit FHRLST 'f186'
+              edit FCSTHR '186'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f192
+              trigger ../../post/jgfs_atmos_post_f192 == complete
+              edit FHRGRP '192'
+              edit FHRLST 'f192'
+              edit FCSTHR '192'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f198
+              trigger ../../post/jgfs_atmos_post_f198 == complete
+              edit FHRGRP '198'
+              edit FHRLST 'f198'
+              edit FCSTHR '198'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f204
+              trigger ../../post/jgfs_atmos_post_f204 == complete
+              edit FHRGRP '204'
+              edit FHRLST 'f204'
+              edit FCSTHR '204'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f210
+              trigger ../../post/jgfs_atmos_post_f210 == complete
+              edit FHRGRP '210'
+              edit FHRLST 'f210'
+              edit FCSTHR '210'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f216
+              trigger ../../post/jgfs_atmos_post_f216 == complete
+              edit FHRGRP '216'
+              edit FHRLST 'f216'
+              edit FCSTHR '216'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f222
+              trigger ../../post/jgfs_atmos_post_f222 == complete
+              edit FHRGRP '222'
+              edit FHRLST 'f222'
+              edit FCSTHR '222'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f228
+              trigger ../../post/jgfs_atmos_post_f228 == complete
+              edit FHRGRP '228'
+              edit FHRLST 'f228'
+              edit FCSTHR '228'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f234
+              trigger ../../post/jgfs_atmos_post_f234 == complete
+              edit FHRGRP '234'
+              edit FHRLST 'f234'
+              edit FCSTHR '234'
+              edit TRDRUN 'YES'
+            task jgfs_atmos_awips_g2_f240
+              trigger ../../post/jgfs_atmos_post_f240 == complete
+              edit FHRGRP '240'
+              edit FHRLST 'f240'
+              edit FCSTHR '240'
+              edit TRDRUN 'YES'
+          endfamily
+        endfamily
+        family gempak
+          task jgfs_atmos_gempak
+            trigger ../../atmos/analysis/jgfs_atmos_analysis == complete
+          task jgfs_atmos_gempak_meta
+            trigger ../../atmos/analysis/jgfs_atmos_analysis == complete
+          task jgfs_atmos_gempak_ncdc_upapgif
+            trigger ./jgfs_atmos_gempak == active or ./jgfs_atmos_gempak == complete
+          task jgfs_atmos_npoess_pgrb2_0p5deg
+            trigger ../post/jgfs_atmos_post_anl eq active or ../post/jgfs_atmos_post_anl == complete
+          task jgfs_atmos_pgrb2_spec_gempak
+            trigger ./jgfs_atmos_npoess_pgrb2_0p5deg == complete
+        endfamily
+        family verf
+          task jgfs_atmos_vminmon
+            trigger ../analysis/jgfs_atmos_analysis == complete
+        endfamily
+      endfamily
+      family wave
+        family init
+          task jgfs_wave_init
+            trigger /prod/primary/18/obsproc/v1.0/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete
+        endfamily
+        family prep
+          task jgfs_wave_prep
+            trigger ../init/jgfs_wave_init == complete
+        endfamily
+        family post
+          task jgfs_wave_postsbs
+            trigger ../../atmos/post/jgfs_atmos_post_manager:release_post000
+          task jgfs_wave_postpnt
+            trigger ../../jgfs_forecast == complete
+          task jgfs_wave_post_bndpnt
+            trigger ../../atmos/post/jgfs_atmos_post_manager:release_post180
+          task jgfs_wave_post_bndpntbll
+            trigger ../../atmos/post/jgfs_atmos_post_manager:release_post180
+          task jgfs_wave_prdgen_gridded
+            trigger ./jgfs_wave_postsbs == active or ./jgfs_wave_postsbs == complete
+          task jgfs_wave_prdgen_bulls
+            trigger ./jgfs_wave_postpnt == complete and ./jgfs_wave_postsbs == complete
+        endfamily
+        family gempak
+          task jgfs_wave_gempak
+            trigger ../post/jgfs_wave_postsbs == active or ../post/jgfs_wave_postsbs == complete
+        endfamily
+      endfamily
+      task jgfs_forecast
+        trigger ./atmos/analysis/jgfs_atmos_analysis:release_fcst and ./wave/prep/jgfs_wave_prep == complete
+    endfamily
+    family gdas
+      edit RUN 'gdas'
+      edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/gdas'
+      family atmos
+        family obsproc
+          family dump
+            task jgdas_atmos_tropcy_qc_reloc
+              trigger :TIME >= 2345 or :TIME < 0545
+          endfamily
+          family prep
+            task jgdas_atmos_emcsfc_sfc_prep
+              trigger /prod/primary/18/obsproc/v1.0/gdas/atmos/dump/jobsproc_gdas_atmos_dump:release_sfcprep
+          endfamily
+        endfamily
+        family init
+          task jgdas_atmos_gldas
+            trigger ../analysis/jgdas_atmos_analysis == complete
+        endfamily
+        family analysis
+          task jgdas_atmos_analysis
+            trigger /prod/primary/18/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../obsproc/prep/jgdas_atmos_emcsfc_sfc_prep == complete
+            event 1 release_fcst
+          task jgdas_atmos_analysis_calc
+            trigger ./jgdas_atmos_analysis == complete
+          task jgdas_atmos_analysis_diag
+            trigger ./jgdas_atmos_analysis == complete
+        endfamily
+        family post
+          task jgdas_atmos_post_manager
+            trigger ../../jgdas_forecast == active
+            event 1 release_postanl
+            event 2 release_post000
+            event 3 release_post001
+            event 4 release_post002
+            event 5 release_post003
+            event 6 release_post004
+            event 7 release_post005
+            event 8 release_post006
+            event 9 release_post007
+            event 10 release_post008
+            event 11 release_post009
+          task jgdas_atmos_post_anl
+            trigger ./jgdas_atmos_post_manager:release_postanl
+            edit FHRGRP '000'
+            edit FHRLST 'anl'
+            edit HR 'anl'
+            edit FHR 'anl'
+          task jgdas_atmos_post_f000
+            trigger ./jgdas_atmos_post_manager:release_post000
+            edit FHR 'f000'
+            edit HR '000'
+            edit FHRGRP '001'
+            edit FHRLST 'f000'
+          task jgdas_atmos_post_f001
+            trigger ./jgdas_atmos_post_manager:release_post001
+            edit FHR 'f001'
+            edit HR '001'
+            edit FHRGRP '002'
+            edit FHRLST 'f001'
+          task jgdas_atmos_post_f002
+            trigger ./jgdas_atmos_post_manager:release_post002
+            edit FHR 'f002'
+            edit HR '002'
+            edit FHRGRP '003'
+            edit FHRLST 'f002'
+          task jgdas_atmos_post_f003
+            trigger ./jgdas_atmos_post_manager:release_post003
+            edit FHR 'f003'
+            edit HR '003'
+            edit FHRGRP '004'
+            edit FHRLST 'f003'
+          task jgdas_atmos_post_f004
+            trigger ./jgdas_atmos_post_manager:release_post004
+            edit FHR 'f004'
+            edit HR '004'
+            edit FHRGRP '005'
+            edit FHRLST 'f004'
+          task jgdas_atmos_post_f005
+            trigger ./jgdas_atmos_post_manager:release_post005
+            edit FHR 'f005'
+            edit HR '005'
+            edit FHRGRP '006'
+            edit FHRLST 'f005'
+          task jgdas_atmos_post_f006
+            trigger ./jgdas_atmos_post_manager:release_post006
+            edit FHR 'f006'
+            edit HR '006'
+            edit FHRGRP '007'
+            edit FHRLST 'f006'
+          task jgdas_atmos_post_f007
+            trigger ./jgdas_atmos_post_manager:release_post007
+            edit FHR 'f007'
+            edit HR '007'
+            edit FHRGRP '008'
+            edit FHRLST 'f007'
+          task jgdas_atmos_post_f008
+            trigger ./jgdas_atmos_post_manager:release_post008
+            edit FHR 'f008'
+            edit HR '008'
+            edit FHRGRP '009'
+            edit FHRLST 'f008'
+          task jgdas_atmos_post_f009
+            trigger ./jgdas_atmos_post_manager:release_post009
+            edit FHR 'f009'
+            edit HR '009'
+            edit FHRGRP '010'
+            edit FHRLST 'f009'
+        endfamily
+        family post_processing
+          task jgdas_atmos_chgres_forenkf
+            trigger ../../jgdas_forecast == complete and ../../../enkfgdas/forecast == complete
+        endfamily
+        family gempak
+          task jgdas_atmos_gempak
+            trigger ../../jgdas_forecast == complete
+          task jgdas_atmos_gempak_meta_ncdc
+            trigger ./jgdas_atmos_gempak == complete
+        endfamily
+        family verf
+          task jgdas_atmos_vminmon
+            trigger ../analysis/jgdas_atmos_analysis == complete
+          task jgdas_atmos_verfrad
+            trigger ../analysis/jgdas_atmos_analysis_diag == complete
+          task jgdas_atmos_verfozn
+            trigger ../analysis/jgdas_atmos_analysis_diag == complete
+        endfamily
+      endfamily
+      family wave
+        family init
+          task jgdas_wave_init
+            trigger /prod/primary/18/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete
+        endfamily
+        family prep
+          task jgdas_wave_prep
+            trigger ../init/jgdas_wave_init == complete
+        endfamily
+        family post
+          task jgdas_wave_postsbs
+            trigger ../../atmos/post/jgdas_atmos_post_manager:release_post000
+          task jgdas_wave_postpnt
+            trigger ../../jgdas_forecast == complete
+        endfamily
+      endfamily
+      task jgdas_forecast
+        trigger ./atmos/analysis/jgdas_atmos_analysis:release_fcst and ./wave/prep/jgdas_wave_prep == complete and ./atmos/init/jgdas_atmos_gldas == complete
+    endfamily
+    family enkfgdas
+      edit RUN 'gdas'
+      edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/enkfgdas'
+      family analysis
+        family create
+          task jenkfgdas_select_obs
+            trigger /prod/primary/18/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and /prod/primary/12/gfs/v16.2/enkfgdas/post == complete
+          task jenkfgdas_diag
+            trigger ./jenkfgdas_select_obs == complete
+          task jenkfgdas_update
+            trigger ./jenkfgdas_diag == complete
+        endfamily
+        family recenter
+          family ecen
+            trigger ../create/jenkfgdas_update == complete and ../../../gdas/atmos/analysis/jgdas_atmos_analysis_calc == complete and /prod/primary/12/gfs/v16.2/gdas/atmos/post_processing/jgdas_atmos_chgres_forenkf == complete
+            edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/enkfgdas/analysis/recenter/ecen'
+            family grp1
+              edit FHRGRP '003'
+              task jenkfgdas_ecen
+            endfamily
+            family grp2
+              edit FHRGRP '006'
+              task jenkfgdas_ecen
+            endfamily
+            family grp3
+              edit FHRGRP '009'
+              task jenkfgdas_ecen
+            endfamily
+          endfamily
+          task jenkfgdas_sfc
+            trigger ../create/jenkfgdas_update == complete and ../../../gdas/atmos/analysis/jgdas_atmos_analysis_calc == complete
+        endfamily
+      endfamily
+      family forecast
+        trigger ./analysis/recenter/ecen == complete and ./analysis/recenter/jenkfgdas_sfc == complete
+        edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/enkfgdas/forecast'
+        family grp1
+          edit ENSGRP '01'
+          task jenkfgdas_fcst
+        endfamily
+        family grp2
+          edit ENSGRP '02'
+          task jenkfgdas_fcst
+        endfamily
+        family grp3
+          edit ENSGRP '03'
+          task jenkfgdas_fcst
+        endfamily
+        family grp4
+          edit ENSGRP '04'
+          task jenkfgdas_fcst
+        endfamily
+        family grp5
+          edit ENSGRP '05'
+          task jenkfgdas_fcst
+        endfamily
+        family grp6
+          edit ENSGRP '06'
+          task jenkfgdas_fcst
+        endfamily
+        family grp7
+          edit ENSGRP '07'
+          task jenkfgdas_fcst
+        endfamily
+        family grp8
+          edit ENSGRP '08'
+          task jenkfgdas_fcst
+        endfamily
+        family grp9
+          edit ENSGRP '09'
+          task jenkfgdas_fcst
+        endfamily
+        family grp10
+          edit ENSGRP '10'
+          task jenkfgdas_fcst
+        endfamily
+        family grp11
+          edit ENSGRP '11'
+          task jenkfgdas_fcst
+        endfamily
+        family grp12
+          edit ENSGRP '12'
+          task jenkfgdas_fcst
+        endfamily
+        family grp13
+          edit ENSGRP '13'
+          task jenkfgdas_fcst
+        endfamily
+        family grp14
+          edit ENSGRP '14'
+          task jenkfgdas_fcst
+        endfamily
+        family grp15
+          edit ENSGRP '15'
+          task jenkfgdas_fcst
+        endfamily
+        family grp16
+          edit ENSGRP '16'
+          task jenkfgdas_fcst
+        endfamily
+        family grp17
+          edit ENSGRP '17'
+          task jenkfgdas_fcst
+        endfamily
+        family grp18
+          edit ENSGRP '18'
+          task jenkfgdas_fcst
+        endfamily
+        family grp19
+          edit ENSGRP '19'
+          task jenkfgdas_fcst
+        endfamily
+        family grp20
+          edit ENSGRP '20'
+          task jenkfgdas_fcst
+        endfamily
+        family grp21
+          edit ENSGRP '21'
+          task jenkfgdas_fcst
+        endfamily
+        family grp22
+          edit ENSGRP '22'
+          task jenkfgdas_fcst
+        endfamily
+        family grp23
+          edit ENSGRP '23'
+          task jenkfgdas_fcst
+        endfamily
+        family grp24
+          edit ENSGRP '24'
+          task jenkfgdas_fcst
+        endfamily
+        family grp25
+          edit ENSGRP '25'
+          task jenkfgdas_fcst
+        endfamily
+        family grp26
+          edit ENSGRP '26'
+          task jenkfgdas_fcst
+        endfamily
+        family grp27
+          edit ENSGRP '27'
+          task jenkfgdas_fcst
+        endfamily
+        family grp28
+          edit ENSGRP '28'
+          task jenkfgdas_fcst
+        endfamily
+        family grp29
+          edit ENSGRP '29'
+          task jenkfgdas_fcst
+        endfamily
+        family grp30
+          edit ENSGRP '30'
+          task jenkfgdas_fcst
+        endfamily
+        family grp31
+          edit ENSGRP '31'
+          task jenkfgdas_fcst
+        endfamily
+        family grp32
+          edit ENSGRP '32'
+          task jenkfgdas_fcst
+        endfamily
+        family grp33
+          edit ENSGRP '33'
+          task jenkfgdas_fcst
+        endfamily
+        family grp34
+          edit ENSGRP '34'
+          task jenkfgdas_fcst
+        endfamily
+        family grp35
+          edit ENSGRP '35'
+          task jenkfgdas_fcst
+        endfamily
+        family grp36
+          edit ENSGRP '36'
+          task jenkfgdas_fcst
+        endfamily
+        family grp37
+          edit ENSGRP '37'
+          task jenkfgdas_fcst
+        endfamily
+        family grp38
+          edit ENSGRP '38'
+          task jenkfgdas_fcst
+        endfamily
+        family grp39
+          edit ENSGRP '39'
+          task jenkfgdas_fcst
+        endfamily
+        family grp40
+          edit ENSGRP '40'
+          task jenkfgdas_fcst
+        endfamily
+      endfamily
+      family post
+        trigger ./forecast == complete
+        task jenkfgdas_post_f003
+          edit FHMIN_EPOS '003'
+          edit FHMAX_EPOS '003'
+          edit FHOUT_EPOS '003'
+        task jenkfgdas_post_f004
+          edit FHMIN_EPOS '004'
+          edit FHMAX_EPOS '004'
+          edit FHOUT_EPOS '004'
+        task jenkfgdas_post_f005
+          edit FHMIN_EPOS '005'
+          edit FHMAX_EPOS '005'
+          edit FHOUT_EPOS '005'
+        task jenkfgdas_post_f006
+          edit FHMIN_EPOS '006'
+          edit FHMAX_EPOS '006'
+          edit FHOUT_EPOS '006'
+        task jenkfgdas_post_f007
+          edit FHMIN_EPOS '007'
+          edit FHMAX_EPOS '007'
+          edit FHOUT_EPOS '007'
+        task jenkfgdas_post_f008
+          edit FHMIN_EPOS '008'
+          edit FHMAX_EPOS '008'
+          edit FHOUT_EPOS '008'
+        task jenkfgdas_post_f009
+          edit FHMIN_EPOS '009'
+          edit FHMAX_EPOS '009'
+          edit FHOUT_EPOS '009'
+      endfamily
+    endfamily
+  endfamily
+

--- a/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
+++ b/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:06:00
-#PBS -l select=1:mpiprocs=80:ompthreads=1:ncpus=80:mem=40GB
+#PBS -l select=1:mpiprocs=80:ompthreads=1:ncpus=80:mem=60GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_calc.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_calc.ecf
@@ -6,6 +6,7 @@
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=128:ompthreads=1:ncpus=128
 #PBS -l place=vscatter:excl
+#PBS -l hyper=true
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
+++ b/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
@@ -31,6 +31,7 @@ module load cdo/${cdo_ver}
 module load hdf5/${hdf5_ver}
 module load netcdf/${netcdf_ver}
 module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
 module load nco/${nco_ver}
 module load wgrib2/${wgrib2_ver}
 

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_master.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
-#PBS -l select=1:mpiprocs=112:ompthreads=1:ncpus=112
+#PBS -l select=1:mpiprocs=126:ompthreads=1:ncpus=126
 #PBS -l place=vscatter:excl
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/jgfs_forecast.ecf
+++ b/ecf/scripts/gfs/jgfs_forecast.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:30:00
-#PBS -l select=101:mpiprocs=42:ompthreads=3:ncpus=126
+#PBS -l select=112:mpiprocs=24:ompthreads=5:ncpus=120
 #PBS -l place=vscatter:excl
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
+++ b/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
@@ -31,6 +31,7 @@ module load cdo/${cdo_ver}
 module load hdf5/${hdf5_ver}
 module load netcdf/${netcdf_ver}
 module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
 module load nco/${nco_ver}
 module load wgrib2/${wgrib2_ver}
 

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -41,7 +41,7 @@ elif [ $step = "anal" ]; then
     export FI_OFI_RXM_SAR_LIMIT=3145728
 
     export NTHREADS_GSI=$nth_anal
-    export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_anal:-$PBS_NP}} -ppn $npe_node_anal --cpu-bind core --depth $NTHREADS_GSI"
+    export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_anal:-$PBS_NP}} -ppn $npe_node_anal --cpu-bind depth --depth $NTHREADS_GSI"
 
     export NTHREADS_CALCINC=${nth_calcinc:-1}
     export APRUN_CALCINC="$launcher \$ncmd"
@@ -49,7 +49,7 @@ elif [ $step = "anal" ]; then
     export NTHREADS_CYCLE=${nth_cycle:-14}
     [[ $NTHREADS_CYCLE -gt $npe_node_max ]] && export NTHREADS_CYCLE=$npe_node_max
     npe_cycle=${ntiles:-6}
-    export APRUN_CYCLE="$launcher -n $npe_cycle -ppn $npe_node_cycle --cpu-bind core --depth $NTHREADS_CYCLE"
+    export APRUN_CYCLE="$launcher -n $npe_cycle -ppn $npe_node_cycle --cpu-bind depth --depth $NTHREADS_CYCLE"
 
     export NTHREADS_GAUSFCANL=1
     npe_gausfcanl=${npe_gausfcanl:-1}
@@ -66,10 +66,10 @@ elif [ $step = "anal" ]; then
 elif [ $step = "gldas" ]; then
 
     export NTHREADS_GLDAS=$nth_gldas
-    export APRUN_GLDAS="$launcher -n $npe_gldas -ppn $npe_node_gldas --cpu-bind core --depth $NTHREADS_GLDAS"
+    export APRUN_GLDAS="$launcher -n $npe_gldas -ppn $npe_node_gldas --cpu-bind depth --depth $NTHREADS_GLDAS"
 
     export NTHREADS_GAUSSIAN=${nth_gaussian:-1}
-    export APRUN_GAUSSIAN="$launcher -n $npe_gaussian -ppn $npe_node_gaussian --cpu-bind core --depth $NTHREADS_GAUSSIAN"
+    export APRUN_GAUSSIAN="$launcher -n $npe_gaussian -ppn $npe_node_gaussian --cpu-bind depth --depth $NTHREADS_GAUSSIAN"
 
     export USE_CFP=${USE_CFP:-"YES"}
     export APRUN_GLDAS_DATA_PROC="$launcher -np $npe_gldas $mpmd"
@@ -81,7 +81,7 @@ elif [ $step = "eobs" ]; then
     export FI_OFI_RXM_SAR_LIMIT=3145728
 
     export NTHREADS_GSI=$nth_eobs
-    export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_eobs:-$PBS_NP}} -ppn $npe_node_eobs --cpu-bind core --depth $NTHREADS_GSI"
+    export APRUN_GSI="$launcher -n ${npe_gsi:-${npe_eobs:-$PBS_NP}} -ppn $npe_node_eobs --cpu-bind depth --depth $NTHREADS_GSI"
 
     export CFP_MP=${CFP_MP:-"NO"}
     export USE_CFP=${USE_CFP:-"YES"}
@@ -95,7 +95,7 @@ elif [ $step = "eupd" ]; then
     export FI_OFI_RXM_SAR_LIMIT=3145728
 
     export NTHREADS_ENKF=$nth_eupd
-    export APRUN_ENKF="$launcher -n ${npe_enkf:-${npe_eupd:-$PBS_NP}} -ppn $npe_node_eupd --cpu-bind core --depth $NTHREADS_ENKF"
+    export APRUN_ENKF="$launcher -n ${npe_enkf:-${npe_eupd:-$PBS_NP}} -ppn $npe_node_eupd --cpu-bind depth --depth $NTHREADS_ENKF"
 
     export CFP_MP=${CFP_MP:-"NO"}
     export USE_CFP=${USE_CFP:-"YES"}
@@ -111,9 +111,9 @@ elif [ $step = "fcst" ]; then
     export NTHREADS_FV3=$nth_fv3
     export cores_per_node=$npe_node_max
     if [ $CDUMP = "gdas" ]; then
-      export APRUN_FV3="$launcher -n ${npe_fcst:-$PBS_NP} -ppn $npe_node_fcst --cpu-bind core --depth $NTHREADS_FV3"
+      export APRUN_FV3="$launcher -n ${npe_fcst:-$PBS_NP} -ppn $npe_node_fcst --cpu-bind depth --depth $NTHREADS_FV3"
     else
-      export APRUN_FV3="$launcher -n ${npe_fcst_gfs:-$PBS_NP} -ppn $npe_node_fcst_gfs --cpu-bind core --depth $NTHREADS_FV3"
+      export APRUN_FV3="$launcher -n ${npe_fcst_gfs:-$PBS_NP} -ppn $npe_node_fcst_gfs --cpu-bind depth --depth $NTHREADS_FV3"
     fi
     export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
     export APRUN_REGRID_NEMSIO="$launcher -n $LEVS"
@@ -130,7 +130,7 @@ elif [ $step = "efcs" ]; then
 
     export NTHREADS_FV3=$nth_efcs
     export cores_per_node=$npe_node_max
-    export APRUN_FV3="$launcher -n ${npe_fv3:-${npe_efcs:-$PBS_NP}} -ppn $npe_node_efcs --cpu-bind core --depth $NTHREADS_FV3"
+    export APRUN_FV3="$launcher -n ${npe_fv3:-${npe_efcs:-$PBS_NP}} -ppn $npe_node_efcs --cpu-bind depth --depth $NTHREADS_FV3"
 
     export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
     export APRUN_REGRID_NEMSIO="$launcher -n $LEVS"
@@ -138,7 +138,7 @@ elif [ $step = "efcs" ]; then
 elif [ $step = "post" ]; then
 
     export NTHREADS_NP=${nth_np:-1}
-    export APRUN_NP="$launcher -n ${npe_np:-${npe_post:-$PBS_NP}} -ppn $npe_node_post --cpu-bind core --depth $NTHREADS_NP"
+    export APRUN_NP="$launcher -n ${npe_np:-${npe_post:-$PBS_NP}} -ppn $npe_node_post --cpu-bind depth --depth $NTHREADS_NP"
 
     export NTHREADS_DWN=${nth_dwn:-1}
     export APRUN_DWN="$launcher -np ${npe_dwn:-$PBS_NP} $mpmd"
@@ -146,7 +146,7 @@ elif [ $step = "post" ]; then
 elif [ $step = "ecen" ]; then
 
     export NTHREADS_ECEN=$nth_ecen
-    export APRUN_ECEN="$launcher -n ${npe_ecen:-$PBS_NP} -ppn $npe_node_ecen --cpu-bind core --depth $NTHREADS_ECEN"
+    export APRUN_ECEN="$launcher -n ${npe_ecen:-$PBS_NP} -ppn $npe_node_ecen --cpu-bind depth --depth $NTHREADS_ECEN"
 
     export NTHREADS_CHGRES=${nth_chgres:-14}
     [[ $NTHREADS_CHGRES -gt $npe_node_max ]] && export NTHREADS_CHGRES=$npe_node_max
@@ -157,21 +157,21 @@ elif [ $step = "ecen" ]; then
 
     export NTHREADS_CYCLE=${nth_cycle:-14}
     [[ $NTHREADS_CYCLE -gt $npe_node_max ]] && export NTHREADS_CYCLE=$npe_node_max
-    export APRUN_CYCLE="$launcher -n $npe_ecen -ppn $npe_node_cycle --cpu-bind core --depth $NTHREADS_CYCLE"
+    export APRUN_CYCLE="$launcher -n $npe_ecen -ppn $npe_node_cycle --cpu-bind depth --depth $NTHREADS_CYCLE"
 
 elif [ $step = "esfc" ]; then
 
     export NTHREADS_ESFC=$nth_esfc
-    export APRUN_ESFC="$launcher -n ${npe_esfc:-$PBS_NP} -ppn $npe_node_esfc --cpu-bind core --depth $NTHREADS_ESFC"
+    export APRUN_ESFC="$launcher -n ${npe_esfc:-$PBS_NP} -ppn $npe_node_esfc --cpu-bind depth --depth $NTHREADS_ESFC"
 
     export NTHREADS_CYCLE=${nth_cycle:-14}
     [[ $NTHREADS_CYCLE -gt $npe_node_max ]] && export NTHREADS_CYCLE=$npe_node_max
-    export APRUN_CYCLE="$launcher -n $npe_esfc -ppn $npe_node_cycle --cpu-bind core --depth $NTHREADS_CYCLE"
+    export APRUN_CYCLE="$launcher -n $npe_esfc -ppn $npe_node_cycle --cpu-bind depth --depth $NTHREADS_CYCLE"
 
 elif [ $step = "epos" ]; then
 
     export NTHREADS_EPOS=$nth_epos
-    export APRUN_EPOS="$launcher -n ${npe_epos:-$PBS_NP} -ppn $npe_node_epos --cpu-bind core --depth $NTHREADS_EPOS"
+    export APRUN_EPOS="$launcher -n ${npe_epos:-$PBS_NP} -ppn $npe_node_epos --cpu-bind depth --depth $NTHREADS_EPOS"
 
 elif [ $step = "fv3ic" ]; then
 

--- a/modulefiles/module_base.wcoss2.lua
+++ b/modulefiles/module_base.wcoss2.lua
@@ -23,6 +23,7 @@ load(pathJoin("hdf5", os.getenv("hdf5_ver")))
 load(pathJoin("netcdf", os.getenv("netcdf_ver")))
 
 load(pathJoin("udunits", os.getenv("udunits_ver")))
+load(pathJoin("gsl", os.getenv("gsl_ver")))
 load(pathJoin("nco", os.getenv("nco_ver")))
 load(pathJoin("prod_util", os.getenv("prod_util_ver")))
 load(pathJoin("grib_util", os.getenv("grib_util_ver")))

--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -129,7 +129,7 @@ if [[ $RUN_ENVIR == "emc" ]]; then
 #   As of 2022021812, gfsv16_historical/global_convinfo.txt.2022031612 is
 #   identical to ../global_convinfo.txt.  Thus, the logic below is not
 #   needed at this time.
-#   Assimilate DO-4 (Spire and GeoOptics)
+#   Assimilate DO-4 (Spire and GeoOptics) and turn off uv 224 VADWND
 #   if [[ "$CDATE" -ge "2022031612" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
 #     export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2022031612
 #   fi

--- a/parm/config/config.fv3.nco.static
+++ b/parm/config/config.fv3.nco.static
@@ -95,17 +95,17 @@ case $case_in in
         export DELTIM=150
         export layout_x=8
         export layout_y=12
-        export layout_x_gfs=24
+        export layout_x_gfs=12
         export layout_y_gfs=24
         export npe_wav=140
         export npe_wav_gfs=448
         export nth_fv3=3
-        export nth_fv3_gfs=3
+        export nth_fv3_gfs=5
         export cdmbgwd="4.0,0.15,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=2
         export WRTTASK_PER_GROUP=64
-        export WRITE_GROUP_GFS=7
-        export WRTTASK_PER_GROUP_GFS=48
+        export WRITE_GROUP_GFS=8
+        export WRTTASK_PER_GROUP_GFS=64
         export WRTIOBUF="32M"
         ;;
     "C1152")

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -165,7 +165,7 @@ elif [ $step = "post" ]; then
 
     export wtime_post="00:12:00"
     export wtime_post_gfs="01:00:00"
-    export npe_post=112
+    export npe_post=126
     export nth_post=1
     export npe_node_post=$npe_post
     export npe_node_post_gfs=$npe_post

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -159,7 +159,7 @@ elif [ $step = "fcst" ]; then
     export nth_fcst=${nth_fv3:-2}
     export nth_fcst_gfs=${nth_fv3_gfs:-2}
     export npe_node_fcst=32
-    export npe_node_fcst_gfs=42
+    export npe_node_fcst_gfs=24
 
 elif [ $step = "post" ]; then
 

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -36,7 +36,7 @@ if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
     git clone --recursive --branch gfsda.v16.2.0 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
-    git submodule update
+    git submodule update --init
     cd ${topdir}
 else
     echo 'Skip.  Directory gsi.fd already exists.'

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -63,7 +63,7 @@ fi
 echo EMC_post checkout ...
 if [[ ! -d gfs_post.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_post.log
-    git clone ${gtg_git_args:-} --branch upp_v8.1.0 https://github.com/NOAA-EMC/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
+    git clone ${gtg_git_args:-} --branch upp_v8.1.2 https://github.com/NOAA-EMC/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
     ################################################################################
     # checkout_gtg
     ## yes: The gtg code at NCAR private repository is available for ops. GFS only.

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -39,7 +39,7 @@ if [[ ! -d gsi.fd ]] ; then
     git clone --recursive https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
     git checkout gfsda.v16.1.6
-    git submodule update
+    git submodule update --init
     cd ${topdir}
 else
     echo 'Skip.  Directory gsi.fd already exists.'

--- a/sorc/syndat_getjtbul.fd/getjtbul.f
+++ b/sorc/syndat_getjtbul.fd/getjtbul.f
@@ -92,12 +92,41 @@ c  OF THE RECORD (OLD NON-Y2K COMPLIANT FORM) OR IF A 4-DIGIT YEAR
 c  BEGINS IN COLUMN 20 (NEW Y2K COMPLIANT FORM) - TEST ON LOCATION OF
 c  LATITUDE BLANK CHARACTER TO FIND OUT ...
 
-         IF(INL1(26).EQ.' ') THEN
+c  Check TABs and replaced it with ' '  (added by Qingfu Liu)
+         DO J=1,80
+           IF(ichar(INL(J:J)).EQ.9)THEN
+              INL(J:J) = ' '
+           END IF
+         END DO
+         DO J=1,80
+           IF(ichar(INL(J:J)).EQ.13)THEN
+              INL(J:J) = ' '
+           END IF
+         END DO
+
+         IF(INL1(26).EQ.' '.or.INL1(27).EQ.' ') THEN
 
 c ... THIS RECORD STILL CONTAINS THE OLD 2-DIGIT FORM OF THE YEAR -
 c ... THIS PROGRAM WILL NOW CONVERT THE RECORD TO A 4-DIGIT YEAR USING
 c      THE "WINDOWING" TECHNIQUE SINCE SUBSEQUENT LOGIC EXPECTS THIS
 
+          IF(INL(18:19).EQ.'20') THEN
+            DUMY2K(1:17) = INL(1:17)
+            DUMY2K(18:19) = '  '
+            DUMY2K(20:80) = INL(18:78)
+            INL= DUMY2K
+            PRINT *, ' '
+            PRINT *, '==> This is an new-format record with a 4-digit '
+            PRINT *, ' '
+          ELSE IF(INL(19:20).EQ.'20') THEN
+            DUMY2K(1:18) = INL(1:18)
+            DUMY2K(19:19) = ' '
+            DUMY2K(20:80) = INL(19:79)
+            INL= DUMY2K
+            PRINT *, ' '
+            PRINT *, '==> This is an new-format record with a 4-digit '
+            PRINT *, ' '
+          ELSE
             PRINT *, ' '
             PRINT *, '==> This is an old-format record with a 2-digit ',
      $       'year "',INL(20:21),'"'
@@ -114,7 +143,7 @@ c      THE "WINDOWING" TECHNIQUE SINCE SUBSEQUENT LOGIC EXPECTS THIS
             PRINT *, '==> 2-digit year converted to 4-digit year "',
      $       INL(20:23),'" via windowing technique'
             PRINT *, ' '
-
+          ENDIF
          ELSE 
 
 c ... THIS RECORD CONTAINS THE NEW 4-DIGIT FORM OF THE YEAR

--- a/versions/build.ver
+++ b/versions/build.ver
@@ -14,7 +14,6 @@ export hdf5_ver=1.10.6
 export netcdf_ver=4.7.4
 export esmf_ver=8.0.1
 
-export nco_ver=4.7.9
 export wgrib2_ver=2.0.7
 
 export crtm_ver=2.3.0

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -28,6 +28,7 @@ export netcdf_ver=4.7.4
 export esmf_ver=8.0.1
 
 export udunits_ver=2.2.28
+export gsl_ver=2.7
 export nco_ver=4.7.9
 export bufr_dump_ver=1.0.0
 export util_shared_ver=1.4.0


### PR DESCRIPTION
**Description**

This PR syncs the `dev_v16` branch with recent updates to the WCOSS2 ops package in the `feature/ops-wcoss2` branch.

Updates include:

- GFSv16.1.6 and GFSv16.1.7 WCOSS-Dell implementation updates
- Copies of `gfs_##.def` files from WCOSS2 ops.
- Adjustments in WCOSS2 ops:
  - memory request in `jenkfgdas_sfc.ecf` (40GB -> 60GB)
  - added `hyper=true` in `jgdas_atmos_analysis_calc.ecf`
  - add gsl module load in `jgdas_wave_prep.ecf` and `jgfs_wave_prep.ecf`
  - remove gsl and nco module loads in `build.ver` (not needed)
  - update gfs_forecast job resources in `jgfs_forecast.ecf`, `config.fv3.nco.static` and `config.resources.nco.static`
  - update gfs_atmos_post resources in `jgfs_atmos_post_master.ecf`
  - update UPP tag to `upp_v8.1.2`
  - in `WCOSS2.env` change launcher flag for threaded execs from `--cpu-bind core` to `--cpu-bind depth`

Refs #665

**Type of change**

- [x] Regular sync

**How Has This Been Tested?**

Updates already tested and promoted into operations in either WCOSS-Dell and/or WCOSS2. Changes should not negatively impact R&D support.