### PR TITLE
Correct errors with gdas and monitoring symlinks

### DIFF
--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -180,6 +180,9 @@ if [ -d "${script_dir}/gdas.cd" ]; then
     [[ ! -d gdas ]] && mkdir -p gdas
     cd gdas || exit 1
     for gdas_sub in bump crtm fv3jedi; do
+      if [ -d ${gdas_sub} ]; then
+         rm -rf "${gdas_sub}"
+      fi
       fix_ver="gdas_${gdas_sub}_ver"
       ${LINK} "${FIX_DIR}/gdas/${gdas_sub}/${!fix_ver}" "${gdas_sub}"
     done
@@ -203,7 +206,7 @@ if [ -d "${script_dir}/gsi_monitor.fd" ]; then
     [[ ! -d gdas ]] && ( mkdir -p gdas || exit 1 )
     cd gdas || exit 1
     ${LINK} "${script_dir}/gsi_monitor.fd/src/Minimization_Monitor/nwprod/gdas/fix/gdas_minmon_cost.txt"                   .
-    ${LINK} "${script_dir}/gsi_monitor.fd/src/Minimization_Monitor/nwprod/gdas/fix/gdas_minmon_gnorm.txt  "                .
+    ${LINK} "${script_dir}/gsi_monitor.fd/src/Minimization_Monitor/nwprod/gdas/fix/gdas_minmon_gnorm.txt"                  .
     ${LINK} "${script_dir}/gsi_monitor.fd/src/Ozone_Monitor/nwprod/gdas_oznmon/fix/gdas_oznmon_base.tar"                   .
     ${LINK} "${script_dir}/gsi_monitor.fd/src/Ozone_Monitor/nwprod/gdas_oznmon/fix/gdas_oznmon_satype.txt"                 .
     ${LINK} "${script_dir}/gsi_monitor.fd/src/Radiance_Monitor/nwprod/gdas_radmon/fix/gdas_radmon_base.tar"                .

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -180,7 +180,7 @@ if [ -d "${script_dir}/gdas.cd" ]; then
     [[ ! -d gdas ]] && mkdir -p gdas
     cd gdas || exit 1
     for gdas_sub in bump crtm fv3jedi; do
-      if [ -d ${gdas_sub} ]; then
+      if [ -d "${gdas_sub}" ]; then
          rm -rf "${gdas_sub}"
       fi
       fix_ver="gdas_${gdas_sub}_ver"
@@ -248,7 +248,7 @@ if [ -d "${script_dir}/gfs_wafs.fd" ]; then
           wafs_awc_wafavn.x  wafs_blending.x  wafs_blending_0p25.x \
           wafs_cnvgrib2.x  wafs_gcip.x  wafs_grib2_0p25.x \
           wafs_makewafs.x  wafs_setmissing.x; do
-        [[ -s ${wafsexe} ]] && rm -f ${wafsexe}
+        [[ -s ${wafsexe} ]] && rm -f "${wafsexe}"
         ${LINK} "${script_dir}/gfs_wafs.fd/exec/${wafsexe}" .
     done
 fi
@@ -272,7 +272,7 @@ if [ -d "${script_dir}/gsi_utils.fd" ]; then
   for exe in calc_analysis.x calc_increment_ens_ncio.x calc_increment_ens.x \
     getsfcensmeanp.x getsigensmeanp_smooth.x getsigensstatp.x \
     interp_inc.x recentersigp.x;do
-    [[ -s "${exe}" ]] && rm -f ${exe}
+    [[ -s "${exe}" ]] && rm -f "${exe}"
     ${LINK} "${script_dir}/gsi_utils.fd/install/bin/${exe}" .
   done
 fi
@@ -374,7 +374,7 @@ cd "${script_dir}"   ||   exit 8
         emcsfc_ice_blend.fd \
         emcsfc_snow2mdl.fd ;do
         [[ -d "${prog}" ]] && rm -rf "${prog}"
-        ${SLINK} "ufs_utils.fd/sorc/${prog}"                                                     ${prog}
+        ${SLINK} "ufs_utils.fd/sorc/${prog}"                                                     "${prog}"
     done
 
     for prog in enkf_chgres_recenter.fd \
@@ -398,7 +398,7 @@ cd "${script_dir}"   ||   exit 8
       webtitle.fd
       do
         if [[ -d "${prog}" ]]; then rm -rf "${prog}"; fi
-        ${LINK} gfs_utils.fd/src/${prog} .
+        ${LINK} gfs_utils.fd/src/"${prog}" .
     done
 
     if [ -d "${script_dir}/gfs_wafs.fd" ]; then

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -398,7 +398,7 @@ cd "${script_dir}"   ||   exit 8
       webtitle.fd
       do
         if [[ -d "${prog}" ]]; then rm -rf "${prog}"; fi
-        ${LINK} gfs_utils.fd/src/"${prog}" .
+        ${LINK} "gfs_utils.fd/src/${prog}" .
     done
 
     if [ -d "${script_dir}/gfs_wafs.fd" ]; then


### PR DESCRIPTION
**Description**

This PR resolves issues reported in issue #1100 by @RussTreadon-NOAA related to an error when rerunning `link_workflow.sh` (when in GDASApp mode) and a dead GSI monitoring symlink under `fix/gdas`.

Fix 1: When link_workflow.sh is rerun an error occurs:

```
-bash-4.2$ ./link_workflow.sh
./link_workflow.sh completed successfully
-bash-4.2$ ./link_workflow.sh
ln: failed to create symbolic link 'bump/20220805': Permission denied ./link_workflow.sh encounted an error at line 184 (rc=1)
```

Update link_workflow.sh gdas section to remove the subfolder symlinks if they already exist before trying to make them. Error goes away now.

Fix 2: Dead symlink for a GSI monitoring file under /fix/gdas

Two extra whitespaces in link_workflow.sh cause a dead link. Remove the whitespaces and link is created correctly.

Fixes #1100

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

Tested by both @RussTreadon-NOAA and @KateFriedman-NOAA.