### PR TITLE
Update the satinfo and convinfo files so the v16.3 parallel experimen…

### DIFF
--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -29,7 +29,7 @@ fi
 # Set parameters specific to L127
 if [ $LEVS = "128" ]; then
     export GRIDOPTS="nlayers(63)=1,nlayers(64)=1,"
-    export SETUP="gpstop=55,nsig_ext=56,$SETUP"
+    export SETUP="gpstop=55,nsig_ext=45,$SETUP"
 fi
 
 # Set namelist option for LETKF

--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -117,12 +117,12 @@ if [[ $RUN_ENVIR == "emc" ]]; then
 
 #   Assimilate DO-2 GeoOptics
     if [[ "$CDATE" -ge "2021031712" && "$CDATE" -lt "2021091612" ]]; then
-        export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021031712
+        export CONVINFO=$FIXgsi/gfsv16_historical/gfsv16.3/global_convinfo.txt.2021031712
     fi
 
 #   Assimilate DO-3 Spire
     if [[ "$CDATE" -ge "2021091612" && "$CDATE" -lt "2022031612" ]]; then
-        export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021091612
+        export CONVINFO=$FIXgsi/gfsv16_historical/gfsv16.3/global_convinfo.txt.2021091612
     fi
 
 
@@ -159,12 +159,12 @@ if [[ $RUN_ENVIR == "emc" ]]; then
 
 #   Turn off assimilation of S-NPP CrIS
     if [[ "$CDATE" -ge "2021052118" && "$CDATE" -lt "2021092206" ]]; then
-	export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021052118
+	export SATINFO=$FIXgsi/gfsv16_historical/gfsv16.3/global_satinfo.txt.2021052118
     fi
 
 #   Turn off assimilation of MetOp-A IASI
     if [[ "$CDATE" -ge "2021092206" && "$CDATE" -lt "2021102612" ]]; then
-	export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021092206
+	export SATINFO=$FIXgsi/gfsv16_historical/gfsv16.3/global_satinfo.txt.2021092206
     fi
 
 #   NOTE:  

--- a/parm/config/config.anal
+++ b/parm/config/config.anal
@@ -117,7 +117,7 @@ if [[ $RUN_ENVIR == "emc" ]]; then
 
 #   Assimilate DO-2 GeoOptics
     if [[ "$CDATE" -ge "2021031712" && "$CDATE" -lt "2021091612" ]]; then
-        export CONVINFO=$FIXgsi/gfsv16_historical/gfsv16.3/global_convinfo.txt.2021031712
+        export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2021031712
     fi
 
 #   Assimilate DO-3 Spire
@@ -159,7 +159,7 @@ if [[ $RUN_ENVIR == "emc" ]]; then
 
 #   Turn off assimilation of S-NPP CrIS
     if [[ "$CDATE" -ge "2021052118" && "$CDATE" -lt "2021092206" ]]; then
-	export SATINFO=$FIXgsi/gfsv16_historical/gfsv16.3/global_satinfo.txt.2021052118
+	export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2021052118
     fi
 
 #   Turn off assimilation of MetOp-A IASI


### PR DESCRIPTION
The gfsv16.3 parallel testing begins from 20211015 18Z.
The relevant GSI fix files (convinfo & satinfo) were modify to include the observations to be assimilated operationally in real-time.  A corresponding change in the global-work under **/parm/config.anal** is necessary so the proper fix files will be used in the assimilation based on cycle date/time.  

In **GSI**:
(1) a subdirectory "gfsv16.3" has been created under /gsi.fd/fix/gfsv16_historical/  for gfsv16.3 implementation specifically.  
The change can be checked on WCOSS-2 in the following directory:
/lfs/h2/emc/da/noscrub/emily.liu/git/global-workflow/gfs.v16.3.0/sorc/gsi.fd/fix/gfsv16_historical/gfsv16.3

(2) The corresponding changes for the convinfo and satinfo files will be made in the GSI repository (gfsda.v16.3 release branch) --- [GSI PR # 412](https://github.com/NOAA-EMC/GSI/pull/412)

In **global-workflow**:
(1) The /parm/config.anal is modified for exporting the updated convinfo and satinfo files from GSI.
(2) The changes can be viewed [here](https://github.com/NOAA-EMC/global-workflow/pull/876/files)

The related issue is[ issue #877](https://github.com/NOAA-EMC/global-workflow/issues/877) 



