### PR TITLE
Replace M_TANKverf with TANKverf_min in config.vrfy, update vrfy.sh a…

### DIFF
--- a/jobs/rocoto/vrfy.sh
+++ b/jobs/rocoto/vrfy.sh
@@ -160,8 +160,8 @@ echo "=============== START TO RUN MINMON ==============="
 if [ $VRFYMINMON = "YES" -a $CDATE != $SDATE ]; then
 
     export COMOUT="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT"
-    export M_TANKverfM0="$M_TANKverf/stats/$PSLOT/$CDUMP.$PDY"
-    export M_TANKverfM1="$M_TANKverf/stats/$PSLOT/$CDUMP.$PDYm1"
+    export M_TANKverf="$TANKverf_min/stats/$PSLOT/$CDUMP.$PDY"
+    export M_TANKverfM1="$TANKverf_min/stats/$PSLOT/$CDUMP.$PDYm1"
     export MY_MACHINE=$machine
 
     $VRFYMINSH

--- a/parm/config/config.vrfy
+++ b/parm/config/config.vrfy
@@ -116,7 +116,7 @@ if [ $VRFYRAD = "YES" -o $VRFYMINMON = "YES" -o $VRFYOZN = "YES" ]; then
     if [[ "$VRFYMINMON" = "YES" ]] ; then
 
         export MINMON_SUFFIX=$PSLOT
-        export M_TANKverf="$NOSCRUB/monitor/minmon"
+        export TANKverf_min="$NOSCRUB/monitor/minmon"
         if [[ "$CDUMP" = "gdas" ]] ; then
             export VRFYMINSH="$HOMEgfs/jobs/JGDAS_ATMOS_VMINMON"
         elif [[ "$CDUMP" = "gfs" ]] ; then


### PR DESCRIPTION
**Description**
Rocoto-based parallel testing using `release/gfs.v16.3.0` found an issue with the directory to which MinMon output is saved.  The issue and proposed fix is documented in issue #993.

**Type of change**
- [ ] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
The following test has been completed on WCOSS2 (Cactus)
1. Clone forked `release/gfs.v16.3.0`
2. Install the GFS v16.3.0 package via `cd sorc`, `./checkout.sh`, `build_all.sh`, `link_fv3gfs.sh emc wcoss2`
3. Set up `EXPDIR` for rocoto-based experiment
4. Run gdas and gfs vrfy using modified `vrfy.sh` and `config.vrfy`
5. Confirm MinMon output written to `$PSLOT` specific output directory
  
**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code

