### PR TITLE
Retire `BASE_SVN`/`base_svn` in develop

### DIFF
--- a/workflow/hosts/hera.yaml
+++ b/workflow/hosts/hera.yaml
@@ -1,5 +1,4 @@
 base_git: '/scratch1/NCEPDEV/global/glopara/git'
-base_svn: '/scratch1/NCEPDEV/global/glopara/svn'
 dmpdir: '/scratch1/NCEPDEV/global/glopara/dump'
 nwprod: '/scratch1/NCEPDEV/global/glopara/nwpara'
 comroot: '/scratch1/NCEPDEV/global/glopara/com'

--- a/workflow/hosts/orion.yaml
+++ b/workflow/hosts/orion.yaml
@@ -1,5 +1,4 @@
 base_git: '/work/noaa/global/glopara/git'
-base_svn: '/work/noaa/global/glopara/svn'
 dmpdir: '/work/noaa/rstprod/dump'
 nwprod: '/work/noaa/global/glopara/nwpara'
 comroot: '/work/noaa/global/glopara/com'


### PR DESCRIPTION
**Description**

This PR retires/removes remaining instances of `base_svn` (lowercase version of `BASE_SVN`) in the `develop` branch. No instances of uppercase `BASE_SVN` remained.

Resolves #1035 

**Type of change**

Cleanup.

**How Has This Been Tested?**

Ran setup scripts, no issues.
  
**Checklist**

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
