### PR TITLE
Fix missing @ symbol with COMINsyn in config.base

### DIFF
--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -38,7 +38,7 @@ export FIXreg2grb2=$HOMEgfs/fix/fix_reg2grb2
 # GLOBAL static environment parameters
 export PACKAGEROOT="@PACKAGEROOT@"
 export COMROOT="@COMROOT@"
-export COMINsyn="@COMINsyn"
+export COMINsyn="@COMINsyn@"
 export DMPDIR="@DMPDIR@"
 export RTMFIX=$CRTM_FIX
 


### PR DESCRIPTION
**Description**

This PR resolves a bug related to a missing `@` symbol for parsing `COMINsyn` into `config.base.emc.dyn`

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Added missing `@` into `config.base.emc.dyn`, generated a test EXPDIR and confirmed the variable now has a setting.
