### PR TITLE
Limit number of CPU for post

### DIFF
--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -387,7 +387,11 @@ elif [ ${step} = "post" ]; then
 
     export wtime_post="02:00:00"
     export wtime_post_gfs="06:00:00"
+    res=$(echo ${CASE} | cut -c2-)
     export npe_post=112
+    if (( npe_post > res )); then
+      export npe_post=${res}
+    fi
     export nth_post=1
     export npe_node_post=12
     export npe_node_dwn=${npe_node_max}


### PR DESCRIPTION
**Description**
Limits the number of MPI tasks for post to the resolution of the forecast. UPP seems to fail if it is given more ranks than the resolution.

Fixes #1060

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Cycled test on Orion
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
