### PR TITLE
Remove duplicate file linking in ush/forecast_postdet.sh

### DIFF
--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -260,7 +260,10 @@ EOF
   fi
   H2OFORC=${H2OFORC:-"global_h2o_pltc.f77"}
   ####
-  # copy CCN_ACTIVATE.BIN for Thompson microphysics
+  #  Copy CCN_ACTIVATE.BIN for Thompson microphysics
+  #  Thompson microphysics used when CCPP_SUITE set to FV3_GSD_v0 or FV3_GSD_noah
+  #  imp_physics should be 8
+  ####
   if [ $imp_physics -eq 8 ]; then
     $NLN $FIX_AM/CCN_ACTIVATE.BIN  $DATA/CCN_ACTIVATE.BIN
     $NLN $FIX_AM/freezeH2O.dat     $DATA/freezeH2O.dat
@@ -501,15 +504,7 @@ EOF
   LONB_STP=${LONB_STP:-$LONB_CASE}
   LATB_STP=${LATB_STP:-$LATB_CASE}
 
-  #------------------------------------------------------------------
-  # make symbolic links to write forecast files directly in memdir
   cd $DATA
-  if [ "$CCPP_SUITE" = 'FV3_GSD_v0' -o "$CCPP_SUITE" = 'FV3_GSD_noah' ]; then
-    $NLN $FIX_AM/CCN_ACTIVATE.BIN  CCN_ACTIVATE.BIN
-    $NLN $FIX_AM/freezeH2O.dat  freezeH2O.dat
-    $NLN $FIX_AM/qr_acr_qg.dat  qr_acr_qg.dat
-    $NLN $FIX_AM/qr_acr_qs.dat  qr_acr_qs.dat
-  fi
 
   affix="nc"
   if [ "$OUTPUT_FILE" = "nemsio" ]; then


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**
There is a duplicate section in ush/forecast_postdet.sh to link four $FIX_AM data files when running Thompson microphysics.
It is now removed.

closes #675 
<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->
 
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas