### PR TITLE
Add postsnd job when bufrsnd it on

### DIFF
--- a/workflow/applications.py
+++ b/workflow/applications.py
@@ -186,6 +186,9 @@ class AppConfig:
         if self.do_gempak:
             configs += ['gempak']
 
+        if self.do_bufrsnd:
+            configs += ['postsnd']
+
         if self.do_awips:
             configs += ['awips']
 


### PR DESCRIPTION
**Description**

In the workflow refactoring, the addition of postsnd to the task list when bufrsnd is true was inadvertently left out. It is now added back in.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Workflow generation on Hera
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
