### PR TITLE
Archive memory adjustment and removal of NODESIZE

### DIFF
--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -304,7 +304,10 @@ elif [ $step = "arch" -o $step = "earc" -o $step = "getic" ]; then
     eval "export npe_$step=1"
     eval "export npe_node_$step=1"
     eval "export nth_$step=1"
-    eval "export memory_$step=50GB"
+    eval "export memory_$step=2048M"
+    if [[ "$machine" == "WCOSS2" ]]; then
+      eval "export memory_$step=50GB"
+    fi
 
 elif [ $step = "eobs" -o $step = "eomg" ]; then
 

--- a/ush/rocoto/rocoto.py
+++ b/ush/rocoto/rocoto.py
@@ -68,7 +68,6 @@ def create_task(task_dict):
     jobname = task_dict.get('jobname', 'demojob')
     account = task_dict.get('account', 'batch')
     queue = task_dict.get('queue', 'debug')
-    nodesize = task_dict.get('nodesize', '1')
     partition = task_dict.get('partition', None)
     walltime = task_dict.get('walltime', '00:01:00')
     log = task_dict.get('log', 'demo.log')
@@ -91,7 +90,6 @@ def create_task(task_dict):
     strings.append(f'\t<jobname><cyclestr>{jobname}</cyclestr></jobname>\n')
     strings.append(f'\t<account>{account}</account>\n')
     strings.append(f'\t<queue>{queue}</queue>\n')
-    strings.append(f'\t<nodesize>{nodesize}</nodesize>\n')
     if partition is not None:
         strings.append(f'\t<partition>{partition}</partition>\n')
     if resources is not None:

--- a/ush/rocoto/setup_workflow.py
+++ b/ush/rocoto/setup_workflow.py
@@ -164,7 +164,6 @@ def get_definitions(base):
 
     machine = base.get('machine', wfu.detectMachine())
     scheduler = wfu.get_scheduler(machine)
-    nodesize = base.get('npe_node_max', '1')
     hpssarch = base.get('HPSSARCH', 'NO').upper()
 
     strings = []
@@ -201,7 +200,6 @@ def get_definitions(base):
     if scheduler in ['slurm']:
         strings.append(f'''\t<!ENTITY PARTITION_SERVICE "{base['QUEUE_SERVICE']}">\n''')
     strings.append(f'\t<!ENTITY SCHEDULER  "{scheduler}">\n')
-    strings.append(f'\t<!ENTITY NODESIZE   "{nodesize}">\n')
     strings.append('\n')
     strings.append('\t<!-- Toggle HPSS archiving -->\n')
     strings.append(f'''\t<!ENTITY ARCHIVE_TO_HPSS "{base['HPSSARCH']}">\n''')

--- a/ush/rocoto/setup_workflow_fcstonly.py
+++ b/ush/rocoto/setup_workflow_fcstonly.py
@@ -94,7 +94,6 @@ def get_definitions(base):
 
     machine = base.get('machine', wfu.detectMachine())
     scheduler = wfu.get_scheduler(machine)
-    nodesize = base.get('npe_node_max', '1')
     hpssarch = base.get('HPSSARCH', 'NO').upper()
 
     strings = []
@@ -134,7 +133,6 @@ def get_definitions(base):
     if scheduler in ['slurm']:
        strings.append(f'''\t<!ENTITY PARTITION_SERVICE "{base['QUEUE_SERVICE']}">\n''')
     strings.append(f'\t<!ENTITY SCHEDULER  "{scheduler}">\n')
-    strings.append(f'\t<!ENTITY NODESIZE   "{nodesize}">\n')
     strings.append('\n')
     strings.append('\t<!-- Toggle HPSS archiving -->\n')
     strings.append(f'''\t<!ENTITY ARCHIVE_TO_HPSS "{base['HPSSARCH']}">\n''')

--- a/ush/rocoto/workflow_utils.py
+++ b/ush/rocoto/workflow_utils.py
@@ -195,7 +195,6 @@ def create_wf_task(task, cdump='gdas', cycledef=None, envar=None, dependency=Non
                  'walltime': f'&WALLTIME_{task.upper()}_{cdump.upper()};', \
                  'native': f'&NATIVE_{task.upper()}_{cdump.upper()};', \
                  'memory': f'&MEMORY_{task.upper()}_{cdump.upper()};', \
-                 'nodesize': '&NODESIZE;', \
                  'resources': f'&RESOURCES_{task.upper()}_{cdump.upper()};', \
                  'log': f'&ROTDIR;/logs/@Y@m@d@H/{taskstr}.log', \
                  'envar': envar, \
@@ -244,7 +243,6 @@ def create_firstcyc_task(cdump='gdas'):
                  'queue': '&QUEUE_SERVICE;', \
                  'walltime': f'&WALLTIME_ARCH_{cdump.upper()};', \
                  'native': f'&NATIVE_ARCH_{cdump.upper()};', \
-                 'nodesize': '&NODESIZE;', \
                  'resources': f'&RESOURCES_ARCH_{cdump.upper()};', \
                  'log': f'&ROTDIR;/logs/@Y@m@d@H/{taskstr}.log', \
                  'dependency': dependencies}


### PR DESCRIPTION
**Description**

This PR includes two changes ahead of merging the GFSv16.3 release branch into the `dev/gfs.v16` branch:

1. set the archive memory value based on machine: revert back to 2048M for R&Ds and keep 50GB for WCOSS2 (more refinement to come later)
2. remove `NODESIZE` from xml generation; no longer needed, particularly for rocoto on WCOSS2

**Type of change**

Maintenance.

**How Has This Been Tested?**

- [x] Clone and Build tests on Hera, Orion, WCOSS2
- [x] Cycled test on Orion and WCOSS2

Refs #744 
Refs #1144
