### PR TITLE
Update MODULEPATH for Orion

### DIFF
--- a/modulefiles/module_base.orion.lua
+++ b/modulefiles/module_base.orion.lua
@@ -2,7 +2,7 @@ help([[
 Load environment to run GFS on Orion
 ]])
 
-prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/apps/contrib/NCEP/hpc-stack/libs/hpc-stack/modulefiles/stack")
 
 load(pathJoin("hpc", "1.1.0"))
 load(pathJoin("hpc-intel", "2018.4"))


### PR DESCRIPTION
**Description**

This PR updates the `MODULEPATH` in `modulefiles/module_base.orion.lua` to a new hpc-stack location set up by @Hang-Lei-NOAA. See issue #1119 for more details on new location.

Update `modulefiles/module_base.orion.lua` `MODULEPATH` to: `/apps/contrib/NCEP/hpc-stack/libs/hpc-stack/modulefiles/stack`

Closes #1119

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

- [x] Clone and build tests on Orion (default checkout/build settings)
- [x] Cycled atmos-only test on Orion (2.5 cycles)
- [x] Coupled forecast-only test on Orion