### PR TITLE
Recursively convert dict to AttrDict in AttrDict

### DIFF
--- a/ush/python/pygw/src/pygw/attrdict.py
+++ b/ush/python/pygw/src/pygw/attrdict.py
@@ -44,6 +44,8 @@ class AttrDict(dict):
                     object.__getattribute__(self, '__frozen'))
         if isFrozen and name not in super(AttrDict, self).keys():
             raise KeyError(name)
+        if isinstance(value, dict):
+            value = AttrDict(value)
         super(AttrDict, self).__setitem__(name, value)
         try:
             p = object.__getattribute__(self, '__parent')


### PR DESCRIPTION
**Description**
Dicts within an AttrDict were not being converted to AttrDicts at creation/update time. This meant (among other things) when updating, nested dicts of the same name would be overwritten instead of merged.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Manual test with nest dicts

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings