### PR TITLE
Fix eupd trace

### DIFF
--- a/scripts/exgdas_enkf_update.sh
+++ b/scripts/exgdas_enkf_update.sh
@@ -153,7 +153,6 @@ $NLN $COMOUT_ANL_ENS/$GBIASe satbias_in
 if [ $USE_CFP = "YES" ]; then
    [[ -f $DATA/untar.sh ]] && rm $DATA/untar.sh
    [[ -f $DATA/mp_untar.sh ]] && rm $DATA/mp_untar.sh
-   set +x
    cat > $DATA/untar.sh << EOFuntar
 #!/bin/sh
 memchar=\$1

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -150,8 +150,6 @@ EOF
     nfiles=$(ls -1 $DATA/INPUT/* | wc -l)
     if [ $nfiles -le 0 ]; then
       echo SUB ${FUNCNAME[0]}: Initial conditions must exist in $DATA/INPUT, ABORT!
-      msg="SUB ${FUNCNAME[0]}: Initial conditions must exist in $DATA/INPUT, ABORT!"
-      postmsg "$jlogfile" "$msg"
       exit 1
     fi
   fi


### PR DESCRIPTION
**Description**
When the preamble was implemented, a `set +x` was inadvertently left in the ensemble update script while the subsequent `set -x` was. This led to much of the trace not appearing in the output.

Also removed a jlog print that is only encountered when ICs are missing. It complicated the real IC missing error with an additional unbound variable error.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Cycled test on WCOSS2 by Kate
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
