### PR TITLE
Fix companion ocean resolution for C48

### DIFF
--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -218,7 +218,7 @@ export LEVS=128
 export CASE="@CASECTL@"
 export CASE_ENKF="@CASEENS@"
 case "$CASE" in
-    "C48") export OCNRES=400;;
+    "C48") export OCNRES=500;;
     "C96") export OCNRES=100;;
     "C192") export OCNRES=050;;
     "C384") export OCNRES=025;;

--- a/parm/config/config.efcs
+++ b/parm/config/config.efcs
@@ -67,7 +67,7 @@ export cplwav=.false.
 
 # ocean model resolution
 case "$CASE_ENKF" in
-    "C48") export OCNRES=400;;
+    "C48") export OCNRES=500;;
     "C96") export OCNRES=100;;
     "C192") export OCNRES=050;;
     "C384") export OCNRES=025;;

--- a/parm/config/config.ocn
+++ b/parm/config/config.ocn
@@ -2,7 +2,7 @@
 
 # OCNRES is currently being set in config.base
 # case "$CASE" in
-#     "C48") export OCNRES=400;;
+#     "C48") export OCNRES=500;;
 #     "C96") export OCNRES=100;;
 #     "C192") export OCNRES=050;;
 #     "C384") export OCNRES=025;;


### PR DESCRIPTION
**Description**
The ocean resolution for atmosphere C48 should by 5 deg, not 4 deg.

Fixes #1054

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
