### PR TITLE
Updated obsproc/prepobs packages and fixes to C384 resources and tracker script

### DIFF
--- a/jobs/JGFS_ATMOS_CYCLONE_TRACKER
+++ b/jobs/JGFS_ATMOS_CYCLONE_TRACKER
@@ -128,23 +128,7 @@ ${USHens_tracker}/data_check_gfs.sh
 if [ $? -eq 6 ]; then exit; fi
 #------------------------------------------------
 
-machine=${machine:-`echo ${SITE}`}
-if [ $machine = TIDE -o $machine = GYRE ] ; then # For WCOSS
-  machine=wcoss
-  ${USHens_tracker}/extrkr_gfs.sh ${loopnum} ${cmodel} ${CDATE} ${pert} ${DATA} 
-elif [ $machine = LUNA -o $machine = SURGE -o $machine = WCOSS_C ] ; then # For CRAY
-  machine=cray
-  ${APRUNTRACK} ${USHens_tracker}/extrkr_gfs.sh ${loopnum} ${cmodel} ${CDATE} ${pert} ${DATA} 
-elif [ $machine = VENUS -o $machine = MARS -o $machine = WCOSS_DELL_P3 ] ; then # For DELL
-  machine=dell
-  mpirun -n 1 ${USHens_tracker}/extrkr_gfs.sh ${loopnum} ${cmodel} ${CDATE} ${pert} ${DATA}
-elif [ $machine = HERA ]; then # For HERA
-  machine=hera
-  ${USHens_tracker}/extrkr_gfs.sh ${loopnum} ${cmodel} ${CDATE} ${pert} ${DATA}
-elif [ $machine = ORION ]; then # For ORION
-  machine=orion
-  ${USHens_tracker}/extrkr_gfs.sh ${loopnum} ${cmodel} ${CDATE} ${pert} ${DATA}
-fi
+${USHens_tracker}/extrkr_gfs.sh ${loopnum} ${cmodel} ${CDATE} ${pert} ${DATA}
 export err=$?; err_chk
 
 

--- a/parm/config/config.fv3.emc.dyn
+++ b/parm/config/config.fv3.emc.dyn
@@ -94,7 +94,7 @@ case $case_in in
         export WRTIOBUF="8M"
         ;;
     "C384")
-        export DELTIM=240
+        export DELTIM=200
         export layout_x=8
         export layout_y=8
         export layout_x_gfs=6
@@ -102,12 +102,12 @@ case $case_in in
         export npe_wav=35
         export npe_wav_gfs=35
         export nth_fv3=1
-        export nth_fv3_gfs=2
+        export nth_fv3_gfs=1
         export cdmbgwd="1.1,0.72,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
-        export WRITE_GROUP=1
+        export WRITE_GROUP=2
         export WRTTASK_PER_GROUP=64
         if [[ "$WRTTASK_PER_GROUP" -gt "$npe_node_max" ]]; then export WRTTASK_PER_GROUP=$npe_node_max ; fi
-        export WRITE_GROUP_GFS=2
+        export WRITE_GROUP_GFS=1
         export WRTTASK_PER_GROUP_GFS=64
         if [[ "$WRTTASK_PER_GROUP_GFS" -gt "$npe_node_max" ]]; then export WRTTASK_PER_GROUP_GFS=$npe_node_max ; fi
         export WRTIOBUF="16M"

--- a/versions/hera.ver
+++ b/versions/hera.ver
@@ -2,8 +2,8 @@ export hpc_ver=1.2.0
 export hpc_intel_ver=18.0.5.274
 export hpc_impi_ver=2018.0.4
 
-export obsproc_run_ver=1.0.2-rd
-export prepobs_run_ver=1.0.1-rd
+export obsproc_run_ver=1.0.2
+export prepobs_run_ver=1.0.1
 
 export hpss_ver=hpss
 export prod_util_ver=1.2.2

--- a/versions/orion.ver
+++ b/versions/orion.ver
@@ -2,8 +2,8 @@ export hpc_ver=1.2.0
 export hpc_intel_ver=2018.4
 export hpc_impi_ver=2018.4
 
-export obsproc_run_ver=1.0.2-rd
-export prepobs_run_ver=1.0.1-rd
+export obsproc_run_ver=1.0.2
+export prepobs_run_ver=1.0.1
 
 export prod_util_ver=1.2.2
 export cmake_ver=3.22.1

--- a/versions/wcoss2.ver
+++ b/versions/wcoss2.ver
@@ -2,8 +2,8 @@ export envvar_ver=1.0
 export prod_envir_ver=${prod_envir_ver:-2.0.4} # Allow override from ops ecflow
 export prod_util_ver=${prod_util_ver:-2.0.9}   # Allow override from ops ecflow
 
-export obsproc_run_ver=1.0.2-rd
-export prepobs_run_ver=1.0.1-rd
+export obsproc_run_ver=1.0.2
+export prepobs_run_ver=1.0.1
 
 export tracker_ver=v1.1.15.5
 export fit_ver="newm.1.5"


### PR DESCRIPTION
**Description**

This PR includes some small updates and bug fixes for the GFSv16.2 package:

1. Updated obsproc/prepobs versions to use new official tags installed on disk (`obsproc.v1.0.2` and `prepobs.v1.0.1`). New tags reproduce WCOSS2 ops prepbufr files still and now include R&D updates merged with main `develop` branches.
2. Updated the C384 block in `config.fv3.emc.dyn` to match `config.fv3.nco.static`. Was missing in prior update and is needed to get serial netcdf efcs jobs running fast enough to fit in timing window. Also set C384 `DELTIM=200` since this value will be staying in WCOSS2 ops for now.
3. Bug fix and consolidation in `JGFS_ATMOS_CYCLONE_TRACKER` script for running on WCOSS2 and supported R&D machines.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

- [x] Cycled tests on WCOSS2
  
Ref #665