### PR TITLE
Fix build script options

### DIFF
--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -36,17 +36,29 @@ _verbose_opt=""
 OPTIND=1
 while getopts ":a:c:hv" option; do
 	case "${option}" in
-		a) _build_ufs_opt+="-a ${OPTARG} ";;
-		c) _partial_opt+="-c ${OPTARG} ";;
-		h) _usage;;
+		a)
+			_build_ufs_opt+="-a ${OPTARG} "
+			shift 2
+			;;
+		c)
+			_partial_opt+="-c ${OPTARG} "
+			shift 2
+			;;
+		h)
+			_usage
+			shift 1
+			;;
 		# s) _build_ufs_opt+="-s ${OPTARG} ";;
-		v) _verbose_opt="-v";;
+		v)
+			_verbose_opt="-v"
+			shift 1
+			;;
 		\?)
-			echo "Unrecognized option: ${option}"
+			echo "[$BASH_SOURCE]: Unrecognized option: ${option}"
 			usage
 			;;
 		:)
-			echo "${option} requires an argument"
+			echo "[$BASH_SOURCE]: ${option} requires an argument"
 			usage
 			;;
 	esac

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -36,23 +36,11 @@ _verbose_opt=""
 OPTIND=1
 while getopts ":a:c:hv" option; do
 	case "${option}" in
-		a)
-			_build_ufs_opt+="-a ${OPTARG} "
-			shift 2
-			;;
-		c)
-			_partial_opt+="-c ${OPTARG} "
-			shift 2
-			;;
-		h)
-			_usage
-			shift 1
-			;;
+		a) _build_ufs_opt+="-a ${OPTARG} ";;
+		c) _partial_opt+="-c ${OPTARG} ";;
+		h) _usage;;
 		# s) _build_ufs_opt+="-s ${OPTARG} ";;
-		v)
-			_verbose_opt="-v"
-			shift 1
-			;;
+		v) _verbose_opt="-v";;
 		\?)
 			echo "[$BASH_SOURCE]: Unrecognized option: ${option}"
 			usage
@@ -63,6 +51,8 @@ while getopts ":a:c:hv" option; do
 			;;
 	esac
 done
+
+shift $((OPTIND-1))
 
 build_dir=$(pwd)
 logs_dir=$build_dir/logs

--- a/sorc/partial_build.sh
+++ b/sorc/partial_build.sh
@@ -153,9 +153,7 @@ verbose=false
 config_file="gfs_build.cfg"
 # Reset option counter for when this script is sourced
 OPTIND=1
-echo $*
 while getopts ":c:hs:v" option; do
-	echo $option
 	case "${option}" in
 		c)
 			config_file="${OPTARG}"

--- a/sorc/partial_build.sh
+++ b/sorc/partial_build.sh
@@ -153,20 +153,29 @@ verbose=false
 config_file="gfs_build.cfg"
 # Reset option counter for when this script is sourced
 OPTIND=1
-while getopts "c:hs:v" option; do
+echo $*
+while getopts ":c:hs:v" option; do
+	echo $option
 	case "${option}" in
-		c) config_file="${OPTARG}";;
-		h) usage;;
+		c)
+			config_file="${OPTARG}"
+			shift 2
+			;;
+		h)
+			usage
+			shift 1
+			;;
 		v)
 			verbose=true
 			parse_argv+=( "--verbose" )
+			shift 1
 			;;
 		\?)
-			echo "Unrecognized option: ${option}"
+			echo "[$BASH_SOURCE]: Unrecognized option: ${option}"
 			usage
 			;;
 		:)
-			echo "${option} requires an argument"
+			echo "[$BASH_SOURCE]: ${option} requires an argument"
 			usage
 			;;
 	esac

--- a/sorc/partial_build.sh
+++ b/sorc/partial_build.sh
@@ -155,18 +155,11 @@ config_file="gfs_build.cfg"
 OPTIND=1
 while getopts ":c:hs:v" option; do
 	case "${option}" in
-		c)
-			config_file="${OPTARG}"
-			shift 2
-			;;
-		h)
-			usage
-			shift 1
-			;;
+		c) config_file="${OPTARG}";;
+		h) usage;;
 		v)
 			verbose=true
 			parse_argv+=( "--verbose" )
-			shift 1
 			;;
 		\?)
 			echo "[$BASH_SOURCE]: Unrecognized option: ${option}"
@@ -178,6 +171,8 @@ while getopts ":c:hs:v" option; do
 			;;
 	esac
 done
+
+shift $((OPTIND-1))
 
 parse_argv+=( "config=$config_file" )
 


### PR DESCRIPTION
**Description**
There was an issue where if build_all.sh was called with only options that are not used by partial_build.sh, partial_build.sh would see those options because `$@` was not overwritten. The getopts sections have been updated to consume those options so they are no longer present if `$@` isn't overwritten in the new script call.

Also fixed the getopts statement in partial_build.sh so we handle errors instead of bash (bash would report the wrong script if the script is sourced)

Fixes #800

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Clone and Build tests on Hera
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
