### PR TITLE
Revert g2tmpl back to 1.10.0

### DIFF
--- a/modulefiles/module_base.hera.lua
+++ b/modulefiles/module_base.hera.lua
@@ -31,7 +31,7 @@ load(pathJoin("fms", "2021.03"))
 
 load(pathJoin("bacio", "2.4.1"))
 load(pathJoin("g2", "3.4.2"))
-load(pathJoin("g2tmpl", "1.10.1"))
+load(pathJoin("g2tmpl", "1.10.0"))
 load(pathJoin("ip", "3.3.3"))
 load(pathJoin("nemsio", "2.5.2"))
 load(pathJoin("sp", "2.3.3"))

--- a/modulefiles/module_base.orion.lua
+++ b/modulefiles/module_base.orion.lua
@@ -30,7 +30,7 @@ load(pathJoin("fms", "2021.03"))
 
 load(pathJoin("bacio", "2.4.1"))
 load(pathJoin("g2", "3.4.2"))
-load(pathJoin("g2tmpl", "1.10.1"))
+load(pathJoin("g2tmpl", "1.10.0"))
 load(pathJoin("ip", "3.3.3"))
 load(pathJoin("nemsio", "2.5.2"))
 load(pathJoin("sp", "2.3.3"))

--- a/modulefiles/module_base.wcoss_dell_p3.lua
+++ b/modulefiles/module_base.wcoss_dell_p3.lua
@@ -38,7 +38,7 @@ load(pathJoin("fms", "2021.03"))
 
 load(pathJoin("bacio", "2.4.1"))
 load(pathJoin("g2", "3.4.2"))
-load(pathJoin("g2tmpl", "1.10.1"))
+load(pathJoin("g2tmpl", "1.10.0"))
 load(pathJoin("ip", "3.3.3"))
 load(pathJoin("nemsio", "2.5.2"))
 load(pathJoin("sp", "2.3.3"))


### PR DESCRIPTION
**Description**

This PR resolves a mismatch bug between `hpc-ips` and `g2tmpl` versions on the WCOSS-Dells. The current `g2tmpl` version `1.10.1` is not available under the current `hpc-ips` `18.0.1.163` version. See issue #772 for more details.

Will also change `g2tmpl` back to `1.10.0` in the `module_base` files for Hera and Orion. The Jet `module_base` is still `1.10.0`.

Fixes #772

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] Forecast-only test on WCOSS-Dell (@RuiyuSun tested)

FYI @RuiyuSun @WenMeng-NOAA 