### PR TITLE
Add "atmos" COMPONENT subfolder to DMPDIR paths (develop)

### DIFF
--- a/jobs/JGLOBAL_WAVE_PREP
+++ b/jobs/JGLOBAL_WAVE_PREP
@@ -86,7 +86,7 @@ else
   fi 
   if [ $WW3ICEINP = "YES" ]; then 
     if [ ! -L $ROTDIR/${CDUMP}.${PDY}/${cyc}/atmos/${WAVICEFILE} ]; then # Check if symlink already exists in ROTDIR
-      $NLN $DMPDIR/$CDUMP.${PDY}/$cyc/${WAVICEFILE} $ROTDIR/$CDUMP.${PDY}/$cyc/atmos/${WAVICEFILE}
+      $NLN $DMPDIR/$CDUMP.${PDY}/$cyc/atmos/${WAVICEFILE} $ROTDIR/$CDUMP.${PDY}/$cyc/atmos/${WAVICEFILE}
     fi
     export COMIN_WAV_ICE=${COMIN_WAV_ICE:-$ROTDIR/$RUN.$PDY/$cyc/atmos}
   fi 

--- a/jobs/rocoto/prep.sh
+++ b/jobs/rocoto/prep.sh
@@ -31,7 +31,7 @@ export COMOUT="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT"
 ###############################################################
 # If ROTDIR_DUMP=YES, copy dump files to rotdir
 if [ $ROTDIR_DUMP = "YES" ]; then
-   $HOMEgfs/ush/getdump.sh $CDATE $CDUMP $DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc} $COMOUT
+   $HOMEgfs/ush/getdump.sh $CDATE $CDUMP $DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}/${COMPONENT} $COMOUT
    status=$?
    [[ $status -ne 0 ]] && exit $status
 
@@ -42,7 +42,7 @@ if [ $ROTDIR_DUMP = "YES" ]; then
    GDUMP=gdas
    gCOMOUT="$ROTDIR/$GDUMP.$gPDY/$gcyc/$COMPONENT"
    if [ ! -s $gCOMOUT/$GDUMP.t${gcyc}z.updated.status.tm00.bufr_d ]; then
-     $HOMEgfs/ush/getdump.sh $GDATE $GDUMP $DMPDIR/${GDUMP}${DUMP_SUFFIX}.${gPDY}/${gcyc} $gCOMOUT
+     $HOMEgfs/ush/getdump.sh $GDATE $GDUMP $DMPDIR/${GDUMP}${DUMP_SUFFIX}.${gPDY}/${gcyc}/${COMPONENT} $gCOMOUT
      status=$?
      [[ $status -ne 0 ]] && exit $status
    fi
@@ -76,7 +76,7 @@ if [ $PROCESS_TROPCY = "YES" ]; then
     [[ $status -ne 0 ]] && exit $status
 
 else
-    [[ $ROTDIR_DUMP = "NO" ]] && cp $DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}/${CDUMP}.t${cyc}z.syndata.tcvitals.tm00 $COMOUT/
+    [[ $ROTDIR_DUMP = "NO" ]] && cp $DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}/${COMPONENT}/${CDUMP}.t${cyc}z.syndata.tcvitals.tm00 $COMOUT/
 fi
 
 
@@ -96,7 +96,7 @@ if [ $DO_MAKEPREPBUFR = "YES" ]; then
     export COMINgdas=${COMINgdas:-$ROTDIR/gdas.$PDY/$cyc/$COMPONENT}
     export COMINgfs=${COMINgfs:-$ROTDIR/gfs.$PDY/$cyc/$COMPONENT}
     if [ $ROTDIR_DUMP = "NO" ]; then
-        COMIN_OBS=${COMIN_OBS:-$DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}}
+        COMIN_OBS=${COMIN_OBS:-$DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}/${COMPONENT}}
         export COMSP=${COMSP:-$COMIN_OBS/$CDUMP.t${cyc}z.}
     else
         export COMSP=${COMSP:-$ROTDIR/${CDUMP}.${PDY}/${cyc}/$COMPONENT/$CDUMP.t${cyc}z.}
@@ -113,14 +113,14 @@ if [ $DO_MAKEPREPBUFR = "YES" ]; then
 
     # If creating NSSTBUFR was disabled, copy from DMPDIR if appropriate.
     if [[ ${DO_MAKE_NSSTBUFR:-"NO"} = "NO" ]]; then
-        [[ $DONST = "YES" ]] && $NCP $DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}/${OPREFIX}nsstbufr $COMOUT/${OPREFIX}nsstbufr
+        [[ $DONST = "YES" ]] && $NCP $DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}/${COMPONENT}/${OPREFIX}nsstbufr $COMOUT/${OPREFIX}nsstbufr
     fi
 
 else
     if [ $ROTDIR_DUMP = "NO" ]; then
-        $NCP $DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}/${OPREFIX}prepbufr               $COMOUT/${OPREFIX}prepbufr
-        $NCP $DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}/${OPREFIX}prepbufr.acft_profiles $COMOUT/${OPREFIX}prepbufr.acft_profiles
-        [[ $DONST = "YES" ]] && $NCP $DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}/${OPREFIX}nsstbufr $COMOUT/${OPREFIX}nsstbufr
+        $NCP $DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}/${COMPONENT}/${OPREFIX}prepbufr               $COMOUT/${OPREFIX}prepbufr
+        $NCP $DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}/${COMPONENT}/${OPREFIX}prepbufr.acft_profiles $COMOUT/${OPREFIX}prepbufr.acft_profiles
+        [[ $DONST = "YES" ]] && $NCP $DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}/${COMPONENT}/${OPREFIX}nsstbufr $COMOUT/${OPREFIX}nsstbufr
     fi
 fi
 

--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -64,18 +64,18 @@ export OBERROR=$FIXgsi/prepobs_errtable.global
 if [[ $RUN_ENVIR == "emc" ]]; then
 	export ABIBF="/dev/null"
 	if [[ "$CDATE" -ge "2019022800" ]] ; then
-		export ABIBF="$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.gsrcsr.tm00.bufr_d"
+		export ABIBF="$DMPDIR/${CDUMP}x.${PDY}/${cyc}/atmos/${CDUMP}.t${cyc}z.gsrcsr.tm00.bufr_d"
 		if [[ "$CDATE" -ge "2019111000" && "$CDATE" -le "2020052612" ]]; then
-			export ABIBF="$DMPDIR/${CDUMP}y.${PDY}/${cyc}/${CDUMP}.t${cyc}z.gsrcsr.tm00.bufr_d"
+			export ABIBF="$DMPDIR/${CDUMP}y.${PDY}/${cyc}/atmos/${CDUMP}.t${cyc}z.gsrcsr.tm00.bufr_d"
 		fi
 	fi
 
 	export AHIBF="/dev/null"
 	if [[ "$CDATE" -ge "2019042300" ]]; then
-		export AHIBF="$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.ahicsr.tm00.bufr_d"
+		export AHIBF="$DMPDIR/${CDUMP}x.${PDY}/${cyc}/atmos/${CDUMP}.t${cyc}z.ahicsr.tm00.bufr_d"
 	fi
 
-	export HDOB=$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.hdob.tm00.bufr_d
+	export HDOB=$DMPDIR/${CDUMP}x.${PDY}/${cyc}/atmos/${CDUMP}.t${cyc}z.hdob.tm00.bufr_d
 
 	#   Use dumps from NCO GFS v16 parallel
 	if [[ "$CDATE" -ge "2020103012" ]]; then

--- a/ush/drive_makeprepbufr.sh
+++ b/ush/drive_makeprepbufr.sh
@@ -39,7 +39,7 @@ DONST=${DONST:-"NO"}
 
 ###############################################################
 # Set script and dependency variables
-export COMPONENT=${COMPONENT:-atmos}
+COMPONENT=${COMPONENT:-atmos}
 
 GDATE=$($NDATE -$assim_freq $CDATE)
 
@@ -55,7 +55,7 @@ GSUFFIX=${GSUFFIX:-$SUFFIX}
 APREFIX="${CDUMP}.t${chh}z."
 ASUFFIX=${ASUFFIX:-$SUFFIX}
 
-COMIN_OBS=${COMIN_OBS:-"$DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}"}
+COMIN_OBS=${COMIN_OBS:-"$DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}/${COMPONENT}"}
 COMIN_GES=${COMIN_GES:-"$ROTDIR/gdas.$gymd/$ghh/$COMPONENT"}
 COMOUT=${COMOUT:-"$ROTDIR/$CDUMP.$cymd/$chh/$COMPONENT"}
 [[ ! -d $COMOUT ]] && mkdir -p $COMOUT

--- a/ush/getdump.sh
+++ b/ush/getdump.sh
@@ -1,12 +1,12 @@
 #!/bin/ksh
 set -x
 
-export COMPONENT=${COMPONENT:-atmos}
+COMPONENT=${COMPONENT:-atmos}
 
 CDATE=${1:-""}
 CDUMP=${2:-""}
-SOURCE_DIR=${3:-$DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}}
-TARGET_DIR=${4:-$ROTDIR/${CDUMP}.${PDY}/$cyc/$COMPONENT}
+SOURCE_DIR=${3:-$DMPDIR/${CDUMP}${DUMP_SUFFIX}.${PDY}/${cyc}/${COMPONENT}}
+TARGET_DIR=${4:-$ROTDIR/${CDUMP}.${PDY}/${cyc}/${COMPONENT}}
 
 DUMP_SUFFIX=${DUMP_SUFFIX:-""}
 

--- a/ush/rocoto/setup_workflow.py
+++ b/ush/rocoto/setup_workflow.py
@@ -425,7 +425,7 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
     data = f'&ROTDIR;/gdas.@Y@m@d/@H/atmos/gdas.t@Hz.atmf009{gridsuffix}'
     dep_dict = {'type': 'data', 'data': data, 'offset': '-06:00:00'}
     deps.append(rocoto.add_dependency(dep_dict))
-    data = f'&DMPDIR;/{cdump}{dumpsuffix}.@Y@m@d/@H/{cdump}.t@Hz.updated.status.tm00.bufr_d'
+    data = f'&DMPDIR;/{cdump}{dumpsuffix}.@Y@m@d/@H/atmos/{cdump}.t@Hz.updated.status.tm00.bufr_d'
     dep_dict = {'type': 'data', 'data': data}
     deps.append(rocoto.add_dependency(dep_dict))
     dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)


### PR DESCRIPTION
**Description**

This PR adds the new `atmos` subfolder to `DMPDIR` paths throughout workflow. Replicates the same updates made in the `dev_v16` branch in PR #813. Changes include:

- add `atmos` to `WAVICEFILE` `DMPDIR` path in `JGLOBAL_WAVE_PREP`
- add `COMPONENT` to all `DMPDIR` paths (`COMPONENT=atmos` already set)
- add `atmos` to all `DMPDIR` paths in `config.anal`
- add `COMPONENT` to `COMIN_OBS` default that uses `DMPDIR` in `drive_makeprepbufr.sh`
- add `COMPONENT` to `SOURCE_DIR` default that uses `DMPDIR` in `getdump.sh`
- add `atmos` to prep job dependency on `updated.status.tm00.bufr_d` in `setup_workflow.py`

Refs: #802

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

Unable to test in cycled mode in `develop` branch...but...

- [x] Ran the prep job on Orion within clone of `feature/gda-atmos` branch by faking prior cycle output that prep ingests.
- [x] Cycled testing via `dev_v16` branch work.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
