### PR TITLE
Correct diagnostic file handling in ush/ozn_xtrct.sh

### DIFF
--- a/ush/ozn_xtrct.sh
+++ b/ush/ozn_xtrct.sh
@@ -232,10 +232,10 @@ EOF
             $NCP ${type}.${ptype}.${PDATE}.ieee_d.${Z} ${TANKverf_ozn}/horiz/
       
 
-            echo "finished processing ptype, type:  $ptype, $type"
+            echo "finished processing ptype, type:  ${ptype}, ${type}"
 
          else
-            echo "diag file for $type.$ptype not found"
+            echo "diag file for ${type}.${ptype} not found"
          fi
 
       done  # type in satype

--- a/ush/ozn_xtrct.sh
+++ b/ush/ozn_xtrct.sh
@@ -102,7 +102,7 @@ ozn_ptype=${ozn_ptype:-"ges anl"}
 #  a problem, reported by an iret value of 2
 #
 
-avail_satype=$(ls -l d*ges* | sed -e 's/_/ /g;s/\./ /' | gawk '{ print $11 "_" $12 }')
+avail_satype=$(ls -1 d*ges* | sed -e 's/_/ /g;s/\./ /' | gawk '{ print $2 "_" $3 }')
 
 if [[ ${DO_DATA_RPT} -eq 1 ]]; then
    if [[ -e ${SATYPE_FILE} ]]; then
@@ -147,102 +147,97 @@ else
    #---------------------------------------------------------------------------
    #  Outer loop over $ozn_ptype (default values 'ges', 'anl')
    #
-   echo "ozn_ptype = ${ozn_ptype}"
    for ptype in ${ozn_ptype}; do
-      echo "ptype = ${ptype}"
 
+      iyy=$(echo ${PDATE} | cut -c1-4)
+      imm=$(echo ${PDATE} | cut -c5-6)
+      idd=$(echo ${PDATE} | cut -c7-8)
+      ihh=$(echo ${PDATE} | cut -c9-10)
  
       for type in ${avail_satype}; do
          if [[ -f "diag_${type}_${ptype}.${PDATE}.gz" ]]; then
             mv diag_${type}_${ptype}.${PDATE}.gz ${type}.${ptype}.gz
             gunzip ./${type}.${ptype}.gz
-         fi
-      done
 
-
-      #--------------------------------------------------------------------
-      #   Run programs for given time
-   
-      iyy=$(echo ${PDATE} | cut -c1-4)
-      imm=$(echo ${PDATE} | cut -c5-6)
-      idd=$(echo ${PDATE} | cut -c7-8)
-      ihh=$(echo ${PDATE} | cut -c9-10)
-
-      for type in ${avail_satype}; do
-         echo "processing ptype, type:  ${ptype}, ${type}"
-         rm -f input
+            echo "processing ptype, type:  ${ptype}, ${type}"
+            rm -f input
 
 cat << EOF > input
-         &INPUT
-         satname='${type}',
-         iyy=${iyy},
-         imm=${imm},
-         idd=${idd},
-         ihh=${ihh},
-         idhh=-720,
-         incr=6,
-         nregion=${nregion},
-         region(1)='global',    rlonmin(1)=-180.0,rlonmax(1)=180.0,rlatmin(1)=-90.0,rlatmax(1)= 90.0,
-         region(2)='70N-90N',   rlonmin(2)=-180.0,rlonmax(2)=180.0,rlatmin(2)= 70.0,rlatmax(2)= 90.0,
-         region(3)='20N-70N',   rlonmin(3)=-180.0,rlonmax(3)=180.0,rlatmin(3)= 20.0,rlatmax(3)= 70.0,
-         region(4)='20S-20N',   rlonmin(4)=-180.0,rlonmax(4)=180.0,rlatmin(4)=-20.0,rlatmax(4)= 20.0,
-         region(5)='20S-70S',   rlonmin(5)=-180.0,rlonmax(5)=180.0,rlatmin(5)=-70.0,rlatmax(5)=-20.0,
-         region(6)='70S-90S',   rlonmin(6)=-180.0,rlonmax(6)=180.0,rlatmin(6)=-90.0,rlatmax(6)=-70.0,
-         validate=${validate},
-         new_hdr=${new_hdr},
-	 ptype=${ptype},
-         netcdf=${netcdf_boolean}
-      /
+            &INPUT
+            satname='${type}',
+            iyy=${iyy},
+            imm=${imm},
+            idd=${idd},
+            ihh=${ihh},
+            idhh=-720,
+            incr=6,
+            nregion=${nregion},
+            region(1)='global',    rlonmin(1)=-180.0,rlonmax(1)=180.0,rlatmin(1)=-90.0,rlatmax(1)= 90.0,
+            region(2)='70N-90N',   rlonmin(2)=-180.0,rlonmax(2)=180.0,rlatmin(2)= 70.0,rlatmax(2)= 90.0,
+            region(3)='20N-70N',   rlonmin(3)=-180.0,rlonmax(3)=180.0,rlatmin(3)= 20.0,rlatmax(3)= 70.0,
+            region(4)='20S-20N',   rlonmin(4)=-180.0,rlonmax(4)=180.0,rlatmin(4)=-20.0,rlatmax(4)= 20.0,
+            region(5)='20S-70S',   rlonmin(5)=-180.0,rlonmax(5)=180.0,rlatmin(5)=-70.0,rlatmax(5)=-20.0,
+            region(6)='70S-90S',   rlonmin(6)=-180.0,rlonmax(6)=180.0,rlatmin(6)=-90.0,rlatmax(6)=-70.0,
+            validate=${validate},
+            new_hdr=${new_hdr},
+            ptype=${ptype},
+            netcdf=${netcdf_boolean}
+         /
 EOF
 
 
-         echo "oznmon_time.x HAS STARTED ${type}"
+            echo "oznmon_time.x HAS STARTED ${type}"
    
-         ./oznmon_time.x < input >   stdout.time.${type}.${ptype}
+            ./oznmon_time.x < input >   stdout.time.${type}.${ptype}
 
-         echo "oznmon_time.x HAS ENDED ${type}"
+            echo "oznmon_time.x HAS ENDED ${type}"
 
-         if [[ ! -d ${TANKverf_ozn}/time ]]; then
-            mkdir -p ${TANKverf_ozn}/time
-         fi
-         $NCP ${type}.${ptype}.ctl             	  ${TANKverf_ozn}/time/
-         $NCP ${type}.${ptype}.${PDATE}.ieee_d 	  ${TANKverf_ozn}/time/
-
-         $NCP bad*                                ${TANKverf_ozn}/time/
-
-         rm -f input
+            if [[ ! -d ${TANKverf_ozn}/time ]]; then
+               mkdir -p ${TANKverf_ozn}/time
+            fi
+            $NCP ${type}.${ptype}.ctl             	  ${TANKverf_ozn}/time/
+            $NCP ${type}.${ptype}.${PDATE}.ieee_d 	  ${TANKverf_ozn}/time/
+   
+            $NCP bad*                                ${TANKverf_ozn}/time/
+   
+            rm -f input
 
 cat << EOF > input
-         &INPUT
-         satname='${type}',
-         iyy=${iyy},
-         imm=${imm},
-         idd=${idd},
-         ihh=${ihh},
-         idhh=-18,
-         incr=6,
-         new_hdr=${new_hdr},
-         ptype=${ptype},
-         netcdf=${netcdf_boolean}
-      /
+            &INPUT
+            satname='${type}',
+            iyy=${iyy},
+            imm=${imm},
+            idd=${idd},
+            ihh=${ihh},
+            idhh=-18,
+            incr=6,
+            new_hdr=${new_hdr},
+            ptype=${ptype},
+            netcdf=${netcdf_boolean}
+         /
 EOF
 
-         echo "oznmon_horiz.x HAS STARTED ${type}"
+            echo "oznmon_horiz.x HAS STARTED ${type}"
    
-         ./oznmon_horiz.x < input >   stdout.horiz.${type}.${ptype}
+            ./oznmon_horiz.x < input >   stdout.horiz.${type}.${ptype}
 
-         echo "oznmon_horiz.x HAS ENDED ${type}"
+            echo "oznmon_horiz.x HAS ENDED ${type}"
 
-         if [[ ! -d ${TANKverf_ozn}/horiz ]]; then
-            mkdir -p ${TANKverf_ozn}/horiz
-         fi
-         $NCP ${type}.${ptype}.ctl                  ${TANKverf_ozn}/horiz/
+            if [[ ! -d ${TANKverf_ozn}/horiz ]]; then
+               mkdir -p ${TANKverf_ozn}/horiz
+            fi
+            $NCP ${type}.${ptype}.ctl                  ${TANKverf_ozn}/horiz/
 
-         $COMPRESS ${type}.${ptype}.${PDATE}.ieee_d
-         $NCP ${type}.${ptype}.${PDATE}.ieee_d.${Z} ${TANKverf_ozn}/horiz/
+            $COMPRESS ${type}.${ptype}.${PDATE}.ieee_d
+            $NCP ${type}.${ptype}.${PDATE}.ieee_d.${Z} ${TANKverf_ozn}/horiz/
       
 
-         echo "finished processing ptype, type:  $ptype, $type"
+            echo "finished processing ptype, type:  $ptype, $type"
+
+         else
+            echo "diag file for $type.$ptype not found"
+         fi
+
       done  # type in satype
 
    done	 # ptype in $ozn_ptype


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**
The OznMon's ush/ozn_xtrct.sh script creates a list of available sat/instrument sources for a given cycle in order to report missing files.  The logic for extracting the list of sources worked on wcoss2 and hera but failed on orion.  The logic used a listing of the diagnostic files which included user name.  That created a parsing problem if the user name was not the expected length.  The solution is to simply do a single line listing (ls -1) and parse the results.  

Additionally the processing logic was condensed and now avoids running the extraction executables in the case of a missing diag file.

Fixes #1004 .


**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

1. Cloned global-workflow from fork.
2. Ran checkout.sh, build_all.sh, link_workflow.sh to set up cycled experiment.
3. Set up `$EXPDIR` for rocoto-based experiment.
4. Populated `$ROTDIR` with files needed to run OznMon (oznstat files).
5. Reduced vrfy.sh to only run the oznmon, and reduced workflow to only run gdasvrfy job.
6. Ran on orion and wcoss2.  Expected files were produced on both platforms; no errors occurred on orion.
  
**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
