### PR TITLE
Update MODULEPATH for gfs_bufr build on Orion

### DIFF
--- a/modulefiles/gfs_bufr.orion.lua
+++ b/modulefiles/gfs_bufr.orion.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to build gfs_bufr on Orion 
 ]])
 
-prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack-gfsv16/modulefiles/stack")
+prepend_path("MODULEPATH", "/apps/contrib/NCEP/hpc-stack/libs/hpc-stack-gfsv16/modulefiles/stack")
 
 load(pathJoin("hpc", os.getenv("hpc_ver")))
 load(pathJoin("hpc-intel", os.getenv("hpc_intel_ver")))


### PR DESCRIPTION
**Description**

The hpc-stack-gfsv16 install moved to a new location that Hang Lei setup, so the `MODULEPATH` in the `gfs_bufr.orion.lua` modulefile needs to update. Updated path already in `module_base.orion.lua`. The change in `gfs_bufr.orion.lua` was overlooked.

New hpc-stack-gfsv16 `MODULEPATH` on Orion: `/apps/contrib/NCEP/hpc-stack/libs/hpc-stack-gfsv16/modulefiles/stack`

Refs #744

**Type of change**

Maintenance.

**How Has This Been Tested?**

- [x] Clone and Build tests on Orion