### PR TITLE
Remove unnecessary sCDATE assignment in forecast_predet.sh

### DIFF
--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -248,7 +248,6 @@ FV3_GFS_predet(){
   gPDY=$(echo $GDATE | cut -c1-8)
   gcyc=$(echo $GDATE | cut -c9-10)
   gmemdir=$ROTDIR/${rprefix}.$gPDY/$gcyc/atmos/$memchar
-  sCDATE=$($NDATE -3 $CDATE)
 
   if [[ "$DOIAU" = "YES" ]]; then
     sCDATE=$($NDATE -3 $CDATE)


### PR DESCRIPTION
**Description**
ush/forecast_predet.sh line 251 contain unnecessary sCDATE assignment. Therefore this line is safe to be removed.

Fixes #956

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
