### PR TITLE
GFS-UTILS update for build and ush scripts

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [gfs-utils]
-hash = 7bf599f
+hash = af933d3
 local_path = sorc/gfs_utils.fd
 repo_url = https://github.com/NOAA-EMC/gfs-utils
 protocol = git

--- a/gempak/ush/gempak_gfs_f00_gif.sh
+++ b/gempak/ush/gempak_gfs_f00_gif.sh
@@ -593,7 +593,7 @@ if [ $SENDCOM = YES ]; then
   export input=${COMOUT}/${hgttmp500dev}
   export HEADER=YES
   export OUTPATH=$DATA/gfs_500_hgt_tmp_nh_anl_${cyc}.tif
-  ${UTILgfs}/ush/make_tif.sh
+  ${USHgfs}/make_tif.sh
 fi 
 
    msg=" GEMPAK_GIF ${fhr} hour completed normally"

--- a/parm/config/config.gldas
+++ b/parm/config/config.gldas
@@ -11,6 +11,6 @@ echo "BEGIN: config.gldas"
 export GLDASSH=$HOMEgfs/scripts/exgdas_atmos_gldas.sh
 export gldas_spinup_hours=72
 export CPCGAUGE=$DMPDIR
-export FINDDATE=$HOMEgfs/util/ush/finddate.sh
+export FINDDATE=$USHgfs/finddate.sh
 
 echo "END: config.gldas"

--- a/scripts/exgfs_atmos_fbwind.sh
+++ b/scripts/exgfs_atmos_fbwind.sh
@@ -79,7 +79,7 @@ fi
 if test "$SENDDBN" = 'YES'
 then
 #    make_ntc_bull.pl WMOBH NONE KWNO NONE tran.fbwnd_pacific ${COMOUTwmo}/tran.fbwnd_pacific.$job_name
-   ${UTILgfs}/ush/make_ntc_bull.pl WMOBH NONE KWNO NONE tran.fbwnd_pacific ${COMOUTwmo}/tran.fbwnd_pacific.$job_name
+   ${USHgfs}/make_ntc_bull.pl WMOBH NONE KWNO NONE tran.fbwnd_pacific ${COMOUTwmo}/tran.fbwnd_pacific.$job_name
 fi
 
 #####################################################################

--- a/sorc/build_gfs_utils.sh
+++ b/sorc/build_gfs_utils.sh
@@ -40,6 +40,6 @@ shift $((OPTIND-1))
 
 BUILD_TYPE=${BUILD_TYPE:-"Release"} \
 BUILD_VERBOSE=${BUILD_VERBOSE:-"NO"} \
-${cwd}/gfs_utils.fd/ush/build.sh
+"${cwd}"/gfs_utils.fd/ush/build.sh
 
 exit

--- a/sorc/build_gfs_utils.sh
+++ b/sorc/build_gfs_utils.sh
@@ -1,10 +1,9 @@
 #! /usr/bin/env bash
 set -eux
 
-function _usage() {
+function usage() {
   cat << EOF
-Builds all of the global-workflow components by calling the individual build
-  scripts in sequence.
+Builds the GFS utility programs.
 
 Usage: ${BASH_SOURCE[0]} [-d][-h][-v]
   -d:
@@ -24,6 +23,9 @@ while getopts ":dv" option; do
   case "${option}" in
     d) export BUILD_TYPE="DEBUG";;
     v) export BUILD_VERBOSE="YES";;
+    h)
+      usage
+      ;;
     :)
       echo "[${BASH_SOURCE[0]}]: ${option} requires an argument"
       usage
@@ -31,11 +33,13 @@ while getopts ":dv" option; do
     *)
       echo "[${BASH_SOURCE[0]}]: Unrecognized option: ${option}"
       usage
-      ;;    
+      ;;
   esac
 done
 shift $((OPTIND-1))
 
-"${cwd}/gfs_utils.fd/sorc/build_gfs_utils.sh"
+BUILD_TYPE=${BUILD_TYPE:-"Release"} \
+BUILD_VERBOSE=${BUILD_VERBOSE:-"NO"} \
+${cwd}/gfs_utils.fd/ush/build.sh
 
 exit

--- a/sorc/build_gfs_utils.sh
+++ b/sorc/build_gfs_utils.sh
@@ -40,6 +40,6 @@ shift $((OPTIND-1))
 
 BUILD_TYPE=${BUILD_TYPE:-"Release"} \
 BUILD_VERBOSE=${BUILD_VERBOSE:-"NO"} \
-"${cwd}"/gfs_utils.fd/ush/build.sh
+"${cwd}/gfs_utils.fd/ush/build.sh"
 
 exit

--- a/sorc/build_gfs_utils.sh
+++ b/sorc/build_gfs_utils.sh
@@ -19,7 +19,7 @@ EOF
 cwd=$(pwd)
 
 OPTIND=1
-while getopts ":dv" option; do
+while getopts ":dvh" option; do
   case "${option}" in
     d) export BUILD_TYPE="DEBUG";;
     v) export BUILD_VERBOSE="YES";;

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -151,7 +151,7 @@ mkdir -p "${logdir}"
 
 # The checkout version should always be a speciifc commit (hash or tag), not a branch
 errs=0
-checkout "gfs_utils.fd"    "https://github.com/NOAA-EMC/gfs-utils"              "7bf599f"          ; errs=$((errs + $?))
+checkout "gfs_utils.fd"    "https://github.com/NOAA-EMC/gfs-utils"              "af933d3"                    ; errs=$((errs + $?))
 checkout "ufs_model.fd"    "https://github.com/ufs-community/ufs-weather-model" "${ufs_model_hash:-3c3548d}" ; errs=$((errs + $?))
 checkout "ufs_utils.fd"    "https://github.com/ufs-community/UFS_UTILS.git"     "8b990c0"                    ; errs=$((errs + $?))
 checkout "verif-global.fd" "https://github.com/NOAA-EMC/EMC_verif-global.git"   "c267780"                    ; errs=$((errs + $?))

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -44,12 +44,12 @@ shift $((OPTIND-1))
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 top_dir=$(cd "$(dirname "${script_dir}")" &> /dev/null && pwd)
-cd ${script_dir}
+cd "${script_dir}"
 
 # shellcheck disable=SC1091
 source gfs_utils.fd/ush/detect_machine.sh  # (sets MACHINE_ID)
 # shellcheck disable=
-machine=$(echo $MACHINE_ID | cut -d. -f1)
+machine=$(echo "${MACHINE_ID}" | cut -d. -f1)
 
 #------------------------------
 #--model fix fields
@@ -133,7 +133,7 @@ cd "${top_dir}/parm/post" || exit 1
     done
 
 cd "${top_dir}/scripts" || exit 8
-    $LINK "${script_dir}/ufs_utils.fd/scripts/exemcsfc_global_sfc_prep.sh" .
+    ${LINK} "${script_dir}/ufs_utils.fd/scripts/exemcsfc_global_sfc_prep.sh" .
 cd "${top_dir}/ush" || exit 8
     for file in emcsfc_ice_blend.sh  fv3gfs_driver_grid.sh  fv3gfs_make_orog.sh  global_cycle_driver.sh \
         emcsfc_snow.sh  fv3gfs_filter_topo.sh  global_cycle.sh  fv3gfs_make_grid.sh ; do
@@ -244,7 +244,7 @@ if [ -d "${script_dir}/gfs_wafs.fd" ]; then
           wafs_awc_wafavn.x  wafs_blending.x  wafs_blending_0p25.x \
           wafs_cnvgrib2.x  wafs_gcip.x  wafs_grib2_0p25.x \
           wafs_makewafs.x  wafs_setmissing.x; do
-        [[ -s $wafsexe ]] && rm -f $wafsexe
+        [[ -s ${wafsexe} ]] && rm -f ${wafsexe}
         ${LINK} "${script_dir}/gfs_wafs.fd/exec/${wafsexe}" .
     done
 fi

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -47,9 +47,9 @@ top_dir=$(cd "$(dirname "${script_dir}")" &> /dev/null && pwd)
 cd ${script_dir}
 
 # shellcheck disable=SC1091
-source gfs_utils.fd/ush/machine-setup.sh > /dev/null 2>&1
+source gfs_utils.fd/ush/detect_machine.sh  # (sets MACHINE_ID)
 # shellcheck disable=
-machine="${target:?}"
+machine=$(echo $MACHINE_ID | cut -d. -f1)
 
 #------------------------------
 #--model fix fields
@@ -139,6 +139,9 @@ cd "${top_dir}/ush" || exit 8
         emcsfc_snow.sh  fv3gfs_filter_topo.sh  global_cycle.sh  fv3gfs_make_grid.sh ; do
         ${LINK} "${script_dir}/ufs_utils.fd/ush/${file}" .
     done
+    for file in finddate.sh  make_ntc_bull.pl  make_NTC_file.pl  make_tif.sh  month_name.sh ; do
+        ${LINK} "${script_dir}/gfs_utils.fd/ush/${file}" .
+    done
 
 #-----------------------------------
 #--add gfs_wafs link if checked out
@@ -227,7 +230,7 @@ for utilexe in fbwndgfs.x gaussian_sfcanl.x gfs_bufr.x regrid_nemsio.x supvit.x 
   syndat_maksynrc.x syndat_qctropcy.x tocsbufr.x enkf_chgres_recenter.x \
   enkf_chgres_recenter_nc.x fv3nc2nemsio.x tave.x vint.x reg2grb2.x ; do
     [[ -s "${utilexe}" ]] && rm -f "${utilexe}"
-    ${LINK} "${script_dir}/gfs_utils.fd/sorc/install/bin/${utilexe}" .
+    ${LINK} "${script_dir}/gfs_utils.fd/install/bin/${utilexe}" .
 done
 
 [[ -s "ufs_model.x" ]] && rm -f ufs_model.x


### PR DESCRIPTION
**Description**

This PR updates the gfs-utils version (af933d3) and ush script symlinks/paths. This will resolve issue #1059 until `finddate.sh` can be used via the `prod_util` module.

* New gfs-utils hash: af933d3
* A number of ush scripts were moved into the new gfs-utils repo but not added to `link_workflow.sh`. This PR adds them to `link_workflow.sh`.
* Several workflow scripts are updated to point to the gfs-utils ush symlinks under the top level `/ush` folder instead of the prior `/util/ush` folder.

Fixes #1059 

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

- [x] Clone and build tests on WCOSS2, Hera, Orion
- [x] Cycled tests on WCOSS2, Hera, Orion
  
Addresses #1059