### PR TITLE
Fix history type of cldfra in the diag_tables

### DIFF
--- a/parm/parm_fv3diag/diag_table
+++ b/parm/parm_fv3diag/diag_table
@@ -22,7 +22,7 @@
 "gfs_dyn",     "ps",          "pressfc",      "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "hs",          "hgtsfc",       "fv3_history",    "all",  .false.,  "none",  2
 
-"gfs_phys",     "cldfra",       "cldfra",        "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "cldfra",        "cldfra",        "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "ALBDO_ave",     "albdo_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "cnvprcp_ave",   "cprat_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "cnvprcpb_ave",  "cpratb_ave",    "fv3_history2d",  "all",  .false.,  "none",  2

--- a/parm/parm_fv3diag/diag_table_cpl
+++ b/parm/parm_fv3diag/diag_table_cpl
@@ -120,7 +120,7 @@
 "gfs_dyn",     "ps",          "pressfc",      "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "hs",          "hgtsfc",       "fv3_history",    "all",  .false.,  "none",  2
 
-"gfs_phys",     "cldfra",       "cldfra",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "cldfra",        "cldfra",        "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "ALBDO_ave",     "albdo_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "cnvprcp_ave",   "cprat_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "cnvprcpb_ave",  "cpratb_ave",    "fv3_history2d",  "all",  .false.,  "none",  2

--- a/parm/parm_fv3diag/diag_table_da
+++ b/parm/parm_fv3diag/diag_table_da
@@ -22,7 +22,7 @@
 "gfs_dyn",     "ps",          "pressfc",      "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "hs",          "hgtsfc",       "fv3_history",    "all",  .false.,  "none",  2
 
-"gfs_phys",     "cldfra",       "cldfra",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "cldfra",        "cldfra",        "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "ALBDO_ave",     "albdo_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "cnvprcp_ave",   "cprat_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "cnvprcpb_ave",  "cpratb_ave",    "fv3_history2d",  "all",  .false.,  "none",  2


### PR DESCRIPTION
**Description**
This PR is aimed to simply change "fv3_history" to "fv3_history2d" for the newly added variable cldfra in the diag_tables. 

Fixes #914 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

<!--
- [ ] Clone and Build tests on WCOSS Dell P3
- [ ] Cycled test on Orion
- [X ] Forecast-only test on Hera
-->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
