### PR TITLE
Add GDAS to the partial build list

### DIFF
--- a/sorc/gfs_build.cfg
+++ b/sorc/gfs_build.cfg
@@ -6,6 +6,7 @@
  Building gsi_enkf (gsi_enkf) .......................... yes
  Building gsi_utils (gsi_utils) ........................ yes
  Building gsi_monitor (gsi_monitor) .................... yes
+ Building gdas (gdas) .................................. yes
  Building gldas (gldas) ................................ yes
  Building UPP (upp) .................................... yes
  Building ufs_utils (ufs_utils) ........................ yes

--- a/sorc/partial_build.sh
+++ b/sorc/partial_build.sh
@@ -9,6 +9,7 @@ declare -a Build_prg=("Build_ufs_model" \
                       "Build_gsi_monitor" \
                       "Build_ww3_prepost" \
                       "Build_reg2grb2" \
+                      "Build_gdas" \
                       "Build_gldas" \
                       "Build_upp" \
                       "Build_ufs_utils" \


### PR DESCRIPTION
**Description**
When the GDAS app was added to the workflow, the corresponding build setting was not added to partial_build and the build configuration file. This means that after `build_all.sh` was updated to correct syntax issues, the build would fail because `$Build_gdas` was undefined.

Note: the GDAS app still does not build currently due to unrelated problems within the gdas repo.

Refs #1043

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Clone and Build on Orion
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings [FAILS; see note above]
- [ ] New and existing tests pass with my changes [FAILS; see note above]
