### PR TITLE
enable APP=S2SWA on WCOSS2

### DIFF
--- a/parm/config/config.aero
+++ b/parm/config/config.aero
@@ -16,6 +16,9 @@ case $machine in
   "S4")
     AERO_INPUTS_DIR="/data/prod/glopara/gocart_emissions"
     ;;
+  "WCOSS2")
+    AERO_INPUTS_DIR="/lfs/h2/emc/global/noscrub/emc.global/data/gocart_emissions"
+    ;;
   *)
     echo "FATAL ERROR: Machine $machine unsupported for aerosols"
     exit 2

--- a/sorc/build_ufs.sh
+++ b/sorc/build_ufs.sh
@@ -11,10 +11,6 @@ export RT_COMPILER="intel"
 source "${cwd}/ufs_model.fd/tests/detect_machine.sh"
 source "${cwd}/ufs_model.fd/tests/module-setup.sh"
 
-if [[ ${MACHINE_ID} =~ wcoss2.* ]]; then
-	APP='S2SW'
-fi
-
 while getopts ":da:v" option; do
   case "${option}" in
     d) BUILD_TYPE="Debug";;

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -156,7 +156,7 @@ mkdir -p "${logdir}"
 # The checkout version should always be a speciifc commit (hash or tag), not a branch
 errs=0
 checkout "gfs_utils.fd"    "https://github.com/NOAA-EMC/gfs-utils"              "0b8ff56"                    ; errs=$((errs + $?))
-checkout "ufs_model.fd"    "https://github.com/ufs-community/ufs-weather-model" "${ufs_model_hash:-6b73f5d}" ; errs=$((errs + $?))
+checkout "ufs_model.fd"    "https://github.com/ufs-community/ufs-weather-model" "${ufs_model_hash:-7a1ce44}" ; errs=$((errs + $?))
 checkout "ufs_utils.fd"    "https://github.com/ufs-community/UFS_UTILS.git"     "8b990c0"                    ; errs=$((errs + $?))
 checkout "verif-global.fd" "https://github.com/NOAA-EMC/EMC_verif-global.git"   "c267780"                    ; errs=$((errs + $?))
 


### PR DESCRIPTION
**Description**
This PR:
- updates the ufs-weather-model hash to [7a1ce44](https://github.com/ufs-community/ufs-weather-model/commit/7a1ce44125b95bca4760b4ce888d76bbc1d9e790)
- enables `APP=S2SWA` on WCOSS2
- fixes #1139 

**NOTE: This model hash has not been tested with the cycled system or any other variant of `APP`**

**Type of change**
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

**How Has This Been Tested?**
Single date S2SWA run on WCOSS2
```
$> python3 setup_expt.py forecast-only --app S2SWA --idate 2013010100 --edate 2013010100 --resdet 384
```

The experiment directories are at:
```
EXPDIR: /lfs/h2/emc/eib/noscrub/rahul.mahajan/gwWork/EXPDIR/s2swa
COMROT: /lfs/h2/emc/ptmp/rahul.mahajan/ROTDIR/s2swa
```

Continuous aerosols has not been tested as the ICs are only available for `2013010100` at the moment on WCOSS2.

- [X] Clone, Build and Run S2SWA tests on WCOSS2

```
     PROGRAM ufs       HAS ENDED.
* . * . * . * . * . * . * . * . * . * . * . * . * . * . * . * . * . * . * . * .
nid001620.cactus.wcoss2.ncep.noaa.gov 0: *****************RESOURCE STATISTICS*******************************
The total amount of wall time                        = 4545.012595
The total amount of time in user mode                = 6892.840149
The total amount of time in sys mode                 = 555.230774
The maximum resident set size (KB)                   = 4249052
Number of page faults without I/O activity           = 5555267
Number of page faults with I/O activity              = 37
Number of times filesystem performed INPUT           = 8843994
Number of times filesystem performed OUTPUT          = 56762080
Number of Voluntary Context Switches                 = 36844
Number of InVoluntary Context Switches               = 14441
*****************END OF RESOURCE STATISTICS*************************

+ exglobal_forecast.sh[195]: export ERR=0
```

```
$> ls $COMROT/gfs.20130101/00/chem/
gocart.inst_aod.20130101_0600z.nc4  gocart.inst_aod.20130102_0000z.nc4  gocart.inst_aod.20130102_1800z.nc4
gocart.inst_aod.20130101_1200z.nc4  gocart.inst_aod.20130102_0600z.nc4  gocart.inst_aod.20130103_0000z.nc4
gocart.inst_aod.20130101_1800z.nc4  gocart.inst_aod.20130102_1200z.nc4
```
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [X] Any dependent changes have been merged and published
