### PR TITLE
Update caculation of restart based on if a wave IC exists

### DIFF
--- a/ush/forecast_det.sh
+++ b/ush/forecast_det.sh
@@ -51,7 +51,18 @@ FV3_GFS_det(){
       cycs=$(echo $SDATE | cut -c9-10)
       flag1=$RSTDIR_ATM/${PDYS}.${cycs}0000.coupler.res
       flag2=$RSTDIR_ATM/coupler.res
-      if [ -s $flag1 ]; then
+
+      #make sure that the wave restart files also exist if cplwav=true
+      waverstok=".true."
+      if [ $cplwav = ".true." ]; then
+        for wavGRD in $waveGRD ; do
+          if [ ! -f ${RSTDIR_WAVE}/${PDYS}.${cycs}0000.restart.${wavGRD} ]; then
+            waverstok=".false."
+          fi
+        done
+      fi
+
+      if [ -s $flag1 -a $waverstok = ".true." ]; then
         CDATE_RST=$SDATE
         [[ $RERUN = "YES" ]] && break
         mv $flag1 ${flag1}.old

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -648,7 +648,12 @@ WW3_postdet() {
       waverstfile=${RSTDIR_WAVE}/${sPDY}.${scyc}0000.restart.${wavGRD}
     fi
     if [ ! -f ${waverstfile} ]; then
-      echo "WARNING: NON-FATAL ERROR wave IC is missing, will start from rest"
+      if [ $RERUN = "NO" ]; then
+        echo "WARNING: NON-FATAL ERROR wave IC is missing, will start from rest"
+      else 
+        echo "ERROR: Wave IC is missing in RERUN, exiting." 
+        exit 1 
+      fi 
     else
       if [ $waveMULTIGRID = ".true." ]; then
         $NLN ${waverstfile} $DATA/restart.${wavGRD}


### PR DESCRIPTION
**Description**

This PR updates the calculation for what the starting time is for restarts by also checking if wave restart files exist. In addition, the model will fatally exit if wave ICs do not exist for RERUN=YES.

This is implementing the fixes made to the operations branch in https://github.com/NOAA-EMC/global-workflow/pull/874 into the develop branch 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

This was tested in the operations branch.  If any tests are desired for the develop, please let me know and I will run them.  

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
