### PR TITLE
Fix radiance verification failing to find diag files

### DIFF
--- a/scripts/exgdas_atmos_verfrad.sh
+++ b/scripts/exgdas_atmos_verfrad.sh
@@ -144,7 +144,7 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
          netcdf=1
       fi
      
-      if [[ -f "diag_${type}_ges.${PDATE}*.${Z}" ]]; then
+      if (( `ls diag_${type}_ges.${PDATE}*.${Z} 2> /dev/null | wc -l` > 0 )); then
         mv diag_${type}_ges.${PDATE}*.${Z} ${type}.${Z}
         ${UNCOMPRESS} ./${type}.${Z}
       else
@@ -152,7 +152,7 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
       fi
      
       if [[ $USE_ANL -eq 1 ]]; then
-        if [[ -f "diag_${type}_anl.${PDATE}*.${Z}" ]]; then
+        if (( `ls diag_${type}_anl.${PDATE}*.${Z} 2> /dev/null | wc -l` > 0 )); then
           mv diag_${type}_anl.${PDATE}*.${Z} ${type}_anl.${Z}
           ${UNCOMPRESS} ./${type}_anl.${Z}
         else

--- a/scripts/exgdas_atmos_verfrad.sh
+++ b/scripts/exgdas_atmos_verfrad.sh
@@ -144,7 +144,7 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
          netcdf=1
       fi
      
-      if [[ $(find . -maxdepth 1 -type f -name diag_${type}_ges.${PDATE}*.${Z} | wc -l) > 0 ]]; then
+      if [[ $(find . -maxdepth 1 -type f -name "diag_${type}_ges.${PDATE}*.${Z}" | wc -l) -gt 0 ]]; then
         mv diag_${type}_ges.${PDATE}*.${Z} ${type}.${Z}
         ${UNCOMPRESS} ./${type}.${Z}
       else
@@ -152,7 +152,7 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
       fi
      
       if [[ $USE_ANL -eq 1 ]]; then
-        if [[ $(find . -maxdepth 1 -type f -name diag_${type}_anl.${PDATE}*.${Z} | wc -l) > 0 ]]; then
+        if [[ $(find . -maxdepth 1 -type f -name "diag_${type}_anl.${PDATE}*.${Z}" | wc -l) -gt 0 ]]; then
           mv diag_${type}_anl.${PDATE}*.${Z} ${type}_anl.${Z}
           ${UNCOMPRESS} ./${type}_anl.${Z}
         else
@@ -173,17 +173,17 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
     ${USHradmon}/radmon_verf_bcoef.sh ${PDATE}
     rc_bcoef=$?
 
-    ${USHradmon}/radmon_verf_bcor.sh ${PDATE}
+    ${USHradmon}/radmon_verf_bcor.sh "${PDATE}"
     rc_bcor=$?
 
-    ${USHradmon}/radmon_verf_time.sh ${PDATE}
+    ${USHradmon}/radmon_verf_time.sh "${PDATE}"
     rc_time=$?
 
     #--------------------------------------
     #  optionally run clean_tankdir script
     #
     if [[ ${CLEAN_TANKVERF:-0} -eq 1 ]]; then
-       "${USHradmon}/clean_tankdir.sh glb 60"
+       "${USHradmon}/clean_tankdir.sh" glb 60
        rc_clean_tankdir=$?
        echo "rc_clean_tankdir = $rc_clean_tankdir"
     fi
@@ -214,7 +214,7 @@ export CHGRP_CMD=${CHGRP_CMD:-"chgrp ${group_name:-rstprod}"}
 rlist="saphir"
 for rtype in $rlist; do
   if compgen -G "$TANKverf_rad/*${rtype}*" > /dev/null; then
-    ${CHGRP_CMD} "$TANKverf_rad/*${rtype}*"
+     ${CHGRP_CMD} "${TANKverf_rad}"/*${rtype}*
   fi
 done
 

--- a/scripts/exgdas_atmos_verfrad.sh
+++ b/scripts/exgdas_atmos_verfrad.sh
@@ -144,7 +144,7 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
          netcdf=1
       fi
      
-      if (( `ls diag_${type}_ges.${PDATE}*.${Z} 2> /dev/null | wc -l` > 0 )); then
+      if [[ $(find . -maxdepth 1 -type f -name diag_${type}_ges.${PDATE}*.${Z} | wc -l) > 0 ]]; then
         mv diag_${type}_ges.${PDATE}*.${Z} ${type}.${Z}
         ${UNCOMPRESS} ./${type}.${Z}
       else
@@ -152,7 +152,7 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
       fi
      
       if [[ $USE_ANL -eq 1 ]]; then
-        if (( `ls diag_${type}_anl.${PDATE}*.${Z} 2> /dev/null | wc -l` > 0 )); then
+        if [[ $(find . -maxdepth 1 -type f -name diag_${type}_anl.${PDATE}*.${Z} | wc -l) > 0 ]]; then
           mv diag_${type}_anl.${PDATE}*.${Z} ${type}_anl.${Z}
           ${UNCOMPRESS} ./${type}_anl.${Z}
         else
@@ -183,7 +183,7 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
     #  optionally run clean_tankdir script
     #
     if [[ ${CLEAN_TANKVERF:-0} -eq 1 ]]; then
-       ${USHradmon}/clean_tankdir.sh glb 60
+       "${USHradmon}/clean_tankdir.sh glb 60"
        rc_clean_tankdir=$?
        echo "rc_clean_tankdir = $rc_clean_tankdir"
     fi
@@ -214,7 +214,7 @@ export CHGRP_CMD=${CHGRP_CMD:-"chgrp ${group_name:-rstprod}"}
 rlist="saphir"
 for rtype in $rlist; do
   if compgen -G "$TANKverf_rad/*${rtype}*" > /dev/null; then
-    ${CHGRP_CMD} $TANKverf_rad/*${rtype}*
+    ${CHGRP_CMD} "$TANKverf_rad/*${rtype}*"
   fi
 done
 

--- a/ush/radmon_verf_angle.sh
+++ b/ush/radmon_verf_angle.sh
@@ -159,12 +159,13 @@ else
             angl_ctl=angle.${ctl_file}
          fi
 
+         angl_file=""
          if [[ $REGIONAL_RR -eq 1 ]]; then
             angl_file=${rgnHH}.${data_file}.${rgnTM}
          fi
 
 
-         rm input
+         if [[ -f input ]]; then rm input; fi
 
          nchanl=-999
 cat << EOF > input
@@ -209,18 +210,18 @@ EOF
    ${USHradmon}/rstprod.sh
 
    tar_file=radmon_angle.tar
-   if compgen -G "angle*.ieee_d* angle*.ctl*" > /dev/null; then
+   if compgen -G "angle*.ieee_d*" > /dev/null || compgen -G "angle*.ctl*" > /dev/null; then
       tar -cf $tar_file angle*.ieee_d* angle*.ctl*
       ${COMPRESS} ${tar_file}
       mv $tar_file.${Z} ${TANKverf_rad}/.
 
-     if [[ $RAD_AREA = "rgn" ]]; then
-        cwd=$(pwd)
-        cd ${TANKverf_rad}
-        tar -xf ${tar_file}.${Z}
-        rm ${tar_file}.${Z}
-        cd ${cwd}
-     fi
+      if [[ $RAD_AREA = "rgn" ]]; then
+         cwd=$(pwd)
+         cd ${TANKverf_rad}
+         tar -xf ${tar_file}.${Z}
+         rm ${tar_file}.${Z}
+         cd ${cwd}
+      fi
    fi
 
    if [[ $ctr -gt 0 && $fail -eq $ctr || $fail -gt $ctr ]]; then

--- a/ush/radmon_verf_bcoef.sh
+++ b/ush/radmon_verf_bcoef.sh
@@ -159,7 +159,7 @@ else
          fi
  
 
-         rm input
+         if [[ -f input ]]; then rm input; fi
 
 
 cat << EOF > input
@@ -206,7 +206,7 @@ EOF
 
    ${USHradmon}/rstprod.sh
 
-   if compgen -G "bcoef*.ieee_d* bcoef*.ctl*" > /dev/null; then
+   if compgen -G "bcoef*.ieee_d*" > /dev/null || compgen -G "bcoef*.ctl*" > /dev/null; then
      tar_file=radmon_bcoef.tar
      tar -cf $tar_file bcoef*.ieee_d* bcoef*.ctl*
      ${COMPRESS} ${tar_file}

--- a/ush/radmon_verf_bcor.sh
+++ b/ush/radmon_verf_bcor.sh
@@ -200,7 +200,7 @@ EOF
    ${USHradmon}/rstprod.sh
    tar_file=radmon_bcor.tar
 
-   if compgen -G "bcor*.ieee_d* bcor*.ctl*" > /dev/null; then
+   if compgen -G "bcor*.ieee_d*" > /dev/null || compgen -G "bcor*.ctl*" > /dev/null; then
      tar -cf $tar_file bcor*.ieee_d* bcor*.ctl*
      ${COMPRESS} ${tar_file}
      mv $tar_file.${Z} ${TANKverf_rad}/.

--- a/ush/radmon_verf_time.sh
+++ b/ush/radmon_verf_time.sh
@@ -187,7 +187,7 @@ if [[ $err -eq 0 ]]; then
 
       for dtype in ${gesanl}; do
 
-         rm input
+         if [[ -f input ]]; then rm input; fi
 
          if [[ $dtype == "anl" ]]; then
             data_file=${type}_anl.${PDATE}.ieee_d
@@ -252,7 +252,7 @@ EOF
 
    ${USHradmon}/rstprod.sh
 
-   if compgen -G "time*.ieee_d* time*.ctl*" > /dev/null; then
+   if compgen -G "time*.ieee_d*" > /dev/null || compgen -G "time*.ctl*" > /dev/null; then
      tar_file=radmon_time.tar
      tar -cf $tar_file time*.ieee_d* time*.ctl*
      ${COMPRESS} ${tar_file}


### PR DESCRIPTION

**Description**

Correct exgdas_atmos_verfrad's failure to find diagnostic files.  Additionally, fixed two other problems in child scripts which caused halts and/or failure to move resulting data files to the correct location.  

Fixes issue #1028.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

1. Set up the necessary data in comrot (radstat and abias files).
2. Modified the workflow xml file to only run the vrfy step.
3. Reduced the vrfy step to only run the radiance monitor.
4. The radiance monitor now correctly locates the diagnostic files.  The 4 child scripts run to completion and produce the expected output in the expected location.

- [x] Cycled test on Orion
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
