### PR TITLE
Externals.cfg was stale and had drifted off

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,50 +1,63 @@
 # External sub-modules of global-workflow
 
-[FV3GFS]
-hash = 9350745855aebe0790813e0ed2ba5ad680e3f75c
-local_path = sorc/fv3gfs.fd
+[UFS]
+tag = Prototype-P8
+local_path = sorc/ufs_model.fd
 repo_url = https://github.com/ufs-community/ufs-weather-model.git
 protocol = git
 required = True
 
-[GSI]
-hash = 9c1fc15d42573b398037319bbf8d5143ad126fb6
-local_path = sorc/gsi.fd
-repo_url = https://github.com/NOAA-EMC/GSI.git
-protocol = git
-required = True
-
-[GLDAS]
-tag = gldas_gfsv16_release.v1.15.0
-local_path = sorc/gldas.fd
-repo_url = https://github.com/NOAA-EMC/GLDAS.git
-protocol = git
-required = True
-
-[UPP]
-#No externals setting = .gitmodules will be invoked for CMakeModules and comupp/src/lib/crtm2 submodules
-hash = ff42e0227d6100285d4179a2572b700fd5a959cb
-local_path = sorc/gfs_post.fd
-repo_url = https://github.com/NOAA-EMC/UPP.git
-protocol = git
-required = True
-
-[UFS_UTILS]
-tag = ufs_utils_1_6_0
+[UFS-Utils]
+hash = a2b0817
 local_path = sorc/ufs_utils.fd
 repo_url = https://github.com/NOAA-EMC/UFS_UTILS.git
 protocol = git
 required = True
 
 [EMC_verif-global]
-tag = verif_global_v2.5.2
+tag = c267780
 local_path = sorc/verif-global.fd
 repo_url = https://github.com/NOAA-EMC/EMC_verif-global.git
 protocol = git
 required = True
 
-[EMC_gfs_wafs]
-hash = c2a29a67d9432b4d6fba99eac7797b81d05202b6
+[GSI-EnKF]
+hash = 67f5ab4
+local_path = sorc/gsi_enkf.fd
+repo_url = https://github.com/NOAA-EMC/GSI.git
+protocol = git
+required = False
+
+[GSI-Utils]
+hash = 322cc7b
+local_path = sorc/gsi_utils.fd
+repo_url = https://github.com/NOAA-EMC/GSI-utils.git
+protocol = git
+required = False
+
+[GSI-Monitor]
+hash = acf8870
+local_path = sorc/gsi_monitor.fd
+repo_url = https://github.com/NOAA-EMC/GSI-monitor.git
+protocol = git
+required = False
+
+[GDASApp]
+hash = 5952c9d
+local_path = sorc/gdas.cd
+repo_url = https://github.com/NOAA-EMC/GDASApp.git
+protocol = git
+required = False
+
+[GLDAS]
+tag = fd8ba62
+local_path = sorc/gldas.fd
+repo_url = https://github.com/NOAA-EMC/GLDAS.git
+protocol = git
+required = False
+
+[EMC-gfs_wafs]
+hash = 014a0b8
 local_path = sorc/gfs_wafs.fd
 repo_url = https://github.com/NOAA-EMC/EMC_gfs_wafs.git
 protocol = git


### PR DESCRIPTION
**Description**

This PR simply revives `Externals.cfg` that had drifted off from `checkout.sh`.
I also testes `Externals.cfg` with `manage_externals` in place of `checkout.sh` on Orion and Hera.
All clones succeeded as expected (including the GSI-fix repository from VLab).

Note: we are not deprecating `checkout.sh` at this time.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [X] Clone on Hera and Orion

  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
