### PR TITLE
Change GLDAS USE_CFP to NO on Hera

### DIFF
--- a/env/HERA.env
+++ b/env/HERA.env
@@ -126,7 +126,7 @@ elif [ $step = "sfcanl" ]; then
 
 elif [ $step = "gldas" ]; then
 
-    export USE_CFP="YES"
+    export USE_CFP="NO"
     export CFP_MP="YES"
 
     nth_max=$(($npe_node_max / $npe_node_gldas))


### PR DESCRIPTION
**Description**

This PR changes `USE_CFP` in the GLDAS block of `HERA.env` from "YES" to "NO". This fixes the GLDAS job failing when it attempts to use CFP on Hera.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes #1089