### PR TITLE
Fix to gfs_bufr code and job

### DIFF
--- a/docs/Release_Notes.gfs.v16.2.1.md
+++ b/docs/Release_Notes.gfs.v16.2.1.md
@@ -1,0 +1,129 @@
+GFS V16.2.1 RELEASE NOTES
+
+-------
+PRELUDE
+-------
+
+Several bug fixes for the GFSv16.2 package to resolve issues with the gfs_forecast job (wave restart calculation) and the gfs_atmos_postsnd (bufr sounding) job.
+
+IMPLEMENTATION INSTRUCTIONS
+---------------------------
+
+The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com are used to manage the GFS.v16.2.1 code. The SPA(s) handling the GFS.v16.2.1 implementation need to have permissions to clone VLab gerrit repositories and the private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are publicly readable and do not require access permissions. Please follow the following steps to install the package on WCOSS2:
+
+```bash
+cd $PACKAGEROOT
+mkdir gfs.v16.2.1
+cd gfs.v16.2.1
+git clone -b EMC-v16.2.1 https://github.com/NOAA-EMC/global-workflow.git .
+cd sorc
+./checkout.sh -o
+```
+
+The checkout script extracts the following GFS components:
+
+| Component | Tag         | POC               |
+| --------- | ----------- | ----------------- |
+| MODEL     | GFS.v16.2.0   | Jun.Wang@noaa.gov |
+| GSI       | gfsda.v16.2.0 | Russ.Treadon@noaa.gov |
+| GLDAS     | gldas_gfsv16_release.v.2.0.0 | Helin.Wei@noaa.gov |
+| UFS_UTILS | ops-gfsv16.2.0 | George.Gayno@noaa.gov |
+| POST      | upp_v8.1.2 | Wen.Meng@noaa.gov |
+| WAFS      | gfs_wafs.v6.2.8 | Yali.Mao@noaa.gov |
+
+To build all the GFS components, execute:
+```bash
+./build_all.sh
+```
+The `build_all.sh` script compiles all GFS components. Runtime output from the build for each package is written to log files in directory logs. To build an individual program, for instance, gsi, use `build_gsi.sh`.
+
+Next, link the executables, fix files, parm files etc in their final respective locations by executing:
+```bash
+./link_fv3gfs.sh nco wcoss2
+```
+
+Lastly, link the ecf scripts by moving back up to the ecf folder and executing:
+```bash
+cd ../ecf
+./setup_ecf_links.sh
+```
+
+SORC CHANGES
+------------
+
+* Workflow
+  * `sorc/gfs_bufr.fd/calpreciptype.f`
+  * `sorc/gfs_bufr.fd/meteorg.f`
+
+FIX CHANGES
+-----------
+
+* No changes from GFS v16.2.0
+
+PARM/CONFIG CHANGES
+-------------------
+
+* Workflow
+  * `env/WCOSS2.env` - postsnd adjustments
+  * `parm/config/config.resources.nco.static` - postsnd adjustments
+  * `parm/config/config.resources.emc.dyn` - postsnd adjustments
+  * `parm/transfer/transfer_rdhpcs_gfs_nawips.list`
+
+JOBS CHANGES
+------------
+
+* No changes from GFS v16.2.0
+
+SCRIPT CHANGES
+--------------
+
+* Workflow
+  * `ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf` - memory adjustment
+  * `ecf/scripts/gfs/atmos/post_processing/bufr_sounding/jgfs_atmos_postsnd.ecf` - resource adjustment
+  * `scripts/exglobal_forecast.sh` - update calculation of starting time of rerun based on if wave restarts exist
+
+MODULE CHANGES
+--------------
+
+* Workflow
+  * `modulefiles/gfs_bufr.wcoss2.lua` - no longer build with -qopenmp
+
+CHANGES TO RESOURCES AND FILE SIZES
+-----------------------------------
+
+* File sizes
+  * No change to GFSv16.2.0.
+* Resource changes
+  * Adjustment to the gfs_atmos_postsnd job resources.
+  * Increase to memory for fbwind job.
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+---------------------------------------
+
+* Which production jobs should be tested as part of this implementation?
+  * The entire GFS v16.2.1 package needs to be installed and tested.
+* Does this change require a 30-day evaluation?
+  * No.
+
+DISSEMINATION INFORMATION
+-------------------------
+
+* Where should this output be sent?
+  * No change from GFS v16.2.0
+* Who are the users?
+  * No change from GFS v16.2.0
+* Which output files should be transferred from PROD WCOSS2 to DEV WCOSS2?
+  * No change from GFS v16.2.0
+* Directory changes
+  * No change from GFS v16.2.0
+* File changes
+  * No change from GFS v16.2.0
+
+HPSS ARCHIVE
+------------
+
+* No change from GFS v16.2.0
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+---------------------------------
+* No change from GFS v16.2.0

--- a/ecf/scripts/gfs/atmos/post_processing/bufr_sounding/jgfs_atmos_postsnd.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/bufr_sounding/jgfs_atmos_postsnd.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
-#PBS -l select=2:mpiprocs=20:ompthreads=6:ncpus=120
+#PBS -l select=4:mpiprocs=10:ompthreads=8:ncpus=80
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 
@@ -40,6 +40,8 @@ module list
 export cyc=%CYC%
 export cycle=t%CYC%z
 export USE_CFP=YES
+export MPICH_MPIIO_HINTS_DISPLAY=1
+export OMP_NUM_THREADS=1
 ############################################################
 # CALL executable job script here
 ############################################################

--- a/ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l select=1:ncpus=1:mem=2GB
+#PBS -l select=1:ncpus=1:mem=4GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -181,6 +181,8 @@ elif [ $step = "fv3ic" ]; then
 
 elif [ $step = "postsnd" ]; then
 
+    export MPICH_MPIIO_HINTS_DISPLAY=1
+    export OMP_NUM_THREADS=1
     export NTHREADS_POSTSND=${nth_postsnd:-1}
     export APRUN_POSTSND="$launcher -n $npe_postsnd --depth=$NTHREADS_POSTSND --cpu-bind depth"
     export NTHREADS_POSTSNDCFP=${nth_postsndcfp:-1}

--- a/modulefiles/gfs_bufr.wcoss2.lua
+++ b/modulefiles/gfs_bufr.wcoss2.lua
@@ -20,6 +20,6 @@ load(pathJoin("w3emc", os.getenv("w3emc_ver")))
 load(pathJoin("bufr", os.getenv("bufr_ver")))
 
 setenv("myFC","ftn")
-setenv("myFCFLAGS","-O3 -convert big_endian -traceback -g -fp-model source -qopenmp")
+setenv("myFCFLAGS","-O3 -convert big_endian -traceback -g -fp-model source")
 setenv("myCPP","/lib/cpp")
 setenv("myCPPFLAGS","-P")

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -381,8 +381,8 @@ elif [ $step = "postsnd" ]; then
 
     export wtime_postsnd="02:00:00"
     export npe_postsnd=40
-    export nth_postsnd=6
-    export npe_node_postsnd=20
+    export nth_postsnd=8
+    export npe_node_postsnd=10
     export npe_postsndcfp=9
     export npe_node_postsndcfp=1
     if [ $OUTPUT_FILE == "nemsio" ]; then

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -318,8 +318,8 @@ elif [ $step = "postsnd" ]; then
 
     export wtime_postsnd="02:00:00"
     export npe_postsnd=40
-    export nth_postsnd=6
-    export npe_node_postsnd=20
+    export nth_postsnd=8
+    export npe_node_postsnd=10
     export npe_postsndcfp=9
     export npe_node_postsndcfp=1
 

--- a/parm/transfer/transfer_rdhpcs_gfs_nawips.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_nawips.list
@@ -24,7 +24,7 @@
 # directory are included, so if no exclude patterns match that file, it will be
 # transferred.
 
-_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/  _REMOTEPATH_/com/nawips/_ENVIR_/gfs._PDY_/
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/  _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gfs._PDY_/
 + /??/
 + /??/atmos/
 + /??/atmos/gempak/

--- a/sorc/gfs_bufr.fd/calpreciptype.f
+++ b/sorc/gfs_bufr.fd/calpreciptype.f
@@ -77,7 +77,7 @@ SUBROUTINE CALPRECIPTYPE(kdt,nrcm,im,ix,lm,lp1,randomno,      &
       ALLOCATE ( RH(LM),TD8(LM),TWET8(LM) )
 
 ! Create look up table
-      call gfuncphys
+!     call gfuncphys
 
       time_vert    = 0.
       time_ncep    = 0.

--- a/sorc/gfs_bufr.fd/meteorg.f
+++ b/sorc/gfs_bufr.fd/meteorg.f
@@ -63,6 +63,7 @@
       use sigio_module 
       use physcons
       use mersenne_twister
+!      use funcphys, only : gfuncphys
       use funcphys
       implicit none 
       include 'mpif.h'
@@ -1109,6 +1110,7 @@ CC due to rounding and interpolation errors, correct it here -G.P. Lou:
 !  prepare buffer data
 !
         if(iope == 0) then
+        call gfuncphys
         do np = 1, npoint
           pi3(np,1)=psn(np)*1000
           do k=1,levs


### PR DESCRIPTION
**Description**

This PR commits changes made and tested on WCOSS2 by NCO, GDIT, and @BoCui-NOAA to resolve job failures in the `gfs_atmos_postsnd` job in operations. A small memory adjustment for the fbwind job is also included, along with an update to a transfer list file.

Updates related to gfs_bufr are:

- Correction to gfs_bufr code (by @BoCui-NOAA )
- Change to gfs_bufr build to no longer build with `-qopenmp`.
- Adjustments to job resources based on testing by @BoCui-NOAA, @WeiWei-NCO , and GDIT.

Thanks to @BoCui-NOAA , GDIT, @HuiyaChuang-NOAA , and @WeiWei-NCO for troubleshooting!

This update will be packaged with the recent gfs_forecast job update (PR #874). It will result in an RFC in WCOSS2 operations and a version increment to GFSv16.2.1. New release notes are also included.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

**How Has This Been Tested?**

NCO, GDIT, and @BoCui-NOAA tested these updates in the para GFS on WCOSS2.
  
Refs #399
