### PR TITLE
Remove SDATE=CDATE IAU settings block in config.base.nco.static

### DIFF
--- a/parm/config/config.base.nco.static
+++ b/parm/config/config.base.nco.static
@@ -194,10 +194,6 @@ export IAU_OFFSET=6
 export DOIAU_ENKF=${DOIAU:-"YES"}   # Enable 4DIAU for EnKF ensemble
 export IAUFHRS_ENKF="3,6,9"
 export IAU_DELTHRS_ENKF=6
-if [[ "$SDATE" = "$CDATE" ]]; then
-  export IAU_OFFSET=0
-  export IAU_FHROT=0
-fi
 
 # Use Jacobians in eupd and thereby remove need to run eomg
 export lobsdiag_forenkf=".true."


### PR DESCRIPTION
**Description**

This PR resolves a bug reported in issue #960 revolving around IAU and FHROT settings in `config.base.nco.static` which result in a failing forecast job when running a new parallel that is warm-started with wave restarts. The following block is removed in `config.base.nco.static`:

```
if [[ "$SDATE" = "$CDATE" ]]; then
  export IAU_OFFSET=0
  export IAU_FHROT=0
fi
```

The above block is unnecessary in operations (and thankfully not an issue in operations since SDATE is very old) but caused issues when used in pre-implementation parallels that used `config.base.nco.static` and warm-started with wave restarts.

Resolves #960

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

The developer running the affected parallel commented out this block and confirmed the forecast job no longer fails.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
