### PR TITLE
Extend `rocoto.py` for handling offsets in data dependencies.

### DIFF
--- a/ush/rocoto/rocoto.py
+++ b/ush/rocoto/rocoto.py
@@ -215,7 +215,7 @@ def add_data_tag(dep_dict):
 
         strings.append(f'{offset_string_b}{data}{offset_string_e}')
 
-    strings.append('<datadep>')
+    strings.append('</datadep>')
 
     return ''.join(strings)
 

--- a/ush/rocoto/rocoto.py
+++ b/ush/rocoto/rocoto.py
@@ -195,22 +195,29 @@ def add_data_tag(dep_dict):
         msg = f'a data value is necessary for {dep_type} dependency'
         raise KeyError(msg)
 
-    if dep_offset is None:
-        if '@' in dep_data:
-            offset_string_b = '<cyclestr>'
+    if not isinstance(dep_data, list):
+        dep_data = [dep_data]
+
+    if not isinstance(dep_offset, list):
+        dep_offset = [dep_offset]
+
+    assert len(dep_data) == len(dep_offset)
+
+    strings = ['<datadep>']
+    for data, offset in zip(dep_data, dep_offset):
+        if '@' in data:
+            offset_str = '' if  offset in [None, ''] else f' offset="{offset}"'
+            offset_string_b = f'<cyclestr{offset_str}>'
             offset_string_e = '</cyclestr>'
         else:
             offset_string_b = ''
             offset_string_e = ''
-    else:
-        offset_string_b = f'<cyclestr offset="{dep_offset}">'
-        offset_string_e = '</cyclestr>'
 
-    string = '<datadep>'
-    string += f'{offset_string_b}{dep_data}{offset_string_e}'
-    string += '</datadep>'
+        strings.append(f'{offset_string_b}{data}{offset_string_e}')
 
-    return string
+    strings.append('<datadep>')
+
+    return ''.join(strings)
 
 def add_cycle_tag(dep_dict):
     '''

--- a/ush/rocoto/setup_workflow_fcstonly.py
+++ b/ush/rocoto/setup_workflow_fcstonly.py
@@ -382,24 +382,20 @@ def get_workflow(dict_configs, cdump='gdas'):
             dep_dict = {'type': 'data', 'data': data}
             deps.append(rocoto.add_dependency(dep_dict))
 
-        # Files from previous cycle
+        # previous cycle
         dep_dict = {'type': 'cycleexist', 'offset': f'-{base["INTERVAL"]}'}
         deps.append(rocoto.add_dependency(dep_dict))
 
+        # Files from previous cycle
         files = [f'@Y@m@d.@H0000.fv_core.res.nc'] + \
                 [f'@Y@m@d.@H0000.fv_core.res.tile{tile_index}.nc' for tile_index in range(1, n_tiles + 1)] + \
                 [f'@Y@m@d.@H0000.fv_tracer.res.tile{tile_index}.nc' for tile_index in range(1, n_tiles + 1)]
 
-        data = f'&ROTDIR;/&CDUMP;.@Y@m@d/@H/atmos/RERUN_RESTART/'
-        dep_dict = {'type': 'data', 'data': data, 'offset': f'-{base["INTERVAL"]}'}
-        # Hack off the trailing </datadep> tag because we are going to concatenate with the rest
-        dependency1 = rocoto.add_dependency(dep_dict)[:-10]
         for file in files:
-            dep_dict = {'type': 'data', 'data': file}
-            # Hack off the leading <datadep> tag to join with the earlier one
-            dependency2 = rocoto.add_dependency(dep_dict)[9:]
-            # Combine the two into a dependency with two different cyclestr tags
-            deps.append(dependency1 + dependency2)
+            data = ['&ROTDIR;/&CDUMP;.@Y@m@d/@H/atmos/RERUN_RESTART/', file]
+            offset = [f'-{base["INTERVAL"]}', None]
+            dep_dict = {'type': 'data', 'data': data, 'offset': offset}
+            deps.append(rocoto.add_dependency(dep_dict))
 
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         task = wfu.create_wf_task('aerosol_init', cdump=cdump, envar=envars, dependency=dependencies)


### PR DESCRIPTION
**Description**
This PR:
- extends `rocoto.py` `data_dep` to handle `offset` in `cyclestr` to any arbitrary number of instances.  
- removes a hack in `aerosol_init` dependency generation block

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] need to test `setup_workflow_fcstonly.py` and compare XML with `develop` when the Aerosol option is turned ON.  Need a volunteer @WalterKolczynski-NOAA?
  
**Checklist**

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
