### PR TITLE
Remove Hera MOD_PATH from build scripts

### DIFF
--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -5,8 +5,6 @@ set +x
 #
 # USER DEFINED STUFF:
 #
-# USE_PREINST_LIBS: set to "true" to use preinstalled libraries.
-#                   Anything other than "true"  will use libraries locally.
 #------------------------------------
 
 _build_ufs_options=""
@@ -27,8 +25,6 @@ while getopts "ac" option;do
    ;;
  esac
 done
-
-export USE_PREINST_LIBS="true"
 
 #------------------------------------
 # END USER DEFINED STUFF

--- a/sorc/build_gfs_wafs.sh
+++ b/sorc/build_gfs_wafs.sh
@@ -4,13 +4,6 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=$(pwd)
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  echo "Using default MODULEPATH"
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-fi
-
 # Check final exec folder exists
 if [ ! -d "../exec" ]; then
   mkdir ../exec

--- a/sorc/build_gfs_wafs.sh
+++ b/sorc/build_gfs_wafs.sh
@@ -6,7 +6,7 @@ cwd=$(pwd)
 
 USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
 if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
+  echo "Using default MODULEPATH"
 else
   export MOD_PATH=${cwd}/lib/modulefiles
 fi

--- a/sorc/build_gldas.sh
+++ b/sorc/build_gldas.sh
@@ -4,13 +4,6 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=$(pwd)
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  echo "Using default MODULEPATH"
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-fi
-
 # Check final exec folder exists
 if [ ! -d "../exec" ]; then
   mkdir ../exec

--- a/sorc/build_gldas.sh
+++ b/sorc/build_gldas.sh
@@ -6,7 +6,7 @@ cwd=$(pwd)
 
 USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
 if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
+  echo "Using default MODULEPATH"
 else
   export MOD_PATH=${cwd}/lib/modulefiles
 fi

--- a/sorc/build_gsi.sh
+++ b/sorc/build_gsi.sh
@@ -4,13 +4,6 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=$(pwd)
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  echo "Using default MODULEPATH"
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-fi
-
 gsitarget=$target
 [[ "$target" == wcoss_cray ]] && gsitarget=cray
 

--- a/sorc/build_gsi.sh
+++ b/sorc/build_gsi.sh
@@ -6,7 +6,7 @@ cwd=$(pwd)
 
 USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
 if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
+  echo "Using default MODULEPATH"
 else
   export MOD_PATH=${cwd}/lib/modulefiles
 fi

--- a/sorc/build_ncep_post.sh
+++ b/sorc/build_ncep_post.sh
@@ -4,13 +4,6 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=$(pwd)
 
-USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
-if [ $USE_PREINST_LIBS = true ]; then
-  echo "Using default MODULEPATH"
-else
-  export MOD_PATH=${cwd}/lib/modulefiles
-fi
-
 # Check final exec folder exists
 if [ ! -d "../exec" ]; then
   mkdir ../exec

--- a/sorc/build_ncep_post.sh
+++ b/sorc/build_ncep_post.sh
@@ -6,7 +6,7 @@ cwd=$(pwd)
 
 USE_PREINST_LIBS=${USE_PREINST_LIBS:-"true"}
 if [ $USE_PREINST_LIBS = true ]; then
-  export MOD_PATH=/scratch3/NCEPDEV/nwprod/lib/modulefiles
+  echo "Using default MODULEPATH"
 else
   export MOD_PATH=${cwd}/lib/modulefiles
 fi


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**
Remove Hera MOD_PATH and USE_PREINST_LIBS from the following scripts:
build_gfs_wafs.sh
build_gldas.sh
build_gsi.sh
build_ncep_post.sh
build_all.sh

closes #298 
<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
Tested on: 
Hera, Jet, Orion, WCOSS1 Venus

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--

-->
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings