### PR TITLE
Bugfix in arch.sh to remove hardwired "htar"

### DIFF
--- a/jobs/rocoto/arch.sh
+++ b/jobs/rocoto/arch.sh
@@ -213,7 +213,7 @@ if [ $CDUMP = "gfs" ]; then
     # Aerosols
     if [ $DO_AERO = "YES" ]; then
         for targrp in chem; do
-            htar -P -cvf $ATARDIR/$CDATE/${targrp}.tar $(cat $ARCH_LIST/${targrp}.txt)
+            $TARCMD -P -cvf $ATARDIR/$CDATE/${targrp}.tar $(cat $ARCH_LIST/${targrp}.txt)
             status=$?
             if [ $status -ne 0 -a $CDATE -ge $firstday ]; then
                 echo "HTAR $CDATE ${targrp}.tar failed"


### PR DESCRIPTION
**Description**
To support "LOCALARCH", $TARCMD is used instead of hardwiring "htar".
One line had a hardwired htar (by mistake); this PR changes "htar" to "$TARCMD".
No dependencies are required for this changed.

**Type of change**
- [ ] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
Tested on Orion with LOCALARCH="YES". Before this bugfix, an error message was returned on Orion saying that "htar" command was not found. After the bugfix, this error was gone and the job completed successfully.

@WalterKolczynski-NOAA asked me to make this PR.
  
