### PR TITLE
Update UFS_UTILS tag and release notes based on NCO feedback

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -29,7 +29,7 @@ protocol = git
 required = True
 
 [UFS_UTILS]
-tag = ops-gfsv16.2.0
+tag = ops-gfsv16.3.0
 local_path = sorc/ufs_utils.fd
 repo_url = https://github.com/ufs-community/UFS_UTILS.git
 protocol = git

--- a/docs/Release_Notes.gfs.v16.3.0.md
+++ b/docs/Release_Notes.gfs.v16.3.0.md
@@ -82,7 +82,7 @@ The checkout script extracts the following GFS components:
 | MODEL     | GFS.v16.3.0   | Jun.Wang@noaa.gov |
 | GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
 | GSI       | gfsda.v16.3.0 | Emily.Liu@noaa.gov |
-| UFS_UTILS | ops-gfsv16.2.1 | George.Gayno@noaa.gov |
+| UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
 | POST      | upp_v8.2.0 | Wen.Meng@noaa.gov |
 | WAFS      | gfs_wafs.v6.3.1 | Yali.Mao@noaa.gov |
 
@@ -399,6 +399,8 @@ FIX CHANGES
     * `fix_gsi/gfsv16_historical/gfsv16.3/global_convinfo.txt.2022031612`
     * `fix_gsi/gfsv16_historical/gfsv16.3/global_satinfo.txt.2021092206`
     * `fix_gsi/gfsv16_historical/gfsv16.3/global_satinfo.txt.2021102612`
+
+* UFS_UTILS: update NCO mode fix file install to copy instead of symlink
 
 * WAFS:
   * `fix/wafs/legend`: new folder prepared for switching. When ICAO2023=yes, use fix/wafs; when ICAO2023=no, use fix/wafs/legend

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -55,7 +55,7 @@ fi
 echo ufs_utils checkout ...
 if [[ ! -d ufs_utils.fd ]] ; then
     rm -f ${topdir}/checkout-ufs_utils.log
-    git clone --branch ops-gfsv16.2.1 https://github.com/ufs-community/UFS_UTILS ufs_utils.fd >> ${topdir}/checkout-ufs_utils.fd.log 2>&1
+    git clone --branch ops-gfsv16.3.0 https://github.com/ufs-community/UFS_UTILS ufs_utils.fd >> ${topdir}/checkout-ufs_utils.fd.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory ufs_utils.fd already exists.'

--- a/sorc/link_fv3gfs.sh
+++ b/sorc/link_fv3gfs.sh
@@ -23,7 +23,7 @@ fi
 
 LINK="ln -fs"
 SLINK="ln -fs"
-[[ $RUN_ENVIR = nco ]] && LINK="cp -rp"
+[[ $RUN_ENVIR = nco ]] && LINK="cp -rpL"
 
 pwd=$(pwd -P)
 


### PR DESCRIPTION
**Description**

This PR includes updates to address comments from NCO regarding the release notes and unexpected differences between the gfsv16.2.2 and gfsv16.3.0 installs:

- New UFS_UTILS tag `ops-gfsv16.3.0` to uncomment the `RUN_ENVIR=nco` line in `link_fixdirs.sh` to properly copy fix files instead of making symlinks. Also update the copy command to resolve symlinks in fix set into actual files in clone fix folder.
- Multiple updates to release notes to mention UFS_UTILS update and add more details regarding GSI and WAFS changes. Also include link to document that further expounds on GSI differences in this upgrade.
- Correct `link_fv3gfs.sh` script `RUN_ENVIR=nco` mode to use `L` flag with the `cp` command to resolve fix set symlinks when setting up the fix set within the NCO/ops clone: `[[ $RUN_ENVIR = nco ]] && LINK="cp -rpL"`

**Type of change**

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**How Has This Been Tested?**

- [x] Clone, build, and link test on WCOSS2 Cactus
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
