### PR TITLE
MPMD variable updates and fix

### DIFF
--- a/env/JET.env
+++ b/env/JET.env
@@ -20,6 +20,7 @@ elif [[ "$PARTITION_BATCH" = "vjet" ]]; then
   export npe_node_max=16
 fi
 export launcher="srun -l --export=ALL"
+export mpmd_opt="--multi-prog"
 
 # Configure STACK
 export OMP_STACKSIZE=2048000
@@ -43,7 +44,7 @@ elif [ $step = "waveinit" -o $step = "waveprep" -o $step = "wavepostsbs" -o $ste
 
     if [ $step = "waveprep" ]; then export MP_PULSE=0 ; fi
     export wavempexec=${launcher}
-    export wave_mpmd=${mpmd}
+    export wave_mpmd=${mpmd_opt}
 
 elif [ $step = "atmanalrun" ]; then
 

--- a/env/S4.env
+++ b/env/S4.env
@@ -21,6 +21,7 @@ elif [[ ${PARTITION_BATCH} = "ivy" ]]; then
    export npe_node_max=20
 fi
 export launcher="srun -l --export=ALL"
+export mpmd_opt="--multi-prog"
 
 # Configure MPI environment
 export OMP_STACKSIZE=2048000
@@ -45,11 +46,10 @@ if [[ ${step} = "prep" || ${step} = "prepbufr" ]]; then
 
 elif [[ ${step} = "waveinit" || ${step} = "waveprep" || ${step} = "wavepostsbs" || ${step} = "wavepostbndpnt" || ${step} = "wavepostbndpntbll" || ${step} = "wavepostpnt" ]]; then
 
-    export mpmd="--multi-prog"
     export CFP_MP="YES"
     if [[ ${step} = "waveprep" ]]; then export MP_PULSE=0 ; fi
     export wavempexec=${launcher}
-    export wave_mpmd=${mpmd}
+    export wave_mpmd=${mpmd_opt}
 
 elif [[ ${step} = "atmanalrun" ]]; then
 

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -17,7 +17,7 @@ step=$1
 
 # WCOSS2 information
 export launcher="mpiexec -l"
-export mpmd="--cpu-bind verbose,core cfp"
+export mpmd_opt="--cpu-bind verbose,core cfp"
 
 export npe_node_max=128
 
@@ -37,13 +37,13 @@ elif [ $step = "waveinit" -o $step = "waveprep" -o $step = "wavepostsbs" -o $ste
 
     if [ $step = "waveprep" -a $CDUMP = "gfs" ]; then NTASKS=$NTASKS_gfs ; fi
     export wavempexec="$launcher -np"
-    export wave_mpmd=${mpmd}
+    export wave_mpmd=${mpmd_opt}
 
 elif [ $step = "atmanalrun" ]; then
 
     export CFP_MP=${CFP_MP:-"YES"}
     export USE_CFP=${USE_CFP:-"YES"}
-    export APRUNCFP="$launcher -np \$ncmd $mpmd"
+    export APRUNCFP="$launcher -np \$ncmd ${mpmd_opt}"
 
     nth_max=$(($npe_node_max / $npe_node_atmanalrun))
 
@@ -55,7 +55,7 @@ elif [ $step = "atmensanalrun" ]; then
 
     export CFP_MP=${CFP_MP:-"YES"}
     export USE_CFP=${USE_CFP:-"YES"}
-    export APRUNCFP="$launcher -np \$ncmd $mpmd"
+    export APRUNCFP="$launcher -np \$ncmd ${mpmd_opt}"
 
     nth_max=$(($npe_node_max / $npe_node_atmensanalrun))
 
@@ -65,7 +65,7 @@ elif [ $step = "atmensanalrun" ]; then
 
 elif [ $step = "aeroanlrun" ]; then
 
-    export APRUNCFP="$launcher -np \$ncmd $mpmd"
+    export APRUNCFP="$launcher -np \$ncmd ${mpmd_opt}"
 
     nth_max=$(($npe_node_max / $npe_node_aeroanlrun))
 
@@ -108,7 +108,7 @@ elif [ $step = "anal" -o $step = "analcalc" ]; then
 
     export CFP_MP=${CFP_MP:-"NO"}
     export USE_CFP=${USE_CFP:-"YES"}
-    export APRUNCFP="$launcher -np \$ncmd $mpmd"
+    export APRUNCFP="$launcher -np \$ncmd ${mpmd_opt}"
 
 elif [ $step = "sfcanl" ]; then
 
@@ -138,7 +138,7 @@ elif [ $step = "gldas" ]; then
     # periods being processed.
     export USE_CFP=${USE_CFP:-"YES"}
     npe_gldas_data_proc=$(($gldas_spinup_hours + 12))
-    export APRUN_GLDAS_DATA_PROC="$launcher -np $npe_gldas_data_proc $mpmd"
+    export APRUN_GLDAS_DATA_PROC="$launcher -np $npe_gldas_data_proc ${mpmd_opt}"
 
 elif [ $step = "eobs" ]; then
 
@@ -154,7 +154,7 @@ elif [ $step = "eobs" ]; then
 
     export CFP_MP=${CFP_MP:-"NO"}
     export USE_CFP=${USE_CFP:-"YES"}
-    export APRUNCFP="$launcher -np \$ncmd $mpmd"
+    export APRUNCFP="$launcher -np \$ncmd ${mpmd_opt}"
 
 elif [ $step = "eupd" ]; then
 
@@ -171,7 +171,7 @@ elif [ $step = "eupd" ]; then
 
     export CFP_MP=${CFP_MP:-"NO"}
     export USE_CFP=${USE_CFP:-"YES"}
-    export APRUNCFP="$launcher -np \$ncmd $mpmd"
+    export APRUNCFP="$launcher -np \$ncmd ${mpmd_opt}"
 
 elif [ $step = "fcst" ]; then
 
@@ -231,7 +231,7 @@ elif [ $step = "post" ]; then
 
     export NTHREADS_DWN=${nth_dwn:-1}
     [[ $NTHREADS_DWN -gt $nth_max ]] && export NTHREADS_DWN=$nth_max
-    export APRUN_DWN="$launcher -np $npe_dwn $mpmd"
+    export APRUN_DWN="$launcher -np $npe_dwn ${mpmd_opt}"
 
 elif [ $step = "ecen" ]; then
 
@@ -290,7 +290,7 @@ elif [ $step = "postsnd" ]; then
 
     export NTHREADS_POSTSNDCFP=${nth_postsndcfp:-1}
     [[ $NTHREADS_POSTSNDCFP -gt $nth_max ]] && export NTHREADS_POSTSNDCFP=$nth_max
-    export APRUN_POSTSNDCFP="$launcher -np $npe_postsndcfp $mpmd"
+    export APRUN_POSTSNDCFP="$launcher -np $npe_postsndcfp ${mpmd_opt}"
 
 elif [ $step = "awips" ]; then
 
@@ -298,7 +298,7 @@ elif [ $step = "awips" ]; then
 
     export NTHREADS_AWIPS=${nth_awips:-2}
     [[ $NTHREADS_AWIPS -gt $nth_max ]] && export NTHREADS_AWIPS=$nth_max
-    export APRUN_AWIPSCFP="$launcher -np $npe_awips $mpmd"
+    export APRUN_AWIPSCFP="$launcher -np $npe_awips ${mpmd_opt}"
 
 elif [ $step = "gempak" ]; then
 
@@ -306,7 +306,7 @@ elif [ $step = "gempak" ]; then
 
     export NTHREADS_GEMPAK=${nth_gempak:-1}
     [[ $NTHREADS_GEMPAK -gt $nth_max ]] && export NTHREADS_GEMPAK=$nth_max
-    export APRUN_GEMPAKCFP="$launcher -np $npe_gempak $mpmd"
+    export APRUN_GEMPAKCFP="$launcher -np $npe_gempak ${mpmd_opt}"
 
 elif [ $step = "waveawipsbulls" ]; then
 

--- a/jobs/JGLOBAL_WAVE_INIT
+++ b/jobs/JGLOBAL_WAVE_INIT
@@ -64,7 +64,7 @@ fi
 
 # Set mpi serial command
 export wavempexec=${wavempexec:-"mpirun -n"}
-export wave_mpmd=${mpmd:-"cfp"}
+export wave_mpmd=${wave_mpmd:-"cfp"}
 
 # Execute the Script  
 $HOMEgfs/scripts/exgfs_wave_init.sh


### PR DESCRIPTION
**Description**

This PR fixes an issue with the `wave_mpmd` variable used in the waveinit job (resulting from prior `mpmd_opt` variable change) and, for consistently, changes the `mpmd` variable to `mpmd_opt` in the other env files (Jet, S4, WCOSS2).

Changes:

1. In `jobs/JGLOBAL_WAVE_INIT` change `wave_mpmd` setting to use `wave_mpmd` set in env files instead of `mpmd` (the latter variable no longer exists and caused a failure in waveinit).

Error in waveinit job (from Orion test):
```
+ exgfs_wave_init.sh[161]: srun -l --export=ALL -n 1 cfp cmdfile
0: slurmstepd: error: execve(): cfp: No such file or directory
```
Upon correcting (from Orion test):
```
+ exgfs_wave_init.sh[161]: srun -l --export=ALL -n 1 --multi-prog cmdfile
```

2. Update `JET.env` and `S4.env` to set `export mpmd_opt="--multi-prog"` at the top (similar to `HERA.env` and `ORION.env`) and replace instances of `mpmd` with `mpmd_opt`. FYI @DavidHuber-NOAA 
3. Update `WCOSS2.env` to rename `mpmd` variable to `mpmd_opt` and update variable usage throughout.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

- [x] Clone and Build tests on WCOSS2
- [x] Coupled forecast-only test on Orion
- [x] Coupled forecast-only test on WCOSS2
- [x] Cycled test on WCOSS2 (folded into on-going high-res real-time run)
