### PR TITLE
Fix settings of dt_inner and lheatstrg

### DIFF
--- a/parm/config/config.fcst
+++ b/parm/config/config.fcst
@@ -208,6 +208,7 @@ elif [ $imp_physics -eq 8 ]; then # Thompson
     export ttendlim="-999"
     export dt_inner=$((DELTIM/2))
     export sedi_semi=.true.
+    if [ $sedi_semi = .true. ]; then export dt_inner=$DELTIM ; fi
     export decfl=10
 
     export hord_mt_nh_nonmono=5

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -203,7 +203,7 @@ EOF
   # Scan suite file to determine whether it uses Noah-MP
   if [ $(grep noahmpdrv ${_suite_file} | wc -l ) -gt 0 ]; then
     lsm="2"
-    lheatstrg=".true."
+    lheatstrg=".false."
     landice=".false."
     iopt_dveg=${iopt_dveg:-"4"}
     iopt_crs=${iopt_crs:-"2"}
@@ -221,7 +221,7 @@ EOF
     IEMS=${IEMS:-2}
   else
     lsm="1"
-    lheatstrg=".false."
+    lheatstrg=".true."
     landice=".true."
     iopt_dveg=${iopt_dveg:-"1"}
     iopt_crs=${iopt_crs:-"1"}

--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -320,7 +320,7 @@ cat >> input.nml <<EOF
   hybedmf      = ${hybedmf:-".false."}
   satmedmf     = ${satmedmf-".true."}
   isatmedmf    = ${isatmedmf-"1"}
-  lheatstrg    = ${lheatstrg-".true."}
+  lheatstrg    = ${lheatstrg-".false."}
   lseaspray    = ${lseaspray:-".true."}
   random_clds  = ${random_clds:-".true."}
   trans_trac   = ${trans_trac:-".true."}


### PR DESCRIPTION
For Thompson microphysics,   currently dt_inner is set to half of physics timestep.  It should be set to the same as the physics timestep if semi-Lag sedimentation is applied to rain and graupel.  

Canopy heat storage is incorrectly turned off for NOAH LSM, and on for NOAH-MP LSM.  This setting needs to be reversed.

Fixes #884

<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--
- [ ] Clone and Build tests on WCOSS Dell P3
- [ ] Cycled test on Orion
- [ ] Forecast-only test on Hera
-->
  
**Checklist**

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
