### PR TITLE
Supported resolutions on platforms and defaults for mode

### DIFF
--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -158,7 +158,7 @@ export DO_WAVE="NO"
 export DO_OCN="NO"
 export DO_ICE="NO"
 export DO_AERO="NO"
-export CCPP_SUITE="FV3_GFS_v17_p8"
+export CCPP_SUITE="@CCPP_SUITE@"
 export WAVE_CDUMP="" # When to include wave suite: gdas, gfs, or both
 export DOBNDPNT_WAVE="NO"
 export cplwav2atm=".false."
@@ -322,7 +322,7 @@ fi
 # fi
 
 # Microphysics Options: 99-ZhaoCarr, 8-Thompson; 6-WSM6, 10-MG, 11-GFDL
-export imp_physics=8
+export imp_physics=@IMP_PHYSICS@
 
 # Shared parameters
 # DA engine

--- a/workflow/hosts/hera.yaml
+++ b/workflow/hosts/hera.yaml
@@ -17,3 +17,4 @@ chgrp_cmd: 'chgrp rstprod'
 hpssarch: 'YES'
 localarch: 'NO'
 atardir: '/NCEPDEV/$HPSS_PROJECT/1year/$USER/$machine/scratch/$PSLOT'
+supported_resolutions: ['C384', 'C192', 'C96', 'C48']

--- a/workflow/hosts/hera.yaml
+++ b/workflow/hosts/hera.yaml
@@ -17,4 +17,4 @@ chgrp_cmd: 'chgrp rstprod'
 hpssarch: 'YES'
 localarch: 'NO'
 atardir: '/NCEPDEV/$HPSS_PROJECT/1year/$USER/$machine/scratch/$PSLOT'
-supported_resolutions: ['C384', 'C192', 'C96', 'C48']
+supported_resolutions: ['C768', 'C384', 'C192', 'C96', 'C48']

--- a/workflow/hosts/orion.yaml
+++ b/workflow/hosts/orion.yaml
@@ -17,4 +17,4 @@ chgrp_cmd: 'chgrp rstprod'
 hpssarch: 'NO'
 localarch: 'NO'
 atardir: '$NOSCRUB/archive_rotdir/$PSLOT'
-supported_resolutions: ['C384', 'C192', 'C96', 'C48']
+supported_resolutions: ['C768', 'C384', 'C192', 'C96', 'C48']

--- a/workflow/hosts/orion.yaml
+++ b/workflow/hosts/orion.yaml
@@ -17,3 +17,4 @@ chgrp_cmd: 'chgrp rstprod'
 hpssarch: 'NO'
 localarch: 'NO'
 atardir: '$NOSCRUB/archive_rotdir/$PSLOT'
+supported_resolutions: ['C384', 'C192', 'C96', 'C48']

--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -154,6 +154,19 @@ def edit_baseconfig(host, inputs):
         }
         tmpl_dict = dict(tmpl_dict, **extend_dict)
 
+    if inputs.mode in ['cycled']:
+        extend_dict = {
+            "@CCPP_SUITE@": 'FV3_GFS_v16',
+            "@IMP_PHYSICS@": 11
+        }
+    elif inputs.mode in ['forecast-only']:
+        extend_dict = {
+            "@CCPP_SUITE@": 'FV3_GFS_v17_p8',
+            "@IMP_PHYSICS@": 8
+        }
+    tmpl_dict = dict(tmpl_dict, **extend_dict)
+
+
     # Open and read the templated config.base.emc.dyn
     base_tmpl = f'{inputs.configdir}/config.base.emc.dyn'
     with open(base_tmpl, 'rt') as fi:
@@ -265,11 +278,20 @@ def query_and_clean(dirname):
 
     return create_dir
 
+def validate_user_request(host, inputs):
+    expt_res = f'C{inputs.resdet}'
+    supp_res = host.info['supported_resolutions']
+    machine = host.machine
+    if expt_res not in supp_res:
+        raise NotImplementedError(f"Supported resolutions on {machine} are:\n{', '.join(supp_res)}")
+
 
 if __name__ == '__main__':
 
     user_inputs = input_args()
     host = Host()
+
+    validate_user_request(host, user_inputs)
 
     comrot = os.path.join(user_inputs.comrot, user_inputs.pslot)
     expdir = os.path.join(user_inputs.expdir, user_inputs.pslot)


### PR DESCRIPTION
**Description**

This PR:
- sets defaults for `cycled` and `forecast-only` modes, specifically `CCPP_SUITE` and `imp_physics`.
- validates if a user requested resolution is supported on the machine.

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

- [X] Clone and test `setup_expt.py` on Orion and Hera
- [X] @WalterKolczynski-NOAA ran a test of C768 on Hera and Orion to confirm that resolution is supported on these machines.
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings