### PR TITLE
Remove new GSI scripts from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,19 +133,10 @@ sorc/wafs_setmissing.fd
 # Ignore scripts from externals
 #------------------------------
 # jobs symlinks
-jobs/JGDAS_ATMOS_ANALYSIS_DIAG
-jobs/JGDAS_ATMOS_CHGRES_FORENKF
 jobs/JGDAS_ATMOS_GLDAS
 jobs/JGDAS_ATMOS_VERFOZN
 jobs/JGDAS_ATMOS_VERFRAD
 jobs/JGDAS_ATMOS_VMINMON
-jobs/JGDAS_ENKF_DIAG
-jobs/JGDAS_ENKF_ECEN
-jobs/JGDAS_ENKF_FCST
-jobs/JGDAS_ENKF_POST
-jobs/JGDAS_ENKF_SELECT_OBS
-jobs/JGDAS_ENKF_SFC
-jobs/JGDAS_ENKF_UPDATE
 jobs/JGFS_ATMOS_VMINMON
 jobs/JGFS_ATMOS_WAFS
 jobs/JGFS_ATMOS_WAFS_BLENDING
@@ -153,21 +144,12 @@ jobs/JGFS_ATMOS_WAFS_BLENDING_0P25
 jobs/JGFS_ATMOS_WAFS_GCIP
 jobs/JGFS_ATMOS_WAFS_GRIB2
 jobs/JGFS_ATMOS_WAFS_GRIB2_0P25
-jobs/JGLOBAL_ATMOS_ANALYSIS
-jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
 # scripts symlinks
 scripts/exemcsfc_global_sfc_prep.sh
-scripts/exgdas_atmos_chgres_forenkf.sh
 scripts/exgdas_atmos_gldas.sh
 scripts/exgdas_atmos_verfozn.sh
 scripts/exgdas_atmos_verfrad.sh
 scripts/exgdas_atmos_vminmon.sh
-scripts/exgdas_enkf_ecen.sh
-scripts/exgdas_enkf_fcst.sh
-scripts/exgdas_enkf_post.sh
-scripts/exgdas_enkf_select_obs.sh
-scripts/exgdas_enkf_sfc.sh
-scripts/exgdas_enkf_update.sh
 scripts/exgfs_atmos_vminmon.sh
 scripts/exgfs_atmos_wafs_blending.sh
 scripts/exgfs_atmos_wafs_blending_0p25.sh
@@ -175,12 +157,7 @@ scripts/exgfs_atmos_wafs_gcip.sh
 scripts/exgfs_atmos_wafs_grib.sh
 scripts/exgfs_atmos_wafs_grib2.sh
 scripts/exgfs_atmos_wafs_grib2_0p25.sh
-scripts/exglobal_atmos_analysis.sh
-scripts/exglobal_atmos_analysis_calc.sh
-scripts/exglobal_diag.sh
 # ush symlinks
-ush/calcanl_gfs.py
-ush/calcinc_gfs.py
 ush/chgres_cube.sh
 ush/emcsfc_ice_blend.sh
 ush/emcsfc_snow.sh
@@ -189,7 +166,6 @@ ush/fv3gfs_driver_grid.sh
 ush/fv3gfs_filter_topo.sh
 ush/fv3gfs_make_grid.sh
 ush/fv3gfs_make_orog.sh
-ush/getncdimlen
 ush/gldas_archive.sh
 ush/gldas_forcing.sh
 ush/gldas_get_data.sh
@@ -200,7 +176,6 @@ ush/global_chgres.sh
 ush/global_chgres_driver.sh
 ush/global_cycle.sh
 ush/global_cycle_driver.sh
-ush/gsi_utils.py
 ush/minmon_xtrct_costs.pl
 ush/minmon_xtrct_gnorms.pl
 ush/minmon_xtrct_reduct.pl


### PR DESCRIPTION
**Description**

When the scripts were moved over from GSI into global workflow, they were never removed from the .gitignore. This has now been addressed.

Follow-up to PR #904

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- Code-management change only; no functional change.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Any dependent changes have been merged and published
