### PR TITLE
Fix group number being treated as octal in gdas arch

### DIFF
--- a/jobs/rocoto/earc.sh
+++ b/jobs/rocoto/earc.sh
@@ -32,7 +32,7 @@ done
 
 export COMPONENT=${COMPONENT:-atmos}
 
-n=$((ENSGRP))
+n=$((10#${ENSGRP}))
 
 # ICS are restarts and always lag INC by $assim_freq hours.
 EARCINC_CYC=$ARCH_CYC
@@ -63,7 +63,7 @@ source "${HOMEgfs}/ush/file_utils.sh"
 ###################################################################
 # ENSGRP > 0 archives a group of ensemble members
 firstday=$($NDATE +24 $SDATE)
-if [[ $ENSGRP -gt 0 ]] && [[ $HPSSARCH = "YES" || $LOCALARCH = "YES" ]]; then
+if (( 10#${ENSGRP} > 0 )) && [[ ${HPSSARCH} = "YES" || ${LOCALARCH} = "YES" ]]; then
 
 #--set the archiving command and create local directories, if necessary
    TARCMD="htar"


### PR DESCRIPTION
**Description**
The group number was being treated as an octal in gdas archive job, resulting in errors for being out-of-range when more than 7 groups were used.

Fixes #1032

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Cycled test on Hera with full 80 members
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
