### PR TITLE
Fix GLDAS j-job link

### DIFF
--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -81,8 +81,8 @@ fi
 #---------------------------------------
 #--add files from external repositories
 #---------------------------------------
+cd ${pwd}/../jobs               ||exit 8
 if [ -d ../sorc/gldas.fd ]; then
-  cd ${pwd}/../jobs               ||exit 8
     $LINK ../sorc/gldas.fd/jobs/JGDAS_ATMOS_GLDAS            .
 fi
 cd ${pwd}/../parm               ||exit 8


### PR DESCRIPTION
**Description**
The cd was misplaced when checking for the existence of gldas.fd to
create the link for the j-job, so the directory was never found and
the job never linked.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Checkout and link on Hera
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
