### PR TITLE
Fit2Obs workflow-side updates and new `newm.1.5` tag

### DIFF
--- a/jobs/rocoto/vrfy.sh
+++ b/jobs/rocoto/vrfy.sh
@@ -87,8 +87,14 @@ if [ $VRFYFITS = "YES" -a $CDUMP = $CDFNL -a $CDATE != $SDATE ]; then
     export TMPDIR="$RUNDIR/$CDATE/$CDUMP"
     [[ ! -d $TMPDIR ]] && mkdir -p $TMPDIR
 
-    xdate=$($NDATE -${VBACKUP_FITS} $CDATE)
+    export xdate=$($NDATE -${VBACKUP_FITS} $CDATE)
 
+    export vday=$(echo $xdate | cut -c1-8)
+    export vcyc=$(echo $xdate | cut -c9-10)
+    export COMDAY=$ROTDIR/logs/$xdate
+    export COM_INA=$ROTDIR/gdas.$vday/$vcyc/atmos
+    export COM_INF='$ROTDIR/vrfyarch/gfs.$fdy/$fzz'
+    export COM_PRP='$ROTDIR/gdas.$pdy/$cyc/atmos'
 
     export RUN_ENVIR_SAVE=$RUN_ENVIR
     export RUN_ENVIR=$OUTPUT_FILE

--- a/parm/config/config.vrfy
+++ b/parm/config/config.vrfy
@@ -40,8 +40,10 @@ if [ $VRFYFITS = "YES" ]; then
     export CUE2RUN=$QUEUE
 
     export VBACKUP_FITS=24
+    export RUN_ENVIR=netcdf
+    export CONVNETC="YES"
+    export ACPROFit="YES"
 
-    export CONVNETC="NO"
     if [ ${netcdf_diag:-".false."} = ".true." ]; then
         export CONVNETC="YES"
     fi
@@ -51,9 +53,9 @@ if [ $VRFYFITS = "YES" ]; then
     elif [ $machine = "WCOSS_DELL_P3" ]; then
         export PREPQFITSH="$fitdir/subfits_dell_nems"
     elif [ $machine = "HERA" ]; then
-        export PREPQFITSH="$fitdir/subfits_hera_slurm"
+        export PREPQFITSH="$fitdir/subfits_hera"
     elif [ $machine = "ORION" ]; then
-        export PREPQFITSH="$fitdir/subfits_orion_netcdf"
+        export PREPQFITSH="$fitdir/subfits_orion"
     else
         echo "Fit2Obs NOT supported on this machine"
     fi

--- a/versions/hera.ver
+++ b/versions/hera.ver
@@ -16,4 +16,4 @@ export gempak_ver=7.4.2
 export wrf_io_ver=1.2.0
 
 export tracker_ver=v1.1.15.5
-export fit_ver="newm.1.4"
+export fit_ver="newm.1.5"

--- a/versions/orion.ver
+++ b/versions/orion.ver
@@ -14,4 +14,4 @@ export esmf_ver=8_0_1
 export nco_ver=4.9.3
 
 export tracker_ver=v1.1.15.5
-export fit_ver="newm.1.4"
+export fit_ver="newm.1.5"

--- a/versions/wcoss2.ver
+++ b/versions/wcoss2.ver
@@ -6,4 +6,4 @@ export obsproc_run_ver=1.0.0-rd
 export prepobs_run_ver=1.0.0-rd
 
 export tracker_ver=v1.1.15.5
-export fit_ver="newm.1.4"
+export fit_ver="newm.1.5"


### PR DESCRIPTION
**Description**

This PR updates the vrfy job settings for Fit2Obs related to an updated version:

- Update `fit_ver` to the new `newm.1.5` tag provided by @jack-woollen . Installed on WCOSS2, Hera, and Orion.
- Add variable settings to Fit2Obs section of `jobs/rocoto/vrfy.sh` that used to live in Fit2Obs scripts but now need to be set on workflow side.
- Similar to updates to `vrfy.sh`, add `RUN_ENVIR`, `CONVNETC`, and `ACPROFit` variables to `config.vrfy` so users can control them.
- Update Hera and Orion `PREPQFITSH` script names.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

- [x] Cycled test on WCOSS2
- [x] Cycled test on Hera
- [x] Tested by @jack-woollen on Orion with a comrot of @lgannoaa 
  
Refs #665

Will sync merge this update into the `release/gfs.v16.3.0` after this goes in.