### PR TITLE
GFSv16.2.2 - RTOFSv2.3 upgrade

### DIFF
--- a/docs/Release_Notes.gfs.v16.2.2.md
+++ b/docs/Release_Notes.gfs.v16.2.2.md
@@ -1,0 +1,123 @@
+GFS V16.2.2 RELEASE NOTES
+
+-------
+PRELUDE
+-------
+
+The upstream dependency system RTOFS is upgraded to v2.3. This results in a version file change within the GFS.
+
+IMPLEMENTATION INSTRUCTIONS
+---------------------------
+
+The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com are used to manage the GFS.v16.2.2 code. The SPA(s) handling the GFS.v16.2.2 implementation need to have permissions to clone VLab gerrit repositories and the private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are publicly readable and do not require access permissions. Please follow the following steps to install the package on WCOSS2:
+
+```bash
+cd $PACKAGEROOT
+mkdir gfs.v16.2.2
+cd gfs.v16.2.2
+git clone -b EMC-v16.2.2 https://github.com/NOAA-EMC/global-workflow.git .
+cd sorc
+./checkout.sh -o
+```
+
+The checkout script extracts the following GFS components:
+
+| Component | Tag         | POC               |
+| --------- | ----------- | ----------------- |
+| MODEL     | GFS.v16.2.0   | Jun.Wang@noaa.gov |
+| GSI       | gfsda.v16.2.0 | Russ.Treadon@noaa.gov |
+| GLDAS     | gldas_gfsv16_release.v.2.0.0 | Helin.Wei@noaa.gov |
+| UFS_UTILS | ops-gfsv16.2.0 | George.Gayno@noaa.gov |
+| POST      | upp_v8.1.2 | Wen.Meng@noaa.gov |
+| WAFS      | gfs_wafs.v6.2.8 | Yali.Mao@noaa.gov |
+
+To build all the GFS components, execute:
+```bash
+./build_all.sh
+```
+The `build_all.sh` script compiles all GFS components. Runtime output from the build for each package is written to log files in directory logs. To build an individual program, for instance, gsi, use `build_gsi.sh`.
+
+Next, link the executables, fix files, parm files etc in their final respective locations by executing:
+```bash
+./link_fv3gfs.sh nco wcoss2
+```
+
+Lastly, link the ecf scripts by moving back up to the ecf folder and executing:
+```bash
+cd ../ecf
+./setup_ecf_links.sh
+```
+
+SORC CHANGES
+------------
+
+* No changes from GFS v16.2.1
+
+FIX CHANGES
+-----------
+
+* No changes from GFS v16.2.1
+
+PARM/CONFIG CHANGES
+-------------------
+
+* No changes from GFS v16.2.1
+
+JOBS CHANGES
+------------
+
+* No changes from GFS v16.2.1
+
+SCRIPT CHANGES
+--------------
+
+* No changes from GFS v16.2.1
+
+MODULE CHANGES
+--------------
+
+* No changes from GFS v16.2.1
+
+VERSION CHANGES
+---------------
+
+The "rtofs_ver" version variable changes from v2.2. to v2.3.
+
+CHANGES TO RESOURCES AND FILE SIZES
+-----------------------------------
+
+* File sizes
+  * No change to GFSv16.2.1
+* Resource changes
+  * No change to GFSv16.2.1
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+---------------------------------------
+
+* Which production jobs should be tested as part of this implementation?
+  * The entire GFS v16.2.2 package needs to be installed and tested.
+* Does this change require a 30-day evaluation?
+  * No.
+
+DISSEMINATION INFORMATION
+-------------------------
+
+* Where should this output be sent?
+  * No change from GFS v16.2.1
+* Who are the users?
+  * No change from GFS v16.2.1
+* Which output files should be transferred from PROD WCOSS2 to DEV WCOSS2?
+  * No change from GFS v16.2.1
+* Directory changes
+  * No change from GFS v16.2.1
+* File changes
+  * No change from GFS v16.2.1
+
+HPSS ARCHIVE
+------------
+
+* No change from GFS v16.2.1
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+---------------------------------
+* No change from GFS v16.2.1

--- a/ecf/versions/gfs.ver
+++ b/ecf/versions/gfs.ver
@@ -5,7 +5,7 @@ export COMPATH=/lfs/h1/ops/canned/com/ukmet:/lfs/h1/ops/canned/com/gfs:/lfs/h1/o
 export ukmet_ver=v2.2.0
 export ecmwf_ver=v2.1.0
 export nam_ver=v4.2.0
-export rtofs_ver=v2.2.0
+export rtofs_ver=v2.3.0
 export radarl2_ver=v1.2
 
 #### NCO requested testing location is v16.2

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -3,7 +3,7 @@ export gfs_ver=v16.2.0
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2
-export rtofs_ver=v2.2
+export rtofs_ver=v2.3
 export radarl2_ver=v1.2
 export obsproc_ver=v1.0
 


### PR DESCRIPTION
**Description**

This PR updates the `rtofs_ver` to v2.3 per the RFC 9814 change in WCOSS2 operations. Release notes are also added.

```
RFC 9814 - RTOFS v2.3.0 - On WCOSS2, implement RTOFS.v2.3.0 into
production. This is the follow-up to RFC 9745 (implemented on July 18) which
initiated the evaluation test for this model upgrade. For this RFC, EVAL will be
turned off and the operational version will be replaced with v2.3.0. In addition,
downstream models (GFS, HMON, HWRF, NOSOFS, and NWPS) will be
updated to pick up the RTOFS.v2.3.0 output files. NCO/IDSB/Dataflow will
update the "prod" link for NOMADS and ftpprd to point to the new version
number. RTOFS v2.3.0 accounts for bug fixes, bias corrections, and changes in
data inputs for operations. The initialization scheme for the previous version of
RTOFS creates an initialization shock, spurious waves, and systematic errors in
the prediction of the ocean state in the equatorial ocean. The technical correction
in v2.3.0 nearly eliminates these systematic errors. To be implemented on
August 2 at 1400Z.
```

**Type of change**

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**How Has This Been Tested?**

NCO tested the GFS with the updated RTOFS package in para on WCOSS2 prior to implementation into operations.
  
Resolves #900
