### PR TITLE
Merge GFS v16.3 operational gsi scripts into develop branch

### DIFF
--- a/jobs/JGDAS_ENKF_FCST
+++ b/jobs/JGDAS_ENKF_FCST
@@ -52,7 +52,6 @@ status=$?
 export CDATE=${CDATE:-${PDY}${cyc}}
 export CDUMP=${CDUMP:-${RUN:-"gdas"}}
 export COMPONENT="atmos"
-export rCDUMP="gdas"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -56,8 +56,8 @@ lupp=${lupp:-".true."}
 cnvw_option=${cnvw_option:-".false."}
 
 # Observation usage options
-cao_check=${cao_check:-".false."}
-ta2tb=${ta2tb:-".false."}
+cao_check=${cao_check:-".true."}
+ta2tb=${ta2tb:-".true."}
 
 # Diagnostic files options
 lobsdiag_forenkf=${lobsdiag_forenkf:-".false."}
@@ -451,9 +451,7 @@ ${NLN} ${RTMFIX}/NPOESS.VISsnow.EmisCoeff.bin  ./crtm_coeffs/NPOESS.VISsnow.Emis
 ${NLN} ${RTMFIX}/NPOESS.VISwater.EmisCoeff.bin ./crtm_coeffs/NPOESS.VISwater.EmisCoeff.bin
 ${NLN} ${RTMFIX}/FASTEM6.MWwater.EmisCoeff.bin ./crtm_coeffs/FASTEM6.MWwater.EmisCoeff.bin
 ${NLN} ${RTMFIX}/AerosolCoeff.bin              ./crtm_coeffs/AerosolCoeff.bin
-${NLN} ${RTMFIX}/CloudCoeff.bin                ./crtm_coeffs/CloudCoeff.bin
-#$NLN $RTMFIX/CloudCoeff.GFDLFV3.-109z-1.bin ./crtm_coeffs/CloudCoeff.bin
-
+${NLN} ${RTMFIX}/CloudCoeff.GFDLFV3.-109z-1.bin ./crtm_coeffs/CloudCoeff.bin
 
 ##############################################################
 # Observational data


### PR DESCRIPTION
Changes were made in the GSI scripts for the operational system that need to be brought back to development:
- Remove hard-wired rCDUMP in EnKF forecast job
- Turn on `cao_check` and `ta2tb`
- Update cloud coefficient fix file

Fixes #1148 

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
