### PR TITLE
Correct shell linter config

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -28,4 +28,3 @@ jobs:
         uses: redhat-plumbers-in-action/differential-shellcheck@latest
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          shell-scripts: ush/preamble.sh


### PR DESCRIPTION
**Description**
Per comment from the developer on PR #1008 after it was merged, the `shell-scripts` option for the shell linter does not do the globbing we expected. However, the linter action also only annotates when syntax issues are *added* (at least, this is my understanding). It will not flag files with existing errors, even if they are otherwise changed. So, immediately processing all shell files shouldn't be an issue (fingers crossed).

Refs: #397

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
N/A?

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
