### PR TITLE
Move configuration.py to pygw

### DIFF
--- a/ush/python/pygw/src/pygw/configuration.py
+++ b/ush/python/pygw/src/pygw/configuration.py
@@ -1,14 +1,13 @@
-#!/usr/bin/env python3
-
+import glob
 import os
 import random
-import glob
 import subprocess
-from pprint import pprint
 from datetime import datetime
 from pathlib import Path
+from pprint import pprint
 from typing import Union, List, Dict, Any
 
+from pygw.attrdict import AttrDict
 
 __all__ = ['Configuration']
 
@@ -85,7 +84,7 @@ class Configuration:
         if isinstance(files, (str, bytes)):
             files = [files]
         files = [self.find_config(file) for file in files]
-        varbles = dict()
+        varbles = AttrDict()
         for key, value in self._get_script_env(files).items():
             if key in self.DATE_ENV_VARS:  # likely a date, convert to datetime
                 varbles[key] = datetime.strptime(value, '%Y%m%d%H')

--- a/workflow/applications.py
+++ b/workflow/applications.py
@@ -2,8 +2,8 @@
 
 from typing import Dict, Any
 from datetime import timedelta
-from configuration import Configuration
 from hosts import Host
+from pygw.configuration import Configuration
 
 __all__ = ['AppConfig']
 
@@ -78,11 +78,11 @@ class AppConfig:
 
     VALID_MODES = ['cycled', 'forecast-only']
 
-    def __init__(self, configuration: Configuration) -> None:
+    def __init__(self, conf: Configuration) -> None:
 
         self.scheduler = Host().scheduler
 
-        _base = configuration.parse_config('config.base')
+        _base = conf.parse_config('config.base')
 
         self.mode = _base['MODE']
 
@@ -134,7 +134,7 @@ class AppConfig:
         self.configs_names = self._get_app_configs()
 
         # Source the config_files for the jobs in the application
-        self.configs = self._source_configs(configuration)
+        self.configs = self._source_configs(conf)
 
         # Update the base config dictionary based on application
         upd_base_map = {'cycled': self._cycled_upd_base,
@@ -286,7 +286,7 @@ class AppConfig:
 
         return base_out
 
-    def _source_configs(self, configuration: Configuration) -> Dict[str, Any]:
+    def _source_configs(self, conf: Configuration) -> Dict[str, Any]:
         """
         Given the configuration object and jobs,
         source the configurations for each config and return a dictionary
@@ -296,7 +296,7 @@ class AppConfig:
         configs = dict()
 
         # Return config.base as well
-        configs['base'] = configuration.parse_config('config.base')
+        configs['base'] = conf.parse_config('config.base')
 
         # Source the list of all config_files involved in the application
         for config in self.configs_names:
@@ -316,7 +316,7 @@ class AppConfig:
                 files += [f'config.{config}']
 
             print(f'sourcing config.{config}')
-            configs[config] = configuration.parse_config(files)
+            configs[config] = conf.parse_config(files)
 
         return configs
 

--- a/workflow/setup_xml.py
+++ b/workflow/setup_xml.py
@@ -6,9 +6,9 @@ Entry point for setting up Rocoto XML for all applications in global-workflow
 import os
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 
-from configuration import Configuration
 from applications import AppConfig
 from rocoto.workflow_xml import RocotoXML
+from pygw.configuration import Configuration
 
 
 def input_args():

--- a/workflow/test_configuration.py
+++ b/workflow/test_configuration.py
@@ -1,5 +1,5 @@
 import sys
-from configuration import Configuration
+from pygw.configuration import Configuration
 
 
 expdir = sys.argv[1]
@@ -18,6 +18,8 @@ print('*'*80)
 print('config.base ...')
 base = cfg.parse_config('config.base')
 cfg.print_config('config.base')
+print(type(base))
+print(base.HOMEgfs)
 
 print('*'*80)
 print('config.anal...')


### PR DESCRIPTION
**Description**

This PR:
- moves `workflow/configuration.py` to `ush/python/pygw/src/pygw/configuration.py` 
- updates the test and workflow generation scripts to use it from `pygw`
- updates `configuration.py` to return configs as `AttrDict` instead of `dict`, same as what the YAML's return.

This is to ensure that sourcing bash configs or yaml configs return the same `type` `AttrDict`.

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

This change is transparent to the user.

**How Has This Been Tested?**

- [X] Clone and setup experiment and then create the XML. No changes in the XML were found which is where these configs are sourced and used.
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [X] Any dependent changes have been merged and published
