### PR TITLE
Update WAFS tag to gfs_wafs.v6.3.1 with associated resource and settings changes

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -43,7 +43,7 @@ protocol = git
 required = True
 
 [EMC_gfs_wafs]
-tag = gfs_wafs.v6.2.8
+tag = gfs_wafs.v6.3.1
 local_path = sorc/gfs_wafs.fd
 repo_url = https://github.com/NOAA-EMC/EMC_gfs_wafs.git
 protocol = git

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=5GB
+#PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=15GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 
@@ -35,6 +35,7 @@ module list
 #############################################################
 export cyc=%CYC%
 export cycle=t%CYC%z
+export ICAO2023=no
 
 ############################################################
 # CALL executable job script here

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=60GB
+#PBS -l select=1:mpiprocs=18:ompthreads=1:ncpus=18:mem=80GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 
@@ -28,6 +28,7 @@ module load cray-pals/${cray_pals_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}
 module load wgrib2/${wgrib2_ver}
+module load cfp/${cfp_ver}
 
 module list
 
@@ -36,6 +37,7 @@ module list
 #############################################################
 export cyc=%CYC%
 export cycle=t%CYC%z
+export ICAO2023=no
 
 ############################################################
 # CALL executable job script here

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2_0p25.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2_0p25.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=10GB
+#PBS -l select=1:mpiprocs=11:ompthreads=1:ncpus=11:mem=80GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 
@@ -28,6 +28,7 @@ module load cray-pals/${cray_pals_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}
 module load wgrib2/${wgrib2_ver}
+module load cfp/${cfp_ver}
 
 module list
 
@@ -36,6 +37,7 @@ module list
 #############################################################
 export cyc=%CYC%
 export cycle=t%CYC%z
+export ICAO2023=no
 
 ############################################################
 # CALL executable job script here

--- a/ecf/scripts/gfs/atmos/post_processing/jgfs_atmos_wafs_gcip.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/jgfs_atmos_wafs_gcip.ecf
@@ -40,6 +40,7 @@ module list
 export cyc=%CYC%
 export cycle=t%CYC%z
 export USE_CFP=YES
+export ICAO2023=no
 
 ############################################################
 # CALL executable job script here

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -218,7 +218,7 @@ elif [ $step = "wafs" ]; then
 
     export wtime_wafs="00:30:00"
     export npe_wafs=1
-    export npe_node_wafs=1
+    export npe_node_wafs=$npe_wafs
     export nth_wafs=1
     export memory_wafs="5GB"
 
@@ -233,34 +233,34 @@ elif [ $step = "wafsgcip" ]; then
 elif [ $step = "wafsgrib2" ]; then
 
     export wtime_wafsgrib2="00:30:00"
-    export npe_wafsgrib2=1
-    export npe_node_wafsgrib2=1
+    export npe_wafsgrib2=18
+    export npe_node_wafsgrib2=$npe_wafsgrib2
     export nth_wafsgrib2=1
-    export memory_wafsgrib2="60GB"
+    export memory_wafsgrib2="80GB"
 
 elif [ $step = "wafsblending" ]; then
 
     export wtime_wafsblending="00:30:00"
     export npe_wafsblending=1
-    export npe_node_wafsblending=1
+    export npe_node_wafsblending=$npe_wafsblending
     export nth_wafsblending=1
     export memory_wafsblending="1GB"
 
 elif [ $step = "wafsgrib20p25" ]; then
 
     export wtime_wafsgrib20p25="00:30:00"
-    export npe_wafsgrib20p25=1
-    export npe_node_wafsgrib20p25=1
+    export npe_wafsgrib20p25=11
+    export npe_node_wafsgrib20p25=$npe_wafsgrib20p25
     export nth_wafsgrib20p25=1
-    export memory_wafsgrib20p25="10GB"
+    export memory_wafsgrib20p25="80GB"
 
 elif [ $step = "wafsblending0p25" ]; then
 
     export wtime_wafsblending0p25="00:30:00"
     export npe_wafsblending0p25=1
-    export npe_node_wafsblending0p25=1
+    export npe_node_wafsblending0p25=$npe_wafsblending0p25
     export nth_wafsblending0p25=1
-    export memory_wafsblending0p25="5GB"
+    export memory_wafsblending0p25="15GB"
 
 elif [ $step = "vrfy" ]; then
 

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -178,7 +178,7 @@ elif [ $step = "wafs" ]; then
 
     export wtime_wafs="00:30:00"
     export npe_wafs=1
-    export npe_node_wafs=1
+    export npe_node_wafs=$npe_wafs
     export nth_wafs=1
     export memory_wafs="5GB"
 
@@ -193,34 +193,34 @@ elif [ $step = "wafsgcip" ]; then
 elif [ $step = "wafsgrib2" ]; then
 
     export wtime_wafsgrib2="00:30:00"
-    export npe_wafsgrib2=1
-    export npe_node_wafsgrib2=1
+    export npe_wafsgrib2=18
+    export npe_node_wafsgrib2=$npe_wafsgrib2
     export nth_wafsgrib2=1
-    export memory_wafsgrib2="60GB"
+    export memory_wafsgrib2="80GB"
 
 elif [ $step = "wafsblending" ]; then
 
     export wtime_wafsblending="00:30:00"
     export npe_wafsblending=1
-    export npe_node_wafsblending=1
+    export npe_node_wafsblending=$npe_wafsblending
     export nth_wafsblending=1
     export memory_wafsblending="1GB"
 
 elif [ $step = "wafsgrib20p25" ]; then
 
     export wtime_wafsgrib20p25="00:30:00"
-    export npe_wafsgrib20p25=1
-    export npe_node_wafsgrib20p25=1
+    export npe_wafsgrib20p25=11
+    export npe_node_wafsgrib20p25=$npe_wafsgrib20p25
     export nth_wafsgrib20p25=1
-    export memory_wafsgrib20p25="10GB"
+    export memory_wafsgrib20p25="80GB"
 
 elif [ $step = "wafsblending0p25" ]; then
 
     export wtime_wafsblending0p25="00:30:00"
     export npe_wafsblending0p25=1
-    export npe_node_wafsblending0p25=1
+    export npe_node_wafsblending0p25=$npe_wafsblending0p25
     export nth_wafsblending0p25=1
-    export memory_wafsblending0p25="5GB"
+    export memory_wafsblending0p25="15GB"
 
 elif [ $step = "vrfy" ]; then
 

--- a/parm/config/config.wafsblending0p25
+++ b/parm/config/config.wafsblending0p25
@@ -11,4 +11,6 @@ export COMIN=$COMINatmos
 export COMOUT=$COMOUTatmos
 export SENDCOM="YES"
 
+export ICAO2023=no
+
 echo "END: config.wafsblending0p25"

--- a/parm/config/config.wafsgcip
+++ b/parm/config/config.wafsgcip
@@ -12,4 +12,6 @@ export COMINgfs=$COMIN
 export COMOUT=$COMOUTatmos
 export SENDCOM="YES"
 
+export ICAO2023=no
+
 echo "END: config.wafsgcip"

--- a/parm/config/config.wafsgrib2
+++ b/parm/config/config.wafsgrib2
@@ -12,4 +12,6 @@ export COMIN=$COMINatmos
 export COMOUT=$COMOUTatmos
 export SENDCOM="YES"
 
+export ICAO2023=no
+
 echo "END: config.wafsgrib2"

--- a/parm/config/config.wafsgrib20p25
+++ b/parm/config/config.wafsgrib20p25
@@ -11,4 +11,6 @@ export COMIN=$COMINatmos
 export COMOUT=$COMOUTatmos
 export SENDCOM="YES"
 
+export ICAO2023=no
+
 echo "END: config.wafsgrib20p25"

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -87,7 +87,7 @@ if [[ ${checkout_wafs} == "YES" ]] ; then
   echo EMC_gfs_wafs checkout ...
   if [[ ! -d gfs_wafs.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_wafs.log
-    git clone --recursive --branch gfs_wafs.v6.2.8 https://github.com/NOAA-EMC/EMC_gfs_wafs.git gfs_wafs.fd >> ${topdir}/checkout-gfs_wafs.log 2>&1
+    git clone --recursive --branch gfs_wafs.v6.3.1 https://github.com/NOAA-EMC/EMC_gfs_wafs.git gfs_wafs.fd >> ${topdir}/checkout-gfs_wafs.log 2>&1
     cd ${topdir}
   else
     echo 'Skip.  Directory gfs_wafs.fd already exists.'


### PR DESCRIPTION
**Description**

This PR updates the WAFS tag, as well as related resource and settings changes provided by @YaliMao-NOAA .

- New `gfs_wafs.v6.3.1` WAFS tag in `Externals.cfg` and `checkout.sh`.
- Update resources for WAFS jobs on WCOSS2.
- Add cfp module load to WAFS ecf scripts that need it.
- Add new `ICAO2023` variable to WAFS ecf scripts and config files for jobs that need it. Set it to "no".

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

These changes are being tested by @lgannoaa currently in GFSv16.3 parallels on WCOSS2. Should further adjustments be needed a follow-up PR will be made into the `release/gfs.v16.3.0` branch.
  
**Checklist**

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
