### PR TITLE
Remove trace from link script

### DIFF
--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -15,7 +15,7 @@ Usage: ${BASH_SOURCE[0]} [-h][-o]
 EOF
   exit 1
 }
-set -eux
+set -eu
 
 RUN_ENVIR="EMC"
 

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -2,6 +2,8 @@
 
 #--make symbolic links for EMC installation and hardcopies for NCO delivery
 
+trap 'echo "${BASH_SOURCE[0]} encounted an error at line ${LINENO} (rc=$?)"' ERR
+
 function usage() {
   cat << EOF
 Builds all of the global-workflow components by calling the individual build
@@ -15,9 +17,10 @@ Usage: ${BASH_SOURCE[0]} [-h][-o]
 EOF
   exit 1
 }
+
 set -eu
 
-RUN_ENVIR="EMC"
+RUN_ENVIR="emc"
 
 # Reset option counter in case this script is sourced
 OPTIND=1
@@ -26,7 +29,7 @@ while getopts ":ho" option; do
     h) usage ;;
     o) 
       echo "-o option received, configuring for NCO"
-      RUN_ENVIR="NCO";;
+      RUN_ENVIR="nco";;
     :)
       echo "[${BASH_SOURCE[0]}]: ${option} requires an argument"
       usage
@@ -105,7 +108,7 @@ done
 
 if [ -d "${script_dir}/ufs_utils.fd" ]; then
   cd "${script_dir}/ufs_utils.fd/fix" || exit 1
-  ./link_fixdirs.sh "${RUN_ENVIR}" "${machine}"
+  ./link_fixdirs.sh "${RUN_ENVIR}" "${machine}" 2> /dev/null
 fi
 
 
@@ -420,6 +423,7 @@ if [[ "${RUN_ENVIR}" == "nco" ]] ; then
 fi
 #------------------------------
 
+echo "${BASH_SOURCE[0]} completed successfully"
 
 exit 0
 


### PR DESCRIPTION
**Description**
Removes the trace from the link script. Since this makes the script silent (including some errors), some messages are added to give feedback about the scripts success or failure.

UFS Utils' [link_fixdirs.sh](https://github.com/ufs-community/UFS_UTILS/blob/develop/fix/link_fixdirs.sh) script turns the trace on when it runs, so its STDERR is thrown away.

Also corrects a bug where the case of `$RUN_ENVIR` set did not match the case it was compared against.

Fixes #1044

**Type of change**

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] `link_workflow.sh -h` on Orion
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
