### PR TITLE
Add module reset hack and postsnd resource adjustment for R&D

### DIFF
--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -411,7 +411,7 @@ elif [ $step = "postsnd" ]; then
         export npe_postsnd=13
         export npe_node_postsnd=4
     fi
-    if [[ "$machine" = "HERA" ]]; then export npe_node_postsnd=2; fi
+    if [[ "$(echo "$npe_node_postsnd * $nth_postsnd" | bc)" -gt "$npe_node_max" ]]; then export npe_node_postsnd=$(echo "$npe_node_max / $nth_postsnd" | bc); fi
 
 elif [ $step = "awips" ]; then
 

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -411,7 +411,9 @@ elif [ $step = "postsnd" ]; then
         export npe_postsnd=13
         export npe_node_postsnd=4
     fi
-    if [[ "$(echo "$npe_node_postsnd * $nth_postsnd" | bc)" -gt "$npe_node_max" ]]; then export npe_node_postsnd=$(echo "$npe_node_max / $nth_postsnd" | bc); fi
+    if [[ "$(echo "$npe_node_postsnd * $nth_postsnd" | bc)" -gt "$npe_node_max" ]]; then
+        export npe_node_postsnd=$(echo "$npe_node_max / $nth_postsnd" | bc)
+    fi
 
 elif [ $step = "awips" ]; then
 

--- a/sorc/machine-setup.sh
+++ b/sorc/machine-setup.sh
@@ -39,6 +39,8 @@ elif [[ -d /scratch1 ]] ; then
     fi
     target=hera
     module purge
+    export LMOD_SYSTEM_DEFAULT_MODULES=contrib
+    module reset
 
 ##---------------------------------------------------------------------------
 elif [[ -d /gpfs/hps && -e /etc/SuSE-release ]] ; then


### PR DESCRIPTION
**Description**

This PR includes two small updates for running `dev_v16` (GFSv16.2.1) on the R&D machines:

1. `module reset` hack in `machine-setup.sh` for Hera; will remove `LMOD_SYSTEM_DEFAULT_MODULES` line after Hera admins get `module reset` working out-of-the-box again
2. adjust postsnd resources in `config.resources.emc.dyn` to reset `npe_node_postsnd` based on `nth_postsnd` and `npe_node_max` when `npe_node_postsnd * nth_postsnd > npe_node_max`

Refs #665

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] Clone and Build tests on Hera and Orion
- [x] Low res cycled test on Hera and Orion