### PR TITLE
Replace print_esmf with esmf_logkind

### DIFF
--- a/parm/config/config.fcst
+++ b/parm/config/config.fcst
@@ -33,8 +33,9 @@ if [ $DONST = "YES" ]; then
     . $EXPDIR/config.nsst
 fi
 
-export print_esmf=".false."
 export esmf_profile=".false."
+export esmf_logkind="ESMF_LOGKIND_MULTI_ON_ERROR" #Options: ESMF_LOGKIND_MULTI_ON_ERROR, ESMF_LOGKIND_MULTI, ESMF_LOGKIND_NONE
+
 
 #######################################################################
 # COUPLING COMPONENTS


### PR DESCRIPTION
**Description**

remove printesmf as it no longer a variable  and add the esmflogkind variable to config.fcst instead which is the equivalent new variable. 

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

Single coupled forecast S2SW on hera, log file: /scratch1/NCEPDEV/climate/Jessica.Meixner/workflowprintesmf/testprint01/COMROOT/testprint01/logs/2013040100/gfsfcst.log
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
