### PR TITLE
Sync bug fix for SDATE=CDATE block in config.base.nco.static into GFSv16.3.0 package

### DIFF
--- a/parm/config/config.base.nco.static
+++ b/parm/config/config.base.nco.static
@@ -187,10 +187,6 @@ export IAU_OFFSET=6
 export DOIAU_ENKF="YES"   # Enable 4DIAU for EnKF ensemble
 export IAUFHRS_ENKF="3,6,9"
 export IAU_DELTHRS_ENKF=6
-if [[ "$SDATE" = "$CDATE" ]]; then
-  export IAU_OFFSET=0
-  export IAU_FHROT=0
-fi
 
 # Use Jacobians in eupd and thereby remove need to run eomg
 export lobsdiag_forenkf=".true."


### PR DESCRIPTION
**Description**

Sync merge fix to bug reported in issue #960. See PR #961 for more details. Fixes #960.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
