### PR TITLE
Use nceplibs-ncio for enkf_chgres_recenter_nc utility

### DIFF
--- a/modulefiles/fv3gfs/enkf_chgres_recenter_nc.wcoss2.lua
+++ b/modulefiles/fv3gfs/enkf_chgres_recenter_nc.wcoss2.lua
@@ -12,6 +12,7 @@ load(pathJoin("netcdf", os.getenv("netcdf_ver")))
 
 load(pathJoin("bacio", os.getenv("bacio_ver")))
 load(pathJoin("w3nco", os.getenv("w3nco_ver")))
+load(pathJoin("ncio", os.getenv("ncio_ver")))
 load(pathJoin("ip", os.getenv("ip_ver")))
 load(pathJoin("sp", os.getenv("sp_ver")))
 

--- a/sorc/build_enkf_chgres_recenter_nc.sh
+++ b/sorc/build_enkf_chgres_recenter_nc.sh
@@ -4,9 +4,11 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=`pwd`
 
+set +x
 module use ${cwd}/../modulefiles/fv3gfs
 module load enkf_chgres_recenter_nc.$target
 module list
+set -x
 
 # Check final exec folder exists
 if [ ! -d "../exec" ]; then
@@ -16,16 +18,6 @@ fi
 cd ${cwd}/enkf_chgres_recenter_nc.fd
 
 export FFLAGS="-O3 -qopenmp -g -traceback -fp-model precise"
-export FV3GFS_NCIO_LIB="${cwd}/gsi.fd/build/lib/libfv3gfs_ncio.a"
-export FV3GFS_NCIO_INC="${cwd}/gsi.fd/build/include"
-
-if [ ! -f $FV3GFS_NCIO_LIB ]; then
-  echo "BUILD ERROR: missing GSI library file"
-  echo "Missing file: $FV3GFS_NCIO_LIB"
-  echo "Please build the GSI first (build_gsi.sh)"
-  echo "EXITING..."
-  exit 1
-fi
 
 make clean
 make

--- a/sorc/enkf_chgres_recenter_nc.fd/input_data.f90
+++ b/sorc/enkf_chgres_recenter_nc.fd/input_data.f90
@@ -2,7 +2,7 @@
 
  use utils
  use setup
- use module_fv3gfs_ncio
+ use module_ncio
 
  implicit none
 

--- a/sorc/enkf_chgres_recenter_nc.fd/makefile
+++ b/sorc/enkf_chgres_recenter_nc.fd/makefile
@@ -1,6 +1,6 @@
 SHELL=  /bin/sh
 
-LIBS= $(FV3GFS_NCIO_LIB) $(BACIO_LIB4) $(W3NCO_LIB4) $(IP_LIB4) $(SP_LIB4) -L$(NETCDF)/lib -lnetcdff -lnetcdf -L${HDF5_LIBRARIES} -lhdf5_hl -lhdf5 -lz 
+LIBS= $(NCIO_LIB) $(BACIO_LIB4) $(W3NCO_LIB4) $(IP_LIB4) $(SP_LIB4) -L$(NETCDF)/lib -lnetcdff -lnetcdf -L${HDF5_LIBRARIES} -lhdf5_hl -lhdf5 -lz
 
 CMD= enkf_chgres_recenter_nc.x
 
@@ -10,17 +10,17 @@ $(CMD): $(OBJS)
 	$(FC) $(FFLAGS) -o $(CMD) $(OBJS) $(LIBS)
 
 driver.o:  setup.o output_data.o interp.o input_data.o driver.f90
-	$(FC) $(FFLAGS) -I$(FV3GFS_NCIO_INC) -I$(NETCDF)/include -c driver.f90
+	$(FC) $(FFLAGS) -I$(NCIO_INC) -I$(NETCDF)/include -c driver.f90
 interp.o:  setup.o utils.o output_data.o input_data.o interp.f90
-	$(FC) $(FFLAGS) -I$(FV3GFS_NCIO_INC) -I$(NETCDF)/include -c interp.f90
+	$(FC) $(FFLAGS) -I$(NCIO_INC) -I$(NETCDF)/include -c interp.f90
 input_data.o:  setup.o utils.o input_data.f90
-	$(FC) $(FFLAGS) -I$(FV3GFS_NCIO_INC) -I$(NETCDF)/include -c input_data.f90
+	$(FC) $(FFLAGS) -I$(NCIO_INC) -I$(NETCDF)/include -c input_data.f90
 output_data.o: setup.o utils.o  input_data.o output_data.f90
-	$(FC) $(FFLAGS) -I$(FV3GFS_NCIO_INC) -I$(NETCDF)/include -c output_data.f90
+	$(FC) $(FFLAGS) -I$(NCIO_INC) -I$(NETCDF)/include -c output_data.f90
 setup.o:  setup.f90
-	$(FC) $(FFLAGS) -I$(FV3GFS_NCIO_INC) -I$(NETCDF)/include -c setup.f90
+	$(FC) $(FFLAGS) -I$(NCIO_INC) -I$(NETCDF)/include -c setup.f90
 utils.o:  utils.f90
-	$(FC) $(FFLAGS) -I$(FV3GFS_NCIO_INC) -I$(NETCDF)/include -c utils.f90
+	$(FC) $(FFLAGS) -I$(NCIO_INC) -I$(NETCDF)/include -c utils.f90
 clean:
 	rm -f *.o *.mod ${CMD}
 install:

--- a/sorc/enkf_chgres_recenter_nc.fd/output_data.f90
+++ b/sorc/enkf_chgres_recenter_nc.fd/output_data.f90
@@ -1,6 +1,6 @@
  module output_data
 
- use module_fv3gfs_ncio
+ use module_ncio
 
  implicit none
 

--- a/versions/build.ver
+++ b/versions/build.ver
@@ -31,5 +31,6 @@ export ip_ver=3.3.3
 export wrf_io_ver=1.1.1
 export gfsio_ver=1.4.1
 export sfcio_ver=1.4.1
+export ncio_ver=1.0.0
 
 export upp_ver=8.1.0


### PR DESCRIPTION

**Description**

This PR:
- removes dependency on GSI built `fv3gfs_ncio` and uses `nceplibs-ncio`.
-  Only updated for WCOSS2

This fix is needed for gfsv16.3.0

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [X] Clone and Build tested the utility `enkf_chgres_recenter_nc` on WCOSS2
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings