### PR TITLE
GFSv16.1.8 updates (Switch to Meteosat-9 AMVs) into operations branch

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.1.6
+tag = gfsda.v16.1.8
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git

--- a/docs/Release_Notes.gfs.v16.1.8.txt
+++ b/docs/Release_Notes.gfs.v16.1.8.txt
@@ -1,0 +1,128 @@
+GFS V16.1.8 RELEASE NOTES
+
+PRELUDE
+
+Meteosat-9 replaces Meteosat-8 as the operational geostationary platform over the Indian Ocean on 20220601.  To maintain continuity of operations, the /fix/fix_gsi/global_convinfo.txt file needs to be modified before this date (as soon as possible is preferable)
+
+IMPLEMENTATION INSTRUCTIONS
+
+  The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com
+  are used to manage the GFS.v16.1.8 code. The SPA(s) handling the GFS.v16.1.8
+  implementation need to have permissions to clone VLab gerrit repositories and
+  the private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are
+  publicly readable and do not require access permissions.  Please follow the
+  following steps to install the package on WCOSS-Dell:
+
+  1) cd $NWROOTp3
+
+  2) mkdir gfs.v16.1.8
+
+  3) cd gfs.v16.1.8
+
+  4) git clone -b EMC-v16.1.8  https://github.com/NOAA-EMC/global-workflow.git .
+
+  5) cd sorc
+
+  6) ./checkout.sh -o
+      * This script extracts the following GFS components:
+	MODEL 	   tag GFS.v16.0.17              	Jun.Wang@noaa.gov
+	GSI   	   tag gfsda.v16.1.8             	Catherine.Thomas@noaa.gov
+	GLDAS 	   tag gldas_gfsv16_release.v1.12.0	Helin.Wei@noaa.gov
+	UFS_UTILS  tag ops-gfsv16.0.0            	George.Gayno@noaa.gov
+	POST  	   tag upp_gfsv16_release.v1.1.4 	Wen.Meng@noaa.gov
+	WAFS  	   tag gfs_wafs.v6.0.22          	Yali.Mao@noaa.gov
+
+  7) ./build_all.sh
+      * This script compiles all GFS components. Runtime output from the build for
+	each package is written to log files in directory logs. To build an
+	individual program, for instance, gsi, use build_gsi.sh.
+
+  8) ./link_fv3gfs.sh nco dell
+
+SORC CHANGES
+
+* No changes from GFS v16.1.7
+
+
+FIX CHANGES
+
+* fix/fix_gsi/
+      *fix/fix_gsi/global_convinfo.txt: Turn on uv satid 56 (three character change)
+
+PARM/CONFIG CHANGES
+
+* No changes from GFS v16.1.7
+
+
+JOBS CHANGES
+
+* No change from GFS v16.1.7
+
+
+SCRIPT CHANGES
+
+* No change from GFS v16.1.7
+
+
+CHANGES TO RESOURCES AND FILE SIZES
+
+* No change from GFS v16.1.7
+
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+
+* Which production jobs should be tested as part of this implementation?
+  * jobs jgdas_atmos_analysis and jgfs_atmos_analysis should be tested.  Prior to 20220601, results should be identical.
+
+* Does this change require a 30-day evaluation?
+  * No.
+
+DISSEMINATION INFORMATION
+
+* Where should this output be sent?
+  * No change from GFS v16.1.7
+
+* Who are the users?
+  * No change from GFS v16.1.7
+
+* Which output files should be transferred from PROD WCOSS to DEV WCOSS?
+  * No change from GFS v16.1.7
+
+* Directory changes
+  * No change from GFS v16.1.7
+
+* File changes
+  * No change from GFS v16.1.7
+
+
+HPSS ARCHIVE
+
+* No change from GFS v16.1.7
+
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+
+* No change from GFS v16.1.7
+
+
+Temporary Location of Changed Files on disk.
+
+On WCOSS:
+Replace:
+ /gpfs/dell1/nco/ops/nwprod/gfs.v16.1.7/fix/fix_gsi/global_convinfo.txt
+and
+/gpfs/dell1/nco/ops/nwprod/gfs.v16.1.7/sorc/gsi.fd/fix/global_convinfo.txt
+(the above two files should be identical)
+with:
+/gpfs/dell2/emc/modeling/save/Andrew.Collard/Meteosat9/global_convinfo.txt.gfs.v16.1.8
+(updating version numbers as appropriate)
+
+On WCOSS2:
+Replace:
+/lfs/h1/ops/prod/packages/gfs.v16.2.0/fix/fix_gsi/global_convinfo.txt
+and
+/lfs/h1/ops/prod/packages/gfs.v16.2.0/sorc/gsi.fd/fix/global_convinfo.txt
+(the above two files should be identical)
+with:
+/u/Andrew.Collard/global_convinfo.txt.gfs.v16.2.1
+(updating version numbers as appropriate)

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -38,7 +38,7 @@ if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
     git clone --recursive https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
-    git checkout gfsda.v16.1.6
+    git checkout gfsda.v16.1.8
     git submodule update --init
     cd ${topdir}
 else


### PR DESCRIPTION
**Description**

This PR merges updates for GFSv16.1.8 (Switch to Meteosat-9 AMVs) into the `operations` branch from the `release/gfs.v16.1.8` branch:

1. new GSI tag (`gfsda.v16.1.8`) in `Externals.cfg` and `sorc/checkout.sh`.
2. new `Release_Notes.gfs.v16.1.8.txt` release notes in `docs/`

DA team confirmed aRFC was implemented into both WCOSS1 and WCOSS2 operations (2022053112). See details in issue https://github.com/NOAA-EMC/global-workflow/issues/798#issuecomment-1144891218.

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

Resolves #798 