### PR TITLE
Update diag table to remove diagnostic wav-ocn coupling fields

### DIFF
--- a/jobs/rocoto/arch.sh
+++ b/jobs/rocoto/arch.sh
@@ -203,7 +203,7 @@ if [ $CDUMP = "gfs" ]; then
     fi
 
     if [ $DO_OCN = "YES" ]; then
-        targrp_list="$targrp_list ocn_ice_grib2_0p5 ocn_ice_grib2_0p25 ocn_2D ocn_3D ocn_xsect ocn_daily wavocn gfs_flux_1p00"
+        targrp_list="$targrp_list ocn_ice_grib2_0p5 ocn_ice_grib2_0p25 ocn_2D ocn_3D ocn_xsect ocn_daily gfs_flux_1p00"
     fi
 
     if [ $DO_ICE = "YES" ]; then

--- a/parm/parm_fv3diag/diag_table_cpl
+++ b/parm/parm_fv3diag/diag_table_cpl
@@ -9,7 +9,6 @@
 ######################
 "ocn%4yr%2mo%2dy%2hr",      6,  "hours", 1, "hours", "time", 6, "hours", "1901 1 1 0 0 0"
 "ocn_daily%4yr%2mo%2dy",      1,  "days",  1, "days",  "time", 1, "days",  "1901 1 1 0 0 0"
-"wavocn%4yr%2mo%2dy%2hr",      6,  "hours", 1, "hours", "time", 6, "hours", "1901 1 1 0 0 0"
 ##############################################
 # static fields
  "ocean_model", "geolon",      "geolon",      "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
@@ -80,23 +79,6 @@
  "ocean_model", "fprec",     "fprec",         "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
  "ocean_model", "LwLatSens", "LwLatSens",     "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
  "ocean_model", "Heat_PmE",  "Heat_PmE",      "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
-
-#wave_variables
- "ocean_model", "geolon",             "geolon",             "wavocn%4yr%2mo%2dy%2hr","all", .false., "none", 2
- "ocean_model", "geolat",             "geolat",             "wavocn%4yr%2mo%2dy%2hr","all", .false., "none", 2
- "ocean_model", "MSTAR",              "MSTAR",              "wavocn%4yr%2mo%2dy%2hr","all", .true.,  "none", 2
- "ocean_model", "LA",                 "LA",                 "wavocn%4yr%2mo%2dy%2hr","all", .true.,  "none", 2
- "ocean_model", "LA_MOD",             "LA_MOD",             "wavocn%4yr%2mo%2dy%2hr","all", .true.,  "none", 2
- "ocean_model", "MSTAR_LT",           "MSTAR_LT",           "wavocn%4yr%2mo%2dy%2hr","all", .true.,  "none", 2
- "ocean_model", "ePBL_h_ML",          "ePBL",               "wavocn%4yr%2mo%2dy%2hr","all", .true.,  "none", 2
- "ocean_model", "ustar",              "ustar",              "wavocn%4yr%2mo%2dy%2hr","all", .true.,  "none", 2
- "ocean_model", "ePBL_TKE_wind",      "ePBL_TKE_wind",      "wavocn%4yr%2mo%2dy%2hr","all", .true.,  "none", 2
- "ocean_model", "ePBL_TKE_MKE",       "ePBL_TKE_MKE",       "wavocn%4yr%2mo%2dy%2hr","all", .true.,  "none", 2
- "ocean_model", "ePBL_TKE_conv",      "ePBL_TKE_conv",      "wavocn%4yr%2mo%2dy%2hr","all", .true.,  "none", 2
- "ocean_model", "ePBL_TKE_forcing",   "ePBL_TKE_forcing",   "wavocn%4yr%2mo%2dy%2hr","all", .true.,  "none", 2
- "ocean_model", "ePBL_TKE_mixing",    "ePBL_TKE_mixing",    "wavocn%4yr%2mo%2dy%2hr","all", .true.,  "none", 2
- "ocean_model", "ePBL_TKE_mech_decay","ePBL_TKE_mech_decay","wavocn%4yr%2mo%2dy%2hr","all", .true.,  "none", 2
- "ocean_model", "ePBL_TKE_conv_decay","ePBL_TKE_conv_decay","wavocn%4yr%2mo%2dy%2hr","all", .true.,  "none", 2
 
 #=============================================================================================
 "gfs_dyn",     "ucomp",       "ugrd",         "fv3_history",    "all",  .false.,  "none",  2

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -844,10 +844,6 @@ MOM6_postdet() {
     dest_file="ocn${VDATE}.${ENSMEM}.${IDATE}.nc"
     ${NLN} ${COMOUTocean}/${dest_file} ${DATA}/${source_file}
 
-    source_file="wavocn_${YYYY_MID}_${MM_MID}_${DD_MID}_${HH_MID}.nc"
-    dest_file=${source_file}
-    ${NLN} ${COMOUTocean}/${dest_file} ${DATA}/${source_file}
-
     source_file="ocn_daily_${YYYY}_${MM}_${DD}.nc"
     dest_file=${source_file}
     if [ ! -a "${DATA}/${source_file}" ]; then

--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -233,7 +233,6 @@ if [ $type = "gfs" ]; then
     rm -f ocn_3D.txt
     rm -f ocn_xsect.txt
     rm -f ocn_daily.txt
-    rm -f wavocn.txt
     touch gfs_flux_1p00.txt
     touch ocn_ice_grib2_0p5.txt
     touch ocn_ice_grib2_0p25.txt
@@ -241,13 +240,11 @@ if [ $type = "gfs" ]; then
     touch ocn_3D.txt
     touch ocn_xsect.txt
     touch ocn_daily.txt
-    touch wavocn.txt
     echo  "${dirname}MOM_input                  " >>ocn_2D.txt
     echo  "${dirname}ocn_2D*                    " >>ocn_2D.txt
     echo  "${dirname}ocn_3D*                    " >>ocn_3D.txt
     echo  "${dirname}ocn*EQ*                    " >>ocn_xsect.txt
     echo  "${dirname}ocn_daily*                 " >>ocn_daily.txt
-    echo  "${dirname}wavocn*                    " >>wavocn.txt
     echo  "${dirname}ocn_ice*0p5x0p5.grb2       " >>ocn_ice_grib2_0p5.txt
     echo  "${dirname}ocn_ice*0p25x0p25.grb2     " >>ocn_ice_grib2_0p25.txt
 


### PR DESCRIPTION
**Description**

This PR removes the wavocn output which is used to evaluate wav->ocean coupling.  When these variables are output without wave coupling it can lead to failures.    

Fixes #977

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**How Has This Been Tested?**


- [x] Forecast-only APP=S2S test on Hera

See com: /scratch1/NCEPDEV/climate/Jessica.Meixner/diags2sfix/s2st01/COMROOT
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
