### PR TITLE
GFSv16.3.4 updates

### DIFF
--- a/docs/Release_Notes.gfs.v16.3.4.md
+++ b/docs/Release_Notes.gfs.v16.3.4.md
@@ -1,0 +1,136 @@
+GFS V16.3.4 RELEASE NOTES
+
+-------
+PRELUDE
+-------
+
+Bugfix upgrade to correct incorrect syndat_stmnames fix file and add missing 2023 CO2 fix files.
+
+IMPLEMENTATION INSTRUCTIONS
+---------------------------
+
+The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub .com are used to manage the GFS.v16.3.4 code.  The SPA(s) handling the GFS.v16.3.4 implementation need to have permissions to clone VLab Gerrit repositories and private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are publicly readable and do not require access permissions.  Please proceed with the following steps to install the package on WCOSS2:
+
+```bash
+cd $PACKAGEROOT
+mkdir gfs.v16.3.4
+cd gfs.v16.3.4
+git clone -b EMC-v16.3.4 https://github.com/NOAA-EMC/global-workflow.git .
+cd sorc
+./checkout.sh -o
+```
+
+The checkout script extracts the following GFS components:
+
+| Component | Tag         | POC               |
+| --------- | ----------- | ----------------- |
+| MODEL     | GFS.v16.3.0   | Jun.Wang@noaa.gov |
+| GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
+| GSI       | gfsda.v16.3.0 | Emily.Liu@noaa.gov |
+| UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
+| POST      | upp_v8.2.0 | Wen.Meng@noaa.gov |
+| WAFS      | gfs_wafs.v6.3.1 | Yali.Mao@noaa.gov |
+
+Note: The library upp/8.2.0 needs to be pre-installed before proceeding with the build step.
+
+To build all the GFS components, execute:
+```bash
+./build_all.sh
+```
+The `build_all.sh` script compiles all GFS components. Runtime output from the build for each package is written to log files in directory logs. To build an individual program, for instance, gsi, use `build_gsi.sh`.
+
+Next, link the executables, fix files, parm files, etc in their final respective locations by executing:
+```bash
+./link_fv3gfs.sh nco wcoss2
+```
+
+Lastly, link the ecf scripts by moving back up to the ecf folder and executing:
+```bash
+cd ../ecf
+./setup_ecf_links.sh
+```
+
+VERSION FILE CHANGES
+--------------------
+
+* `versions/run.ver` - change version=v16.3.4 and gfs_ver=v16.3.4
+
+SORC CHANGES
+------------
+
+* No changes from GFS v16.3.3
+
+JOBS CHANGES
+------------
+
+* No changes from GFS v16.3.3
+
+PARM/CONFIG CHANGES
+-------------------
+
+* No changes from GFS v16.3.3
+
+SCRIPT CHANGES
+--------------
+
+* No changes from GFS v16.3.3
+
+FIX CHANGES
+-----------
+
+* Workflow:
+  * Corrected storm names:
+    * `fix_am/syndat_stmnames`
+  * Missing 2023 CO2 files not copied from recent v16.2.3 upgrade:
+    * `fix_am/co2dat_4a/global_co2historicaldata_2021.txt`
+    * `fix_am/co2dat_4a/global_co2historicaldata_2022.txt_proj_u`
+    * `fix_am/co2dat_4a/global_co2historicaldata_2023.txt_proj`
+    * `fix_am/fix_co2_proj/global_co2historicaldata_2023.txt`
+    * `fix_am/fix_co2_update/global_co2historicaldata_2022.txt`
+
+MODULE CHANGES
+--------------
+
+* A couple R&D modulefiles were updated for developer support and do not impact WCOSS2 ops.
+
+CHANGES TO FILE SIZES
+---------------------
+
+* No changes from GFS v16.3.3
+
+ENVIRONMENT AND RESOURCE CHANGES
+--------------------------------
+
+* No changes from GFS v16.3.3
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+---------------------------------------
+
+* Which production jobs should be tested as part of this implementation?
+  * The entire GFS v16.3.4 package needs to be installed and tested on WCOSS-2
+* Does this change require a 30-day evaluation?
+  * No
+
+DISSEMINATION INFORMATION
+-------------------------
+
+* No changes from GFS v16.3.3
+
+HPSS ARCHIVE
+------------
+
+* No changes from GFS v16.3.3
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+---------------------------------
+
+* No changes from GFS v16.3.3
+
+DOCUMENTATION
+-------------
+
+* No changes from GFS v16.3.3
+
+PREPARED BY
+-----------
+Kate.Friedman@noaa.gov

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_05.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_05.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem001/
++ /??/atmos/mem001/**
++ /??/atmos/mem002/
++ /??/atmos/mem002/**
++ /??/atmos/mem003/
++ /??/atmos/mem003/**
++ /??/atmos/mem004/
++ /??/atmos/mem004/**
++ /??/atmos/mem005/
++ /??/atmos/mem005/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem001/
++ /??/atmos/mem001/**
++ /??/atmos/mem002/
++ /??/atmos/mem002/**
++ /??/atmos/mem003/
++ /??/atmos/mem003/**
++ /??/atmos/mem004/
++ /??/atmos/mem004/**
++ /??/atmos/mem005/
++ /??/atmos/mem005/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_10.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_10.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem006/
++ /??/atmos/mem006/**
++ /??/atmos/mem007/
++ /??/atmos/mem007/**
++ /??/atmos/mem008/
++ /??/atmos/mem008/**
++ /??/atmos/mem009/
++ /??/atmos/mem009/**
++ /??/atmos/mem010/
++ /??/atmos/mem010/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem006/
++ /??/atmos/mem006/**
++ /??/atmos/mem007/
++ /??/atmos/mem007/**
++ /??/atmos/mem008/
++ /??/atmos/mem008/**
++ /??/atmos/mem009/
++ /??/atmos/mem009/**
++ /??/atmos/mem010/
++ /??/atmos/mem010/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_15.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_15.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem011/
++ /??/atmos/mem011/**
++ /??/atmos/mem012/
++ /??/atmos/mem012/**
++ /??/atmos/mem013/
++ /??/atmos/mem013/**
++ /??/atmos/mem014/
++ /??/atmos/mem014/**
++ /??/atmos/mem015/
++ /??/atmos/mem015/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem011/
++ /??/atmos/mem011/**
++ /??/atmos/mem012/
++ /??/atmos/mem012/**
++ /??/atmos/mem013/
++ /??/atmos/mem013/**
++ /??/atmos/mem014/
++ /??/atmos/mem014/**
++ /??/atmos/mem015/
++ /??/atmos/mem015/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_20.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_20.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem016/
++ /??/atmos/mem016/**
++ /??/atmos/mem017/
++ /??/atmos/mem017/**
++ /??/atmos/mem018/
++ /??/atmos/mem018/**
++ /??/atmos/mem019/
++ /??/atmos/mem019/**
++ /??/atmos/mem020/
++ /??/atmos/mem020/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem016/
++ /??/atmos/mem016/**
++ /??/atmos/mem017/
++ /??/atmos/mem017/**
++ /??/atmos/mem018/
++ /??/atmos/mem018/**
++ /??/atmos/mem019/
++ /??/atmos/mem019/**
++ /??/atmos/mem020/
++ /??/atmos/mem020/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_25.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_25.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem021/
++ /??/atmos/mem021/**
++ /??/atmos/mem022/
++ /??/atmos/mem022/**
++ /??/atmos/mem023/
++ /??/atmos/mem023/**
++ /??/atmos/mem024/
++ /??/atmos/mem024/**
++ /??/atmos/mem025/
++ /??/atmos/mem025/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem021/
++ /??/atmos/mem021/**
++ /??/atmos/mem022/
++ /??/atmos/mem022/**
++ /??/atmos/mem023/
++ /??/atmos/mem023/**
++ /??/atmos/mem024/
++ /??/atmos/mem024/**
++ /??/atmos/mem025/
++ /??/atmos/mem025/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_30.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_30.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem026/
++ /??/atmos/mem026/**
++ /??/atmos/mem027/
++ /??/atmos/mem027/**
++ /??/atmos/mem028/
++ /??/atmos/mem028/**
++ /??/atmos/mem029/
++ /??/atmos/mem029/**
++ /??/atmos/mem030/
++ /??/atmos/mem030/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem026/
++ /??/atmos/mem026/**
++ /??/atmos/mem027/
++ /??/atmos/mem027/**
++ /??/atmos/mem028/
++ /??/atmos/mem028/**
++ /??/atmos/mem029/
++ /??/atmos/mem029/**
++ /??/atmos/mem030/
++ /??/atmos/mem030/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_35.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_35.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem031/
++ /??/atmos/mem031/**
++ /??/atmos/mem032/
++ /??/atmos/mem032/**
++ /??/atmos/mem033/
++ /??/atmos/mem033/**
++ /??/atmos/mem034/
++ /??/atmos/mem034/**
++ /??/atmos/mem035/
++ /??/atmos/mem035/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem031/
++ /??/atmos/mem031/**
++ /??/atmos/mem032/
++ /??/atmos/mem032/**
++ /??/atmos/mem033/
++ /??/atmos/mem033/**
++ /??/atmos/mem034/
++ /??/atmos/mem034/**
++ /??/atmos/mem035/
++ /??/atmos/mem035/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_40.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_40.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem036/
++ /??/atmos/mem036/**
++ /??/atmos/mem037/
++ /??/atmos/mem037/**
++ /??/atmos/mem038/
++ /??/atmos/mem038/**
++ /??/atmos/mem039/
++ /??/atmos/mem039/**
++ /??/atmos/mem040/
++ /??/atmos/mem040/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem036/
++ /??/atmos/mem036/**
++ /??/atmos/mem037/
++ /??/atmos/mem037/**
++ /??/atmos/mem038/
++ /??/atmos/mem038/**
++ /??/atmos/mem039/
++ /??/atmos/mem039/**
++ /??/atmos/mem040/
++ /??/atmos/mem040/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_45.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_45.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem041/
++ /??/atmos/mem041/**
++ /??/atmos/mem042/
++ /??/atmos/mem042/**
++ /??/atmos/mem043/
++ /??/atmos/mem043/**
++ /??/atmos/mem044/
++ /??/atmos/mem044/**
++ /??/atmos/mem045/
++ /??/atmos/mem045/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem041/
++ /??/atmos/mem041/**
++ /??/atmos/mem042/
++ /??/atmos/mem042/**
++ /??/atmos/mem043/
++ /??/atmos/mem043/**
++ /??/atmos/mem044/
++ /??/atmos/mem044/**
++ /??/atmos/mem045/
++ /??/atmos/mem045/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_50.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_50.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem046/
++ /??/atmos/mem046/**
++ /??/atmos/mem047/
++ /??/atmos/mem047/**
++ /??/atmos/mem048/
++ /??/atmos/mem048/**
++ /??/atmos/mem049/
++ /??/atmos/mem049/**
++ /??/atmos/mem050/
++ /??/atmos/mem050/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem046/
++ /??/atmos/mem046/**
++ /??/atmos/mem047/
++ /??/atmos/mem047/**
++ /??/atmos/mem048/
++ /??/atmos/mem048/**
++ /??/atmos/mem049/
++ /??/atmos/mem049/**
++ /??/atmos/mem050/
++ /??/atmos/mem050/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_55.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_55.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem051/
++ /??/atmos/mem051/**
++ /??/atmos/mem052/
++ /??/atmos/mem052/**
++ /??/atmos/mem053/
++ /??/atmos/mem053/**
++ /??/atmos/mem054/
++ /??/atmos/mem054/**
++ /??/atmos/mem055/
++ /??/atmos/mem055/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem051/
++ /??/atmos/mem051/**
++ /??/atmos/mem052/
++ /??/atmos/mem052/**
++ /??/atmos/mem053/
++ /??/atmos/mem053/**
++ /??/atmos/mem054/
++ /??/atmos/mem054/**
++ /??/atmos/mem055/
++ /??/atmos/mem055/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_60.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_60.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem056/
++ /??/atmos/mem056/**
++ /??/atmos/mem057/
++ /??/atmos/mem057/**
++ /??/atmos/mem058/
++ /??/atmos/mem058/**
++ /??/atmos/mem059/
++ /??/atmos/mem059/**
++ /??/atmos/mem060/
++ /??/atmos/mem060/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem056/
++ /??/atmos/mem056/**
++ /??/atmos/mem057/
++ /??/atmos/mem057/**
++ /??/atmos/mem058/
++ /??/atmos/mem058/**
++ /??/atmos/mem059/
++ /??/atmos/mem059/**
++ /??/atmos/mem060/
++ /??/atmos/mem060/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_65.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_65.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem061/
++ /??/atmos/mem061/**
++ /??/atmos/mem062/
++ /??/atmos/mem062/**
++ /??/atmos/mem063/
++ /??/atmos/mem063/**
++ /??/atmos/mem064/
++ /??/atmos/mem064/**
++ /??/atmos/mem065/
++ /??/atmos/mem065/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem061/
++ /??/atmos/mem061/**
++ /??/atmos/mem062/
++ /??/atmos/mem062/**
++ /??/atmos/mem063/
++ /??/atmos/mem063/**
++ /??/atmos/mem064/
++ /??/atmos/mem064/**
++ /??/atmos/mem065/
++ /??/atmos/mem065/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_70.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_70.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem066/
++ /??/atmos/mem066/**
++ /??/atmos/mem067/
++ /??/atmos/mem067/**
++ /??/atmos/mem068/
++ /??/atmos/mem068/**
++ /??/atmos/mem069/
++ /??/atmos/mem069/**
++ /??/atmos/mem070/
++ /??/atmos/mem070/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem066/
++ /??/atmos/mem066/**
++ /??/atmos/mem067/
++ /??/atmos/mem067/**
++ /??/atmos/mem068/
++ /??/atmos/mem068/**
++ /??/atmos/mem069/
++ /??/atmos/mem069/**
++ /??/atmos/mem070/
++ /??/atmos/mem070/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_75.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_75.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem071/
++ /??/atmos/mem071/**
++ /??/atmos/mem072/
++ /??/atmos/mem072/**
++ /??/atmos/mem073/
++ /??/atmos/mem073/**
++ /??/atmos/mem074/
++ /??/atmos/mem074/**
++ /??/atmos/mem075/
++ /??/atmos/mem075/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem071/
++ /??/atmos/mem071/**
++ /??/atmos/mem072/
++ /??/atmos/mem072/**
++ /??/atmos/mem073/
++ /??/atmos/mem073/**
++ /??/atmos/mem074/
++ /??/atmos/mem074/**
++ /??/atmos/mem075/
++ /??/atmos/mem075/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_80.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_80.list
@@ -1,0 +1,61 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem076/
++ /??/atmos/mem076/**
++ /??/atmos/mem077/
++ /??/atmos/mem077/**
++ /??/atmos/mem078/
++ /??/atmos/mem078/**
++ /??/atmos/mem079/
++ /??/atmos/mem079/**
++ /??/atmos/mem080/
++ /??/atmos/mem080/**
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/mem076/
++ /??/atmos/mem076/**
++ /??/atmos/mem077/
++ /??/atmos/mem077/**
++ /??/atmos/mem078/
++ /??/atmos/mem078/**
++ /??/atmos/mem079/
++ /??/atmos/mem079/**
++ /??/atmos/mem080/
++ /??/atmos/mem080/**
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_enkfgdas_enkf_misc.list
+++ b/parm/transfer/transfer_gfs_enkfgdas_enkf_misc.list
@@ -1,0 +1,43 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/*
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/*
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_gdas_gdas_1a.list
+++ b/parm/transfer/transfer_gfs_gdas_gdas_1a.list
@@ -1,0 +1,57 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/*atmf000*
++ /??/atmos/*atmf001*
++ /??/atmos/*atmf002*
++ /??/atmos/*atmf003*
++ /??/atmos/*atmf004*
++ /??/atmos/*atmf005*
++ /??/atmos/*atmf006*
+- /??/atmos/*
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/gdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/*atmf000*
++ /??/atmos/*atmf001*
++ /??/atmos/*atmf002*
++ /??/atmos/*atmf003*
++ /??/atmos/*atmf004*
++ /??/atmos/*atmf005*
++ /??/atmos/*atmf006*
+- /??/atmos/*
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_gdas_gdas_1b.list
+++ b/parm/transfer/transfer_gfs_gdas_gdas_1b.list
@@ -1,0 +1,53 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/*atmf007*
++ /??/atmos/*atmf008*
++ /??/atmos/*atmf009*
++ /??/atmos/*atmg*
++ /??/atmos/*atmanl*
+- /??/atmos/*
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/gdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/*atmf007*
++ /??/atmos/*atmf008*
++ /??/atmos/*atmf009*
++ /??/atmos/*atmg*
++ /??/atmos/*atmanl*
+- /??/atmos/*
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_gdas_gdas_1c.list
+++ b/parm/transfer/transfer_gfs_gdas_gdas_1c.list
@@ -1,0 +1,67 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gdas._PDY_/
+- /??/atmos/*atmf000*
+- /??/atmos/*atmf001*
+- /??/atmos/*atmf002*
+- /??/atmos/*atmf003*
+- /??/atmos/*atmf004*
+- /??/atmos/*atmf005*
+- /??/atmos/*atmf006*
+- /??/atmos/*atmf007*
+- /??/atmos/*atmf008*
+- /??/atmos/*atmf009*
+- /??/atmos/*atmg*
+- /??/atmos/*atmanl*
++ /*
++ /??/
++ /??/atmos/
++ /??/atmos/*
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/gdas._PDYm1_/
+- /??/atmos/*atmf000*
+- /??/atmos/*atmf001*
+- /??/atmos/*atmf002*
+- /??/atmos/*atmf003*
+- /??/atmos/*atmf004*
+- /??/atmos/*atmf005*
+- /??/atmos/*atmf006*
+- /??/atmos/*atmf007*
+- /??/atmos/*atmf008*
+- /??/atmos/*atmf009*
+- /??/atmos/*atmg*
+- /??/atmos/*atmanl*
++ /*
++ /??/
++ /??/atmos/
++ /??/atmos/*
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_gdas_gdas_misc.list
+++ b/parm/transfer/transfer_gfs_gdas_gdas_misc.list
@@ -1,0 +1,76 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+#com/arch/_ENVIR_/VOS/
+#+ ship_names
+#+ activeShiprev
+#- *
+#B 4500000
+
+
+_COMROOT_/gfs/_SHORTVER_/syndat/
+B 180
+ 
+_COMROOT_/gfs/_SHORTVER_/gdascounts/
++ /data_counts._MONPREV_/***
+- *
+B 16000000
+ 
+_COMROOT_/gfs/_SHORTVER_/gdascounts/
++ /data_counts._MONCUR_/***
+- *
+B 16000000
+ 
+_COMROOT_/gfs/_SHORTVER_/gdascounts/
++ /satcounts._MONPREV_/***
+- *
+B 16000000
+ 
+_COMROOT_/gfs/_SHORTVER_/gdascounts/
++ /satcounts._MONCUR_/***
+- *
+B 16000000
+ 
+_COMROOT_/gfs/_SHORTVER_/sdm_rtdm/
++ /obcount_30day/
++ /obcount_30day/gdas/
++ /obcount_30day/gdas/gdas._PDYm1_/***
++ /obcount_30day/gdas/gdas._PDY_/***
+- *
+B 2000000
+ 
+_COMROOT_/gfs/_SHORTVER_/sdm_rtdm/
++ /avgdata/
++ /avgdata/obcount_30davg.gdas._MONPREV_
++ /avgdata/obcount_30davg.gdas.current
+- *
+B 256000
+ 
+_COMROOT_/gfs/_SHORTVER_/gdascounts/
++ /index.shtml
++ /index_backup.shtml
+- *
+B 6
+

--- a/parm/transfer/transfer_gfs_gfs_1.list
+++ b/parm/transfer/transfer_gfs_gfs_1.list
@@ -1,0 +1,50 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
+- /??/atmos/gfs.t??z.atmf???.nc
+- /??/atmos/gfs.t??z.sfcf???.nc
+- /??/atmos/gfs.t??z.master.*
+- /??/atmos/gempak/
+- /??/atmos/gempak/*
+- /??/wave/
+- /??/wave/*
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDYm1_/
++ /??/
++ /??/atmos/
+- /??/atmos/gfs.t??z.atmf???.nc
+- /??/atmos/gfs.t??z.sfcf???.nc
+- /??/atmos/gfs.t??z.master.*
+- /??/atmos/gempak/
+- /??/atmos/gempak/*
+- /??/wave/
+- /??/wave/*
+B 100
+

--- a/parm/transfer/transfer_gfs_gfs_10a.list
+++ b/parm/transfer/transfer_gfs_gfs_10a.list
@@ -1,0 +1,49 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.master.*1
++ /??/atmos/gfs.t??z.master.*3
++ /??/atmos/gfs.t??z.master.*5
++ /??/atmos/gfs.t??z.master.*7
++ /??/atmos/gfs.t??z.master.*9
+- *
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.master.*1
++ /??/atmos/gfs.t??z.master.*3
++ /??/atmos/gfs.t??z.master.*5
++ /??/atmos/gfs.t??z.master.*7
++ /??/atmos/gfs.t??z.master.*9
+- *
+B 100
+
+

--- a/parm/transfer/transfer_gfs_gfs_10b.list
+++ b/parm/transfer/transfer_gfs_gfs_10b.list
@@ -1,0 +1,50 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.master.*0
++ /??/atmos/gfs.t??z.master.*2
++ /??/atmos/gfs.t??z.master.*4
++ /??/atmos/gfs.t??z.master.*6
++ /??/atmos/gfs.t??z.master.*8
+- *
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.master.*0
++ /??/atmos/gfs.t??z.master.*2
++ /??/atmos/gfs.t??z.master.*4
++ /??/atmos/gfs.t??z.master.*6
++ /??/atmos/gfs.t??z.master.*8
+- *
+ 
+B 100
+
+

--- a/parm/transfer/transfer_gfs_gfs_2.list
+++ b/parm/transfer/transfer_gfs_gfs_2.list
@@ -1,0 +1,99 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.atmf000.nc
++ /??/atmos/gfs.t??z.atmf007.nc
++ /??/atmos/gfs.t??z.atmf014.nc
++ /??/atmos/gfs.t??z.atmf021.nc
++ /??/atmos/gfs.t??z.atmf028.nc
++ /??/atmos/gfs.t??z.atmf035.nc
++ /??/atmos/gfs.t??z.atmf042.nc
++ /??/atmos/gfs.t??z.atmf049.nc
++ /??/atmos/gfs.t??z.atmf056.nc
++ /??/atmos/gfs.t??z.atmf063.nc
++ /??/atmos/gfs.t??z.atmf070.nc
++ /??/atmos/gfs.t??z.atmf077.nc
++ /??/atmos/gfs.t??z.atmf084.nc
++ /??/atmos/gfs.t??z.atmf091.nc
++ /??/atmos/gfs.t??z.atmf098.nc
++ /??/atmos/gfs.t??z.atmf105.nc
++ /??/atmos/gfs.t??z.atmf112.nc
++ /??/atmos/gfs.t??z.atmf119.nc
++ /??/atmos/gfs.t??z.atmf138.nc
++ /??/atmos/gfs.t??z.atmf159.nc
++ /??/atmos/gfs.t??z.atmf180.nc
++ /??/atmos/gfs.t??z.atmf201.nc
++ /??/atmos/gfs.t??z.atmf222.nc
++ /??/atmos/gfs.t??z.atmf243.nc
++ /??/atmos/gfs.t??z.atmf264.nc
++ /??/atmos/gfs.t??z.atmf285.nc
++ /??/atmos/gfs.t??z.atmf306.nc
++ /??/atmos/gfs.t??z.atmf327.nc
++ /??/atmos/gfs.t??z.atmf348.nc
++ /??/atmos/gfs.t??z.atmf369.nc
+- *
+B 100
+ 
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.atmf000.nc
++ /??/atmos/gfs.t??z.atmf007.nc
++ /??/atmos/gfs.t??z.atmf014.nc
++ /??/atmos/gfs.t??z.atmf021.nc
++ /??/atmos/gfs.t??z.atmf028.nc
++ /??/atmos/gfs.t??z.atmf035.nc
++ /??/atmos/gfs.t??z.atmf042.nc
++ /??/atmos/gfs.t??z.atmf049.nc
++ /??/atmos/gfs.t??z.atmf056.nc
++ /??/atmos/gfs.t??z.atmf063.nc
++ /??/atmos/gfs.t??z.atmf070.nc
++ /??/atmos/gfs.t??z.atmf077.nc
++ /??/atmos/gfs.t??z.atmf084.nc
++ /??/atmos/gfs.t??z.atmf091.nc
++ /??/atmos/gfs.t??z.atmf098.nc
++ /??/atmos/gfs.t??z.atmf105.nc
++ /??/atmos/gfs.t??z.atmf112.nc
++ /??/atmos/gfs.t??z.atmf119.nc
++ /??/atmos/gfs.t??z.atmf138.nc
++ /??/atmos/gfs.t??z.atmf159.nc
++ /??/atmos/gfs.t??z.atmf180.nc
++ /??/atmos/gfs.t??z.atmf201.nc
++ /??/atmos/gfs.t??z.atmf222.nc
++ /??/atmos/gfs.t??z.atmf243.nc
++ /??/atmos/gfs.t??z.atmf264.nc
++ /??/atmos/gfs.t??z.atmf285.nc
++ /??/atmos/gfs.t??z.atmf306.nc
++ /??/atmos/gfs.t??z.atmf327.nc
++ /??/atmos/gfs.t??z.atmf348.nc
++ /??/atmos/gfs.t??z.atmf369.nc
+- *
+B 100
+ 

--- a/parm/transfer/transfer_gfs_gfs_3.list
+++ b/parm/transfer/transfer_gfs_gfs_3.list
@@ -1,0 +1,99 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.atmf001.nc
++ /??/atmos/gfs.t??z.atmf008.nc
++ /??/atmos/gfs.t??z.atmf015.nc
++ /??/atmos/gfs.t??z.atmf022.nc
++ /??/atmos/gfs.t??z.atmf029.nc
++ /??/atmos/gfs.t??z.atmf036.nc
++ /??/atmos/gfs.t??z.atmf043.nc
++ /??/atmos/gfs.t??z.atmf050.nc
++ /??/atmos/gfs.t??z.atmf057.nc
++ /??/atmos/gfs.t??z.atmf064.nc
++ /??/atmos/gfs.t??z.atmf071.nc
++ /??/atmos/gfs.t??z.atmf078.nc
++ /??/atmos/gfs.t??z.atmf085.nc
++ /??/atmos/gfs.t??z.atmf092.nc
++ /??/atmos/gfs.t??z.atmf099.nc
++ /??/atmos/gfs.t??z.atmf106.nc
++ /??/atmos/gfs.t??z.atmf113.nc
++ /??/atmos/gfs.t??z.atmf120.nc
++ /??/atmos/gfs.t??z.atmf141.nc
++ /??/atmos/gfs.t??z.atmf162.nc
++ /??/atmos/gfs.t??z.atmf183.nc
++ /??/atmos/gfs.t??z.atmf204.nc
++ /??/atmos/gfs.t??z.atmf225.nc
++ /??/atmos/gfs.t??z.atmf246.nc
++ /??/atmos/gfs.t??z.atmf267.nc
++ /??/atmos/gfs.t??z.atmf288.nc
++ /??/atmos/gfs.t??z.atmf309.nc
++ /??/atmos/gfs.t??z.atmf330.nc
++ /??/atmos/gfs.t??z.atmf351.nc
++ /??/atmos/gfs.t??z.atmf372.nc
+- *
+B 100
+ 
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.atmf001.nc
++ /??/atmos/gfs.t??z.atmf008.nc
++ /??/atmos/gfs.t??z.atmf015.nc
++ /??/atmos/gfs.t??z.atmf022.nc
++ /??/atmos/gfs.t??z.atmf029.nc
++ /??/atmos/gfs.t??z.atmf036.nc
++ /??/atmos/gfs.t??z.atmf043.nc
++ /??/atmos/gfs.t??z.atmf050.nc
++ /??/atmos/gfs.t??z.atmf057.nc
++ /??/atmos/gfs.t??z.atmf064.nc
++ /??/atmos/gfs.t??z.atmf071.nc
++ /??/atmos/gfs.t??z.atmf078.nc
++ /??/atmos/gfs.t??z.atmf085.nc
++ /??/atmos/gfs.t??z.atmf092.nc
++ /??/atmos/gfs.t??z.atmf099.nc
++ /??/atmos/gfs.t??z.atmf106.nc
++ /??/atmos/gfs.t??z.atmf113.nc
++ /??/atmos/gfs.t??z.atmf120.nc
++ /??/atmos/gfs.t??z.atmf141.nc
++ /??/atmos/gfs.t??z.atmf162.nc
++ /??/atmos/gfs.t??z.atmf183.nc
++ /??/atmos/gfs.t??z.atmf204.nc
++ /??/atmos/gfs.t??z.atmf225.nc
++ /??/atmos/gfs.t??z.atmf246.nc
++ /??/atmos/gfs.t??z.atmf267.nc
++ /??/atmos/gfs.t??z.atmf288.nc
++ /??/atmos/gfs.t??z.atmf309.nc
++ /??/atmos/gfs.t??z.atmf330.nc
++ /??/atmos/gfs.t??z.atmf351.nc
++ /??/atmos/gfs.t??z.atmf372.nc
+- *
+B 100
+ 

--- a/parm/transfer/transfer_gfs_gfs_4.list
+++ b/parm/transfer/transfer_gfs_gfs_4.list
@@ -1,0 +1,99 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.atmf002.nc
++ /??/atmos/gfs.t??z.atmf009.nc
++ /??/atmos/gfs.t??z.atmf016.nc
++ /??/atmos/gfs.t??z.atmf023.nc
++ /??/atmos/gfs.t??z.atmf030.nc
++ /??/atmos/gfs.t??z.atmf037.nc
++ /??/atmos/gfs.t??z.atmf044.nc
++ /??/atmos/gfs.t??z.atmf051.nc
++ /??/atmos/gfs.t??z.atmf058.nc
++ /??/atmos/gfs.t??z.atmf065.nc
++ /??/atmos/gfs.t??z.atmf072.nc
++ /??/atmos/gfs.t??z.atmf079.nc
++ /??/atmos/gfs.t??z.atmf086.nc
++ /??/atmos/gfs.t??z.atmf093.nc
++ /??/atmos/gfs.t??z.atmf100.nc
++ /??/atmos/gfs.t??z.atmf107.nc
++ /??/atmos/gfs.t??z.atmf114.nc
++ /??/atmos/gfs.t??z.atmf123.nc
++ /??/atmos/gfs.t??z.atmf144.nc
++ /??/atmos/gfs.t??z.atmf165.nc
++ /??/atmos/gfs.t??z.atmf186.nc
++ /??/atmos/gfs.t??z.atmf207.nc
++ /??/atmos/gfs.t??z.atmf228.nc
++ /??/atmos/gfs.t??z.atmf249.nc
++ /??/atmos/gfs.t??z.atmf270.nc
++ /??/atmos/gfs.t??z.atmf291.nc
++ /??/atmos/gfs.t??z.atmf312.nc
++ /??/atmos/gfs.t??z.atmf333.nc
++ /??/atmos/gfs.t??z.atmf354.nc
++ /??/atmos/gfs.t??z.atmf375.nc
+- *
+B 100
+ 
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.atmf002.nc
++ /??/atmos/gfs.t??z.atmf009.nc
++ /??/atmos/gfs.t??z.atmf016.nc
++ /??/atmos/gfs.t??z.atmf023.nc
++ /??/atmos/gfs.t??z.atmf030.nc
++ /??/atmos/gfs.t??z.atmf037.nc
++ /??/atmos/gfs.t??z.atmf044.nc
++ /??/atmos/gfs.t??z.atmf051.nc
++ /??/atmos/gfs.t??z.atmf058.nc
++ /??/atmos/gfs.t??z.atmf065.nc
++ /??/atmos/gfs.t??z.atmf072.nc
++ /??/atmos/gfs.t??z.atmf079.nc
++ /??/atmos/gfs.t??z.atmf086.nc
++ /??/atmos/gfs.t??z.atmf093.nc
++ /??/atmos/gfs.t??z.atmf100.nc
++ /??/atmos/gfs.t??z.atmf107.nc
++ /??/atmos/gfs.t??z.atmf114.nc
++ /??/atmos/gfs.t??z.atmf123.nc
++ /??/atmos/gfs.t??z.atmf144.nc
++ /??/atmos/gfs.t??z.atmf165.nc
++ /??/atmos/gfs.t??z.atmf186.nc
++ /??/atmos/gfs.t??z.atmf207.nc
++ /??/atmos/gfs.t??z.atmf228.nc
++ /??/atmos/gfs.t??z.atmf249.nc
++ /??/atmos/gfs.t??z.atmf270.nc
++ /??/atmos/gfs.t??z.atmf291.nc
++ /??/atmos/gfs.t??z.atmf312.nc
++ /??/atmos/gfs.t??z.atmf333.nc
++ /??/atmos/gfs.t??z.atmf354.nc
++ /??/atmos/gfs.t??z.atmf375.nc
+- *
+B 100
+ 

--- a/parm/transfer/transfer_gfs_gfs_5.list
+++ b/parm/transfer/transfer_gfs_gfs_5.list
@@ -1,0 +1,99 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.atmf003.nc
++ /??/atmos/gfs.t??z.atmf010.nc
++ /??/atmos/gfs.t??z.atmf017.nc
++ /??/atmos/gfs.t??z.atmf024.nc
++ /??/atmos/gfs.t??z.atmf031.nc
++ /??/atmos/gfs.t??z.atmf038.nc
++ /??/atmos/gfs.t??z.atmf045.nc
++ /??/atmos/gfs.t??z.atmf052.nc
++ /??/atmos/gfs.t??z.atmf059.nc
++ /??/atmos/gfs.t??z.atmf066.nc
++ /??/atmos/gfs.t??z.atmf073.nc
++ /??/atmos/gfs.t??z.atmf080.nc
++ /??/atmos/gfs.t??z.atmf087.nc
++ /??/atmos/gfs.t??z.atmf094.nc
++ /??/atmos/gfs.t??z.atmf101.nc
++ /??/atmos/gfs.t??z.atmf108.nc
++ /??/atmos/gfs.t??z.atmf115.nc
++ /??/atmos/gfs.t??z.atmf126.nc
++ /??/atmos/gfs.t??z.atmf147.nc
++ /??/atmos/gfs.t??z.atmf168.nc
++ /??/atmos/gfs.t??z.atmf189.nc
++ /??/atmos/gfs.t??z.atmf210.nc
++ /??/atmos/gfs.t??z.atmf231.nc
++ /??/atmos/gfs.t??z.atmf252.nc
++ /??/atmos/gfs.t??z.atmf273.nc
++ /??/atmos/gfs.t??z.atmf294.nc
++ /??/atmos/gfs.t??z.atmf315.nc
++ /??/atmos/gfs.t??z.atmf336.nc
++ /??/atmos/gfs.t??z.atmf357.nc
++ /??/atmos/gfs.t??z.atmf378.nc
+- *
+B 100
+ 
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.atmf003.nc
++ /??/atmos/gfs.t??z.atmf010.nc
++ /??/atmos/gfs.t??z.atmf017.nc
++ /??/atmos/gfs.t??z.atmf024.nc
++ /??/atmos/gfs.t??z.atmf031.nc
++ /??/atmos/gfs.t??z.atmf038.nc
++ /??/atmos/gfs.t??z.atmf045.nc
++ /??/atmos/gfs.t??z.atmf052.nc
++ /??/atmos/gfs.t??z.atmf059.nc
++ /??/atmos/gfs.t??z.atmf066.nc
++ /??/atmos/gfs.t??z.atmf073.nc
++ /??/atmos/gfs.t??z.atmf080.nc
++ /??/atmos/gfs.t??z.atmf087.nc
++ /??/atmos/gfs.t??z.atmf094.nc
++ /??/atmos/gfs.t??z.atmf101.nc
++ /??/atmos/gfs.t??z.atmf108.nc
++ /??/atmos/gfs.t??z.atmf115.nc
++ /??/atmos/gfs.t??z.atmf126.nc
++ /??/atmos/gfs.t??z.atmf147.nc
++ /??/atmos/gfs.t??z.atmf168.nc
++ /??/atmos/gfs.t??z.atmf189.nc
++ /??/atmos/gfs.t??z.atmf210.nc
++ /??/atmos/gfs.t??z.atmf231.nc
++ /??/atmos/gfs.t??z.atmf252.nc
++ /??/atmos/gfs.t??z.atmf273.nc
++ /??/atmos/gfs.t??z.atmf294.nc
++ /??/atmos/gfs.t??z.atmf315.nc
++ /??/atmos/gfs.t??z.atmf336.nc
++ /??/atmos/gfs.t??z.atmf357.nc
++ /??/atmos/gfs.t??z.atmf378.nc
+- *
+B 100
+ 

--- a/parm/transfer/transfer_gfs_gfs_6.list
+++ b/parm/transfer/transfer_gfs_gfs_6.list
@@ -1,0 +1,99 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.atmf004.nc
++ /??/atmos/gfs.t??z.atmf011.nc
++ /??/atmos/gfs.t??z.atmf018.nc
++ /??/atmos/gfs.t??z.atmf025.nc
++ /??/atmos/gfs.t??z.atmf032.nc
++ /??/atmos/gfs.t??z.atmf039.nc
++ /??/atmos/gfs.t??z.atmf046.nc
++ /??/atmos/gfs.t??z.atmf053.nc
++ /??/atmos/gfs.t??z.atmf060.nc
++ /??/atmos/gfs.t??z.atmf067.nc
++ /??/atmos/gfs.t??z.atmf074.nc
++ /??/atmos/gfs.t??z.atmf081.nc
++ /??/atmos/gfs.t??z.atmf088.nc
++ /??/atmos/gfs.t??z.atmf095.nc
++ /??/atmos/gfs.t??z.atmf102.nc
++ /??/atmos/gfs.t??z.atmf109.nc
++ /??/atmos/gfs.t??z.atmf116.nc
++ /??/atmos/gfs.t??z.atmf129.nc
++ /??/atmos/gfs.t??z.atmf150.nc
++ /??/atmos/gfs.t??z.atmf171.nc
++ /??/atmos/gfs.t??z.atmf192.nc
++ /??/atmos/gfs.t??z.atmf213.nc
++ /??/atmos/gfs.t??z.atmf234.nc
++ /??/atmos/gfs.t??z.atmf255.nc
++ /??/atmos/gfs.t??z.atmf276.nc
++ /??/atmos/gfs.t??z.atmf297.nc
++ /??/atmos/gfs.t??z.atmf318.nc
++ /??/atmos/gfs.t??z.atmf339.nc
++ /??/atmos/gfs.t??z.atmf360.nc
++ /??/atmos/gfs.t??z.atmf381.nc
+- *
+B 100
+ 
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.atmf004.nc
++ /??/atmos/gfs.t??z.atmf011.nc
++ /??/atmos/gfs.t??z.atmf018.nc
++ /??/atmos/gfs.t??z.atmf025.nc
++ /??/atmos/gfs.t??z.atmf032.nc
++ /??/atmos/gfs.t??z.atmf039.nc
++ /??/atmos/gfs.t??z.atmf046.nc
++ /??/atmos/gfs.t??z.atmf053.nc
++ /??/atmos/gfs.t??z.atmf060.nc
++ /??/atmos/gfs.t??z.atmf067.nc
++ /??/atmos/gfs.t??z.atmf074.nc
++ /??/atmos/gfs.t??z.atmf081.nc
++ /??/atmos/gfs.t??z.atmf088.nc
++ /??/atmos/gfs.t??z.atmf095.nc
++ /??/atmos/gfs.t??z.atmf102.nc
++ /??/atmos/gfs.t??z.atmf109.nc
++ /??/atmos/gfs.t??z.atmf116.nc
++ /??/atmos/gfs.t??z.atmf129.nc
++ /??/atmos/gfs.t??z.atmf150.nc
++ /??/atmos/gfs.t??z.atmf171.nc
++ /??/atmos/gfs.t??z.atmf192.nc
++ /??/atmos/gfs.t??z.atmf213.nc
++ /??/atmos/gfs.t??z.atmf234.nc
++ /??/atmos/gfs.t??z.atmf255.nc
++ /??/atmos/gfs.t??z.atmf276.nc
++ /??/atmos/gfs.t??z.atmf297.nc
++ /??/atmos/gfs.t??z.atmf318.nc
++ /??/atmos/gfs.t??z.atmf339.nc
++ /??/atmos/gfs.t??z.atmf360.nc
++ /??/atmos/gfs.t??z.atmf381.nc
+- *
+B 100
+ 

--- a/parm/transfer/transfer_gfs_gfs_7.list
+++ b/parm/transfer/transfer_gfs_gfs_7.list
@@ -1,0 +1,99 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.atmf005.nc
++ /??/atmos/gfs.t??z.atmf012.nc
++ /??/atmos/gfs.t??z.atmf019.nc
++ /??/atmos/gfs.t??z.atmf026.nc
++ /??/atmos/gfs.t??z.atmf033.nc
++ /??/atmos/gfs.t??z.atmf040.nc
++ /??/atmos/gfs.t??z.atmf047.nc
++ /??/atmos/gfs.t??z.atmf054.nc
++ /??/atmos/gfs.t??z.atmf061.nc
++ /??/atmos/gfs.t??z.atmf068.nc
++ /??/atmos/gfs.t??z.atmf075.nc
++ /??/atmos/gfs.t??z.atmf082.nc
++ /??/atmos/gfs.t??z.atmf089.nc
++ /??/atmos/gfs.t??z.atmf096.nc
++ /??/atmos/gfs.t??z.atmf103.nc
++ /??/atmos/gfs.t??z.atmf110.nc
++ /??/atmos/gfs.t??z.atmf117.nc
++ /??/atmos/gfs.t??z.atmf132.nc
++ /??/atmos/gfs.t??z.atmf153.nc
++ /??/atmos/gfs.t??z.atmf174.nc
++ /??/atmos/gfs.t??z.atmf195.nc
++ /??/atmos/gfs.t??z.atmf216.nc
++ /??/atmos/gfs.t??z.atmf237.nc
++ /??/atmos/gfs.t??z.atmf258.nc
++ /??/atmos/gfs.t??z.atmf279.nc
++ /??/atmos/gfs.t??z.atmf300.nc
++ /??/atmos/gfs.t??z.atmf321.nc
++ /??/atmos/gfs.t??z.atmf342.nc
++ /??/atmos/gfs.t??z.atmf363.nc
++ /??/atmos/gfs.t??z.atmf384.nc
+- *
+B 100
+ 
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.atmf005.nc
++ /??/atmos/gfs.t??z.atmf012.nc
++ /??/atmos/gfs.t??z.atmf019.nc
++ /??/atmos/gfs.t??z.atmf026.nc
++ /??/atmos/gfs.t??z.atmf033.nc
++ /??/atmos/gfs.t??z.atmf040.nc
++ /??/atmos/gfs.t??z.atmf047.nc
++ /??/atmos/gfs.t??z.atmf054.nc
++ /??/atmos/gfs.t??z.atmf061.nc
++ /??/atmos/gfs.t??z.atmf068.nc
++ /??/atmos/gfs.t??z.atmf075.nc
++ /??/atmos/gfs.t??z.atmf082.nc
++ /??/atmos/gfs.t??z.atmf089.nc
++ /??/atmos/gfs.t??z.atmf096.nc
++ /??/atmos/gfs.t??z.atmf103.nc
++ /??/atmos/gfs.t??z.atmf110.nc
++ /??/atmos/gfs.t??z.atmf117.nc
++ /??/atmos/gfs.t??z.atmf132.nc
++ /??/atmos/gfs.t??z.atmf153.nc
++ /??/atmos/gfs.t??z.atmf174.nc
++ /??/atmos/gfs.t??z.atmf195.nc
++ /??/atmos/gfs.t??z.atmf216.nc
++ /??/atmos/gfs.t??z.atmf237.nc
++ /??/atmos/gfs.t??z.atmf258.nc
++ /??/atmos/gfs.t??z.atmf279.nc
++ /??/atmos/gfs.t??z.atmf300.nc
++ /??/atmos/gfs.t??z.atmf321.nc
++ /??/atmos/gfs.t??z.atmf342.nc
++ /??/atmos/gfs.t??z.atmf363.nc
++ /??/atmos/gfs.t??z.atmf384.nc
+- *
+B 100
+ 

--- a/parm/transfer/transfer_gfs_gfs_8.list
+++ b/parm/transfer/transfer_gfs_gfs_8.list
@@ -1,0 +1,97 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.atmf006.nc
++ /??/atmos/gfs.t??z.atmf013.nc
++ /??/atmos/gfs.t??z.atmf020.nc
++ /??/atmos/gfs.t??z.atmf027.nc
++ /??/atmos/gfs.t??z.atmf034.nc
++ /??/atmos/gfs.t??z.atmf041.nc
++ /??/atmos/gfs.t??z.atmf048.nc
++ /??/atmos/gfs.t??z.atmf055.nc
++ /??/atmos/gfs.t??z.atmf062.nc
++ /??/atmos/gfs.t??z.atmf069.nc
++ /??/atmos/gfs.t??z.atmf076.nc
++ /??/atmos/gfs.t??z.atmf083.nc
++ /??/atmos/gfs.t??z.atmf090.nc
++ /??/atmos/gfs.t??z.atmf097.nc
++ /??/atmos/gfs.t??z.atmf104.nc
++ /??/atmos/gfs.t??z.atmf111.nc
++ /??/atmos/gfs.t??z.atmf118.nc
++ /??/atmos/gfs.t??z.atmf135.nc
++ /??/atmos/gfs.t??z.atmf156.nc
++ /??/atmos/gfs.t??z.atmf177.nc
++ /??/atmos/gfs.t??z.atmf198.nc
++ /??/atmos/gfs.t??z.atmf219.nc
++ /??/atmos/gfs.t??z.atmf240.nc
++ /??/atmos/gfs.t??z.atmf261.nc
++ /??/atmos/gfs.t??z.atmf282.nc
++ /??/atmos/gfs.t??z.atmf303.nc
++ /??/atmos/gfs.t??z.atmf324.nc
++ /??/atmos/gfs.t??z.atmf345.nc
++ /??/atmos/gfs.t??z.atmf366.nc
+- *
+B 100
+ 
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.atmf006.nc
++ /??/atmos/gfs.t??z.atmf013.nc
++ /??/atmos/gfs.t??z.atmf020.nc
++ /??/atmos/gfs.t??z.atmf027.nc
++ /??/atmos/gfs.t??z.atmf034.nc
++ /??/atmos/gfs.t??z.atmf041.nc
++ /??/atmos/gfs.t??z.atmf048.nc
++ /??/atmos/gfs.t??z.atmf055.nc
++ /??/atmos/gfs.t??z.atmf062.nc
++ /??/atmos/gfs.t??z.atmf069.nc
++ /??/atmos/gfs.t??z.atmf076.nc
++ /??/atmos/gfs.t??z.atmf083.nc
++ /??/atmos/gfs.t??z.atmf090.nc
++ /??/atmos/gfs.t??z.atmf097.nc
++ /??/atmos/gfs.t??z.atmf104.nc
++ /??/atmos/gfs.t??z.atmf111.nc
++ /??/atmos/gfs.t??z.atmf118.nc
++ /??/atmos/gfs.t??z.atmf135.nc
++ /??/atmos/gfs.t??z.atmf156.nc
++ /??/atmos/gfs.t??z.atmf177.nc
++ /??/atmos/gfs.t??z.atmf198.nc
++ /??/atmos/gfs.t??z.atmf219.nc
++ /??/atmos/gfs.t??z.atmf240.nc
++ /??/atmos/gfs.t??z.atmf261.nc
++ /??/atmos/gfs.t??z.atmf282.nc
++ /??/atmos/gfs.t??z.atmf303.nc
++ /??/atmos/gfs.t??z.atmf324.nc
++ /??/atmos/gfs.t??z.atmf345.nc
++ /??/atmos/gfs.t??z.atmf366.nc
+- *
+B 100
+ 

--- a/parm/transfer/transfer_gfs_gfs_9a.list
+++ b/parm/transfer/transfer_gfs_gfs_9a.list
@@ -1,0 +1,51 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.sfcf??0.nc
++ /??/atmos/gfs.t??z.sfcf??2.nc
++ /??/atmos/gfs.t??z.sfcf??4.nc
++ /??/atmos/gfs.t??z.sfcf??6.nc
++ /??/atmos/gfs.t??z.sfcf??8.nc
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.sfcf??0.nc
++ /??/atmos/gfs.t??z.sfcf??2.nc
++ /??/atmos/gfs.t??z.sfcf??4.nc
++ /??/atmos/gfs.t??z.sfcf??6.nc
++ /??/atmos/gfs.t??z.sfcf??8.nc
+- *
+ 
+B 100
+
+

--- a/parm/transfer/transfer_gfs_gfs_9b.list
+++ b/parm/transfer/transfer_gfs_gfs_9b.list
@@ -1,0 +1,51 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.sfcf??1.nc
++ /??/atmos/gfs.t??z.sfcf??3.nc
++ /??/atmos/gfs.t??z.sfcf??5.nc
++ /??/atmos/gfs.t??z.sfcf??7.nc
++ /??/atmos/gfs.t??z.sfcf??9.nc
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.sfcf??1.nc
++ /??/atmos/gfs.t??z.sfcf??3.nc
++ /??/atmos/gfs.t??z.sfcf??5.nc
++ /??/atmos/gfs.t??z.sfcf??7.nc
++ /??/atmos/gfs.t??z.sfcf??9.nc
+- *
+ 
+B 100
+
+

--- a/parm/transfer/transfer_gfs_gfs_gempak.list
+++ b/parm/transfer/transfer_gfs_gfs_gempak.list
@@ -1,0 +1,45 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gempak/
++ /??/atmos/gempak/*
+- *
+
+B 100
+
+_COMROOT_/gfs/_SHORTVER_/gfs._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/gempak/
++ /??/atmos/gempak/*
+- *
+
+B 100
+
+

--- a/parm/transfer/transfer_gfs_gfs_misc.list
+++ b/parm/transfer/transfer_gfs_gfs_misc.list
@@ -1,0 +1,43 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/gfs/_SHORTVER_/sdm_rtdm/
++ /avgdata/
++ /avgdata/obcount_30davg.gfs._MONPREV_
++ /avgdata/obcount_30davg.gfs.current
+- *
+B 256000
+ 
+
+_COMROOT_/gfs/_SHORTVER_/sdm_rtdm/
++ /obcount_30day/
++ /obcount_30day/gfs/
++ /obcount_30day/gfs/gfs._PDYm1_/***
++ /obcount_30day/gfs/gfs._PDY_/***
+- *
+B 2000000
+ 
+

--- a/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_1.list
+++ b/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_1.list
@@ -1,0 +1,50 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDYm1_/
++ /00/
++ /00/atmos/
++ /00/atmos/mem???/
++ /00/atmos/mem???/gdas.t??z.atmf006.nc
++ /00/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDY_/
++ /00/
++ /00/atmos/
++ /00/atmos/mem???/
++ /00/atmos/mem???/gdas.t??z.atmf006.nc
++ /00/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_2.list
+++ b/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_2.list
@@ -1,0 +1,50 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDYm1_/
++ /06/
++ /06/atmos/
++ /06/atmos/mem???/
++ /06/atmos/mem???/gdas.t??z.atmf006.nc
++ /06/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDY_/
++ /06/
++ /06/atmos/
++ /06/atmos/mem???/
++ /06/atmos/mem???/gdas.t??z.atmf006.nc
++ /06/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_3.list
+++ b/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_3.list
@@ -1,0 +1,50 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDYm1_/
++ /12/
++ /12/atmos/
++ /12/atmos/mem???/
++ /12/atmos/mem???/gdas.t??z.atmf006.nc
++ /12/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDY_/
++ /12/
++ /12/atmos/
++ /12/atmos/mem???/
++ /12/atmos/mem???/gdas.t??z.atmf006.nc
++ /12/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_4.list
+++ b/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_4.list
@@ -1,0 +1,50 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDYm1_/
++ /18/
++ /18/atmos/
++ /18/atmos/mem???/
++ /18/atmos/mem???/gdas.t??z.atmf006.nc
++ /18/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDY_/
++ /18/
++ /18/atmos/
++ /18/atmos/mem???/
++ /18/atmos/mem???/gdas.t??z.atmf006.nc
++ /18/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_5.list
+++ b/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_5.list
@@ -1,0 +1,52 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDYm1_/
++ /00/
++ /00/atmos/
++ /00/atmos/mem???/
++ /00/atmos/mem???/gdas.t??z.ratminc.nc
++ /00/atmos/gdas.t??z.atmf006.ensmean.nc
++ /00/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDY_/
++ /00/
++ /00/atmos/
++ /00/atmos/mem???/
++ /00/atmos/mem???/gdas.t??z.ratminc.nc
++ /00/atmos/gdas.t??z.atmf006.ensmean.nc
++ /00/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_6.list
+++ b/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_6.list
@@ -1,0 +1,52 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDYm1_/
++ /06/
++ /06/atmos/
++ /06/atmos/mem???/
++ /06/atmos/mem???/gdas.t??z.ratminc.nc
++ /06/atmos/gdas.t??z.atmf006.ensmean.nc
++ /06/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDY_/
++ /06/
++ /06/atmos/
++ /06/atmos/mem???/
++ /06/atmos/mem???/gdas.t??z.ratminc.nc
++ /06/atmos/gdas.t??z.atmf006.ensmean.nc
++ /06/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_7.list
+++ b/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_7.list
@@ -1,0 +1,52 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDYm1_/
++ /12/
++ /12/atmos/
++ /12/atmos/mem???/
++ /12/atmos/mem???/gdas.t??z.ratminc.nc
++ /12/atmos/gdas.t??z.atmf006.ensmean.nc
++ /12/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDY_/
++ /12/
++ /12/atmos/
++ /12/atmos/mem???/
++ /12/atmos/mem???/gdas.t??z.ratminc.nc
++ /12/atmos/gdas.t??z.atmf006.ensmean.nc
++ /12/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_8.list
+++ b/parm/transfer/transfer_rdhpcs_enkfgdas_enkf_8.list
@@ -1,0 +1,52 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDYm1_/
++ /18/
++ /18/atmos/
++ /18/atmos/mem???/
++ /18/atmos/mem???/gdas.t??z.ratminc.nc
++ /18/atmos/gdas.t??z.atmf006.ensmean.nc
++ /18/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/com/gfs/_ENVIR_/enkfgdas._PDY_/
++ /18/
++ /18/atmos/
++ /18/atmos/mem???/
++ /18/atmos/mem???/gdas.t??z.ratminc.nc
++ /18/atmos/gdas.t??z.atmf006.ensmean.nc
++ /18/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_1.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_1.list
@@ -1,0 +1,50 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /00/
++ /00/atmos/
++ /00/atmos/mem???/
++ /00/atmos/mem???/gdas.t??z.atmf006.nc
++ /00/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /00/
++ /00/atmos/
++ /00/atmos/mem???/
++ /00/atmos/mem???/gdas.t??z.atmf006.nc
++ /00/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_2.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_2.list
@@ -1,0 +1,49 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /06/
++ /06/atmos/
++ /06/atmos/mem???/
++ /06/atmos/mem???/gdas.t??z.atmf006.nc
++ /06/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /06/
++ /06/atmos/
++ /06/atmos/mem???/
++ /06/atmos/mem???/gdas.t??z.atmf006.nc
++ /06/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_3.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_3.list
@@ -1,0 +1,52 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+#_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDYm1_/
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /12/
++ /12/atmos/
++ /12/atmos/mem???/
++ /12/atmos/mem???/gdas.t??z.atmf006.nc
++ /12/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+#_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /12/
++ /12/atmos/
++ /12/atmos/mem???/
++ /12/atmos/mem???/gdas.t??z.atmf006.nc
++ /12/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_4.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_4.list
@@ -1,0 +1,52 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+#_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDYm1_/
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /18/
++ /18/atmos/
++ /18/atmos/mem???/
++ /18/atmos/mem???/gdas.t??z.atmf006.nc
++ /18/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+#_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /18/
++ /18/atmos/
++ /18/atmos/mem???/
++ /18/atmos/mem???/gdas.t??z.atmf006.nc
++ /18/atmos/mem???/gdas.t??z.atmf009.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_5.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_5.list
@@ -1,0 +1,52 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /00/
++ /00/atmos/
++ /00/atmos/mem???/
++ /00/atmos/mem???/gdas.t??z.ratminc.nc
++ /00/atmos/gdas.t??z.atmf006.ensmean.nc
++ /00/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /00/
++ /00/atmos/
++ /00/atmos/mem???/
++ /00/atmos/mem???/gdas.t??z.ratminc.nc
++ /00/atmos/gdas.t??z.atmf006.ensmean.nc
++ /00/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_6.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_6.list
@@ -1,0 +1,52 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /06/
++ /06/atmos/
++ /06/atmos/mem???/
++ /06/atmos/mem???/gdas.t??z.ratminc.nc
++ /06/atmos/gdas.t??z.atmf006.ensmean.nc
++ /06/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /06/
++ /06/atmos/
++ /06/atmos/mem???/
++ /06/atmos/mem???/gdas.t??z.ratminc.nc
++ /06/atmos/gdas.t??z.atmf006.ensmean.nc
++ /06/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_7.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_7.list
@@ -1,0 +1,52 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /12/
++ /12/atmos/
++ /12/atmos/mem???/
++ /12/atmos/mem???/gdas.t??z.ratminc.nc
++ /12/atmos/gdas.t??z.atmf006.ensmean.nc
++ /12/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /12/
++ /12/atmos/
++ /12/atmos/mem???/
++ /12/atmos/mem???/gdas.t??z.ratminc.nc
++ /12/atmos/gdas.t??z.atmf006.ensmean.nc
++ /12/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_8.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_8.list
@@ -1,0 +1,52 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+# This directory is a good candidate for compression
+#Z
+
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDYm1_/
++ /18/
++ /18/atmos/
++ /18/atmos/mem???/
++ /18/atmos/mem???/gdas.t??z.ratminc.nc
++ /18/atmos/gdas.t??z.atmf006.ensmean.nc
++ /18/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
++ /18/
++ /18/atmos/
++ /18/atmos/mem???/
++ /18/atmos/mem???/gdas.t??z.ratminc.nc
++ /18/atmos/gdas.t??z.atmf006.ensmean.nc
++ /18/atmos/gdas.t??z.atmf009.ensmean.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_gdas.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_gdas.list
@@ -1,0 +1,72 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+#_COMROOT_/gfs/_SHORTVER_/gdas._PDYm1_/ _REMOTEPATH_/com/gfs/_ENVIR_/gdas._PDYm1_/
+_COMROOT_/gfs/_SHORTVER_/gdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/gdas.t??z*tcvitals*
++ /??/atmos/gdas.*bufr*
++ /??/atmos/gdas.t??z.abias_pc
++ /??/atmos/gdas.t??z.abias_air
++ /??/atmos/gdas.t??z.abias
++ /??/atmos/gdas.t??z.sfcf*.nc
++ /??/atmos/gdas.t??z.engicegrb
++ /??/atmos/gdas.t??z.atmf0*.nc
++ /??/atmos/gdas.t??z.radstat
++ /??/atmos/gdas.t??z.atmanl.nc
++ /??/atmos/gdas.t??z.atmges.nc
++ /??/atmos/gdas.t??z.atmgm3.nc
++ /??/atmos/gdas.t??z.atmgp3.nc
++ /??/atmos/gdas.t??z.sfcanl.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+#_COMROOT_/gfs/_SHORTVER_/gdas._PDY_/ _REMOTEPATH_/com/gfs/_ENVIR_/gdas._PDY_/
+_COMROOT_/gfs/_SHORTVER_/gdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gdas.t??z*tcvitals*
++ /??/atmos/gdas.*bufr*
++ /??/atmos/gdas.t??z.abias_pc
++ /??/atmos/gdas.t??z.abias_air
++ /??/atmos/gdas.t??z.abias
++ /??/atmos/gdas.t??z.sfcf*.nc
++ /??/atmos/gdas.t??z.engicegrb
++ /??/atmos/gdas.t??z.atmf0*.nc
++ /??/atmos/gdas.t??z.radstat
++ /??/atmos/gdas.t??z.atmanl.nc
++ /??/atmos/gdas.t??z.atmges.nc
++ /??/atmos/gdas.t??z.atmgm3.nc
++ /??/atmos/gdas.t??z.atmgp3.nc
++ /??/atmos/gdas.t??z.sfcanl.nc
++ /??/atmos/gdas.t??z.sstgrb
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_gfs_gempak.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gempak.list
@@ -1,0 +1,40 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+#_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/  _REMOTEPATH_/com/nawips/_ENVIR_/gfs._PDY_/
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/  _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gempak/
++ /??/atmos/gempak/gfs_??????????f???
++ /??/atmos/gempak/gfs40_??????????f???
++ /??/atmos/gempak/gfs_*.snd
++ /??/atmos/gempak/gfs_*.sfc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/parm/transfer/transfer_rdhpcs_gfs_gfs.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gfs.list
@@ -1,0 +1,70 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+#_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/ _REMOTEPATH_/com/gfs/_ENVIR_/gfs._PDY_/
+_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gfs._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gfs.t??z.*bufr*
++ /??/atmos/gfs.t??z.engicegrb
++ /??/atmos/gfs.t??z.*tcvitals*tm00
++ /??/atmos/gfs.t??z.atmanl.nc
++ /??/atmos/gfs.t??z.sfcanl.nc
++ /??/atmos/gfs.t??z.master.grb2f*
++ /??/atmos/gfs.t??z.pgrb2.0p25.f*
++ /??/atmos/gfs.t??z.sfluxgrbf*
++ /??/atmos/gfs.t??z.gcip.f00.grib2
++ /??/atmos/gfs.t??z.atmf000.nc
++ /??/atmos/gfs.t??z.atmf003.nc
++ /??/atmos/gfs.t??z.atmf006.nc
++ /??/atmos/gfs.t??z.atmf009.nc
++ /??/atmos/gfs.t??z.atmf012.nc
++ /??/atmos/gfs.t??z.atmf015.nc
++ /??/atmos/gfs.t??z.atmf018.nc
++ /??/atmos/gfs.t??z.atmf021.nc
++ /??/atmos/gfs.t??z.atmf024.nc
++ /??/atmos/gfs.t??z.atmf027.nc
++ /??/atmos/gfs.t??z.atmf030.nc
++ /??/atmos/gfs.t??z.atmf033.nc
++ /??/atmos/gfs.t??z.atmf036.nc
++ /??/atmos/gfs.t??z.atmf039.nc
++ /??/atmos/gfs.t??z.atmf042.nc
++ /??/atmos/gfs.t??z.atmf045.nc
++ /??/atmos/gfs.t??z.atmf048.nc
++ /??/atmos/gfs.t??z.sfcf024.nc
++ /??/atmos/gfs.t??z.sfcf027.nc
++ /??/atmos/gfs.t??z.sfcf030.nc
++ /??/atmos/gfs.t??z.sfcf033.nc
++ /??/atmos/gfs.t??z.sfcf036.nc
++ /??/atmos/gfs.t??z.sfcf039.nc
++ /??/atmos/gfs.t??z.sfcf042.nc
++ /??/atmos/gfs.t??z.sfcf045.nc
++ /??/atmos/gfs.t??z.sfcf048.nc
+- *
+E
+# This directory is a good candidate for compression
+#Z
+

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.3
-export gfs_ver=v16.3.3
+export version=v16.3.4
+export gfs_ver=v16.3.4
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2


### PR DESCRIPTION
**Description**

This PR includes updates for the GFSv16.3.4 bugfix implementation in ops.

- New release notes for v16.3.4.
- Update `version` and `gfs_ver` in `run.ver` to v16.3.4.
- Pull in NCO install transfer files.

**Type of change**

Operations update.

**How Has This Been Tested?**

- [x] Clone and Build tests on WCOSS2

Refs #744