### PR TITLE
WCOSS2 GFSv16.2.0 resource updates and NHC change

### DIFF
--- a/docs/Release_Notes.gfs.v16.2.0.md
+++ b/docs/Release_Notes.gfs.v16.2.0.md
@@ -118,7 +118,7 @@ All components updated their codes to build on WCOSS2:
 FIX CHANGES
 -----------
 
-* No changes from GFS v16.1.7
+* No changes from GFS v16.1.8
 
 PARM/CONFIG CHANGES
 -------------------
@@ -354,7 +354,7 @@ CHANGES TO RESOURCES AND FILE SIZES
 -----------------------------------
 
 * File sizes
-  * No change to GFSv16.1.7.
+  * No change to GFSv16.1.8.
 * Resource changes to meet operational time windows:
   * See updated Ecflow scripts for adjusted compute resources for WCOSS2.
   * Pre-hand-off development testing results:
@@ -379,21 +379,21 @@ DISSEMINATION INFORMATION
 -------------------------
 
 * Where should this output be sent?
-  * No change from GFS v16.1.7
+  * No change from GFS v16.1.8
 * Who are the users?
-  * No change from GFS v16.1.7
+  * No change from GFS v16.1.8
 * Which output files should be transferred from PROD WCOSS to DEV WCOSS?
-  * No change from GFS v16.1.7
+  * No change from GFS v16.1.8
 * Directory changes
-  * No change from GFS v16.1.7
+  * No change from GFS v16.1.8
 * File changes
-  * No change from GFS v16.1.7
+  * No change from GFS v16.1.8
 
 HPSS ARCHIVE
 ------------
 
-* No change from GFS v16.1.7
+* No change from GFS v16.1.8
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
-* No change from GFS v16.1.7
+* No change from GFS v16.1.8

--- a/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak.ecf
+++ b/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l select=1:ncpus=2:mpiprocs=2:mem=1GB
+#PBS -l select=1:ncpus=2:mpiprocs=2:mem=4GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_master.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:12:00
-#PBS -l select=1:mpiprocs=112:ompthreads=1:ncpus=112
+#PBS -l select=1:mpiprocs=126:ompthreads=1:ncpus=126
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l select=1:ncpus=1:mem=1GB
+#PBS -l select=1:ncpus=1:mem=3GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l select=1:ncpus=1:mem=1GB
+#PBS -l select=1:ncpus=1:mem=3GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/bufr_sounding/jgfs_atmos_postsnd.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/bufr_sounding/jgfs_atmos_postsnd.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
-#PBS -l select=2:mpiprocs=120:ompthreads=1:ncpus=120
+#PBS -l select=2:mpiprocs=20:ompthreads=6:ncpus=120
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/bufr_sounding/jgfs_atmos_postsnd.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/bufr_sounding/jgfs_atmos_postsnd.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
-#PBS -l select=2:mpiprocs=20:ompthreads=1:ncpus=20
+#PBS -l select=2:mpiprocs=120:ompthreads=1:ncpus=120
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l select=1:ncpus=1:mem=1GB
+#PBS -l select=1:ncpus=1:mem=2GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -182,7 +182,7 @@ elif [ $step = "fv3ic" ]; then
 elif [ $step = "postsnd" ]; then
 
     export NTHREADS_POSTSND=${nth_postsnd:-1}
-    export APRUN_POSTSND="$launcher -n $npe_postsnd --depth=6 --cpu-bind depth"
+    export APRUN_POSTSND="$launcher -n $npe_postsnd --depth=$NTHREADS_POSTSND --cpu-bind depth"
     export NTHREADS_POSTSNDCFP=${nth_postsndcfp:-1}
     export APRUN_POSTSNDCFP="$launcher -np $npe_postsndcfp $mpmd"
 

--- a/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
+++ b/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
@@ -74,7 +74,7 @@ export ARCHSYND=${ROTDIR}/syndat  # this location is unique, do not change
 if [ ! -d ${ARCHSYND} ]; then mkdir -p $ARCHSYND; fi
 
 export HOMENHCp1=${HOMENHCp1:-/gpfs/?p1/nhc/save/guidance/storm-data/ncep}
-export HOMENHC=${HOMENHC:-/gpfs/dell2/nhc/save/guidance/storm-data/ncep}
+export HOMENHC=${HOMENHC:-/lfs/h1/ops/prod/dcom/nhc/atcf/ncep}
 
 # JY export TANK_TROPCY=${TANK_TROPCY:-${DCOMROOT}/${envir}}   # path to tropical cyclone record database
 export TANK_TROPCY=${TANK_TROPCY:-${DCOMROOT}}   # path to tropical cyclone record database

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -397,7 +397,7 @@ elif [ $step = "awips" ]; then
     export npe_awips=1
     export npe_node_awips=1
     export nth_awips=1
-    export memory_awips="1GB"
+    export memory_awips="3GB"
     if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
         export npe_awips=2
         export npe_node_awips=2
@@ -412,7 +412,7 @@ elif [ $step = "gempak" ]; then
     export npe_node_gempak=2
     export npe_node_gempak_gfs=28
     export nth_gempak=1
-    export memory_gempak="1GB"
+    export memory_gempak="4GB"
     export memory_gempak_gfs="2GB"
 
 else

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -381,7 +381,7 @@ elif [ $step = "postsnd" ]; then
 
     export wtime_postsnd="02:00:00"
     export npe_postsnd=40
-    export nth_postsnd=1
+    export nth_postsnd=6
     export npe_node_postsnd=20
     export npe_postsndcfp=9
     export npe_node_postsndcfp=1

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -318,7 +318,7 @@ elif [ $step = "postsnd" ]; then
 
     export wtime_postsnd="02:00:00"
     export npe_postsnd=40
-    export nth_postsnd=1
+    export nth_postsnd=6
     export npe_node_postsnd=20
     export npe_postsndcfp=9
     export npe_node_postsndcfp=1

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -329,7 +329,7 @@ elif [ $step = "awips" ]; then
     export npe_awips=1
     export npe_node_awips=1
     export nth_awips=1
-    export memory_awips="1GB"
+    export memory_awips="3GB"
 
 elif [ $step = "gempak" ]; then
 
@@ -339,7 +339,7 @@ elif [ $step = "gempak" ]; then
     export npe_node_gempak=2
     export npe_node_gempak_gfs=28
     export nth_gempak=1
-    export memory_gempak="1GB"
+    export memory_gempak="4GB"
     export memory_gempak_gfs="2GB"
 
 else


### PR DESCRIPTION
**Description**

Resource updates from NCO and GDIT based on testing on Dogwood after oversubscription updates and bufr sounding consult. A change in `jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC` to set `HOMENHC` default to `/lfs/h1/ops/prod/dcom/nhc/atcf/ncep`. Also, updated release notes to set prior GFS version to v16.1.8.

Awaiting one more postsnd job resource update confirmation from GDIT consult (change `nth_postsnd` to 8 from 6). Will see if the GSI update for v16.1.8 makes it in before NCO does a fresh install on WCOSS2 for 18z Friday the 20th.

Cutting `EMC-v16.2.0.7` tag after this goes in.

**How Has This Been Tested?**

Tests by EMC, NCO, and GDIT on Dogwood and Cactus.
  
Refs: #399, #798