### PR TITLE
Remove prod_envir module load from WCOSS2

### DIFF
--- a/modulefiles/module_base.wcoss2.lua
+++ b/modulefiles/module_base.wcoss2.lua
@@ -12,7 +12,6 @@ load(pathJoin("cfp", "2.0.4"))
 setenv("USE_CFP","YES")
 
 load(pathJoin("python", "3.8.6"))
-load(pathJoin("prod_envir", "2.0.4"))
 load(pathJoin("gempak", "7.14.1"))
 load(pathJoin("perl", "5.32.0"))
 load(pathJoin("libjpeg", "9c"))


### PR DESCRIPTION
**Description**

The `prod_envir` module load in `module_base.wcoss2.lua` is not needed and is being removed in this PR.

**Type of change**

Cleanup.

**How Has This Been Tested?**

- [x] Cycled test on WCOSS2
