### PR TITLE
Update sorc/checkout.sh to checkout latest version of GSI-Monitor

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -36,7 +36,7 @@ protocol = git
 required = False
 
 [GSI-Monitor]
-hash = acf8870
+hash = c64cc47
 local_path = sorc/gsi_monitor.fd
 repo_url = https://github.com/NOAA-EMC/GSI-monitor.git
 protocol = git

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -165,7 +165,7 @@ fi
 
 if [[ $CHECKOUT_GSI == "YES" || $CHECKOUT_GDAS == "YES" ]]; then
   checkout "gsi_utils.fd"    "https://github.com/NOAA-EMC/GSI-Utils.git"   "322cc7b"; errs=$((errs + $?))
-  checkout "gsi_monitor.fd"  "https://github.com/NOAA-EMC/GSI-Monitor.git" "acf8870"; errs=$((errs + $?))
+  checkout "gsi_monitor.fd"  "https://github.com/NOAA-EMC/GSI-Monitor.git" "c64cc47"; errs=$((errs + $?))
   checkout "gldas.fd"        "https://github.com/NOAA-EMC/GLDAS.git"       "fd8ba62"; errs=$((errs + $?))
 fi
 


### PR DESCRIPTION

**Description**

Move the hash value for gsi-monitor from acf8870 to c64cc47 to pick up recent fix to radmon_angle.x executable.  

This fixes issue #1024 .

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**How Has This Been Tested?**

- [x] Clone, Checkout, and Build on WCOSS2, Orion, Hera

- Inspected file sorc/gsi_monitor.fd/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radang.fd/angle_bias.f90 and verified it contains the file contents consistent with hash c64cc47. 
- Ran the Radiance Monitor using a pared down vrfy job step and confirmed the results are as anticipated.

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes