### PR TITLE
Add --init to GSI submodule command

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -44,7 +44,7 @@ if [[ ! -d gsi.fd ]] ; then
     git clone --recursive https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${logdir}/checkout-gsi.log 2>&1
     cd gsi.fd
     git checkout a62dec6
-    git submodule update
+    git submodule update --init
     cd ${topdir}
 else
     echo 'Skip.  Directory gsi.fd already exists.'


### PR DESCRIPTION
**Description**

This PR adds the `--init` flag to the GSI submodule command in `checkout.sh`. It's needed to obtain libsrc submodule during checkout and allows the GSI to build correctly since this GSI hash still needs the libsrc submodule during build.

Fixes #780

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] Clone and Build tests on Orion
