### PR TITLE
Improved error messages from exglobal_atmos_analysis.sh

### DIFF
--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -537,9 +537,6 @@ $NLN $SFCGES sfcf06
 $NLN $SFCG09 sfcf09
 
 # Link hourly backgrounds (if present)
-if [ -f $ATMG04 -a -f $ATMG05 -a -f $ATMG07 -a -f $ATMG08 ]; then
-   nhr_obsbin=1
-fi
 
 [[ -f $ATMG04 ]] && $NLN $ATMG04 sigf04
 [[ -f $ATMG05 ]] && $NLN $ATMG05 sigf05
@@ -562,6 +559,7 @@ if [ $DOHYBVAR = "YES" ]; then
    fhrs="06"
    if [ $l4densvar = ".true." ]; then
       fhrs="03 04 05 06 07 08 09"
+      nhr_obsbin=1
    fi
 
    for imem in $(seq 1 $NMEM_ENKF); do


### PR DESCRIPTION
**Description**
The logical test used to set gsi namelist variable `nhr_obsbin` was not consistent with other checks in the script which use variable `l4densvar`.  This relocates the setting for `nhr_obsbin` to be consistent with other tests using `l4densvar`, which will allow the appropriate error messages to be output by the executable.

Fixes #1123
Fixes [NCO bugzilla #1196](http://www2.spa.ncep.noaa.gov/bugzilla/show_bug.cgi?id=1196)

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
The global-workflow with the updated `exglobal_atmos_analysis.sh` has been exercised in gdasanal jobs on both WCOSS2 and Hera.   Tests in which expected background files were missing confirm that the generated error messages conform to NCO's request.

- [x] Clone and Build on WCOSS2 and Hera
- [x] Single job (gdasanal) tests on WCOSS2 and Hera

  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass with my changes
