### PR TITLE
Remove MPICH_MPIIO_HINTS analcalc setting

### DIFF
--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -127,8 +127,6 @@ elif [ $step = "anal" ]; then
 
 elif [ $step = "analcalc" ]; then
 
-    export MPICH_MPIIO_HINTS="*:romio_cb_write=disable"
-
     export wtime_analcalc="00:10:00"
     export npe_analcalc=127
     export ntasks=$npe_analcalc


### PR DESCRIPTION
**Description**

Remove the MPICH_MPIIO_HINTS analcalc setting from `config.resources.nco.static`. Leaving it in the `config.resources.emc.dyn` version.

Refs: #665