### PR TITLE
RTOFSv2.3 upgrade changes

### DIFF
--- a/docs/Release_Notes.gfs.v16.1.8.txt
+++ b/docs/Release_Notes.gfs.v16.1.8.txt
@@ -1,0 +1,128 @@
+GFS V16.1.8 RELEASE NOTES
+
+PRELUDE
+
+Meteosat-9 replaces Meteosat-8 as the operational geostationary platform over the Indian Ocean on 20220601.  To maintain continuity of operations, the /fix/fix_gsi/global_convinfo.txt file needs to be modified before this date (as soon as possible is preferable)
+
+IMPLEMENTATION INSTRUCTIONS
+
+  The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com
+  are used to manage the GFS.v16.1.8 code. The SPA(s) handling the GFS.v16.1.8
+  implementation need to have permissions to clone VLab gerrit repositories and
+  the private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are
+  publicly readable and do not require access permissions.  Please follow the
+  following steps to install the package on WCOSS-Dell:
+
+  1) cd $NWROOTp3
+
+  2) mkdir gfs.v16.1.8
+
+  3) cd gfs.v16.1.8
+
+  4) git clone -b EMC-v16.1.8  https://github.com/NOAA-EMC/global-workflow.git .
+
+  5) cd sorc
+
+  6) ./checkout.sh -o
+      * This script extracts the following GFS components:
+	MODEL 	   tag GFS.v16.0.17              	Jun.Wang@noaa.gov
+	GSI   	   tag gfsda.v16.1.8             	Catherine.Thomas@noaa.gov
+	GLDAS 	   tag gldas_gfsv16_release.v1.12.0	Helin.Wei@noaa.gov
+	UFS_UTILS  tag ops-gfsv16.0.0            	George.Gayno@noaa.gov
+	POST  	   tag upp_gfsv16_release.v1.1.4 	Wen.Meng@noaa.gov
+	WAFS  	   tag gfs_wafs.v6.0.22          	Yali.Mao@noaa.gov
+
+  7) ./build_all.sh
+      * This script compiles all GFS components. Runtime output from the build for
+	each package is written to log files in directory logs. To build an
+	individual program, for instance, gsi, use build_gsi.sh.
+
+  8) ./link_fv3gfs.sh nco dell
+
+SORC CHANGES
+
+* No changes from GFS v16.1.7
+
+
+FIX CHANGES
+
+* fix/fix_gsi/
+      *fix/fix_gsi/global_convinfo.txt: Turn on uv satid 56 (three character change)
+
+PARM/CONFIG CHANGES
+
+* No changes from GFS v16.1.7
+
+
+JOBS CHANGES
+
+* No change from GFS v16.1.7
+
+
+SCRIPT CHANGES
+
+* No change from GFS v16.1.7
+
+
+CHANGES TO RESOURCES AND FILE SIZES
+
+* No change from GFS v16.1.7
+
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+
+* Which production jobs should be tested as part of this implementation?
+  * jobs jgdas_atmos_analysis and jgfs_atmos_analysis should be tested.  Prior to 20220601, results should be identical.
+
+* Does this change require a 30-day evaluation?
+  * No.
+
+DISSEMINATION INFORMATION
+
+* Where should this output be sent?
+  * No change from GFS v16.1.7
+
+* Who are the users?
+  * No change from GFS v16.1.7
+
+* Which output files should be transferred from PROD WCOSS to DEV WCOSS?
+  * No change from GFS v16.1.7
+
+* Directory changes
+  * No change from GFS v16.1.7
+
+* File changes
+  * No change from GFS v16.1.7
+
+
+HPSS ARCHIVE
+
+* No change from GFS v16.1.7
+
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+
+* No change from GFS v16.1.7
+
+
+Temporary Location of Changed Files on disk.
+
+On WCOSS:
+Replace:
+ /gpfs/dell1/nco/ops/nwprod/gfs.v16.1.7/fix/fix_gsi/global_convinfo.txt
+and
+/gpfs/dell1/nco/ops/nwprod/gfs.v16.1.7/sorc/gsi.fd/fix/global_convinfo.txt
+(the above two files should be identical)
+with:
+/gpfs/dell2/emc/modeling/save/Andrew.Collard/Meteosat9/global_convinfo.txt.gfs.v16.1.8
+(updating version numbers as appropriate)
+
+On WCOSS2:
+Replace:
+/lfs/h1/ops/prod/packages/gfs.v16.2.0/fix/fix_gsi/global_convinfo.txt
+and
+/lfs/h1/ops/prod/packages/gfs.v16.2.0/sorc/gsi.fd/fix/global_convinfo.txt
+(the above two files should be identical)
+with:
+/u/Andrew.Collard/global_convinfo.txt.gfs.v16.2.1
+(updating version numbers as appropriate)

--- a/docs/Release_Notes.gfs.v16.2.2.md
+++ b/docs/Release_Notes.gfs.v16.2.2.md
@@ -1,0 +1,123 @@
+GFS V16.2.2 RELEASE NOTES
+
+-------
+PRELUDE
+-------
+
+The upstream dependency system RTOFS is upgraded to v2.3. This results in a version file change within the GFS.
+
+IMPLEMENTATION INSTRUCTIONS
+---------------------------
+
+The NOAA VLab and both the NOAA-EMC and NCAR organization spaces on GitHub.com are used to manage the GFS.v16.2.2 code. The SPA(s) handling the GFS.v16.2.2 implementation need to have permissions to clone VLab gerrit repositories and the private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are publicly readable and do not require access permissions. Please follow the following steps to install the package on WCOSS2:
+
+```bash
+cd $PACKAGEROOT
+mkdir gfs.v16.2.2
+cd gfs.v16.2.2
+git clone -b EMC-v16.2.2 https://github.com/NOAA-EMC/global-workflow.git .
+cd sorc
+./checkout.sh -o
+```
+
+The checkout script extracts the following GFS components:
+
+| Component | Tag         | POC               |
+| --------- | ----------- | ----------------- |
+| MODEL     | GFS.v16.2.0   | Jun.Wang@noaa.gov |
+| GSI       | gfsda.v16.2.0 | Russ.Treadon@noaa.gov |
+| GLDAS     | gldas_gfsv16_release.v.2.0.0 | Helin.Wei@noaa.gov |
+| UFS_UTILS | ops-gfsv16.2.0 | George.Gayno@noaa.gov |
+| POST      | upp_v8.1.2 | Wen.Meng@noaa.gov |
+| WAFS      | gfs_wafs.v6.2.8 | Yali.Mao@noaa.gov |
+
+To build all the GFS components, execute:
+```bash
+./build_all.sh
+```
+The `build_all.sh` script compiles all GFS components. Runtime output from the build for each package is written to log files in directory logs. To build an individual program, for instance, gsi, use `build_gsi.sh`.
+
+Next, link the executables, fix files, parm files etc in their final respective locations by executing:
+```bash
+./link_fv3gfs.sh nco wcoss2
+```
+
+Lastly, link the ecf scripts by moving back up to the ecf folder and executing:
+```bash
+cd ../ecf
+./setup_ecf_links.sh
+```
+
+SORC CHANGES
+------------
+
+* No changes from GFS v16.2.1
+
+FIX CHANGES
+-----------
+
+* No changes from GFS v16.2.1
+
+PARM/CONFIG CHANGES
+-------------------
+
+* No changes from GFS v16.2.1
+
+JOBS CHANGES
+------------
+
+* No changes from GFS v16.2.1
+
+SCRIPT CHANGES
+--------------
+
+* No changes from GFS v16.2.1
+
+MODULE CHANGES
+--------------
+
+* No changes from GFS v16.2.1
+
+VERSION CHANGES
+---------------
+
+The "rtofs_ver" version variable changes from v2.2. to v2.3.
+
+CHANGES TO RESOURCES AND FILE SIZES
+-----------------------------------
+
+* File sizes
+  * No change to GFSv16.2.1
+* Resource changes
+  * No change to GFSv16.2.1
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+---------------------------------------
+
+* Which production jobs should be tested as part of this implementation?
+  * The entire GFS v16.2.2 package needs to be installed and tested.
+* Does this change require a 30-day evaluation?
+  * No.
+
+DISSEMINATION INFORMATION
+-------------------------
+
+* Where should this output be sent?
+  * No change from GFS v16.2.1
+* Who are the users?
+  * No change from GFS v16.2.1
+* Which output files should be transferred from PROD WCOSS2 to DEV WCOSS2?
+  * No change from GFS v16.2.1
+* Directory changes
+  * No change from GFS v16.2.1
+* File changes
+  * No change from GFS v16.2.1
+
+HPSS ARCHIVE
+------------
+
+* No change from GFS v16.2.1
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+---------------------------------
+* No change from GFS v16.2.1

--- a/ecf/versions/gfs.ver
+++ b/ecf/versions/gfs.ver
@@ -5,7 +5,7 @@ export COMPATH=/lfs/h1/ops/canned/com/ukmet:/lfs/h1/ops/canned/com/gfs:/lfs/h1/o
 export ukmet_ver=v2.2.0
 export ecmwf_ver=v2.1.0
 export nam_ver=v4.2.0
-export rtofs_ver=v2.2.0
+export rtofs_ver=v2.3.0
 export radarl2_ver=v1.2
 
 #### NCO requested testing location is v16.2

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -3,7 +3,7 @@ export gfs_ver=v16.2.0
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2
-export rtofs_ver=v2.2
+export rtofs_ver=v2.3
 export radarl2_ver=v1.2
 export obsproc_ver=v1.0
 


### PR DESCRIPTION
**Description**

This PR brings in `operations` updates for the GFSv16.2.2 upgrade (RTOFSv2.3). It includes:

- Updating `rtofs_ver` from v2.2.0 to v2.3.0 in `versions/run.ver` and `ecf/versions/gfs.ver`.
- Add release notes for GFSv16.2.2.
- Also add missing release notes for GFSv16.1.8.

Refs: #665, #900

**Type of change**

Sync merge

**How Has This Been Tested?**

This update is currently running in WCOSS2 operations.