### PR TITLE
Refactor checkout script

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -1,115 +1,164 @@
 #!/bin/sh
-#set -xue
-set -x
+set +x
+set -u
 
-while getopts "om:" option; do
- case $option in
-  o)
-   echo "Received -o flag for optional checkout of operational-only codes"
-   checkout_gtg="YES"
-   checkout_wafs="YES"
-   ;;
-  m)
-   echo "Received -m flag with argument, will check out ufs-weather-model hash $OPTARG instead of default"
-   ufs_model_hash=$OPTARG
-   ;;
-  :)
-   echo "option -$OPTARG needs an argument"
-   ;;
-  *)
-   echo "invalid option -$OPTARG, exiting..."
-   exit
-   ;;
- esac
+function usage() {
+	cat <<-EOF
+		Clones and checks out external components necessary for 
+		  global workflow. If the directory already exists, skip 
+		  cloning and just check out the requested version (unless 
+		  -c option is used).
+
+		Usage: $BASH_SOURCE [-c][-h][-m ufs_hash][-o]
+		  -c:
+		    Create a fresh clone (delete existing directories)
+		  -h:
+		    Print this help message and exit
+		  -m ufs_hash:
+		  	Check out this UFS hash instead of the default
+		  -o:
+		  	Check out operational-only code (GTG and WAFS)
+
+	EOF
+	exit 1
+}
+
+function checkout() {
+	#
+	# Clone or fetch repo, then checkout specific hash and update submodules
+	#
+	# Environment variables:
+	#   logdir [default: $(pwd)]: where you want logfiles written
+	#   CLEAN [default: NO]:      whether to delete existing directories and create a fresh clone
+	# 
+	# Usage: checkout <dir> <remote> <version>
+	#
+	#   Arguments
+	#     dir:     Directory for the clone
+	#     remote:  URL of the remote repository
+	#     version: Commit to check out; should always be a speciifc commit (hash or tag), not a branch
+	#
+	#   Returns
+	#     Exit code of last failed command, or 0 if successful
+	#
+
+	dir="$1"
+	remote="$2"
+	version="$3"
+
+	name=$(echo ${dir} | cut -d '.' -f 1)
+	echo "Starting checkout for ${name}"
+
+	logfile="${logdir:-$(pwd)}/checkout_${name}.log"
+
+	if [[ -f "${logfile}" ]]; then
+		rm "${logfile}"
+	fi
+
+	if [[ "${c:-NO}" == "YES" ]]; then
+		rm -Rf "$dir"
+	fi
+	if [[ ! -d "${dir}" ]]; then
+		echo "|-- Cloning ${remote} into ${dir}"
+		git clone "${remote}" "${dir}" >> "${logfile}" 2>&1
+		status=$?
+		if ((status > 0)); then
+			echo "    WARNING: Error while cloning ${name}"
+			echo
+			return "${status}"
+		fi
+	else
+		# Fetch any updates from server
+		git fetch
+	fi
+	cd "${dir}"
+	echo "|-- Checking out ${version} of ${name}"
+	git checkout "${version}" >> "${logfile}" 2>&1
+	status=$?
+	if ((status > 0)); then
+		echo "    WARNING: Error while checking out ${version} in ${name}"
+		echo
+		return "${status}"
+	fi
+	git submodule update --init --recursive >> "${logfile}" 2>&1
+	echo "|-- Updating submodules of ${name} (if any)"
+	status=$?
+	if ((status > 0)); then
+		echo "    WARNING: Error while updating submodules of ${name}"
+		echo
+		return "${status}"
+	fi
+	echo
+	return 0
+}
+
+while getopts ":chm:o" option; do
+	case $option in
+		c)
+			echo "Recieved -c flag, will delete any existing directories and start clean"
+			export CLEAN="YES"
+			;;
+		h)usage;;
+		o)
+			echo "Received -o flag for optional checkout of operational-only codes"
+			checkout_gtg="YES"
+			checkout_wafs="YES"
+			;;
+		m)
+			echo "Received -m flag with argument, will check out ufs-weather-model hash $OPTARG instead of default"
+			ufs_model_hash=$OPTARG
+			;;
+		:)
+			echo "option -$OPTARG needs an argument"
+			usage
+			;;
+		*)
+			echo "invalid option -$OPTARG, exiting..."
+			usage
+			;;
+	esac
 done
+shift $((OPTIND-1))
 
 topdir=$(pwd)
-logdir="${topdir}/logs"
+export logdir="${topdir}/logs"
 mkdir -p ${logdir}
 
-echo ufs-weather-model checkout ...
-if [[ ! -d ufs_model.fd ]] ; then
-    git clone https://github.com/ufs-community/ufs-weather-model ufs_model.fd >> ${logdir}/checkout-ufs_model.log 2>&1
-    cd ufs_model.fd
-    git checkout ${ufs_model_hash:-Prototype-P8b}
-    git submodule update --init --recursive
+# The checkout version should always be a speciifc commit (hash or tag), not a branch
+errs=0
+checkout "ufs_model.fd"    "https://github.com/ufs-community/ufs-weather-model" "${ufs_model_hash:-Prototype-P8b}"; errs=$((errs + $?))
+checkout "gsi.fd"          "https://github.com/NOAA-EMC/GSI.git"                "a62dec6"                         ; errs=$((errs + $?))
+checkout "gldas.fd"        "https://github.com/NOAA-EMC/GLDAS.git"              "gldas_gfsv16_release.v.1.28.0"   ; errs=$((errs + $?))
+checkout "ufs_utils.fd"    "https://github.com/ufs-community/UFS_UTILS.git"     "04ad17e"                         ; errs=$((errs + $?))
+checkout "verif-global.fd" "https://github.com/NOAA-EMC/EMC_verif-global.git"   "c267780"                         ; errs=$((errs + $?))
 
-    ################################################################################
-    # checkout_gtg
-    ## yes: The gtg code at NCAR private repository is available for ops. GFS only.
-    #       Only approved persons/groups have access permission.
-    ## no:  No need to check out gtg code for general GFS users.
-    ################################################################################
-    checkout_gtg=${checkout_gtg:-"NO"}
-    if [[ ${checkout_gtg} == "YES" ]] ; then
-      cd FV3/upp
-      ./manage_externals/checkout_externals
-      cp sorc/post_gtg.fd/*F90 sorc/ncep_post.fd/.
-      cp sorc/post_gtg.fd/gtg.config.gfs parm/gtg.config.gfs
-    fi
-    cd ${topdir}
-else
-    echo 'Skip.  Directory ufs_model.fd already exists.'
-fi 
-
-echo gsi checkout ...
-if [[ ! -d gsi.fd ]] ; then
-    rm -f ${topdir}/checkout-gsi.log
-    git clone --recursive https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${logdir}/checkout-gsi.log 2>&1
-    cd gsi.fd
-    git checkout a62dec6
-    git submodule update --init
-    cd ${topdir}
-else
-    echo 'Skip.  Directory gsi.fd already exists.'
+if [[ "${checkout_wafs:-NO}" == "YES" ]]; then
+	checkout "gfs_wafs.fd" "https://github.com/NOAA-EMC/EMC_gfs_wafs.git" "c2a29a6"; errs=$((errs + $?))
 fi
 
-echo gldas checkout ...
-if [[ ! -d gldas.fd ]] ; then
-    rm -f ${topdir}/checkout-gldas.log
-    git clone https://github.com/NOAA-EMC/GLDAS.git gldas.fd >> ${logdir}/checkout-gldas.fd.log 2>&1
-    cd gldas.fd
-    git checkout gldas_gfsv16_release.v.1.28.0
-    cd ${topdir}
-else
-    echo 'Skip.  Directory gldas.fd already exists.'
+if [[ "${checkout_gtg:-NO}" == "YES" ]]; then
+	################################################################################
+	# checkout_gtg
+	## yes: The gtg code at NCAR private repository is available for ops. GFS only.
+	#       Only approved persons/groups have access permission.
+	## no:  No need to check out gtg code for general GFS users.
+	################################################################################
+
+	echo "Checking out GTG extension for UPP"
+	cd "${topdir}/ufs_model.fd/FV3/upp"
+	logfile="${logdir}/checkout_gtg.log"
+	./manage_externals/checkout_externals >> "${logfile}" 2>&1
+	status=$?
+	if (( status > 0 )); then
+		echo "WARNING: Error while checking out GTG"
+		errs=$((errs + status))
+	fi
+	cp sorc/post_gtg.fd/*F90 sorc/ncep_post.fd/.
+	cp sorc/post_gtg.fd/gtg.config.gfs parm/gtg.config.gfs
 fi
 
-echo ufs_utils checkout ...
-if [[ ! -d ufs_utils.fd ]] ; then
-    rm -f ${topdir}/checkout-ufs_utils.log
-    git clone --recursive https://github.com/ufs-community/UFS_UTILS.git ufs_utils.fd >> ${logdir}/checkout-ufs_utils.fd.log 2>&1
-    cd ufs_utils.fd
-    git checkout 04ad17e
-    cd ${topdir}
-else
-    echo 'Skip.  Directory ufs_utils.fd already exists.'
+if (( errs > 0 )); then
+	echo "WARNING: One or more errors encountered during checkout process, please check logs before building"
 fi
-
-checkout_wafs=${checkout_wafs:-"NO"}
-if [[ ${checkout_wafs} == "YES" ]] ; then
-  echo EMC_gfs_wafs checkout ...
-  if [[ ! -d gfs_wafs.fd ]] ; then
-    rm -f ${topdir}/checkout-gfs_wafs.log
-    git clone --recursive https://github.com/NOAA-EMC/EMC_gfs_wafs.git gfs_wafs.fd >> ${logdir}/checkout-gfs_wafs.log 2>&1
-    cd gfs_wafs.fd
-    git checkout c2a29a67d9432b4d6fba99eac7797b81d05202b6
-    cd ${topdir}
-  else
-    echo 'Skip.  Directory gfs_wafs.fd already exists.'
-  fi
-fi
-
-echo EMC_verif-global checkout ...
-if [[ ! -d verif-global.fd ]] ; then
-    rm -f ${topdir}/checkout-verif-global.log
-    git clone --recursive https://github.com/NOAA-EMC/EMC_verif-global.git verif-global.fd >> ${logdir}/checkout-verif-global.log 2>&1
-    cd verif-global.fd
-    # git checkout verif_global_v2.8.0
-    git checkout c267780
-    cd ${topdir}
-else
-    echo 'Skip. Directory verif-global.fd already exist.'
-fi
-
-exit 0
+echo
+exit $errs

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -151,14 +151,12 @@ if [[ "${checkout_gtg:-NO}" == "YES" ]]; then
 	echo "Checking out GTG extension for UPP"
 	cd "${topdir}/ufs_model.fd/FV3/upp"
 	logfile="${logdir}/checkout_gtg.log"
-	./manage_externals/checkout_externals >> "${logfile}" 2>&1
+	git -c submodule."post_gtg.fd".update=checkout submodule update --init --recursive >> "${logfile}" 2>&1
 	status=$?
 	if (( status > 0 )); then
 		echo "WARNING: Error while checking out GTG"
 		errs=$((errs + status))
 	fi
-	cp sorc/post_gtg.fd/*F90 sorc/ncep_post.fd/.
-	cp sorc/post_gtg.fd/gtg.config.gfs parm/gtg.config.gfs
 fi
 
 if (( errs > 0 )); then

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -48,7 +48,7 @@ function checkout() {
 	version="$3"
 
 	name=$(echo ${dir} | cut -d '.' -f 1)
-	echo "Starting checkout for ${name}"
+	echo "Performing checkout of ${name}"
 
 	logfile="${logdir:-$(pwd)}/checkout_${name}.log"
 
@@ -57,11 +57,12 @@ function checkout() {
 	fi
 
 	cd "${topdir}"
-	if [[ "${c:-NO}" == "YES" ]]; then
+	if [[  -d "${dir}" && "${c:-NO}" == "YES" ]]; then
+		echo "|-- Removing existing clone in ${dir}"		
 		rm -Rf "$dir"
 	fi
 	if [[ ! -d "${dir}" ]]; then
-		echo "|-- Cloning ${remote} into ${dir}"
+		echo "|-- Cloning from ${remote} into ${dir}"
 		git clone "${remote}" "${dir}" >> "${logfile}" 2>&1
 		status=$?
 		if ((status > 0)); then
@@ -71,10 +72,11 @@ function checkout() {
 		fi
 	else
 		# Fetch any updates from server
+		echo "|-- Fetching updates from ${remote}"
 		git fetch
 	fi
 	cd "${dir}"
-	echo "|-- Checking out ${version} of ${name}"
+	echo "|-- Checking out ${version}"
 	git checkout "${version}" >> "${logfile}" 2>&1
 	status=$?
 	if ((status > 0)); then
@@ -83,7 +85,7 @@ function checkout() {
 		return "${status}"
 	fi
 	git submodule update --init --recursive >> "${logfile}" 2>&1
-	echo "|-- Updating submodules of ${name} (if any)"
+	echo "|-- Updating submodules (if any)"
 	status=$?
 	if ((status > 0)); then
 		echo "    WARNING: Error while updating submodules of ${name}"

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -57,7 +57,7 @@ function checkout() {
 	fi
 
 	cd "${topdir}"
-	if [[  -d "${dir}" && "${c:-NO}" == "YES" ]]; then
+	if [[  -d "${dir}" && "${CLEAN:-NO}" == "YES" ]]; then
 		echo "|-- Removing existing clone in ${dir}"		
 		rm -Rf "$dir"
 	fi
@@ -102,7 +102,7 @@ while getopts ":chm:o" option; do
 			echo "Recieved -c flag, will delete any existing directories and start clean"
 			export CLEAN="YES"
 			;;
-		h)usage;;
+		h)	usage;;
 		o)
 			echo "Received -o flag for optional checkout of operational-only codes"
 			checkout_gtg="YES"

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -28,6 +28,7 @@ function checkout() {
 	# Clone or fetch repo, then checkout specific hash and update submodules
 	#
 	# Environment variables:
+	#   topdir [default: $(pwd)]: parent directory to your checkout
 	#   logdir [default: $(pwd)]: where you want logfiles written
 	#   CLEAN [default: NO]:      whether to delete existing directories and create a fresh clone
 	# 
@@ -55,6 +56,7 @@ function checkout() {
 		rm "${logfile}"
 	fi
 
+	cd "${topdir}"
 	if [[ "${c:-NO}" == "YES" ]]; then
 		rm -Rf "$dir"
 	fi
@@ -120,7 +122,7 @@ while getopts ":chm:o" option; do
 done
 shift $((OPTIND-1))
 
-topdir=$(pwd)
+export topdir=$(pwd)
 export logdir="${topdir}/logs"
 mkdir -p ${logdir}
 


### PR DESCRIPTION
**Description**
The checkout script is refactored. First, the repetitive checkout code is abstracted into a function that is called for each component. Second, if the clone already exists, checkout will still checkout the requested commit. Third, a new option (-c) is added that will delete any existing clones a create a fresh clone. These last two options allow updating of versions without needing to manually delete directories (and remembering which are created by checkout)

Additionally, a usage statement and code documentation are added.

There is no change to the existing command-line options, only new options. No change is necessary by users (although the checkout order and print messages have changed). The new syntax is as follows:
```
checkout.sh [-c][-h][-m ufs_hash][-o]
  -c:
      Create a fresh clone (delete existing directories)
  -h:
      Print this help message and exit
  -m ufs_hash:
      Check out this UFS hash instead of the default
  -o:
      Check out operational-only code (GTG and WAFS). Only authorized users can check out GTG.
```

Fixes #808

**Type of change**
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
- [x] Checkout on Hera as before
- [x] Checkout on Hera using -c to delete existing directories
- [x] Checkout on Hera to update version in-place
- [x] Checkout on Hera with non-existent hash to verify error-checking
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
