### PR TITLE
Correct incorrect increment prefix variable

### DIFF
--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -96,7 +96,7 @@ EOF
         read_increment=".false."
         res_latlon_dynamics=""
       else
-        increment_file=$memdir/${CDUMP}.t${cyc}z.${PREFIX_INC}atminc.nc
+        increment_file=$memdir/${CDUMP}.t${cyc}z.${PREFIX_ATMINC}atminc.nc
         if [ -f $increment_file ]; then
           $NLN $increment_file $DATA/INPUT/fv3_increment.nc
           read_increment=".true."


### PR DESCRIPTION
**Description**
This PR corrects a typo in `ush/forecast_postdet.sh`. Undefined variable `PREFIX_INC` is replaced with defined variable `PREFIX_ATMINC`.

Fixes #804

**Type of change**
- [x]  Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
The typo in `/ush/forecast_postdet.sh` has been corrected and tested on Orion. With `PREFIX_INC` replaced by `PREFIX_ATMINC`, the `efcs*` jobs correctly use the re-centered increment (i.e., `ratminc`). This change is now being cycled in a C96/C48L127 JEDI-GDAS parallel on Orion.

**Checklist**
- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  My changes generate no new warnings
- [x]  New and existing tests pass with my changes
- [x]  Any dependent changes have been merged and published
