### PR TITLE
Update C48 forecast to run with one thread

### DIFF
--- a/parm/config/config.fv3
+++ b/parm/config/config.fv3
@@ -50,15 +50,13 @@ case ${case_in} in
         export layout_y=2
         export layout_x_gfs=3
         export layout_y_gfs=2
-        export nth_fv3=2
-        export nth_fv3_gfs=2
+        export nth_fv3=1
+        export nth_fv3_gfs=1
         export cdmbgwd="0.071,2.1,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=1
         export WRTTASK_PER_GROUP=64
-	if [[ "${WRTTASK_PER_GROUP}" -gt "${npe_node_max}" ]]; then export WRTTASK_PER_GROUP=${npe_node_max} ; fi
         export WRITE_GROUP_GFS=1
         export WRTTASK_PER_GROUP_GFS=64
-        if [[ "${WRTTASK_PER_GROUP_GFS}" -gt "${npe_node_max}" ]]; then export WRTTASK_PER_GROUP_GFS=${npe_node_max} ; fi
         export WRTIOBUF="1M"
         ;;
     "C96")
@@ -72,10 +70,8 @@ case ${case_in} in
         export cdmbgwd="0.14,1.8,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=1
         export WRTTASK_PER_GROUP=64
-	if [[ "${WRTTASK_PER_GROUP}" -gt "${npe_node_max}" ]]; then export WRTTASK_PER_GROUP=${npe_node_max} ; fi
         export WRITE_GROUP_GFS=1
         export WRTTASK_PER_GROUP_GFS=64
-	if [[ "${WRTTASK_PER_GROUP_GFS}" -gt "${npe_node_max}" ]]; then export WRTTASK_PER_GROUP_GFS=${npe_node_max} ; fi
         export WRTIOBUF="4M"
         export n_split=6
         ;;
@@ -90,10 +86,8 @@ case ${case_in} in
         export cdmbgwd="0.23,1.5,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=1
         export WRTTASK_PER_GROUP=64
-	if [[ "${WRTTASK_PER_GROUP}" -gt "${npe_node_max}" ]]; then export WRTTASK_PER_GROUP=${npe_node_max} ; fi
         export WRITE_GROUP_GFS=2
         export WRTTASK_PER_GROUP_GFS=64
-	if [[ "${WRTTASK_PER_GROUP_GFS}" -gt "${npe_node_max}" ]]; then export WRTTASK_PER_GROUP_GFS=${npe_node_max} ; fi
         export WRTIOBUF="8M"
         ;;
     "C384")
@@ -107,10 +101,8 @@ case ${case_in} in
         export cdmbgwd="1.1,0.72,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=2
         export WRTTASK_PER_GROUP=64
-	if [[ "${WRTTASK_PER_GROUP}" -gt "${npe_node_max}" ]]; then export WRTTASK_PER_GROUP=${npe_node_max} ; fi
         export WRITE_GROUP_GFS=${WRITE_GROUP_GFS:-2}
         export WRTTASK_PER_GROUP_GFS=${WRTTASK_PER_GROUP_GFS:-64}
-	if [[ "${WRTTASK_PER_GROUP_GFS}" -gt "${npe_node_max}" ]]; then export WRTTASK_PER_GROUP_GFS=${npe_node_max} ; fi
         export WRTIOBUF=${WRTIOBUF:-"16M"}
         ;;
     "C768")
@@ -124,10 +116,8 @@ case ${case_in} in
         export cdmbgwd="4.0,0.15,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=2
         export WRTTASK_PER_GROUP=64
-	if [[ "${WRTTASK_PER_GROUP}" -gt "${npe_node_max}" ]]; then export WRTTASK_PER_GROUP=${npe_node_max} ; fi
         export WRITE_GROUP_GFS=4
         export WRTTASK_PER_GROUP_GFS=64
-	if [[ "${WRTTASK_PER_GROUP_GFS}" -gt "${npe_node_max}" ]]; then export WRTTASK_PER_GROUP_GFS=${npe_node_max} ; fi
         export WRTIOBUF="32M"
         ;;
     "C1152")
@@ -165,6 +155,9 @@ case ${case_in} in
         exit 1
         ;;
 esac
+
+if [[ "${WRTTASK_PER_GROUP}" -gt "${npe_node_max}" ]]; then export WRTTASK_PER_GROUP=${npe_node_max} ; fi
+if [[ "${WRTTASK_PER_GROUP_GFS}" -gt "${npe_node_max}" ]]; then export WRTTASK_PER_GROUP_GFS=${npe_node_max} ; fi
 
 # Calculate chunksize based on resolution
 export RESTILE=$(echo ${case_in} |cut -c2-)


### PR DESCRIPTION
**Description**
C48 forecasts currently fail on WCOSS2 when running with two threads. Two threads are likely not really needed, so the forecast job is reduced to single-threaded on all platforms, at least until the problem can be corrected.

Also moves the block capping the write block size to the node size outside the resolution-specific block, since that is needed for all resolutions.

Fixes #1129 

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

This PR also removes the repeated common logic from each of the case statements.

**How Has This Been Tested?**

Tested as part of other ongoing PR's 
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas