### PR TITLE
Update EMC_verif-global to verif_global_v2.9.5 (dev_v16)

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -36,7 +36,7 @@ protocol = git
 required = True
 
 [EMC_verif-global]
-tag = verif_global_v2.9.0
+tag = verif_global_v2.9.5
 local_path = sorc/verif-global.fd
 repo_url = https://github.com/NOAA-EMC/EMC_verif-global.git
 protocol = git

--- a/jobs/rocoto/metp.sh
+++ b/jobs/rocoto/metp.sh
@@ -1,4 +1,4 @@
-#!/bin/ksh -x
+#!/bin/bash -x
 
 ###############################################################
 ## Abstract:
@@ -10,6 +10,7 @@
 ## CDUMP  : cycle name (gdas / gfs)
 ## PDY    : current date (YYYYMMDD)
 ## cyc    : current cycle (HH)
+## SDATE_GFS  : first date of GFS cycle (YYYYMMDDHHMM)
 ## METPCASE : METplus verification use case (g2g1 | g2o1 | pcp1)
 ###############################################################
 
@@ -24,7 +25,7 @@ status=$?
 ###############################################################
 echo
 echo "=============== START TO SOURCE RELEVANT CONFIGS ==============="
-configs="base vrfy metp"
+configs="base metp"
 for config in $configs; do
     . $EXPDIR/config.${config}
     status=$?
@@ -41,11 +42,12 @@ status=$?
 
 ###############################################################
 export COMPONENT=${COMPONENT:-atmos}
-export CDATEm1=$($NDATE -24 $CDATE)
-export PDYm1=$(echo $CDATEm1 | cut -c1-8)
+export VDATE="$(echo $($NDATE -${VRFYBACK_HRS} $CDATE) | cut -c1-8)"
 
+export pid=${pid:-$$}
+export jobid=${job}.${pid}
 export COMIN="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT"
-export DATAROOT="$RUNDIR/$CDATE/$CDUMP/vrfy"
+export DATAROOT="$RUNDIR/$CDATE/$CDUMP/metp.${jobid}"
 [[ -d $DATAROOT ]] && rm -rf $DATAROOT
 mkdir -p $DATAROOT
 
@@ -58,7 +60,9 @@ if [ $CDUMP = "gfs" ]; then
     if [ $RUN_GRID2GRID_STEP1 = "YES" -o $RUN_GRID2OBS_STEP1 = "YES" -o $RUN_PRECIP_STEP1 = "YES" ]; then
 
         $VERIF_GLOBALSH 
- 
+        status=$?
+        [[ $status -ne 0 ]] && exit $status
+        [[ $status -eq 0 ]] && echo "Succesfully ran $VERIF_GLOBALSH"
     fi
 fi
 

--- a/parm/config/config.metp
+++ b/parm/config/config.metp
@@ -14,56 +14,86 @@ export RUN_PRECIP_STEP1="YES"    # Run precip verification using METplus
 
 
 #----------------------------------------------------------
-# METplus, Verify grid-to-grid, and/or grid-to-obs, and/or precipitation options
+# METplus: Verify grid-to-grid, grid-to-obs, precipitation options
 #----------------------------------------------------------
-
-if [ "$CDUMP" = "gfs" ] ; then
-    if [ $RUN_GRID2GRID_STEP1 = "YES" -o $RUN_GRID2OBS_STEP1 = "YES" -o $RUN_PRECIP_STEP1 = "YES" ]; then
-        export HOMEverif_global=${HOMEgfs}/sorc/verif-global.fd
-        export VERIF_GLOBALSH=$HOMEverif_global/ush/run_verif_global_in_global_workflow.sh
-        ## INPUT DATA SETTINGS
-        export model_list=$PSLOT
-        export model_data_dir_list=$ARCDIR/..
-        export model_fileformat_list="pgbf{lead?fmt=%H}.${CDUMP}.{init?fmt=%Y%m%d%H}.grib2"
-        export model_hpssdir_list=$ATARDIR/.. 
-        export get_data_from_hpss="NO"
-        export hpss_walltime="10"
-        ## OUTPUT SETTINGS
-        export OUTPUTROOT=$RUNDIR/$CDUMP/$CDATE/vrfy/metplus_exp
-        export model_arch_dir_list=$ARCDIR/..
-        export make_met_data_by="VALID"
-        export gather_by="VSDB"
-        ## DATE SETTINGS
-        export VRFYBACK_HRS="24"
-        ## METPLUS SETTINGS
-        export METplus_verbosity="INFO"
-        export MET_verbosity="2"
-        export log_MET_output_to_METplus="yes"
-        ## FORECAST VERIFICATION SETTINGS
-        export fhr_min=$FHMIN_GFS
-        export fhr_max=$FHMAX_GFS
-        # GRID-TO-GRID STEP 1
-        export g2g1_type_list="anom pres sfc"
-        export g2g1_anl_name="self_anl"
-        export g2g1_anl_fileformat_list="pgbanl.gfs.{valid?fmt=%Y%m%d%H}.grib2"
-        export g2g1_grid="G002"
-        # GRID-TO-OBS STEP 1
-        export g2o1_type_list="upper_air conus_sfc"
-        export g2o1_obtype_upper_air="ADPUPA"
-        export g2o1_grid_upper_air="G003"
-        export g2o1_fhr_out_upper_air="6"
-        export g2o1_obtype_conus_sfc="ONLYSF ADPUPA"
-        export g2o1_grid_conus_sfc="G104"
-        export g2o1_fhr_out_conus_sfc="3"
-        export g2o1_prepbufr_data_runhpss="YES"
-        # PRECIP STEP 1
-        export precip1_obtype="ccpa"
-        export precip1_accum_length="24"
-        export precip1_model_bucket_list="06"
-        export precip1_model_varname_list="APCP"
-        export precip1_model_fileformat_list="pgbf{lead?fmt=%H}.gfs.{init?fmt=%Y%m%d%H}.grib2"
-        export precip1_grid="G211"
-    fi
-fi
+## EMC_VERIF_GLOBAL SETTINGS
+export HOMEverif_global=${HOMEgfs}/sorc/verif-global.fd
+export VERIF_GLOBALSH=$HOMEverif_global/ush/run_verif_global_in_global_workflow.sh
+## INPUT DATA SETTINGS
+export model=$PSLOT
+export model_file_format="pgbf{lead?fmt=%2H}.${CDUMP}.{init?fmt=%Y%m%d%H}.grib2"
+export model_hpss_dir=$ATARDIR/.. 
+export get_data_from_hpss="NO"
+export hpss_walltime="10"
+## OUTPUT SETTINGS
+export model_stat_dir=$ARCDIR/..
+export make_met_data_by="VALID"
+export SENDMETVIEWER="NO"
+## DATE SETTINGS
+export VRFYBACK_HRS="0"
+## METPLUS SETTINGS
+export METplus_verbosity="INFO"
+export MET_verbosity="2"
+export log_MET_output_to_METplus="yes"
+# GRID-TO-GRID STEP 1: gfsmetpg2g1
+export g2g1_type_list="anom pres sfc"
+export g2g1_anom_truth_name="self_anl"
+export g2g1_anom_truth_file_format="pgbanl.${CDUMP}.{valid?fmt=%Y%m%d%H}.grib2"
+export g2g1_anom_fhr_min=$FHMIN_GFS
+export g2g1_anom_fhr_max=$FHMAX_GFS
+export g2g1_anom_grid="G002"
+export g2g1_anom_gather_by="VSDB"
+export g2g1_pres_truth_name="self_anl"
+export g2g1_pres_truth_file_format="pgbanl.${CDUMP}.{valid?fmt=%Y%m%d%H}.grib2"
+export g2g1_pres_fhr_min=$FHMIN_GFS
+export g2g1_pres_fhr_max=$FHMAX_GFS
+export g2g1_pres_grid="G002"
+export g2g1_pres_gather_by="VSDB"
+export g2g1_sfc_truth_name="self_f00"
+export g2g1_sfc_truth_file_format="pgbf00.${CDUMP}.{valid?fmt=%Y%m%d%H}.grib2"
+export g2g1_sfc_fhr_min=$FHMIN_GFS
+export g2g1_sfc_fhr_max=$FHMAX_GFS
+export g2g1_sfc_grid="G002"
+export g2g1_sfc_gather_by="VSDB"
+export g2g1_mv_database_name="mv_${PSLOT}_grid2grid_metplus"
+export g2g1_mv_database_group="NOAA NCEP"
+export g2g1_mv_database_desc="Grid-to-grid METplus data for global workflow experiment ${PSLOT}"
+# GRID-TO-OBS STEP 1: gfsmetpg2o1
+export g2o1_type_list="upper_air conus_sfc"
+export g2o1_upper_air_msg_type_list="ADPUPA"
+export g2o1_upper_air_vhr_list="00 06 12 18"
+export g2o1_upper_air_fhr_min=$FHMIN_GFS
+export g2o1_upper_air_fhr_max="240"
+export g2o1_upper_air_grid="G003"
+export g2o1_upper_air_gather_by="VSDB"
+export g2o1_conus_sfc_msg_type_list="ONLYSF ADPUPA"
+export g2o1_conus_sfc_vhr_list="00 03 06 09 12 15 18 21"
+export g2o1_conus_sfc_fhr_min=$FHMIN_GFS
+export g2o1_conus_sfc_fhr_max="240"
+export g2o1_conus_sfc_grid="G104"
+export g2o1_conus_sfc_gather_by="VSDB"
+export g2o1_polar_sfc_msg_type_list="IABP"
+export g2o1_polar_sfc_vhr_list="00 03 06 09 12 15 18 21"
+export g2o1_polar_sfc_fhr_min=$FHMIN_GFS
+export g2o1_polar_sfc_fhr_max="240"
+export g2o1_polar_sfc_grid="G219"
+export g2o1_polar_sfc_gather_by="VSDB"
+export g2o1_prepbufr_data_run_hpss="NO"
+export g2o1_mv_database_name="mv_${PSLOT}_grid2obs_metplus"
+export g2o1_mv_database_group="NOAA NCEP"
+export g2o1_mv_database_desc="Grid-to-obs METplus data for global workflow experiment ${PSLOT}"
+# PRECIP STEP 1: gfsmetppcp1
+export precip1_type_list="ccpa_accum24hr"
+export precip1_ccpa_accum24hr_model_bucket="06"
+export precip1_ccpa_accum24hr_model_var="APCP"
+export precip1_ccpa_accum24hr_model_file_format="pgbf{lead?fmt=%2H}.${CDUMP}.{init?fmt=%Y%m%d%H}.grib2"
+export precip1_ccpa_accum24hr_fhr_min=$FHMIN_GFS
+export precip1_ccpa_accum24hr_fhr_max="180"
+export precip1_ccpa_accum24hr_grid="G211"
+export precip1_ccpa_accum24hr_gather_by="VSDB"
+export precip1_obs_data_run_hpss="NO"
+export precip1_mv_database_name="mv_${PSLOT}_precip_metplus"
+export precip1_mv_database_group="NOAA NCEP"
+export precip1_mv_database_desc="Precip METplus data for global workflow experiment ${PSLOT}"
 
 echo "END: config.metp"

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -97,7 +97,7 @@ fi
 echo EMC_verif-global checkout ...
 if [[ ! -d verif-global.fd ]] ; then
     rm -f ${topdir}/checkout-verif-global.log
-    git clone --recursive --branch verif_global_v2.9.0 https://github.com/NOAA-EMC/EMC_verif-global.git verif-global.fd >> ${topdir}/checkout-verif-global.log 2>&1
+    git clone --recursive --branch verif_global_v2.9.5 https://github.com/NOAA-EMC/EMC_verif-global.git verif-global.fd >> ${topdir}/checkout-verif-global.log 2>&1
     cd ${topdir}
 else
     echo 'Skip. Directory verif-global.fd already exist.'


### PR DESCRIPTION
**Description**

This PR updates the version of EMC_verif-global (METplus) in the `dev_v16` branch to v2.9.5. Updates include:

- Update checkout version to `verif_global_v2.9.5` in `Externals.cfg` and `sorc/checkout.sh`.
- Bring in associated updates to `config.metp` and `metp.sh`; pulled in updated copies from develop branch per recommendation by @malloryprow .

Incoming changes match `config.metp` changes that @lgannoaa made in his branch for testing the GFSv16.3.0 package. That parallel sets `VRFYBACK_HRS` to 24 instead of 0 (out of need) but the config is otherwise the same. @malloryprow recommends `VRFYBACK_HRS=0` for regular experiments.

Refs: #665

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

- [x] Cycled test on WCOSS2

Xingren Wu tested new METplus EMC_verif-global v2.9.5 on WCOSS2 within a data impact experiment using the `dev_v16` branch. @malloryprow reviewed logs/output and confirmed it worked as intended.

Will sync this update into the `release/gfs.v16.3.0` branch after this PR goes into the `dev_v16` branch.
