### PR TITLE
Fix post comparison with zero-padded numbers

### DIFF
--- a/ush/fv3gfs_downstream_nems.sh
+++ b/ush/fv3gfs_downstream_nems.sh
@@ -77,10 +77,8 @@ elif [ $FH -eq 0 ] ; then
 else
   export paramlist=${paramlist:-$PARMpost/global_1x1_paramlist_g2}
   export paramlistb=${paramlistb:-$PARMpost/global_master-catchup_parmlist_g2}
-  export fhr3=$(expr $FH + 0 )
-  if [ $fhr3 -lt 100 ]; then export fhr3="0$fhr3"; fi
-  if [ $fhr3 -lt 10 ];  then export fhr3="0$fhr3"; fi
-  if [ $fhr3%${FHOUT_PGB} -eq 0 ]; then
+  export fhr3=$(printf "%03d" ${FH})
+  if (( fhr3%FHOUT_PGB == 0 )); then
     export PGBS=YES
   fi
 fi


### PR DESCRIPTION
**Description**
An error was introduced with PR #929 that was causing 0p50 and 1p00 grib files to not be produced due to an error in comparing a zero-padded string. Switching to arithmatic comparison solves the issue. Also updated the method
of the zero-padding to the preferred printf since the code was in close proximity.
**Type of change**

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Coupled test on Hera
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
