### PR TITLE
Update GLDAS tag to gldas_gfsv16_release.v.2.1.0

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -15,7 +15,7 @@ protocol = git
 required = True
 
 [GLDAS]
-tag = gldas_gfsv16_release.v.2.0.0
+tag = gldas_gfsv16_release.v.2.1.0
 local_path = sorc/gldas.fd
 repo_url = https://github.com/NOAA-EMC/GLDAS.git
 protocol = git

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -46,7 +46,7 @@ fi
 echo gldas checkout ...
 if [[ ! -d gldas.fd ]] ; then
     rm -f ${topdir}/checkout-gldas.log
-    git clone --branch gldas_gfsv16_release.v.2.0.0 https://github.com/NOAA-EMC/GLDAS  gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
+    git clone --branch gldas_gfsv16_release.v.2.1.0 https://github.com/NOAA-EMC/GLDAS  gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory gldas.fd already exists.'


### PR DESCRIPTION
**Description**

This PR updates the GLDAS tag to `gldas_gfsv16_release.v.2.1.0`. This new GLDAS tag includes:
- updates for hpc-stack-gfsv16 modules on Hera/Orion
- adding the "atmos" subfolder to the PRCP CPC gauge GDA path

There are no other changes in this tag compared to the current WCOSS2 prod install version (`gldas_gfsv16_release.v.2.0.0`).

**Type of change**

Maintenance related to updates outside of GLDAS and support for GFSv16.2.0 on Hera/Orion.

**How Has This Been Tested?**

- [ ] Clone and build tests on WCOSS2, Hera, and Orion
- [ ] Cycled test on WCOSS2

Updated tag gets PRCP CPC gauge files from the new WCOSS2 GDA correctly (uses `atmos` subfolder in path).
  
Refs: #665, #802
