### PR TITLE
Add preipicating hydrometeors for zeroing out increments and tapering increments in the stratosphere

### DIFF
--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -252,7 +252,7 @@ if [ $DONST = "YES" ]; then export FNTSFA="        "; fi
 export nst_anl=.true.
 
 # Analysis increments to zero in CALCINCEXEC
-export INCREMENTS_TO_ZERO="'liq_wat_inc','icmr_inc'"
+export INCREMENTS_TO_ZERO="'liq_wat_inc','icmr_inc','rwmr_inc','snmr_inc','grle_inc'"
 
 if [ $OUTPUT_FILE = "nemsio" ]; then
     export DO_CALC_INCREMENT="YES"
@@ -260,7 +260,7 @@ if [ $OUTPUT_FILE = "nemsio" ]; then
 fi
 
 # Stratospheric increments to zero
-export INCVARS_ZERO_STRAT="'sphum_inc','liq_wat_inc','icmr_inc'"
+export INCVARS_ZERO_STRAT="'sphum_inc','liq_wat_inc','icmr_inc','rwmr_inc','snmr_inc','grle_inc'"
 export INCVARS_EFOLD="5"
 
 # Swith to generate netcdf or binary diagnostic files.  If not specified,

--- a/parm/config/config.base.nco.static
+++ b/parm/config/config.base.nco.static
@@ -235,7 +235,7 @@ if [ $DONST = "YES" ]; then export FNTSFA="        "; fi
 export nst_anl=.true.
 
 # Analysis increments to zero in CALCINCEXEC
-export INCREMENTS_TO_ZERO="'liq_wat_inc','icmr_inc'"
+export INCREMENTS_TO_ZERO="'liq_wat_inc','icmr_inc','rwmr_inc','snmr_inc','grle_inc'"
 
 if [ $OUTPUT_FILE = "nemsio" ]; then
     export DO_CALC_INCREMENT="YES"
@@ -243,7 +243,7 @@ if [ $OUTPUT_FILE = "nemsio" ]; then
 fi
 
 # Stratospheric increments to zero
-export INCVARS_ZERO_STRAT="'sphum_inc','liq_wat_inc','icmr_inc'"
+export INCVARS_ZERO_STRAT="'sphum_inc','liq_wat_inc','icmr_inc','rwmr_inc','snmr_inc','grle_inc'"
 export INCVARS_EFOLD="5"
 
 # Swith to generate netcdf or binary diagnostic files.  If not specified,


### PR DESCRIPTION
**Description**

This PR contains changes for /parm/config.base.nco.static and config.base.emc.dyn:
Added precipitating hydrometeors in the list to zero out the increments for IAU
Added precipitating hydrometeors in the list to taper out increments in the startosphere.

Fixes #869 