### PR TITLE
Add `parm/config` python abstraction

### DIFF
--- a/config_manager/config_manager.py
+++ b/config_manager/config_manager.py
@@ -25,7 +25,7 @@ c.eupd.write_to(pathlib.Path("./eupd.sh"))
 import glob
 import pathlib
 import itertools
-from typing import List
+from typing import Any, Iterable, List
 
 
 class ConfigFile:
@@ -35,10 +35,10 @@ class ConfigFile:
         self.name = name
         self.path = path
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {self.name}:{self.path} />"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.name}: {self.path}"
 
     @property
@@ -59,26 +59,30 @@ class ConfigManager:
     def __init__(self, config_files_root: pathlib.Path):
         self.config_files_root = config_files_root.resolve()
 
-    def __iter__(self):
-        return iter(self.keys)
+    def __iter__(self) -> Iterable:
+        """returns an iterable of tuples (name, path)"""
+        return iter([(x.name, x.path) for x in self.map])
 
-    def __len__(self):
+    def __len__(self) -> int:
+        """number of configs in ConfigManager"""
         return len(self.keys)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {len(self.map)}/>"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{', '.join(self.keys)}"
 
-    def __getitem__(self, __name: str):
+    def __getitem__(self, __name: str) -> ConfigFile:
+        """allows ConfigManager["config_name"] access"""
         return list(filter(lambda x: x.name == __name, self.map))[0]
 
-    def __getattr__(self, __name: str):
+    def __getattr__(self, __name: str) -> ConfigFile:
+        """allows ConfigManager.config_name access"""
         return self.__getitem__(__name)
 
     @property
-    def map(self):
+    def map(self) -> List[ConfigFile]:
         """returns list of ConfigFile"""
         return [
             ConfigFile(config_file.name.split(".", 1)[1], config_file)
@@ -88,18 +92,19 @@ class ConfigManager:
         ]
 
     @property
-    def keys(self):
+    def keys(self) -> List[str]:
         """returns unique list of config names"""
         return sorted({x.name for x in self.map})
 
     @property
-    def paths(self):
+    def paths(self) -> List[pathlib.Path]:
         """returns unique list of config paths"""
         return sorted({x.path for x in self.map})
 
 
 def files_by_path(target: pathlib.Path, extensions: List[str]) -> List[pathlib.Path]:
-    """returns a list of files"""
+    """returns a list of files using `target` as root and 
+    filtering by `extensions`"""
     return [
         pathlib.Path(_file).resolve()
         for _file in itertools.chain(

--- a/config_manager/config_manager.py
+++ b/config_manager/config_manager.py
@@ -1,0 +1,116 @@
+"""
+Abstracts the config directory.
+
+Example:
+c = ConfigManager(pathlib.Path("../parm/config"))
+
+print(c)
+>>> anal, analcalc, analdiag, arch, awips, base.emc.dyn, base.nco.static, earc, ecen, echgres, ediag, efcs, eobs, epos, esfc, eupd, fcst, fv3.emc.dyn, fv3.nco.static, fv3ic, gempak, getic, gldas, metp, nsst, post, postsnd, prep, prepbufr, resources.emc.dyn, resources.nco.static, vrfy, wafs, wafsblending, wafsblending0p25, wafsgcip, wafsgrib2, wafsgrib20p25, wave, waveawipsbulls, waveawipsgridded, wavegempak, waveinit, wavepostbndpnt, wavepostbndpntbll, wavepostpnt, wavepostsbs, waveprep
+
+print(c.eupd.path)
+>>> /home/rlong/Sandbox/temp/global-workflow/parm/config/config.eupd
+
+print(c.eupd.name)
+>>> eupd
+
+print(c.eupd.content)
+>>> ...prints content of eupd
+
+
+c.eupd.write_to(pathlib.Path("./eupd.sh"))
+>>> ...writes content of eupd to file at `./eupd.sh"
+
+"""
+
+import glob
+import pathlib
+import itertools
+from typing import List
+
+
+class ConfigFile:
+    """represents a config file"""
+
+    def __init__(self, name, path):
+        self.name = name
+        self.path = path
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {self.name}:{self.path} />"
+
+    def __str__(self):
+        return f"{self.name}: {self.path}"
+
+    @property
+    def content(self) -> List[str]:
+        """return the config file contents"""
+        with open(self.path, "r", encoding="utf-8") as _file:
+            return _file.readlines()
+
+    def write_to(self, output_path: pathlib.Path) -> None:
+        """writes the content of a config file to `output_path`"""
+        with open(output_path, "w", encoding="utf-8") as _file:
+            _file.writelines(self.content)
+
+
+class ConfigManager:
+    """interface to manage config files"""
+
+    def __init__(self, config_files_root: pathlib.Path):
+        self.config_files_root = config_files_root.resolve()
+
+    def __iter__(self):
+        return iter(self.keys)
+
+    def __len__(self):
+        return len(self.keys)
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {len(self.map)}/>"
+
+    def __str__(self):
+        return f"{', '.join(self.keys)}"
+
+    def __getitem__(self, __name: str):
+        return list(filter(lambda x: x.name == __name, self.map))[0]
+
+    def __getattr__(self, __name: str):
+        return self.__getitem__(__name)
+
+    @property
+    def map(self):
+        """returns list of ConfigFile"""
+        return [
+            ConfigFile(config_file.name.split(".", 1)[1], config_file)
+            for config_file in files_by_path(
+                pathlib.Path(self.config_files_root), ["*"]
+            )
+        ]
+
+    @property
+    def keys(self):
+        """returns unique list of config names"""
+        return sorted({x.name for x in self.map})
+
+    @property
+    def paths(self):
+        """returns unique list of config paths"""
+        return sorted({x.path for x in self.map})
+
+
+def files_by_path(target: pathlib.Path, extensions: List[str]) -> List[pathlib.Path]:
+    """returns a list of files"""
+    return [
+        pathlib.Path(_file).resolve()
+        for _file in itertools.chain(
+            *[
+                glob.glob(f"{target.resolve()}/**/*.{x}", recursive=True)
+                for x in extensions
+            ],
+        )
+        if not any([pathlib.Path(_file).is_dir()])
+    ]
+
+
+if __name__ == "__main__":
+    pass

--- a/config_manager/test_config_manager.py
+++ b/config_manager/test_config_manager.py
@@ -1,0 +1,49 @@
+
+import os
+import pathlib
+import tempfile
+from config_manager.config_manager import ConfigManager
+
+
+def test_configManager_loadsFromPath():
+    c = ConfigManager(pathlib.Path("../parm/config"))
+    expected = 0
+    actual = len(c)
+    assert expected < actual
+
+def test_configFile_showsCorrectPath():
+    c = ConfigManager(pathlib.Path("../parm/config"))
+    expected = "config.eupd"
+    actual = str(c.eupd.path)
+    assert expected in actual
+
+def test_configFile_showsCorrectName():
+    c = ConfigManager(pathlib.Path("../parm/config"))
+    expected = "eupd"
+    actual = str(c.eupd.name)
+    assert expected == actual
+
+def test_configFile_showsCorrectContent():
+    c = ConfigManager(pathlib.Path("../parm/config"))
+    expected = "########## config.eupd ##########\n"
+    actual = c.eupd.content
+    assert expected in actual
+
+def test_configFile_writesCorrectContent():
+    c = ConfigManager(pathlib.Path("../parm/config"))
+    expected = "########## config.eupd ##########\n"
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        print('created temporary directory', tmpdirname)
+        output_file = pathlib.Path(os.path.join(tmpdirname, "eupd.sh"))
+        c.eupd.write_to(output_file)
+        with open(output_file) as _file:
+            assert expected in _file.readlines()
+
+
+
+
+# print(c)
+#     print(c.eupd.path)
+#     print(c.eupd.name)
+#     print(c.eupd.content)
+#     c.eupd.write_to(pathlib.Path("./test_test_test.sh"))

--- a/config_manager/test_config_manager.py
+++ b/config_manager/test_config_manager.py
@@ -38,12 +38,3 @@ def test_configFile_writesCorrectContent():
         c.eupd.write_to(output_file)
         with open(output_file) as _file:
             assert expected in _file.readlines()
-
-
-
-
-# print(c)
-#     print(c.eupd.path)
-#     print(c.eupd.name)
-#     print(c.eupd.content)
-#     c.eupd.write_to(pathlib.Path("./test_test_test.sh"))


### PR DESCRIPTION
**Description**

Abstracts the `parm/config` directory into a python object in order to dynamically interact with library's config files.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
This request includes necessary unit tests.  I did not move the `parm/config` directory into a static fixture as the library's own functionality depends on the existence of `parm/config`.  

The unit tests are machine/environment agnostic.
  
**Checklist**

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
