### PR TITLE
Update "excl" to "exclhost" for exclusive jobs on WCOSS2

### DIFF
--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_select_obs.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_select_obs.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=12:mpiprocs=40:ompthreads=3:ncpus=120
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_update.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_update.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
 #PBS -l select=35:mpiprocs=9:ompthreads=14:ncpus=126
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/analysis/recenter/ecen/jenkfgdas_ecen.ecf
+++ b/ecf/scripts/enkfgdas/analysis/recenter/ecen/jenkfgdas_ecen.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=3:mpiprocs=32:ompthreads=4:ncpus=128
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/forecast/jenkfgdas_fcst.ecf
+++ b/ecf/scripts/enkfgdas/forecast/jenkfgdas_fcst.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:40:00
 #PBS -l select=4:mpiprocs=128:ompthreads=1:ncpus=128
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/post/jenkfgdas_post_master.ecf
+++ b/ecf/scripts/enkfgdas/post/jenkfgdas_post_master.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
 #PBS -l select=3:mpiprocs=32:ompthreads=4:ncpus=128
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:50:00
 #PBS -l select=52:mpiprocs=15:ompthreads=8:ncpus=120
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 export model=gfs

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_calc.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_calc.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=128:ompthreads=1:ncpus=128
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l hyper=true
 #PBS -l debug=true
 

--- a/ecf/scripts/gdas/atmos/init/jgdas_atmos_gldas.ecf
+++ b/ecf/scripts/gdas/atmos/init/jgdas_atmos_gldas.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
 #PBS -l select=1:mpiprocs=112:ompthreads=1:ncpus=112
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_master.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_master.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:12:00
 #PBS -l select=1:mpiprocs=112:ompthreads=1:ncpus=112
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/jgdas_forecast.ecf
+++ b/ecf/scripts/gdas/jgdas_forecast.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:00:00
 #PBS -l select=27:mpiprocs=32:ompthreads=3:ncpus=96
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis.ecf
+++ b/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:40:00
 #PBS -l select=55:mpiprocs=15:ompthreads=8:ncpus=120
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 export model=gfs

--- a/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis_calc.ecf
+++ b/ecf/scripts/gfs/atmos/analysis/jgfs_atmos_analysis_calc.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=128:ompthreads=1:ncpus=128
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_master.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_master.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
 #PBS -l select=1:mpiprocs=126:ompthreads=1:ncpus=126
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/bufr_sounding/jgfs_atmos_postsnd.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/bufr_sounding/jgfs_atmos_postsnd.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
 #PBS -l select=2:mpiprocs=20:ompthreads=1:ncpus=20
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/jgfs_forecast.ecf
+++ b/ecf/scripts/gfs/jgfs_forecast.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:30:00
 #PBS -l select=112:mpiprocs=24:ompthreads=5:ncpus=120
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:00:00
 #PBS -l select=3:ncpus=80:ompthreads=1
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpntbll.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpntbll.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:00:00
 #PBS -l select=4:ncpus=112:ompthreads=1
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:30:00
 #PBS -l select=4:ncpus=50:ompthreads=1
-#PBS -l place=vscatter:excl
+#PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
 model=gfs

--- a/parm/config/config.base.nco.static
+++ b/parm/config/config.base.nco.static
@@ -64,7 +64,6 @@ export REALTIME="YES"
 export FIXgsi="$HOMEgfs/fix/fix_gsi"
 export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
 export HOMEpost="$HOMEgfs"
-export HOMEobsproc="/lfs/h1/ops/prod/packages/obsproc.v1.0.0"
 export BASE_VERIF="$BASE_GIT/verif/global/tags/vsdb"
 
 # CONVENIENT utility scripts and other environment parameters

--- a/parm/config/config.base.nco.static
+++ b/parm/config/config.base.nco.static
@@ -64,6 +64,7 @@ export REALTIME="YES"
 export FIXgsi="$HOMEgfs/fix/fix_gsi"
 export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
 export HOMEpost="$HOMEgfs"
+export HOMEobsproc="/lfs/h1/ops/prod/packages/obsproc.v1.0.0"
 export BASE_VERIF="$BASE_GIT/verif/global/tags/vsdb"
 
 # CONVENIENT utility scripts and other environment parameters

--- a/ush/rocoto/workflow_utils.py
+++ b/ush/rocoto/workflow_utils.py
@@ -338,7 +338,7 @@ def get_resources(machine, cfg, task, reservation, cdump='gdas'):
         if machine in ['WCOSS2'] and task not in ['arch', 'earc', 'getic']:
             natstr = "-l place=vscatter"
             if memory is None:
-               natstr += ":excl"
+               natstr += ":exclhost"
 
     elif machine in ['WCOSS']:
         resstr = f'<cores>{tasks}</cores>'


### PR DESCRIPTION
**Description**

This PR updates the `excl` PBS statement to `exclhost` after cgroups was implemented on WCOSS2. With cgroups implementation, memory limits are now being enforced and exclusive jobs needs to set `place=exclhost` to use all memory on the node(s). If you don't specify memory (and without exclhost) then you'll default to 1G/core.

The rocoto `workflow_utils.py` is also updated to use `exclhost` now for generated xmls on WCOSS2.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

NCO made and tested this update on WCOSS2 Dogwood after cgroups implementation. @lgannoaa also updated his ecflow test with these updates and confirmed his test runs again on Dogwood.
  
Refs #399 