### PR TITLE
Replace --aerosols with new apps

### DIFF
--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -174,35 +174,27 @@ case "${APP}" in
     export WAVE_CDUMP="both"
     export confignamevarfornems="leapfrog_atm_wav"
     ;;
-  S2S)
+  S2S*)
     export DO_COUPLED="YES"
     export DO_OCN="YES"
     export DO_ICE="YES"
     export CCPP_SUITE="FV3_GFS_v17_coupled_p8"
     export confignamevarfornems="cpld"
-    ;;
-  S2SW)
-    export DO_COUPLED="YES"
-    export DO_WAVE="YES"
-    export DO_OCN="YES"
-    export DO_ICE="YES"
-    export CCPP_SUITE="FV3_GFS_v17_coupled_p8"
-    export WAVE_CDUMP="both"
-    export cplwav2atm=".true."
-    export confignamevarfornems="cpld_wave"
+
+    if [[ $APP =~ 'A$' ]]; then
+        export DO_AERO="YES"
+        export confignamevarfornems="${confignamevarfornems}_aero"
+    fi
+
+    if [[ $APP =~ '^S2SW' ]]; then
+        export DO_WAVE="YES"
+        export WAVE_CDUMP="both"    
+        export cplwav2atm=".true."
+        export confignamevarfornems="${confignamevarfornems}_wave"
+    fi
+
     source $EXPDIR/config.defaults.s2sw
-    ;;
-  S2SWA)
-    export DO_COUPLED="YES"
-    export DO_WAVE="YES"
-    export DO_OCN="YES"
-    export DO_ICE="YES"
-    export DO_AERO="YES"
-    export CCPP_SUITE="FV3_GFS_v17_coupled_p8"
-    export WAVE_CDUMP="both"
-    export cplwav2atm=".true."
-    export confignamevarfornems="cpld_aero_wave"
-    source $EXPDIR/config.defaults.s2sw
+
     ;;
   *)
     echo "Unrecognized APP: ${1}"

--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -181,12 +181,12 @@ case "${APP}" in
     export CCPP_SUITE="FV3_GFS_v17_coupled_p8"
     export confignamevarfornems="cpld"
 
-    if [[ $APP =~ 'A$' ]]; then
+    if [[ "$APP" =~ A$ ]]; then
         export DO_AERO="YES"
         export confignamevarfornems="${confignamevarfornems}_aero"
     fi
 
-    if [[ $APP =~ '^S2SW' ]]; then
+    if [[ "$APP" =~ ^S2SW ]]; then
         export DO_WAVE="YES"
         export WAVE_CDUMP="both"    
         export cplwav2atm=".true."

--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -1,4 +1,4 @@
-#!/bin/ksh -x
+#!/bin/bash -x
 
 ########## config.base ##########
 # Common to all steps
@@ -63,8 +63,8 @@ export DO_VRFY="YES"       # VRFY step
 #  use RUNMOS flag (currently in config.vrfy)
 export REALTIME="YES"
 
-# Experiment mode (cycled or free-forecast)
-export MODE="@MODE@" # cycled/free
+# Experiment mode (cycled or forecast-only)
+export MODE="@MODE@" # cycled/forecast-only
 
 ####################################################
 # DO NOT ADD MACHINE DEPENDENT STUFF BELOW THIS LINE
@@ -154,35 +154,32 @@ export DO_COUPLED="NO"
 export DO_WAVE="NO"
 export DO_OCN="NO"
 export DO_ICE="NO"
-export DO_AERO=@DO_AERO@
+export DO_AERO="NO"
 export CCPP_SUITE="FV3_GFS_v17_p8"
 export WAVE_CDUMP="" # When to include wave suite: gdas, gfs, or both
 export cplwav2atm=".false."
 
-aero_nems_string=""
-if [[ $DO_AERO = "YES" ]]; then
-    aero_nems_string="_aero"
-else
-    aero_nems_string=""
-fi
-
 case "${APP}" in
   ATM)
     echo "APP=ATM; will use defaults"
-    export confignamevarfornems="atm${aero_nems_string}"
+    export confignamevarfornems="atm"
+    ;;
+  ATMA)
+    export DO_AERO="YES"
+    export confignamevarfornems="atm_aero"
     ;;
   ATMW)
     export DO_COUPLED="YES"
     export DO_WAVE="YES"
     export WAVE_CDUMP="both"
-    export confignamevarfornems="leapfrog_atm${aero_nems_string}_wav"
+    export confignamevarfornems="leapfrog_atm_wav"
     ;;
   S2S)
     export DO_COUPLED="YES"
     export DO_OCN="YES"
     export DO_ICE="YES"
     export CCPP_SUITE="FV3_GFS_v17_coupled_p8"
-    export confignamevarfornems="cpld${aero_nems_string}"
+    export confignamevarfornems="cpld"
     ;;
   S2SW)
     export DO_COUPLED="YES"
@@ -192,7 +189,19 @@ case "${APP}" in
     export CCPP_SUITE="FV3_GFS_v17_coupled_p8"
     export WAVE_CDUMP="both"
     export cplwav2atm=".true."
-    export confignamevarfornems="cpld${aero_nems_string}_wave"
+    export confignamevarfornems="cpld_wave"
+    source $EXPDIR/config.defaults.s2sw
+    ;;
+  S2SWA)
+    export DO_COUPLED="YES"
+    export DO_WAVE="YES"
+    export DO_OCN="YES"
+    export DO_ICE="YES"
+    export DO_AERO="YES"
+    export CCPP_SUITE="FV3_GFS_v17_coupled_p8"
+    export WAVE_CDUMP="both"
+    export cplwav2atm=".true."
+    export confignamevarfornems="cpld_aero_wave"
     source $EXPDIR/config.defaults.s2sw
     ;;
   *)

--- a/ush/rocoto/setup_expt.py
+++ b/ush/rocoto/setup_expt.py
@@ -152,11 +152,7 @@ def edit_baseconfig(host, inputs):
             "@CASEENS@": f'C{inputs.resens}',
             "@NMEM_ENKF@": inputs.nens,
         }
-    elif inputs.mode in ['forecast-only']:
-        extend_dict = {
-            "@DO_AERO@": inputs.aerosols,
-        }
-    tmpl_dict = dict(tmpl_dict, **extend_dict)
+        tmpl_dict = dict(tmpl_dict, **extend_dict)
 
     # Open and read the templated config.base.emc.dyn
     base_tmpl = f'{inputs.configdir}/config.base.emc.dyn'
@@ -240,9 +236,7 @@ def input_args():
 
     # forecast only mode additional arguments
     forecasts.add_argument('--app', help='UFS application', type=str, choices=[
-        'ATM', 'ATMW', 'S2S', 'S2SW'], required=False, default='ATM')
-    forecasts.add_argument('--aerosols', help="Run with coupled aerosols", required=False,
-                           action='store_const', const="YES", default="NO")
+        'ATM', 'ATMA', 'ATMW', 'S2S', 'S2SW', 'S2SWA'], required=False, default='ATM')
 
     args = parser.parse_args()
 

--- a/ush/rocoto/setup_workflow_fcstonly.py
+++ b/ush/rocoto/setup_workflow_fcstonly.py
@@ -257,7 +257,7 @@ def get_workflow(dict_configs, cdump='gdas'):
 
     tasks = []
 
-    if app[0:3] in ['S2S']:
+    if 'S2S' in app:
         # Copy prototype ICs
         deps = []
         base_cplic = dict_configs['coupled_ic']['BASE_CPLIC']
@@ -357,7 +357,7 @@ def get_workflow(dict_configs, cdump='gdas'):
         deps = []
         dep_dict = {'type': 'task', 'name': f'{cdump}waveinit'}
         deps.append(rocoto.add_dependency(dep_dict))
-        if app[0:3] not in ['S2S']:
+        if 'S2S' not in app:
             dep_dict = {'type': 'task', 'name': f'{cdump}init'}
             deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)

--- a/ush/rocoto/setup_workflow_fcstonly.py
+++ b/ush/rocoto/setup_workflow_fcstonly.py
@@ -257,7 +257,7 @@ def get_workflow(dict_configs, cdump='gdas'):
 
     tasks = []
 
-    if app in ['S2S', 'S2SW']:
+    if app[0:3] in ['S2S']:
         # Copy prototype ICs
         deps = []
         base_cplic = dict_configs['coupled_ic']['BASE_CPLIC']
@@ -357,7 +357,7 @@ def get_workflow(dict_configs, cdump='gdas'):
         deps = []
         dep_dict = {'type': 'task', 'name': f'{cdump}waveinit'}
         deps.append(rocoto.add_dependency(dep_dict))
-        if app not in ['S2S', 'S2SW']:
+        if app[0:3] not in ['S2S']:
             dep_dict = {'type': 'task', 'name': f'{cdump}init'}
             deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)


### PR DESCRIPTION
**Description**
Removes the `--aerosols` option for setup_expt and replaces it with new apps for aerosols to match the idiom for other components. Currently, ATMA and S2SWA are supported.

**Type of change**
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**How Has This Been Tested?**
- [x] Run experiment and workflow setup on Hera
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
