### PR TITLE
change gdasechgres dependency to just gdasefcs01 instead of gdasefmn

### DIFF
--- a/workflow/rocoto/workflow_tasks.py
+++ b/workflow/rocoto/workflow_tasks.py
@@ -437,7 +437,7 @@ class Tasks:
         dep_dict = {'type': 'cycleexist', 'offset': '-06:00:00'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
-   
+
         resources = self.get_resource('atmanalpost')
         task = create_wf_task('atmanalpost', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies)
 
@@ -999,7 +999,7 @@ class Tasks:
 
         resources = self.get_resource('atmensanalpost')
         task = create_wf_task('atmensanalpost', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies)
-   
+
         return task
 
     def ecen(self):
@@ -1109,7 +1109,7 @@ class Tasks:
         deps = []
         dep_dict = {'type': 'task', 'name': f'{self.cdump}fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}efmn'}
+        dep_dict = {'type': 'task', 'name': f'{self.cdump}efcs01'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 


### PR DESCRIPTION
**Description**

Presently, `gdasechgres` has 2 dependencies:
- `gdasfcst` - deterministic forecast
- `gdasefmn` - ensemble forecasts (all of them).

The work done in `gdasechgres` actually depends only on the `mem001/atmos/gdas.tHHz.atmf006.nc`.
This file is used as a template as well as obtaining `hgtsfc`.
As such, there is no reason to depend on the entire ensemble of forecasts to be complete before `gdasechgres` can start.

This PR:
- replaces the dependency of `gdasechgres` on `gdasefmn` with `gdasefcs01`.

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

Tested as part of #922 
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes