### PR TITLE
Remove SDATE=CDATE IAU block in NCO config.base

### DIFF
--- a/parm/config/config.base.nco.static
+++ b/parm/config/config.base.nco.static
@@ -187,10 +187,6 @@ export IAU_OFFSET=6
 export DOIAU_ENKF="YES"   # Enable 4DIAU for EnKF ensemble
 export IAUFHRS_ENKF="3,6,9"
 export IAU_DELTHRS_ENKF=6
-if [[ "$SDATE" = "$CDATE" ]]; then
-  export IAU_OFFSET=0
-  export IAU_FHROT=0
-fi
 
 # Use Jacobians in eupd and thereby remove need to run eomg
 export lobsdiag_forenkf=".true."


### PR DESCRIPTION
**Description**

Bug fix for IAU settings for warm start runs with wave restarts in `config.base.nco.static`.

- Remove the block in config.base.nco.static that checks if CDATE=SDATE and turns IAU settings to 0.
- This block is not needed in operations and causes issues in pre-implementation developer testing when starting a new warm-started parallel with wave restarts.

Merge into the `dev_v16.2.x` branch first and then sync merge into the `release/gfs.v16.3.0` branch.

Fixes #960

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

@lgannoaa confirmed that commenting out this block in his test's config.base allows the forecast job to stop failing and work.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
