### PR TITLE
Set COMPILER in link for detect machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,8 @@ ush/ufsda
 ush/wafs_blending.sh
 ush/wafs_grib2.regrid.sh
 ush/wafs_intdsk.sh
+ush/finddate.sh
+ush/make_NTC_file.pl
+ush/make_ntc_bull.pl
+ush/make_tif.sh
+ush/month_name.sh

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -46,6 +46,7 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 top_dir=$(cd "$(dirname "${script_dir}")" &> /dev/null && pwd)
 cd "${script_dir}"
 
+COMPILER="intel"
 # shellcheck disable=SC1091
 source gfs_utils.fd/ush/detect_machine.sh  # (sets MACHINE_ID)
 # shellcheck disable=


### PR DESCRIPTION
**Description**
The new detect_machine script in gfs-utils requires COMPILER be set.

Also added the gfs-utils scripts to the git ignore list.

Fixes #1090 

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Checkout and link on Orion
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
