### PR TITLE
Resource adjustments and updated obsproc/prepobs packages for tcvitals bug fix

### DIFF
--- a/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
+++ b/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:06:00
-#PBS -l select=1:mpiprocs=80:ompthreads=1:ncpus=80:mem=60GB
+#PBS -l select=1:mpiprocs=80:ompthreads=1:ncpus=80:mem=80GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak.ecf
+++ b/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l select=1:ncpus=2:mpiprocs=2:mem=4GB
+#PBS -l select=1:ncpus=2:mpiprocs=2:mem=20GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak_meta_ncdc.ecf
+++ b/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak_meta_ncdc.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l select=1:ncpus=1:mem=1GB
+#PBS -l select=1:ncpus=1:mem=20GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
-#PBS -l select=1:ncpus=28:mpiprocs=28:mem=2GB
+#PBS -l select=1:ncpus=28:mpiprocs=28:mem=200GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_meta.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_meta.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
-#PBS -l select=1:ncpus=23:mpiprocs=23:mem=2GB
+#PBS -l select=1:ncpus=23:mpiprocs=23:mem=200GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l select=1:ncpus=1:mem=3GB
+#PBS -l select=1:ncpus=1:mem=10GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l select=1:ncpus=1:mem=3GB
+#PBS -l select=1:ncpus=1:mem=10GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
+#PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=5GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=5GB
+#PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=60GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2_0p25.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2_0p25.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
+#PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=10GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
+#PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=5GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/wave/gempak/jgfs_wave_gempak.ecf
+++ b/ecf/scripts/gfs/wave/gempak/jgfs_wave_gempak.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
-#PBS -l select=1:ncpus=1:mem=1GB
+#PBS -l select=1:ncpus=1:mem=10GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_postsbs.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_postsbs.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
-#PBS -l select=1:mpiprocs=8:ompthreads=1:ncpus=8:mem=10GB
+#PBS -l select=1:mpiprocs=8:ompthreads=1:ncpus=8:mem=40GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
+++ b/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l select=1:mpiprocs=65:ompthreads=1:ncpus=65:mem=150GB
+#PBS -l select=1:mpiprocs=65:ompthreads=1:ncpus=65:mem=200GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/parm/config/config.fv3.emc.dyn
+++ b/parm/config/config.fv3.emc.dyn
@@ -116,7 +116,7 @@ case $case_in in
         export DELTIM=150
         export layout_x=8
         export layout_y=12
-        export layout_x_gfs=16
+        export layout_x_gfs=12
         export layout_y_gfs=24
         export npe_wav=140
         export npe_wav_gfs=448
@@ -127,7 +127,7 @@ case $case_in in
         export WRTTASK_PER_GROUP=64
         if [[ "$WRTTASK_PER_GROUP" -gt "$npe_node_max" ]]; then export WRTTASK_PER_GROUP=$npe_node_max ; fi
         export WRITE_GROUP_GFS=8
-        export WRTTASK_PER_GROUP_GFS=48
+        export WRTTASK_PER_GROUP_GFS=64
         if [[ "$WRTTASK_PER_GROUP_GFS" -gt "$npe_node_max" ]]; then export WRTTASK_PER_GROUP_GFS=$npe_node_max ; fi
         export WRTIOBUF="32M"
         ;;

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -64,7 +64,8 @@ elif [ $step = "waveprep" ]; then
     export nth_waveprep=1
     export npe_node_waveprep=$npe_waveprep
     export npe_node_waveprep_gfs=$npe_waveprep_gfs
-    export memory_waveprep="200GB"
+    export memory_waveprep="100GB"
+    export memory_waveprep_gfs="200GB"
     export NTASKS=$npe_waveprep
     export NTASKS_gfs=$npe_waveprep_gfs
 
@@ -110,7 +111,7 @@ elif [ $step = "wavegempak" ]; then
     export nth_wavegempak=1
     export npe_node_wavegempak=$npe_wavegempak
     export NTASKS=$npe_wavegempak
-    export memory_wavegempak="1GB"
+    export memory_wavegempak="10GB"
 
 elif [ $step = "waveawipsbulls" ]; then
 

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -43,7 +43,9 @@ if [ $step = "prep" -o $step = "prepbufr" ]; then
     eval "export npe_$step=4"
     eval "export npe_node_$step=2"
     eval "export nth_$step=1"
-    eval "export memory_$step=40G"
+    if [[ "$machine" != "WCOSS2" ]]; then
+      eval "export memory_$step=40G"
+    fi
 
 elif [ $step = "waveinit" ]; then
 
@@ -62,7 +64,7 @@ elif [ $step = "waveprep" ]; then
     export nth_waveprep=1
     export npe_node_waveprep=$npe_waveprep
     export npe_node_waveprep_gfs=$npe_waveprep_gfs
-    export memory_waveprep="150GB"
+    export memory_waveprep="200GB"
     export NTASKS=$npe_waveprep
     export NTASKS_gfs=$npe_waveprep_gfs
 
@@ -74,7 +76,7 @@ elif [ $step = "wavepostsbs" ]; then
     export nth_wavepostsbs=1
     export npe_node_wavepostsbs=$npe_wavepostsbs
     export memory_wavepostsbs="10GB"
-    export memory_wavepostsbs_gfs="10GB"
+    export memory_wavepostsbs_gfs="40GB"
     export NTASKS=$npe_wavepostsbs
 
 elif [ $step = "wavepostbndpnt" ]; then
@@ -192,15 +194,16 @@ elif [ $step = "fcst" ]; then
     export npe_node_fcst=$(echo "$npe_node_max / $nth_fcst" | bc)
     export npe_node_fcst_gfs=$(echo "$npe_node_max / $nth_fcst_gfs" | bc)
     if [[ "$machine" == "WCOSS2" ]]; then
+       export wtime_fcst_gfs="02:30:00"
        export npe_node_fcst=32
-       export npe_node_fcst_gfs=42
+       export npe_node_fcst_gfs=24
     fi
 
 elif [ $step = "post" ]; then
 
     export wtime_post="00:12:00"
     export wtime_post_gfs="01:00:00"
-    export npe_post=112
+    export npe_post=126
     export nth_post=1
     export npe_node_post=$npe_post
     export npe_node_post_gfs=$npe_post
@@ -215,7 +218,7 @@ elif [ $step = "wafs" ]; then
     export npe_wafs=1
     export npe_node_wafs=1
     export nth_wafs=1
-    export memory_wafs="1GB"
+    export memory_wafs="5GB"
 
 elif [ $step = "wafsgcip" ]; then
 
@@ -231,7 +234,7 @@ elif [ $step = "wafsgrib2" ]; then
     export npe_wafsgrib2=1
     export npe_node_wafsgrib2=1
     export nth_wafsgrib2=1
-    export memory_wafsgrib2="5GB"
+    export memory_wafsgrib2="60GB"
 
 elif [ $step = "wafsblending" ]; then
 
@@ -247,7 +250,7 @@ elif [ $step = "wafsgrib20p25" ]; then
     export npe_wafsgrib20p25=1
     export npe_node_wafsgrib20p25=1
     export nth_wafsgrib20p25=1
-    export memory_wafsgrib20p25="1GB"
+    export memory_wafsgrib20p25="10GB"
 
 elif [ $step = "wafsblending0p25" ]; then
 
@@ -255,7 +258,7 @@ elif [ $step = "wafsblending0p25" ]; then
     export npe_wafsblending0p25=1
     export npe_node_wafsblending0p25=1
     export nth_wafsblending0p25=1
-    export memory_wafsblending0p25="1GB"
+    export memory_wafsblending0p25="5GB"
 
 elif [ $step = "vrfy" ]; then
 
@@ -298,7 +301,7 @@ elif [ $step = "arch" -o $step = "earc" -o $step = "getic" ]; then
     eval "export npe_$step=1"
     eval "export npe_node_$step=1"
     eval "export nth_$step=1"
-    eval "export memory_$step=2048M"
+    eval "export memory_$step=50GB"
 
 elif [ $step = "eobs" -o $step = "eomg" ]; then
 
@@ -340,6 +343,9 @@ elif [ $step = "eupd" ]; then
       if [[ "$machine" = "WCOSS_DELL_P3" ]]; then
 	export npe_eupd=960
         export nth_eupd=7
+      elif [[ "$machine" = "WCOSS2" ]]; then
+        export npe_eupd=315
+        export nth_eupd=14
       fi
     elif [ $CASE = "C384" ]; then
       export npe_eupd=270
@@ -376,7 +382,7 @@ elif [ $step = "esfc" ]; then
     export nth_esfc=1
     export nth_cycle=$nth_esfc
     export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
-    export memory_esfc="40GB"
+    export memory_esfc="80GB"
 
 elif [ $step = "efcs" ]; then
 
@@ -413,7 +419,7 @@ elif [ $step = "awips" ]; then
     export npe_awips=1
     export npe_node_awips=1
     export nth_awips=1
-    export memory_awips="3GB"
+    export memory_awips="10GB"
     if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
         export npe_awips=2
         export npe_node_awips=2
@@ -428,8 +434,8 @@ elif [ $step = "gempak" ]; then
     export npe_node_gempak=2
     export npe_node_gempak_gfs=28
     export nth_gempak=1
-    export memory_gempak="4GB"
-    export memory_gempak_gfs="2GB"
+    export memory_gempak="20GB"
+    export memory_gempak_gfs="200GB"
 
 else
 

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -195,7 +195,6 @@ elif [ $step = "fcst" ]; then
     export npe_node_fcst=$(echo "$npe_node_max / $nth_fcst" | bc)
     export npe_node_fcst_gfs=$(echo "$npe_node_max / $nth_fcst_gfs" | bc)
     if [[ "$machine" == "WCOSS2" ]]; then
-       export wtime_fcst_gfs="02:30:00"
        export npe_node_fcst=32
        export npe_node_fcst_gfs=24
     fi

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -194,7 +194,7 @@ elif [ $step = "fcst" ]; then
     export nth_fcst_gfs=${nth_fv3_gfs:-2}
     export npe_node_fcst=$(echo "$npe_node_max / $nth_fcst" | bc)
     export npe_node_fcst_gfs=$(echo "$npe_node_max / $nth_fcst_gfs" | bc)
-    if [[ "$machine" == "WCOSS2" ]]; then
+    if [[ "$machine" == "WCOSS2" && "$CASE" = "C768" ]]; then
        export npe_node_fcst=32
        export npe_node_fcst_gfs=24
     fi

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -48,7 +48,7 @@ elif [ $step = "waveprep" ]; then
     export nth_waveprep=1
     export npe_node_waveprep=$npe_waveprep
     export npe_node_waveprep_gfs=$npe_waveprep_gfs
-    export memory_waveprep="150GB"
+    export memory_waveprep="200GB"
     export NTASKS=$npe_waveprep
     export NTASKS_gfs=$npe_waveprep_gfs
 
@@ -60,7 +60,7 @@ elif [ $step = "wavepostsbs" ]; then
     export nth_wavepostsbs=1
     export npe_node_wavepostsbs=$npe_wavepostsbs
     export memory_wavepostsbs="10GB"
-    export memory_wavepostsbs_gfs="10GB"
+    export memory_wavepostsbs_gfs="40GB"
     export NTASKS=$npe_wavepostsbs
 
 elif [ $step = "wavepostbndpnt" ]; then
@@ -179,7 +179,7 @@ elif [ $step = "wafs" ]; then
     export npe_wafs=1
     export npe_node_wafs=1
     export nth_wafs=1
-    export memory_wafs="1GB"
+    export memory_wafs="5GB"
 
 elif [ $step = "wafsgcip" ]; then
 
@@ -195,7 +195,7 @@ elif [ $step = "wafsgrib2" ]; then
     export npe_wafsgrib2=1
     export npe_node_wafsgrib2=1
     export nth_wafsgrib2=1
-    export memory_wafsgrib2="5GB"
+    export memory_wafsgrib2="60GB"
 
 elif [ $step = "wafsblending" ]; then
 
@@ -211,7 +211,7 @@ elif [ $step = "wafsgrib20p25" ]; then
     export npe_wafsgrib20p25=1
     export npe_node_wafsgrib20p25=1
     export nth_wafsgrib20p25=1
-    export memory_wafsgrib20p25="1GB"
+    export memory_wafsgrib20p25="10GB"
 
 elif [ $step = "wafsblending0p25" ]; then
 
@@ -219,7 +219,7 @@ elif [ $step = "wafsblending0p25" ]; then
     export npe_wafsblending0p25=1
     export npe_node_wafsblending0p25=1
     export nth_wafsblending0p25=1
-    export memory_wafsblending0p25="1GB"
+    export memory_wafsblending0p25="5GB"
 
 elif [ $step = "vrfy" ]; then
 
@@ -255,7 +255,7 @@ elif [ $step = "arch" -o $step = "earc" -o $step = "getic" ]; then
     eval "export npe_$step=1"
     eval "export npe_node_$step=1"
     eval "export nth_$step=1"
-    eval "export memory_$step=2048M"
+    eval "export memory_$step=50GB"
 
 elif [ $step = "eobs" -o $step = "eomg" ]; then
 
@@ -298,7 +298,7 @@ elif [ $step = "esfc" ]; then
     export nth_esfc=1
     export nth_cycle=$nth_esfc
     export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
-    export memory_esfc="40GB"
+    export memory_esfc="80GB"
 
 elif [ $step = "efcs" ]; then
 
@@ -329,7 +329,7 @@ elif [ $step = "awips" ]; then
     export npe_awips=1
     export npe_node_awips=1
     export nth_awips=1
-    export memory_awips="3GB"
+    export memory_awips="10GB"
 
 elif [ $step = "gempak" ]; then
 
@@ -339,8 +339,8 @@ elif [ $step = "gempak" ]; then
     export npe_node_gempak=2
     export npe_node_gempak_gfs=28
     export nth_gempak=1
-    export memory_gempak="4GB"
-    export memory_gempak_gfs="2GB"
+    export memory_gempak="20GB"
+    export memory_gempak_gfs="200GB"
 
 else
 

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -48,7 +48,8 @@ elif [ $step = "waveprep" ]; then
     export nth_waveprep=1
     export npe_node_waveprep=$npe_waveprep
     export npe_node_waveprep_gfs=$npe_waveprep_gfs
-    export memory_waveprep="200GB"
+    export memory_waveprep="100GB"
+    export memory_waveprep_gfs="200GB"
     export NTASKS=$npe_waveprep
     export NTASKS_gfs=$npe_waveprep_gfs
 
@@ -94,7 +95,7 @@ elif [ $step = "wavegempak" ]; then
     export nth_wavegempak=1
     export npe_node_wavegempak=$npe_wavegempak
     export NTASKS=$npe_wavegempak
-    export memory_wavegempak="1GB"
+    export memory_wavegempak="10GB"
 
 elif [ $step = "waveawipsbulls" ]; then
 

--- a/versions/hera.ver
+++ b/versions/hera.ver
@@ -2,8 +2,8 @@ export hpc_ver=1.2.0
 export hpc_intel_ver=18.0.5.274
 export hpc_impi_ver=2018.0.4
 
-export obsproc_run_ver=1.0.0-rd
-export prepobs_run_ver=1.0.0-rd
+export obsproc_run_ver=1.0.2-rd
+export prepobs_run_ver=1.0.1-rd
 
 export hpss_ver=hpss
 export prod_util_ver=1.2.2

--- a/versions/orion.ver
+++ b/versions/orion.ver
@@ -2,8 +2,8 @@ export hpc_ver=1.2.0
 export hpc_intel_ver=2018.4
 export hpc_impi_ver=2018.4
 
-export obsproc_run_ver=1.0.0-rd
-export prepobs_run_ver=1.0.0-rd
+export obsproc_run_ver=1.0.2-rd
+export prepobs_run_ver=1.0.1-rd
 
 export prod_util_ver=1.2.2
 export cmake_ver=3.22.1

--- a/versions/wcoss2.ver
+++ b/versions/wcoss2.ver
@@ -2,8 +2,8 @@ export envvar_ver=1.0
 export prod_envir_ver=${prod_envir_ver:-2.0.4} # Allow override from ops ecflow
 export prod_util_ver=${prod_util_ver:-2.0.9}   # Allow override from ops ecflow
 
-export obsproc_run_ver=1.0.0-rd
-export prepobs_run_ver=1.0.0-rd
+export obsproc_run_ver=1.0.2-rd
+export prepobs_run_ver=1.0.1-rd
 
 export tracker_ver=v1.1.15.5
 export fit_ver="newm.1.5"


### PR DESCRIPTION
**Description**

This PR includes memory updates and new obsproc/prepobs package versions:

- Memory increases for some non-exclusive jobs that were getting the `Cgroup mem limit exceeded` warning message on WCOSS2.
- Also translated a few more high res WCOSS2 resource settings from `config.resources.nco.static` to `config.resources.emc.dyn` and from `config.fv3.nco.static` to `config.fv3.emc.dyn`.
- New obsproc R&D v1.0.2, includes WCOSS2 ops updates and tcvitals bug fix. Updated `obsproc_run_ver` in `versions/*.ver` files for WCOSS2, Hera, Orion.
- New prepobs R&D v1.0.1, includes WCOSS2 ops updates and tcvitals bug fix. Updated `prepobs_run_ver` in `versions/*.ver` files for WCOSS2, Hera, Orion.

New obsproc/prepobs packages have been installed on WCOSS2, Hera, and Orion.

Will merge these changes into the `release/gfs.v16.3.0` branch next.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] Clone and build tests on WCOSS2, Hera, Orion (obsproc/prepobs packages)
- [x] Cycled test on WCOSS2
  
Refs #665, #744
