### PR TITLE
Update EMC_verif-global tag to verif_global_v2.10.0 in GFSv16.3.0 package

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -36,7 +36,7 @@ protocol = git
 required = True
 
 [EMC_verif-global]
-tag = verif_global_v2.9.5
+tag = verif_global_v2.10.0
 local_path = sorc/verif-global.fd
 repo_url = https://github.com/NOAA-EMC/EMC_verif-global.git
 protocol = git

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -97,7 +97,7 @@ fi
 echo EMC_verif-global checkout ...
 if [[ ! -d verif-global.fd ]] ; then
     rm -f ${topdir}/checkout-verif-global.log
-    git clone --recursive --branch verif_global_v2.9.5 https://github.com/NOAA-EMC/EMC_verif-global.git verif-global.fd >> ${topdir}/checkout-verif-global.log 2>&1
+    git clone --recursive --branch verif_global_v2.10.0 https://github.com/NOAA-EMC/EMC_verif-global.git verif-global.fd >> ${topdir}/checkout-verif-global.log 2>&1
     cd ${topdir}
 else
     echo 'Skip. Directory verif-global.fd already exist.'


### PR DESCRIPTION
**Description**

This is a sync merge PR to pull in new EMC_verif-global `verif_global_v2.10.0` tag from `dev_v16.2.x` into the `release/gfs.v16.3.0` branch (GFSv16.3.0 package). See issue #971 for more.

**Type of change**

Sync merge

**How Has This Been Tested?**

No testing required.

FYI @lgannoaa 
