### PR TITLE
Update gfs-utils hash for WCOSS2 support

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [gfs-utils]
-hash = 93898e1
+hash = 3a609ea
 local_path = sorc/gfs_utils.fd
 repo_url = https://github.com/NOAA-EMC/gfs-utils
 protocol = git

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -152,7 +152,7 @@ mkdir -p "${logdir}"
 
 # The checkout version should always be a speciifc commit (hash or tag), not a branch
 errs=0
-checkout "gfs_utils.fd"    "https://github.com/NOAA-EMC/gfs-utils"              "93898e1"          ; errs=$((errs + $?))
+checkout "gfs_utils.fd"    "https://github.com/NOAA-EMC/gfs-utils"              "3a609ea"          ; errs=$((errs + $?))
 checkout "ufs_model.fd"    "https://github.com/ufs-community/ufs-weather-model" "${ufs_model_hash}"; errs=$((errs + $?))
 checkout "ufs_utils.fd"    "https://github.com/ufs-community/UFS_UTILS.git"     "8b990c0"          ; errs=$((errs + $?))
 checkout "verif-global.fd" "https://github.com/NOAA-EMC/EMC_verif-global.git"   "c267780"          ; errs=$((errs + $?))


### PR DESCRIPTION
**Description**

This PR updates the gfs-utils hash to add WCOSS2 support for that component.

Resolves #1047

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

Build test on WCOSS2.
