### PR TITLE
Fix product generation at some fcst hrs

### DIFF
--- a/ush/fv3gfs_downstream_nems.sh
+++ b/ush/fv3gfs_downstream_nems.sh
@@ -78,7 +78,7 @@ else
   export paramlist=${paramlist:-$PARMpost/global_1x1_paramlist_g2}
   export paramlistb=${paramlistb:-$PARMpost/global_master-catchup_parmlist_g2}
   export fhr3=$(printf "%03d" ${FH})
-  if (( fhr3%FHOUT_PGB == 0 )); then
+  if (( FH%FHOUT_PGB == 0 )); then
     export PGBS=YES
   fi
 fi


### PR DESCRIPTION
**Description**

0.5 and 1.0 degree grib files were not being generated for most two-digit
forecast hours due to a problem using a zero-padded number.

Fixes #985

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Forecast-only test on Hera
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
