### PR TITLE
for ops: Update calculation of starting time of rerun based on if wave restarts exist 

### DIFF
--- a/scripts/exglobal_forecast.sh
+++ b/scripts/exglobal_forecast.sh
@@ -449,10 +449,7 @@ if [ $cplwav = ".true." ]; then
         echo "WARNING: Wave ICs are absent, will start from rest"
       fi
     else
-      if [ ! -f ${RSTDIR_WAVE}/${PDYT}.${cyct}0000.restart.${wavGRD} ]; then
-        echo "ERROR: wave IC is missing for RERUN, exiting"
-        exit 1
-      else
+      if [ -f ${RSTDIR_WAVE}/${PDYT}.${cyct}0000.restart.${wavGRD} ]; then
         $NLN ${RSTDIR_WAVE}/${PDYT}.${cyct}0000.restart.${wavGRD} $DATA/restart.${wavGRD}
       fi
     fi

--- a/scripts/exglobal_forecast.sh
+++ b/scripts/exglobal_forecast.sh
@@ -443,10 +443,10 @@ if [ $cplwav = ".true." ]; then
 
   for wavGRD in $waveGRD ; do
     if [ $RERUN = "NO" ]; then
-      if [ ! -f ${WRDIR}/${sPDY}.${scyc}0000.restart.${wavGRD} ]; then 
-        echo "WARNING: NON-FATAL ERROR wave IC is missing, will start from rest"
-      else
+      if [ -f ${WRDIR}/${sPDY}.${scyc}0000.restart.${wavGRD} ]; then
         $NLN ${WRDIR}/${sPDY}.${scyc}0000.restart.${wavGRD} $DATA/restart.${wavGRD}
+      else
+        echo "WARNING: Wave ICs are absent, will start from rest"
       fi
     else
       if [ ! -f ${RSTDIR_WAVE}/${PDYT}.${cyct}0000.restart.${wavGRD} ]; then

--- a/scripts/exglobal_forecast.sh
+++ b/scripts/exglobal_forecast.sh
@@ -181,7 +181,18 @@ if [ $CDUMP = "gfs" -a $rst_invt1 -gt 0 -a $FHMAX -gt $rst_invt1 -a $filecount -
         cycs=$(echo $SDATE | cut -c9-10)
         flag1=$RSTDIR_ATM/${PDYS}.${cycs}0000.coupler.res
         flag2=$RSTDIR_ATM/coupler.res
-        if [ -s $flag1 ]; then
+        #make sure that the wave restart files also exist if cplwav=true
+        waverstok=".true."
+        if [ $cplwav = ".true." ]; then
+          for wavGRD in $waveGRD ; do
+            if [ ! -f ${RSTDIR_WAVE}/${PDYS}.${cycs}0000.restart.${wavGRD} ]; then
+              waverstok=".false."
+            fi
+          done
+        fi
+
+        if [ -s $flag1 -a $waverstok = ".true." ]; then
+	#if [ -s $flag1 ]; then
             CDATE_RST=$SDATE          
             [[ $RERUN = "YES" ]] && break
             mv $flag1 ${flag1}.old

--- a/scripts/exglobal_forecast.sh
+++ b/scripts/exglobal_forecast.sh
@@ -445,13 +445,16 @@ if [ $cplwav = ".true." ]; then
     if [ $RERUN = "NO" ]; then
       if [ ! -f ${WRDIR}/${sPDY}.${scyc}0000.restart.${wavGRD} ]; then 
         echo "WARNING: NON-FATAL ERROR wave IC is missing, will start from rest"
+      else
+        $NLN ${WRDIR}/${sPDY}.${scyc}0000.restart.${wavGRD} $DATA/restart.${wavGRD}
       fi
-      $NLN ${WRDIR}/${sPDY}.${scyc}0000.restart.${wavGRD} $DATA/restart.${wavGRD}
     else
       if [ ! -f ${RSTDIR_WAVE}/${PDYT}.${cyct}0000.restart.${wavGRD} ]; then
-        echo "WARNING: NON-FATAL ERROR wave IC is missing, will start from rest"
+        echo "ERROR: wave IC is missing for RERUN, exiting"
+        exit 1
+      else
+        $NLN ${RSTDIR_WAVE}/${PDYT}.${cyct}0000.restart.${wavGRD} $DATA/restart.${wavGRD}
       fi
-      $NLN ${RSTDIR_WAVE}/${PDYT}.${cyct}0000.restart.${wavGRD} $DATA/restart.${wavGRD}
     fi
     eval $NLN $datwave/${wavprfx}.log.${wavGRD}.${PDY}${cyc} log.${wavGRD}
   done


### PR DESCRIPTION
**Description**

When WCOSS2 had some degraded file system performance, the wave model stalled for ~20 minutes meaning that the atmospheric model advanced significantly more than 12 hours ahead in forecast time from the wave model.  Upon restart, the wave model ICs were not there and the wave post jobs failed due to missing information.   

This PR updates the calculation for what the starting time is for restarts by also checking if wave restart files exist.  In addition, the model will fatally exit if wave ICs do not exist for RERUN=YES. 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**


- [x] Tested forecast script with canned data from ops to check re-run date calculation
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
