### PR TITLE
External package and serial enkf forecast updates

### DIFF
--- a/parm/config/config.efcs
+++ b/parm/config/config.efcs
@@ -64,7 +64,7 @@ if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
     export  ichunk2d=0; export jchunk2d=0
     export  ichunk3d=0; export jchunk3d=0;  export kchunk3d=0
     RESTILE=`echo $CASE_ENKF |cut -c 2-`
-    export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
+    export OUTPUT_FILETYPES=" 'netcdf' 'netcdf' "
     if [ $RESTILE -ge 384 ]; then
         export ichunk2d=$((4*RESTILE))
         export jchunk2d=$((2*RESTILE))

--- a/parm/config/config.vrfy
+++ b/parm/config/config.vrfy
@@ -16,10 +16,10 @@ export CDFNL="gdas"               # Scores verification against GDAS/GFS analysi
 
 export MKPGB4PRCP="YES"           # Make 0.25-deg pgb files in ARCDIR for precip verification
 export VRFYFITS="YES"             # Fit to observations
-export VSDB_STEP1="YES"           # Populate VSDB database
+export VSDB_STEP1="NO"           # Populate VSDB database
 export VSDB_STEP2="NO"
-export VRFYG2OBS="YES"            # Grid to observations, see note below if turning ON
-export VRFYPRCP="YES"             # Precip threat scores
+export VRFYG2OBS="NO"            # Grid to observations, see note below if turning ON
+export VRFYPRCP="NO"             # Precip threat scores
 export VRFYRAD="YES"              # Radiance data assimilation monitoring
 export VRFYOZN="YES"              # Ozone data assimilation monitoring
 export VRFYMINMON="YES"           # GSI minimization monitoring
@@ -34,8 +34,7 @@ export RUNMOS="NO"                # whether to run entire MOS package
 
 if [ $VRFYFITS = "YES" ]; then
 
-    export fit_ver="newm.1.3"
-    export fitdir="$BASE_GIT/verif/global/Fit2Obs/${fit_ver}/batrun"
+    export fitdir="$BASE_GIT/Fit2Obs/${fit_ver}/batrun"
     export PRVT=$HOMEgfs/fix/fix_gsi/prepobs_errtable.global
     export HYBLEVS=$HOMEgfs/fix/fix_am/global_hyblev.l${LEVS}.txt
     export CUE2RUN=$QUEUE
@@ -47,9 +46,8 @@ if [ $VRFYFITS = "YES" ]; then
         export CONVNETC="YES"
     fi
 
-    if [ $machine = "WCOSS_C" ]; then
-        export fitdir="$BASE_GIT/verif/global/parafits.fv3nems/batrun"
-        export PREPQFITSH="$fitdir/subfits_cray_nems"
+    if [ $machine = "WCOSS2" ]; then
+        export PREPQFITSH="$fitdir/subfits_wcoss2"
     elif [ $machine = "WCOSS_DELL_P3" ]; then
         export PREPQFITSH="$fitdir/subfits_dell_nems"
     elif [ $machine = "HERA" ]; then
@@ -142,17 +140,13 @@ fi
 # Cyclone genesis and cyclone track verification
 #-------------------------------------------------
 
-export ens_tracker_ver=v1.1.15.1
 if [ $machine = "WCOSS_DELL_P3" ] ; then
     export ens_tracker_ver=v1.1.15.3
+    export HOMEens_tracker=$BASE_GIT/tracker/ens_tracker.${ens_tracker_ver}
 fi
-export HOMEens_tracker=$BASE_GIT/tracker/ens_tracker.${ens_tracker_ver}
-if [ $machine = "ORION" ] ; then
-    export HOMEens_tracker=$BASE_GIT/tracker/TC_tracker.v1.1.15.2
-fi
+export HOMEens_tracker=$BASE_GIT/TC_tracker/${tracker_ver}
 
 if [ "$VRFYTRAK" = "YES" ]; then
-
     export TRACKERSH="$HOMEgfs/jobs/JGFS_ATMOS_CYCLONE_TRACKER"
     if [ "$CDUMP" = "gdas" ]; then
         export FHOUT_CYCLONE=3            
@@ -163,22 +157,16 @@ if [ "$VRFYTRAK" = "YES" ]; then
     fi
 fi
 
-
 if [[ "$VRFYGENESIS" == "YES" && "$CDUMP" == "gfs" ]]; then
-
     export GENESISSH="$HOMEgfs/jobs/JGFS_ATMOS_CYCLONE_GENESIS"
 fi
 
 if [[ "$VRFYFSU" == "YES" && "$CDUMP" == "gfs" ]]; then
-
     export GENESISFSU="$HOMEgfs/jobs/JGFS_ATMOS_FSU_GENESIS"
 fi
 
 if [[ "$RUNMOS" == "YES" && "$CDUMP" == "gfs" ]]; then
-
-    if [ $machine = "WCOSS_C" ] ; then
-        export RUNGFSMOSSH="$HOMEgfs/scripts/run_gfsmos_master.sh.cray"
-    elif [ $machine = "WCOSS_DELL_P3" ] ; then
+    if [ $machine = "WCOSS_DELL_P3" ] ; then
         export RUNGFSMOSSH="$HOMEgfs/scripts/run_gfsmos_master.sh.dell"
     elif [ $machine = "HERA" ] ; then
         export RUNGFSMOSSH="$HOMEgfs/scripts/run_gfsmos_master.sh.hera"
@@ -188,7 +176,5 @@ if [[ "$RUNMOS" == "YES" && "$CDUMP" == "gfs" ]]; then
         export RUNGFSMOSSH=""
     fi
 fi
-
-
 
 echo "END: config.vrfy"

--- a/versions/hera.ver
+++ b/versions/hera.ver
@@ -2,8 +2,8 @@ export hpc_ver=1.2.0
 export hpc_intel_ver=18.0.5.274
 export hpc_impi_ver=2018.0.4
 
-export obsproc_run_ver=1.0.0
-export prepobs_run_ver=1.0.0
+export obsproc_run_ver=1.0.0-rd
+export prepobs_run_ver=1.0.0-rd
 
 export hpss_ver=hpss
 export prod_util_ver=1.2.2
@@ -14,3 +14,6 @@ export esmf_ver=8_0_1
 export nco_ver=4.9.3
 export gempak_ver=7.4.2
 export wrf_io_ver=1.2.0
+
+export tracker_ver=v1.1.15.5
+export fit_ver="newm.1.4"

--- a/versions/orion.ver
+++ b/versions/orion.ver
@@ -2,8 +2,8 @@ export hpc_ver=1.2.0
 export hpc_intel_ver=2018.4
 export hpc_impi_ver=2018.4
 
-export obsproc_run_ver=1.0.0
-export prepobs_run_ver=1.0.0
+export obsproc_run_ver=1.0.0-rd
+export prepobs_run_ver=1.0.0-rd
 
 export prod_util_ver=1.2.2
 export cmake_ver=3.22.1
@@ -12,3 +12,6 @@ export python_ver=3.7.5
 export wrf_io_ver=1.2.0
 export esmf_ver=8_0_1
 export nco_ver=4.9.3
+
+export tracker_ver=v1.1.15.5
+export fit_ver="newm.1.4"

--- a/versions/wcoss2.ver
+++ b/versions/wcoss2.ver
@@ -2,5 +2,8 @@ export envvar_ver=1.0
 export prod_envir_ver=${prod_envir_ver:-2.0.4} # Allow override from ops ecflow
 export prod_util_ver=${prod_util_ver:-2.0.9}   # Allow override from ops ecflow
 
-export obsproc_run_ver=1.0.0
-export prepobs_run_ver=1.0.0
+export obsproc_run_ver=1.0.0-rd
+export prepobs_run_ver=1.0.0-rd
+
+export tracker_ver=v1.1.15.5
+export fit_ver="newm.1.4"


### PR DESCRIPTION
**Description**

This PR updates the following:

- Change enkf forecast jobs to run serially; based on WCOSS2 changes
- Updates for external packages: upstream obsproc/prepobs and downstream tracker and fit2obs
- Tracker and fit2obs updates include adding `tracker_ver` and `fit_ver` to target version files and consolidating those sections of `config.vrfy` while still retaining WCOSS_DELL_P3 support
- Removal of WCOSS_C references in `config.vrfy`

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

- [x] Clone and Build tests on WCOSS2
- [x] Cycled test on WCOSS2

Refs #665 
