### PR TITLE
Correct crtm path in UFS DA atmospheric analysis scripts (#1110)

### DIFF
--- a/scripts/exgdas_global_atmos_analysis_run.sh
+++ b/scripts/exgdas_global_atmos_analysis_run.sh
@@ -126,7 +126,7 @@ for fieldset in $fieldsets; do
 done
 
 # CRTM coeffs
-$NLN $FV3JEDI_FIX/crtm/2.3.0_jedi $DATA/crtm
+${NLN} "${FV3JEDI_FIX}"/crtm/2.3.0 "${DATA}"/crtm
 
 #  Link executable to $DATA
 $NLN $JEDIVAREXE $DATA/fv3jedi_var.x

--- a/scripts/exgdas_global_atmos_analysis_run.sh
+++ b/scripts/exgdas_global_atmos_analysis_run.sh
@@ -126,7 +126,7 @@ for fieldset in $fieldsets; do
 done
 
 # CRTM coeffs
-${NLN} "${FV3JEDI_FIX}"/crtm/2.3.0 "${DATA}"/crtm
+${NLN} "${FV3JEDI_FIX}/crtm/2.3.0" "${DATA}/crtm"
 
 #  Link executable to $DATA
 $NLN $JEDIVAREXE $DATA/fv3jedi_var.x

--- a/scripts/exgdas_global_atmos_ensanal_run.sh
+++ b/scripts/exgdas_global_atmos_ensanal_run.sh
@@ -119,7 +119,7 @@ for fieldset in $fieldsets; do
 done
 
 # CRTM coeffs
-$NLN $FV3JEDI_FIX/crtm/2.3.0_jedi $DATA/crtm
+${NLN} "${FV3JEDI_FIX}"/crtm/2.3.0 "${DATA}"/crtm
 
 #  Link executable to $DATA
 $NLN $JEDIENSEXE $DATA/fv3jedi_ens.x

--- a/scripts/exgdas_global_atmos_ensanal_run.sh
+++ b/scripts/exgdas_global_atmos_ensanal_run.sh
@@ -119,7 +119,7 @@ for fieldset in $fieldsets; do
 done
 
 # CRTM coeffs
-${NLN} "${FV3JEDI_FIX}"/crtm/2.3.0 "${DATA}"/crtm
+${NLN} "${FV3JEDI_FIX}/crtm/2.3.0" "${DATA}/crtm"
 
 #  Link executable to $DATA
 $NLN $JEDIENSEXE $DATA/fv3jedi_ens.x


### PR DESCRIPTION
**Description**
UFS DA unified forward operator (UFO) validation uses `crtm/2.3.0` for radiances.     UFS DA scripts which exercise UFO for radiance assimilation should use the same CRTM coefficients.   UFS DA scripts `exgdas_global_atmos_analysis_run.sh` and `exgdas_global_atmos_ensanal_run.sh` currently use CRTM coefficients from `crtm/2.3.0_jedi`.   This is not correct. 

The CRTM coefficient path for the two UFS DA analysis scripts in question has been updated in [`feature/ufsda_crtm`.](https://github.com/NOAA-EMC/global-workflow/tree/feature/ufsda_crtm)

Fixes #1110 

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)


**How Has This Been Tested?**
- [x] Singe cycle test on Hera

The 2021122106 cycle was run on Hera using the updated ex scripts from `feature/ufsda_crtm`.   The log files and run directories were checked to confirm that CRTM coefficients were taken from `crtm/2.3.0`.
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

