### PR TITLE
Final pre-production freeze updates for GFSv16.2.0 package on WCOSS2

### DIFF
--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -15,7 +15,7 @@ The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com a
 cd $PACKAGEROOT
 mkdir gfs.v16.2.0
 cd gfs.v16.2.0
-git clone -b EMC-v16.2.0.6 https://github.com/NOAA-EMC/global-workflow.git .
+git clone -b EMC-v16.2.0.7 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_calc.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_calc.ecf
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=128:ompthreads=1:ncpus=128
 #PBS -l place=vscatter:exclhost
-#PBS -l hyper=true
 #PBS -l debug=true
 
 model=gfs

--- a/modulefiles/modulefile.fv3nc2nemsio.wcoss2.lua
+++ b/modulefiles/modulefile.fv3nc2nemsio.wcoss2.lua
@@ -15,4 +15,4 @@ load(pathJoin("w3nco", os.getenv("w3nco_ver")))
 load(pathJoin("nemsio", os.getenv("nemsio_ver")))
 
 setenv("FCMP","ftn")
-setenv("FFLAGS","-free -O3")
+setenv("FFLAGS","-free -O3 -g -traceback")

--- a/parm/config/config.analcalc
+++ b/parm/config/config.analcalc
@@ -8,4 +8,8 @@ echo "BEGIN: config.analcalc"
 # Get task specific resources
 . $EXPDIR/config.resources analcalc
 
+if [[ "$CDUMP" == "gfs" ]]; then
+   export nth_echgres=$nth_echgres_gfs
+fi
+
 echo "END: config.analcalc"

--- a/parm/config/config.efcs
+++ b/parm/config/config.efcs
@@ -64,7 +64,7 @@ if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
     export  ichunk2d=0; export jchunk2d=0
     export  ichunk3d=0; export jchunk3d=0;  export kchunk3d=0
     RESTILE=`echo $CASE_ENKF |cut -c 2-`
-    export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
+    export OUTPUT_FILETYPES=" 'netcdf' 'netcdf' "
     if [ $RESTILE -ge 384 ]; then
         export ichunk2d=$((4*RESTILE))
         export jchunk2d=$((2*RESTILE))

--- a/parm/config/config.fv3.nco.static
+++ b/parm/config/config.fv3.nco.static
@@ -75,7 +75,7 @@ case $case_in in
         export WRTIOBUF="8M"
         ;;
     "C384")
-        export DELTIM=240
+        export DELTIM=200
         export layout_x=8
         export layout_y=8
         export layout_x_gfs=6
@@ -85,7 +85,7 @@ case $case_in in
         export nth_fv3=1
         export nth_fv3_gfs=1
         export cdmbgwd="1.1,0.72,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
-        export WRITE_GROUP=1
+        export WRITE_GROUP=2
         export WRTTASK_PER_GROUP=64
         export WRITE_GROUP_GFS=1
         export WRTTASK_PER_GROUP_GFS=64

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -152,6 +152,8 @@ elif [ $step = "analcalc" ]; then
     export npe_analcalc=127
     export ntasks=$npe_analcalc
     export nth_analcalc=1
+    export nth_echgres=4
+    export nth_echgres_gfs=12
     export npe_node_analcalc=$npe_node_max
     if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export npe_analcalc=127 ; fi
 

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -130,6 +130,8 @@ elif [ $step = "analcalc" ]; then
     export npe_analcalc=127
     export ntasks=$npe_analcalc
     export nth_analcalc=1
+    export nth_echgres=4
+    export nth_echgres_gfs=12
     export npe_node_analcalc=$npe_node_max
 
 elif [ $step = "analdiag" ]; then

--- a/sorc/build_enkf_chgres_recenter.sh
+++ b/sorc/build_enkf_chgres_recenter.sh
@@ -15,7 +15,7 @@ fi
 
 cd ${cwd}/enkf_chgres_recenter.fd
 
-export FFLAGS="-O3 -r8 -i4 -qopenmp -traceback -fp-model precise"
+export FFLAGS="-O3 -r8 -i4 -qopenmp -g -traceback -fp-model precise"
 
 make clean
 make

--- a/sorc/build_enkf_chgres_recenter_nc.sh
+++ b/sorc/build_enkf_chgres_recenter_nc.sh
@@ -15,7 +15,7 @@ fi
 
 cd ${cwd}/enkf_chgres_recenter_nc.fd
 
-export FFLAGS="-O3 -qopenmp -traceback -fp-model precise"
+export FFLAGS="-O3 -qopenmp -g -traceback -fp-model precise"
 export FV3GFS_NCIO_LIB="${cwd}/gsi.fd/build/lib/libfv3gfs_ncio.a"
 export FV3GFS_NCIO_INC="${cwd}/gsi.fd/build/include"
 

--- a/sorc/fbwndgfs.fd/makefile.GENERIC
+++ b/sorc/fbwndgfs.fd/makefile.GENERIC
@@ -50,7 +50,7 @@ PROFLIB =	-lprof
 # To compile with flowtracing turned on, use the second line
 # To compile giving profile additonal information, use the third line
 # WARNING:  SIMULTANEOUSLY PROFILING AND FLOWTRACING IS NOT RECOMMENDED 
-FFLAGS =        -O3  -g -I ${IP_INC8} -assume byterecl -convert big_endian -r8 -i8 
+FFLAGS =        -O3 -g -traceback -I ${IP_INC8} -assume byterecl -convert big_endian -r8 -i8 
 #FFLAGS =	 -F
 #FFLAGS =	 -Wf"-ez"
 

--- a/sorc/gaussian_sfcanl.fd/makefile.sh
+++ b/sorc/gaussian_sfcanl.fd/makefile.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export FFLAGS="-O3 -fp-model precise -g -r8 -i4"
+export FFLAGS="-O3 -fp-model precise -g -traceback -r8 -i4"
 # for debugging
 #export FFLAGS="-g -r8 -i4 -warn unused -check bounds"
 

--- a/sorc/supvit.fd/makefile
+++ b/sorc/supvit.fd/makefile
@@ -7,7 +7,7 @@ LDFLAGS=
 ##ccs FFLAGS= -O -qflttrap=ov:zero:inv:enable -qcheck -qextchk -qwarn64 -qintsize=$(ISIZE) -qrealsize=$(RSIZE)
 # FFLAGS= -O2 -check bounds -check format -xHost -fpe0
 # DEBUG= -check bounds -check format
-FFLAGS= -O2 -g -i$(ISIZE) -r$(RSIZE)
+FFLAGS= -O2 -g -traceback -i$(ISIZE) -r$(RSIZE)
 
 supvit:     supvit_main.f supvit_modules.o
 	@echo " "

--- a/ush/gfs_bufr.sh
+++ b/ush/gfs_bufr.sh
@@ -112,4 +112,13 @@ ln -sf ${STNLIST:-$PARMbufrsnd/bufr_stalist.meteo.gfs} fort.8
 ln -sf $PARMbufrsnd/bufr_ij13km.txt fort.7
 
 ${APRUN_POSTSND} $EXECbufrsnd/gfs_bufr < gfsparm > out_gfs_bufr_$FEND
-export err=$?;err_chk
+
+export err=$?
+
+if [ $err -ne 0 ]; then
+   msg="GFS postsnd job error, Please check files "
+   echo $msg
+   echo $COMIN/${RUN}.${cycle}.atmf${hh2}.${atmfm}
+   echo $COMIN/${RUN}.${cycle}.sfcf${hh2}.${atmfm}
+   err_chk
+fi

--- a/util/sorc/mkgfsawps.fd/makefile.wcoss2
+++ b/util/sorc/mkgfsawps.fd/makefile.wcoss2
@@ -26,7 +26,7 @@ PROFLIB =	-lprof
 # To compile with flowtracing turned on, use the second line
 # To compile giving profile additonal information, use the third line
 # WARNING:  SIMULTANEOUSLY PROFILING AND FLOWTRACING IS NOT RECOMMENDED 
-FFLAGS =        -O3 -g -convert big_endian -r8 -i4 -assume noold_ldout_format
+FFLAGS =        -O3 -g -traceback -convert big_endian -r8 -i4 -assume noold_ldout_format
 
 # Lines from here on down should not need to be changed.  They are the
 # actual rules which make uses to build a.out.

--- a/util/sorc/overgridid.fd/makefile
+++ b/util/sorc/overgridid.fd/makefile
@@ -1,7 +1,7 @@
 LIBS =    ${W3NCO_LIB4} ${BACIO_LIB4}
 OBJS=     overgridid.o
 overgridid:	overgridid.f
-	ftn -o overgridid overgridid.f $(LIBS)
+	ftn -g -traceback -o overgridid overgridid.f $(LIBS)
 clean:
 	-rm -f $(OBJS)
 

--- a/util/sorc/rdbfmsua.fd/makefile.wcoss2
+++ b/util/sorc/rdbfmsua.fd/makefile.wcoss2
@@ -41,7 +41,7 @@ OBJS=	rdbfmsua.o
 FC =		ftn
 # FFLAGS =	-O3 -q32 -I${GEMINC} -I${NAWIPS}/os/${NA_OS}/include
 # FFLAGS =	-I${GEMINC} -I${NAWIPS}/os/${NA_OS}/include
-FFLAGS =	-I${GEMINC} -I${OS_INC}
+FFLAGS =	-g -traceback -I${GEMINC} -I${OS_INC}
 # LDFLAGS =       -O3 -q32 -s
 # LDFLAGS =       -Wl,-Map,MAPFILE
 

--- a/util/sorc/webtitle.fd/makefile
+++ b/util/sorc/webtitle.fd/makefile
@@ -16,7 +16,7 @@ FC =	ftn
 LIBS=   ${W3NCO_LIB4}
 
 CMD =	webtitle       
-FFLAGS = 
+FFLAGS = -g -traceback
 #FFLAGS = -debug 
 
 # Lines from here on down should not need to be changed.  They are the


### PR DESCRIPTION
**Description**

This PR includes a final set of changes for the GFSv16.2.0 ahead of NCO freezing the production models before WCOSS2 go-live. Changes included:

1. analysis_calc resource updates: remove `hyper=true` in `jgdas_atmos_analysis_calc.ecf` and set threads for echgres execs in job
2. set enkf forecast jobs to run with serial netcdf instead of parallel netcdf; includes adjustment to resources to speed it up (`WRITE_GROUP=2`)
3. change C384 `DELTIM` to 200 while 240 is examined for stability issues
4. add missing `-g` and `-traceback` flags in global-workflow utility builds (found upon review of builds)
5. updated error handling in `ush/gfs_bufr.sh` (made by @BoCui-NOAA and requested by NCO)
6. update release notes to reflect new tag name for hand-off: `EMC-v16.2.0.7`

Will cut new hand-off tag for NCO after this goes in: `EMC-v16.2.0.7`

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**How Has This Been Tested?**

- [x] Build tests on WCOSS2
- [x] Cycled NCO para test on Cactus
- [x] Cycled EMC para test on Cactus
  
**Checklist**

- [x] I have performed a self-review of my own code
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes

Resolves #790
Resolves #791
Refs #399 