### PR TITLE
Fix link script usage statement

### DIFF
--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -2,7 +2,7 @@
 
 #--make symbolic links for EMC installation and hardcopies for NCO delivery
 
-function _usage() {
+function usage() {
   cat << EOF
 Builds all of the global-workflow components by calling the individual build
   scripts in sequence.


### PR DESCRIPTION
**Description**
The function being called when passed -h was not the same as the one used for the function definition (there was a leading `_`).

Fixes #1044

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] `link_workflow.sh -h` on Orion
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
