### PR TITLE
Update component versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,8 @@ fix/wafs
 parm/config/config.base
 parm/gldas
 parm/mon
-parm/post/AEROSOL_LUTS.datoptics_luts_DUST.dat
+parm/post/AEROSOL_LUTS.dat
+parm/post/optics_luts_DUST.dat
 parm/post/gtg.config.gfs
 parm/post/gtg_imprintings.txt
 parm/post/optics_luts_SALT.dat

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ sorc/gfs_post.fd
 sorc/gfs_wafs.fd
 sorc/gldas.fd
 sorc/gsi.fd
+sorc/gsi_monitor.fd
 sorc/ufs_utils.fd
 sorc/verif-global.fd
 

--- a/modulefiles/gsi_monitor.hera.lua
+++ b/modulefiles/gsi_monitor.hera.lua
@@ -1,0 +1,16 @@
+help([[
+Build environment for GSI monitor on Hera
+]])
+
+prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
+
+load(pathJoin("hpc", "1.1.0"))
+load(pathJoin("hpc-intel", "18.0.5.274"))
+load(pathJoin("hpc-impi", "2018.0.4"))
+
+load(pathJoin("cmake", "3.20.1"))
+
+load(pathJoin("hdf5", "1.10.6"))
+load(pathJoin("netcdf", "4.7.4"))
+
+load(pathJoin("w3emc", "2.9.1"))

--- a/modulefiles/gsi_monitor.orion.lua
+++ b/modulefiles/gsi_monitor.orion.lua
@@ -8,7 +8,7 @@ load(pathJoin("hpc", "1.1.0"))
 load(pathJoin("hpc-intel", "2018.4"))
 load(pathJoin("hpc-impi", "2018.4"))
 
-load(pathJoin("cmake", "3.20.1"))
+load(pathJoin("cmake", "3.22.1"))
 
 load(pathJoin("hdf5", "1.10.6"))
 load(pathJoin("netcdf", "4.7.4"))

--- a/modulefiles/gsi_monitor.orion.lua
+++ b/modulefiles/gsi_monitor.orion.lua
@@ -1,0 +1,16 @@
+help([[
+Build environment for GSI monitor on Orion
+]])
+
+prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack")
+
+load(pathJoin("hpc", "1.1.0"))
+load(pathJoin("hpc-intel", "2018.4"))
+load(pathJoin("hpc-impi", "2018.4"))
+
+load(pathJoin("cmake", "3.20.1"))
+
+load(pathJoin("hdf5", "1.10.6"))
+load(pathJoin("netcdf", "4.7.4"))
+
+load(pathJoin("w3emc", "2.9.1"))

--- a/modulefiles/gsi_monitor.wcoss_dell_p3.lua
+++ b/modulefiles/gsi_monitor.wcoss_dell_p3.lua
@@ -8,7 +8,7 @@ load(pathJoin("hpc", "1.1.0"))
 load(pathJoin("hpc-ips", "18.0.1.163"))
 load(pathJoin("hpc-impi", "18.0.1"))
 
-load(pathJoin("cmake", "3.20.1"))
+load(pathJoin("cmake", "3.20.2"))
 
 load(pathJoin("hdf5", "1.10.6"))
 load(pathJoin("netcdf", "4.7.4"))

--- a/modulefiles/gsi_monitor.wcoss_dell_p3.lua
+++ b/modulefiles/gsi_monitor.wcoss_dell_p3.lua
@@ -1,0 +1,16 @@
+help([[
+Build environment for GSI monitor on WCOSS Dell
+]])
+
+prepend_path("MODULEPATH", "/usrx/local/nceplibs/dev/hpc-stack/libs/hpc-stack/modulefiles/stack")
+
+load(pathJoin("hpc", "1.1.0"))
+load(pathJoin("hpc-ips", "18.0.1.163"))
+load(pathJoin("hpc-impi", "18.0.1"))
+
+load(pathJoin("cmake", "3.20.1"))
+
+load(pathJoin("hdf5", "1.10.6"))
+load(pathJoin("netcdf", "4.7.4"))
+
+load(pathJoin("w3emc", "2.9.1"))

--- a/modulefiles/workflow_utils.wcoss_dell_p3.lua
+++ b/modulefiles/workflow_utils.wcoss_dell_p3.lua
@@ -8,7 +8,7 @@ load(pathJoin("hpc", "1.1.0"))
 load(pathJoin("hpc-ips", "18.0.1.163"))
 load(pathJoin("hpc-impi", "18.0.1"))
 
-load(pathJoin("cmake", "3.20.0"))
+load(pathJoin("cmake", "3.20.2"))
 
 load(pathJoin("jasper", "2.0.25"))
 load(pathJoin("zlib", "1.2.11"))

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -135,6 +135,20 @@ $Build_gsi && {
 }
 
 #------------------------------------
+# build gsi monitor
+#------------------------------------
+$Build_gsi_monitor && {
+	echo " .... Building gsi monitor .... "
+	./build_gsi_monitor.sh $_ops_opt $_verbose_opt > $logs_dir/build_gsi_monitor.log 2>&1
+	rc=$?
+	if [[ $rc -ne 0 ]] ; then
+		echo "Fatal error in building gsi monitor."
+		echo "The log file is in $logs_dir/build_gsi_monitor.log"
+	fi
+	((err+=$rc))
+}
+
+#------------------------------------
 # build UPP
 #------------------------------------
 $Build_upp && {

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -31,14 +31,16 @@ function _usage() {
 }
 
 _build_ufs_opt=""
+_ops_opt=""
 _verbose_opt=""
 # Reset option counter in case this script is sourced
 OPTIND=1
-while getopts ":a:c:hv" option; do
+while getopts ":a:c:hov" option; do
 	case "${option}" in
 		a) _build_ufs_opt+="-a ${OPTARG} ";;
 		c) _partial_opt+="-c ${OPTARG} ";;
 		h) _usage;;
+		o) _ops_opt+="-o";;
 		# s) _build_ufs_opt+="-s ${OPTARG} ";;
 		v) _verbose_opt="-v";;
 		\?)
@@ -123,7 +125,7 @@ $Build_ufs_model && {
 #------------------------------------
 $Build_gsi && {
 	echo " .... Building gsi .... "
-	./build_gsi.sh $_verbose_opt > $logs_dir/build_gsi.log 2>&1
+	./build_gsi.sh $_ops_opt $_verbose_opt > $logs_dir/build_gsi.log 2>&1
 	rc=$?
 	if [[ $rc -ne 0 ]] ; then
 		echo "Fatal error in building gsi."
@@ -137,7 +139,7 @@ $Build_gsi && {
 #------------------------------------
 $Build_upp && {
 	echo " .... Building UPP .... "
-	./build_upp.sh $_verbose_opt > $logs_dir/build_upp.log 2>&1
+	./build_upp.sh $_ops_opt $_verbose_opt > $logs_dir/build_upp.log 2>&1
 	rc=$?
 	if [[ $rc -ne 0 ]] ; then
 		echo "Fatal error in building UPP."

--- a/sorc/build_gsi.sh
+++ b/sorc/build_gsi.sh
@@ -4,8 +4,23 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=$(pwd)
 
-gsitarget=$target
-[[ "$target" == wcoss_cray ]] && gsitarget=cray
+OPTIND=1
+while getopts ":dov" option; do
+	case "${option}" in
+		d) export BUILD_TYPE="DEBUG";;
+		o) _ops="YES";;
+		v) export BUILD_VERBOSE="YES";;
+		\?)
+			echo "[$BASH_SOURCE]: Unrecognized option: ${option}"
+			usage
+			;;
+		:)
+			echo "[$BASH_SOURCE]: ${option} requires an argument"
+			usage
+			;;
+	esac
+done
+shift $((OPTIND-1))
 
 # Check final exec folder exists
 if [ ! -d "../exec" ]; then
@@ -13,8 +28,9 @@ if [ ! -d "../exec" ]; then
 fi
 
 cd gsi.fd/ush/
-./build_all_cmake.sh "PRODUCTION" "$cwd/gsi.fd"
-##./build_all_cmake.sh "PRODUCTION" "$cwd/gsi.fd" "NCO"  # use this line for pruned NCO install
+export GSI_MODE="GFS"
+export REGRESSION_TESTS="NO"
+./build.sh "$cwd/gsi.fd"
 
 exit
 

--- a/sorc/build_gsi_monitor.sh
+++ b/sorc/build_gsi_monitor.sh
@@ -4,10 +4,10 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=$(pwd)
 
-BUILD_DIR="${cwd}/build/gsi_monitor"
 BUILD_TYPE="Release"
 DIR_ROOT="${cwd}/gsi_monitor.fd"
-INSTALL_PREFIX="${cwd}/../exec"
+BUILD_DIR="${DIR_ROOT}/build"
+INSTALL_PREFIX="${DIR_ROOT}/install"
 GSI_INSTALL_PREFIX="${cwd}/gsi.fd/install"
 
 OPTIND=1
@@ -42,11 +42,6 @@ else
   exit 1
 fi
 
-# Check final exec folder exists
-# if [ ! -d "${INSTALL_PREFIX}" ]; then
-#   mkdir "${INSTALL_PREFIX}"
-# fi
-
 if [[ -d "${BUILD_DIR}" ]]; then
 	rm -Rf "${BUILD_DIR}"
 fi
@@ -78,5 +73,8 @@ cmake $CMAKE_OPTS $DIR_ROOT
 make -j ${BUILD_JOBS:-8} VERBOSE=${BUILD_VERBOSE:-}
 make install
 set +x
+
+# Clean up build directory
+rm -Rf "${BUILD_DIR}"
 
 exit

--- a/sorc/build_gsi_monitor.sh
+++ b/sorc/build_gsi_monitor.sh
@@ -1,0 +1,82 @@
+#! /usr/bin/env bash
+set -eux
+
+source ./machine-setup.sh > /dev/null 2>&1
+cwd=$(pwd)
+
+BUILD_DIR="${cwd}/build/gsi_monitor"
+BUILD_TYPE="Release"
+DIR_ROOT="${cwd}/gsi_monitor.fd"
+INSTALL_PREFIX="${cwd}/../exec"
+GSI_INSTALL_PREFIX="${cwd}/gsi.fd/install"
+
+OPTIND=1
+while getopts ":dov" option; do
+	case "${option}" in
+		d) export BUILD_TYPE="DEBUG";;
+		o) _ops="YES";;
+		v) export BUILD_VERBOSE="YES";;
+		\?)
+			echo "[$BASH_SOURCE]: Unrecognized option: ${option}"
+			usage
+			;;
+		:)
+			echo "[$BASH_SOURCE]: ${option} requires an argument"
+			usage
+			;;
+	esac
+done
+shift $((OPTIND-1))
+
+# Load necessary modules
+source machine-setup.sh > /dev/null 2>&1
+module use ${cwd}/../modulefiles
+modulefile=${cwd}/../modulefiles/gsi_monitor.${target}
+if [[ -f ${modulefile}.lua ]]; then
+  set +x
+  module load gsi_monitor.$target
+  module list
+  set -x
+else
+  echo "FATAL: modulefile ${modulefile}.lua not found!"
+  exit 1
+fi
+
+# Check final exec folder exists
+# if [ ! -d "${INSTALL_PREFIX}" ]; then
+#   mkdir "${INSTALL_PREFIX}"
+# fi
+
+if [[ -d "${BUILD_DIR}" ]]; then
+	rm -Rf "${BUILD_DIR}"
+fi
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+CMAKE_OPTS=""
+
+CMAKE_OPTS+="-DBUILD_UTIL_ALLMON=YES"
+
+if [[ -d "${GSI_INSTALL_PREFIX}" ]]; then
+	CMAKE_OPTS+=" -Dncdiag_ROOT=${GSI_INSTALL_PREFIX}"
+else
+	echo <<- EOF
+		FATAL: ${GSI_INSTALL_PREFIX} does not exist
+		  Have you built GSI yet?
+	EOF
+	exit 2
+fi
+
+# Collect BUILD Options
+CMAKE_OPTS+=" -DCMAKE_BUILD_TYPE=${BUILD_TYPE}"
+
+# Install destination for built executables, libraries, CMake Package config
+CMAKE_OPTS+=" -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}"
+
+set -x
+cmake $CMAKE_OPTS $DIR_ROOT
+make -j ${BUILD_JOBS:-8} VERBOSE=${BUILD_VERBOSE:-}
+make install
+set +x
+
+exit

--- a/sorc/build_upp.sh
+++ b/sorc/build_upp.sh
@@ -4,10 +4,29 @@ set -eux
 source ./machine-setup.sh > /dev/null 2>&1
 cwd=$(pwd)
 
+OPTIND=1
+_opts=""
+while getopts ":dov" option; do
+	case "${option}" in
+		d) export BUILD_TYPE="DEBUG";;
+		o) _opts+="-g";;
+		v) _opts+="-v";;
+		\?)
+			echo "[$BASH_SOURCE]: Unrecognized option: ${option}"
+			usage
+			;;
+		:)
+			echo "[$BASH_SOURCE]: ${option} requires an argument"
+			usage
+			;;
+	esac
+done
+shift $((OPTIND-1))
+
 # Check final exec folder exists
 if [ ! -d "../exec" ]; then
   mkdir ../exec
 fi
 
 cd ufs_model.fd/FV3/upp/tests
-./compile_upp.sh
+./compile_upp.sh ${_opts}

--- a/sorc/build_upp.sh
+++ b/sorc/build_upp.sh
@@ -9,8 +9,8 @@ _opts=""
 while getopts ":dov" option; do
 	case "${option}" in
 		d) export BUILD_TYPE="DEBUG";;
-		o) _opts+="-g";;
-		v) _opts+="-v";;
+		o) _opts+="-g ";;
+		v) _opts+="-v ";;
 		\?)
 			echo "[$BASH_SOURCE]: Unrecognized option: ${option}"
 			usage

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -70,13 +70,13 @@ function checkout() {
 			echo
 			return "${status}"
 		fi
+		cd "${dir}"
 	else
 		# Fetch any updates from server
 		cd "${dir}"
 		echo "|-- Fetching updates from ${remote}"
 		git fetch
 	fi
-	cd "${dir}"
 	echo "|-- Checking out ${version}"
 	git checkout "${version}" >> "${logfile}" 2>&1
 	status=$?

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -131,7 +131,7 @@ mkdir -p ${logdir}
 # The checkout version should always be a speciifc commit (hash or tag), not a branch
 errs=0
 checkout "ufs_model.fd"    "https://github.com/ufs-community/ufs-weather-model" "${ufs_model_hash:-Prototype-P8c}"; errs=$((errs + $?))
-checkout "gsi.fd"          "https://github.com/NOAA-EMC/GSI.git"                "1f6d3aa"                         ; errs=$((errs + $?))
+checkout "gsi.fd"          "https://github.com/NOAA-EMC/GSI.git"                "ad84f17"                         ; errs=$((errs + $?))
 checkout "gldas.fd"        "https://github.com/NOAA-EMC/GLDAS.git"              "e8b42da"                         ; errs=$((errs + $?))
 checkout "ufs_utils.fd"    "https://github.com/ufs-community/UFS_UTILS.git"     "a2b0817"                         ; errs=$((errs + $?))
 checkout "verif-global.fd" "https://github.com/NOAA-EMC/EMC_verif-global.git"   "c267780"                         ; errs=$((errs + $?))

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -131,13 +131,13 @@ mkdir -p ${logdir}
 # The checkout version should always be a speciifc commit (hash or tag), not a branch
 errs=0
 checkout "ufs_model.fd"    "https://github.com/ufs-community/ufs-weather-model" "${ufs_model_hash:-Prototype-P8c}"; errs=$((errs + $?))
-checkout "gsi.fd"          "https://github.com/NOAA-EMC/GSI.git"                "a62dec6"                         ; errs=$((errs + $?))
-checkout "gldas.fd"        "https://github.com/NOAA-EMC/GLDAS.git"              "gldas_gfsv16_release.v.1.28.0"   ; errs=$((errs + $?))
-checkout "ufs_utils.fd"    "https://github.com/ufs-community/UFS_UTILS.git"     "04ad17e"                         ; errs=$((errs + $?))
+checkout "gsi.fd"          "https://github.com/NOAA-EMC/GSI.git"                "1f6d3aa"                         ; errs=$((errs + $?))
+checkout "gldas.fd"        "https://github.com/NOAA-EMC/GLDAS.git"              "e8b42da"                         ; errs=$((errs + $?))
+checkout "ufs_utils.fd"    "https://github.com/ufs-community/UFS_UTILS.git"     "a2b0817"                         ; errs=$((errs + $?))
 checkout "verif-global.fd" "https://github.com/NOAA-EMC/EMC_verif-global.git"   "c267780"                         ; errs=$((errs + $?))
 
 if [[ "${checkout_wafs:-NO}" == "YES" ]]; then
-	checkout "gfs_wafs.fd" "https://github.com/NOAA-EMC/EMC_gfs_wafs.git" "c2a29a6"; errs=$((errs + $?))
+	checkout "gfs_wafs.fd" "https://github.com/NOAA-EMC/EMC_gfs_wafs.git" "014a0b8"; errs=$((errs + $?))
 fi
 
 if [[ "${checkout_gtg:-NO}" == "YES" ]]; then

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -72,6 +72,7 @@ function checkout() {
 		fi
 	else
 		# Fetch any updates from server
+		cd "${dir}"
 		echo "|-- Fetching updates from ${remote}"
 		git fetch
 	fi
@@ -132,7 +133,8 @@ mkdir -p ${logdir}
 errs=0
 checkout "ufs_model.fd"    "https://github.com/ufs-community/ufs-weather-model" "${ufs_model_hash:-Prototype-P8c}"; errs=$((errs + $?))
 checkout "gsi.fd"          "https://github.com/NOAA-EMC/GSI.git"                "ad84f17"                         ; errs=$((errs + $?))
-checkout "gldas.fd"        "https://github.com/NOAA-EMC/GLDAS.git"              "e8b42da"                         ; errs=$((errs + $?))
+checkout "gsi_monitor.fd"  "https://github.com/NOAA-EMC/GSI-Monitor.git"        "affeae9"                         ; errs=$((errs + $?))
+checkout "gldas.fd"        "https://github.com/NOAA-EMC/GLDAS.git"              "fd8ba62"                         ; errs=$((errs + $?))
 checkout "ufs_utils.fd"    "https://github.com/ufs-community/UFS_UTILS.git"     "a2b0817"                         ; errs=$((errs + $?))
 checkout "verif-global.fd" "https://github.com/NOAA-EMC/EMC_verif-global.git"   "c267780"                         ; errs=$((errs + $?))
 

--- a/sorc/gfs_build.cfg
+++ b/sorc/gfs_build.cfg
@@ -4,6 +4,7 @@
  Building ufs_model (ufs_model) ........................ yes
  Building ww3_prepost (ww3_prepost) .................... yes
  Building gsi (gsi) .................................... yes
+ Building gsi_monitor (gsi_monitor) .................... yes
  Building gldas (gldas) ................................ yes
  Building UPP (upp) .................................... yes
  Building ufs_utils (ufs_utils) ........................ yes

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -207,7 +207,6 @@ cd ${pwd}/../ush                ||exit 8
     $LINK ../sorc/gsi_monitor.fd/src/Minimization_Monitor/nwprod/minmon_shared/ush/minmon_xtrct_gnorms.pl           .
     $LINK ../sorc/gsi_monitor.fd/src/Minimization_Monitor/nwprod/minmon_shared/ush/minmon_xtrct_reduct.pl           .
     $LINK ../sorc/gsi_monitor.fd/src/Ozone_Monitor/nwprod/oznmon_shared/ush/ozn_xtrct.sh                            .
-    $LINK ../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_ck_stdout.sh                  .
     $LINK ../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_err_rpt.sh                    .
     $LINK ../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_verf_angle.sh                 .
     $LINK ../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_verf_bcoef.sh                 .

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -176,43 +176,43 @@ cd ${pwd}/../fix                ||exit 8
     [[ -d gdas ]] && rm -rf gdas
     mkdir -p gdas
     cd gdas
-    $LINK ../../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas/fix/gdas_minmon_cost.txt                   .
-    $LINK ../../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas/fix/gdas_minmon_gnorm.txt                  .
-    $LINK ../../sorc/gsi.fd/util/Ozone_Monitor/nwprod/gdas_oznmon/fix/gdas_oznmon_base.tar                   .
-    $LINK ../../sorc/gsi.fd/util/Ozone_Monitor/nwprod/gdas_oznmon/fix/gdas_oznmon_satype.txt                 .
-    $LINK ../../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/fix/gdas_radmon_base.tar                .
-    $LINK ../../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/fix/gdas_radmon_satype.txt              .
-    $LINK ../../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/fix/gdas_radmon_scaninfo.txt            .
+    $LINK ../../sorc/gsi_monitor.fd/src/Minimization_Monitor/nwprod/gdas/fix/gdas_minmon_cost.txt                   .
+    $LINK ../../sorc/gsi_monitor.fd/src/Minimization_Monitor/nwprod/gdas/fix/gdas_minmon_gnorm.txt                  .
+    $LINK ../../sorc/gsi_monitor.fd/src/Ozone_Monitor/nwprod/gdas_oznmon/fix/gdas_oznmon_base.tar                   .
+    $LINK ../../sorc/gsi_monitor.fd/src/Ozone_Monitor/nwprod/gdas_oznmon/fix/gdas_oznmon_satype.txt                 .
+    $LINK ../../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/gdas_radmon/fix/gdas_radmon_base.tar                .
+    $LINK ../../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/gdas_radmon/fix/gdas_radmon_satype.txt              .
+    $LINK ../../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/gdas_radmon/fix/gdas_radmon_scaninfo.txt            .
 cd ${pwd}/../jobs               ||exit 8
-    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas/jobs/JGDAS_ATMOS_VMINMON                      .
-    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gfs/jobs/JGFS_ATMOS_VMINMON                        .
-    $LINK ../sorc/gsi.fd/util/Ozone_Monitor/nwprod/gdas_oznmon/jobs/JGDAS_ATMOS_VERFOZN                      .
-    $LINK ../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/jobs/JGDAS_ATMOS_VERFRAD                   .
+    $LINK ../sorc/gsi_monitor.fd/src/Minimization_Monitor/nwprod/gdas/jobs/JGDAS_ATMOS_VMINMON                      .
+    $LINK ../sorc/gsi_monitor.fd/src/Minimization_Monitor/nwprod/gfs/jobs/JGFS_ATMOS_VMINMON                        .
+    $LINK ../sorc/gsi_monitor.fd/src/Ozone_Monitor/nwprod/gdas_oznmon/jobs/JGDAS_ATMOS_VERFOZN                      .
+    $LINK ../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/gdas_radmon/jobs/JGDAS_ATMOS_VERFRAD                   .
 cd ${pwd}/../parm               ||exit 8
     [[ -d mon ]] && rm -rf mon
     mkdir -p mon
     cd mon
-    $LINK ../../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/parm/gdas_radmon.parm                   da_mon.parm
-    # $LINK ../../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas/parm/gdas_minmon.parm                      .
-    # $LINK ../../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gfs/parm/gfs_minmon.parm                        .
-    $LINK ../../sorc/gsi.fd/util/Ozone_Monitor/nwprod/gdas_oznmon/parm/gdas_oznmon.parm                      .
-    # $LINK ../../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/parm/gdas_radmon.parm                   .
+    $LINK ../../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/gdas_radmon/parm/gdas_radmon.parm                   da_mon.parm
+    # $LINK ../../sorc/gsi_monitor.fd/src/Minimization_Monitor/nwprod/gdas/parm/gdas_minmon.parm                      .
+    # $LINK ../../sorc/gsi_monitor.fd/src/Minimization_Monitor/nwprod/gfs/parm/gfs_minmon.parm                        .
+    $LINK ../../sorc/gsi_monitor.fd/src/Ozone_Monitor/nwprod/gdas_oznmon/parm/gdas_oznmon.parm                      .
+    # $LINK ../../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/gdas_radmon/parm/gdas_radmon.parm                   .
 cd ${pwd}/../scripts            ||exit 8
-    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas/scripts/exgdas_atmos_vminmon.sh               .
-    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gfs/scripts/exgfs_atmos_vminmon.sh                 .
-    $LINK ../sorc/gsi.fd/util/Ozone_Monitor/nwprod/gdas_oznmon/scripts/exgdas_atmos_verfozn.sh               .
-    $LINK ../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/scripts/exgdas_atmos_verfrad.sh            .
+    $LINK ../sorc/gsi_monitor.fd/src/Minimization_Monitor/nwprod/gdas/scripts/exgdas_atmos_vminmon.sh               .
+    $LINK ../sorc/gsi_monitor.fd/src/Minimization_Monitor/nwprod/gfs/scripts/exgfs_atmos_vminmon.sh                 .
+    $LINK ../sorc/gsi_monitor.fd/src/Ozone_Monitor/nwprod/gdas_oznmon/scripts/exgdas_atmos_verfozn.sh               .
+    $LINK ../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/gdas_radmon/scripts/exgdas_atmos_verfrad.sh            .
 cd ${pwd}/../ush                ||exit 8
-    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/minmon_shared/ush/minmon_xtrct_costs.pl            .
-    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/minmon_shared/ush/minmon_xtrct_gnorms.pl           .
-    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/minmon_shared/ush/minmon_xtrct_reduct.pl           .
-    $LINK ../sorc/gsi.fd/util/Ozone_Monitor/nwprod/oznmon_shared/ush/ozn_xtrct.sh                            .
-    $LINK ../sorc/gsi.fd/util/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_ck_stdout.sh                  .
-    $LINK ../sorc/gsi.fd/util/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_err_rpt.sh                    .
-    $LINK ../sorc/gsi.fd/util/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_verf_angle.sh                 .
-    $LINK ../sorc/gsi.fd/util/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_verf_bcoef.sh                 .
-    $LINK ../sorc/gsi.fd/util/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_verf_bcor.sh                  .
-    $LINK ../sorc/gsi.fd/util/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_verf_time.sh                  .
+    $LINK ../sorc/gsi_monitor.fd/src/Minimization_Monitor/nwprod/minmon_shared/ush/minmon_xtrct_costs.pl            .
+    $LINK ../sorc/gsi_monitor.fd/src/Minimization_Monitor/nwprod/minmon_shared/ush/minmon_xtrct_gnorms.pl           .
+    $LINK ../sorc/gsi_monitor.fd/src/Minimization_Monitor/nwprod/minmon_shared/ush/minmon_xtrct_reduct.pl           .
+    $LINK ../sorc/gsi_monitor.fd/src/Ozone_Monitor/nwprod/oznmon_shared/ush/ozn_xtrct.sh                            .
+    $LINK ../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_ck_stdout.sh                  .
+    $LINK ../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_err_rpt.sh                    .
+    $LINK ../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_verf_angle.sh                 .
+    $LINK ../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_verf_bcoef.sh                 .
+    $LINK ../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_verf_bcor.sh                  .
+    $LINK ../sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_verf_time.sh                  .
     
 
 #------------------------------

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -259,11 +259,16 @@ done
 
 for gsiexe in  calc_analysis.x calc_increment_ens_ncio.x calc_increment_ens.x \
     getsfcensmeanp.x getsigensmeanp_smooth.x getsigensstatp.x enkf.x gsi.x \
-    interp_inc.x ncdiag_cat_serial.x oznmon_horiz.x oznmon_time.x radmon_angle.x \
-    radmon_bcoef.x radmon_bcor.x radmon_time.x recentersigp.x;do
+    interp_inc.x ncdiag_cat_serial.x recentersigp.x;do
     [[ -s $gsiexe ]] && rm -f $gsiexe
     $LINK ../sorc/gsi.fd/install/bin/$gsiexe .
 done
+
+for gsimonexe in oznmon_horiz.x oznmon_time.x radmon_angle.x \
+    radmon_bcoef.x radmon_bcor.x radmon_time.x; do
+    [[ -s $gsimonexe ]] && rm -f $gsimonexe
+    $LINK ../sorc/gsi_monitor.fd/install/bin/$gsimonexe .
+done 
 
 for gldasexe in gdas2gldas  gldas2gdas  gldas_forcing  gldas_model  gldas_post  gldas_rst; do
     [[ -s $gldasexe ]] && rm -f $gldasexe
@@ -306,22 +311,22 @@ cd ${pwd}/../sorc   ||   exit 8
     $SLINK gsi.fd/src/ncdiag                                                               ncdiag_cat.fd
 
     [[ -d oznmon_horiz.fd ]] && rm -rf oznmon_horiz.fd
-    $SLINK gsi.fd/util/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_horiz.fd             oznmon_horiz.fd
+    $SLINK gsi_monitor.fd/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_horiz.fd             oznmon_horiz.fd
 
     [[ -d oznmon_time.fd ]] && rm -rf oznmon_time.fd
-    $SLINK gsi.fd/util/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_time.fd              oznmon_time.fd
+    $SLINK gsi_monitor.fd/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_time.fd              oznmon_time.fd
 
     [[ -d radmon_angle.fd ]] && rm -rf radmon_angle.fd
-    $SLINK gsi.fd/util/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radang.fd           radmon_angle.fd
+    $SLINK gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radang.fd           radmon_angle.fd
 
     [[ -d radmon_bcoef.fd ]] && rm -rf radmon_bcoef.fd
-    $SLINK gsi.fd/util/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcoef.fd         radmon_bcoef.fd
+    $SLINK gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcoef.fd         radmon_bcoef.fd
 
     [[ -d radmon_bcor.fd ]] && rm -rf radmon_bcor.fd
-    $SLINK gsi.fd/util/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcor.fd          radmon_bcor.fd
+    $SLINK gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcor.fd          radmon_bcor.fd
 
     [[ -d radmon_time.fd ]] && rm -rf radmon_time.fd
-    $SLINK gsi.fd/util/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radtime.fd          radmon_time.fd
+    $SLINK gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radtime.fd          radmon_time.fd
 
     [[ -d recentersigp.fd ]] && rm -rf recentersigp.fd
     $SLINK gsi.fd/util/EnKF/gfs/src/recentersigp.fd                                        recentersigp.fd

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -259,7 +259,7 @@ done
 
 for gsiexe in  calc_analysis.x calc_increment_ens_ncio.x calc_increment_ens.x \
     getsfcensmeanp.x getsigensmeanp_smooth.x getsigensstatp.x enkf.x gsi.x \
-    interp_inc.x nc_diag_cat.x oznmon_horiz.x oznmon_time.x radmon_angle.x \
+    interp_inc.x ncdiag_cat_serial.x oznmon_horiz.x oznmon_time.x radmon_angle.x \
     radmon_bcoef.x radmon_bcor.x radmon_time.x recentersigp.x;do
     [[ -s $gsiexe ]] && rm -f $gsiexe
     $LINK ../sorc/gsi.fd/install/bin/$gsiexe .

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -97,7 +97,7 @@ cd ${pwd}/../parm/post          ||exit 8
         postxconfig-NT-GFS-GOES.txt postxconfig-NT-GFS-TWO.txt postxconfig-NT-GFS-WAFS-ANL.txt postxconfig-NT-GFS-WAFS.txt \
         postxconfig-NT-GFS.txt postxconfig-NT-gefs-aerosol.txt postxconfig-NT-gefs-chem.txt params_grib2_tbl_new \
         post_tag_gfs128 post_tag_gfs65 gtg.config.gfs gtg_imprintings.txt \
-        AEROSOL_LUTS.datoptics_luts_DUST.dat optics_luts_SALT.dat optics_luts_SOOT.dat optics_luts_SUSO.dat optics_luts_WASO.dat \
+        AEROSOL_LUTS.dat optics_luts_DUST.dat optics_luts_SALT.dat optics_luts_SOOT.dat optics_luts_SUSO.dat optics_luts_WASO.dat \
         ; do
         $LINK ../../sorc/upp.fd/parm/$file .
     done
@@ -176,16 +176,16 @@ cd ${pwd}/../fix                ||exit 8
     [[ -d gdas ]] && rm -rf gdas
     mkdir -p gdas
     cd gdas
-    $LINK ../../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas.v1.0.0/fix/gdas_minmon_cost.txt            .
-    $LINK ../../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas.v1.0.0/fix/gdas_minmon_gnorm.txt           .
+    $LINK ../../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas/fix/gdas_minmon_cost.txt                   .
+    $LINK ../../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas/fix/gdas_minmon_gnorm.txt                  .
     $LINK ../../sorc/gsi.fd/util/Ozone_Monitor/nwprod/gdas_oznmon/fix/gdas_oznmon_base.tar                   .
     $LINK ../../sorc/gsi.fd/util/Ozone_Monitor/nwprod/gdas_oznmon/fix/gdas_oznmon_satype.txt                 .
     $LINK ../../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/fix/gdas_radmon_base.tar                .
     $LINK ../../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/fix/gdas_radmon_satype.txt              .
     $LINK ../../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/fix/gdas_radmon_scaninfo.txt            .
 cd ${pwd}/../jobs               ||exit 8
-    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas.v1.0.0/jobs/JGDAS_ATMOS_VMINMON               .
-    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gfs.v1.0.0/jobs/JGFS_ATMOS_VMINMON                 .
+    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas/jobs/JGDAS_ATMOS_VMINMON                      .
+    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gfs/jobs/JGFS_ATMOS_VMINMON                        .
     $LINK ../sorc/gsi.fd/util/Ozone_Monitor/nwprod/gdas_oznmon/jobs/JGDAS_ATMOS_VERFOZN                      .
     $LINK ../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/jobs/JGDAS_ATMOS_VERFRAD                   .
 cd ${pwd}/../parm               ||exit 8
@@ -193,19 +193,19 @@ cd ${pwd}/../parm               ||exit 8
     mkdir -p mon
     cd mon
     $LINK ../../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/parm/gdas_radmon.parm                   da_mon.parm
-#   $LINK ../../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas.v1.0.0/parm/gdas_minmon.parm               .
-#   $LINK ../../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gfs.v1.0.0/parm/gfs_minmon.parm                 .
+    # $LINK ../../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas/parm/gdas_minmon.parm                      .
+    # $LINK ../../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gfs/parm/gfs_minmon.parm                        .
     $LINK ../../sorc/gsi.fd/util/Ozone_Monitor/nwprod/gdas_oznmon/parm/gdas_oznmon.parm                      .
-#   $LINK ../../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/parm/gdas_radmon.parm                   .
+    # $LINK ../../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/parm/gdas_radmon.parm                   .
 cd ${pwd}/../scripts            ||exit 8
-    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas.v1.0.0/scripts/exgdas_atmos_vminmon.sh        .
-    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gfs.v1.0.0/scripts/exgfs_atmos_vminmon.sh          .
+    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gdas/scripts/exgdas_atmos_vminmon.sh               .
+    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/gfs/scripts/exgfs_atmos_vminmon.sh                 .
     $LINK ../sorc/gsi.fd/util/Ozone_Monitor/nwprod/gdas_oznmon/scripts/exgdas_atmos_verfozn.sh               .
     $LINK ../sorc/gsi.fd/util/Radiance_Monitor/nwprod/gdas_radmon/scripts/exgdas_atmos_verfrad.sh            .
 cd ${pwd}/../ush                ||exit 8
-    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/minmon_shared.v1.0.1/ush/minmon_xtrct_costs.pl     .
-    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/minmon_shared.v1.0.1/ush/minmon_xtrct_gnorms.pl    .
-    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/minmon_shared.v1.0.1/ush/minmon_xtrct_reduct.pl    .
+    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/minmon_shared/ush/minmon_xtrct_costs.pl            .
+    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/minmon_shared/ush/minmon_xtrct_gnorms.pl           .
+    $LINK ../sorc/gsi.fd/util/Minimization_Monitor/nwprod/minmon_shared/ush/minmon_xtrct_reduct.pl           .
     $LINK ../sorc/gsi.fd/util/Ozone_Monitor/nwprod/oznmon_shared/ush/ozn_xtrct.sh                            .
     $LINK ../sorc/gsi.fd/util/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_ck_stdout.sh                  .
     $LINK ../sorc/gsi.fd/util/Radiance_Monitor/nwprod/radmon_shared/ush/radmon_err_rpt.sh                    .
@@ -258,11 +258,11 @@ for ufs_utilsexe in \
 done
 
 for gsiexe in  calc_analysis.x calc_increment_ens_ncio.x calc_increment_ens.x \
-    getsfcensmeanp.x getsigensmeanp_smooth.x getsigensstatp.x global_enkf.x global_gsi.x \
-    interp_inc.x ncdiag_cat.x oznmon_horiz.x oznmon_time.x radmon_angle.x \
+    getsfcensmeanp.x getsigensmeanp_smooth.x getsigensstatp.x enkf.x gsi.x \
+    interp_inc.x nc_diag_cat.x oznmon_horiz.x oznmon_time.x radmon_angle.x \
     radmon_bcoef.x radmon_bcor.x radmon_time.x recentersigp.x;do
     [[ -s $gsiexe ]] && rm -f $gsiexe
-    $LINK ../sorc/gsi.fd/exec/$gsiexe .
+    $LINK ../sorc/gsi.fd/install/bin/$gsiexe .
 done
 
 for gldasexe in gdas2gldas  gldas2gdas  gldas_forcing  gldas_model  gldas_post  gldas_rst; do

--- a/sorc/partial_build.sh
+++ b/sorc/partial_build.sh
@@ -5,6 +5,7 @@
 declare -a Build_prg=("Build_ufs_model" \
                       "Build_ww3_prepost" \
                       "Build_gsi" \
+                      "Build_gsi_monitor" \
                       "Build_ww3_prepost" \
                       "Build_reg2grb2" \
                       "Build_gldas" \


### PR DESCRIPTION
**Description**
Updates the version of components except UFS and verify to the current tip of their respective develop branches.
    
Verify is not yet updated because we are currently on a branch that hasn't been merged to develop yet in order to use the module/py environment fix.
    
GSI will still need to be updated further before use after the resolution of NOAA-EMC/GSI/issues/348

Also updated the GSI and UPP build scripts to take in debug (`-d`), operations (`-o`), and verbose (`-v`) options and apply them as appropriate to the component build scripts. The ops flag for GSI still needs work, as I encountered issues using the [build_4nco_global.sh](https://github.com/NOAA-EMC/GSI/blob/develop/ush/build_4nco_global.sh) or [prune_4nco_global.sh](https://github.com/NOAA-EMC/GSI/blob/develop/ush/prune_4nco_global.sh) scripts.

Also fixes a typo in the `parm/post` file list.

Updates are in preparation for the [COM reorg](https://github.com/NOAA-EMC/global-workflow/issues/761)

**Type of change**
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
- [x] Clone and Build tests on Hera
- [x] Clone and Build tests on Orion
- [x] Clone and Build tests on Dell
- [x] Forecast-only test on Hera
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
