### PR TITLE
Add missing jobids in some pre-job scripts

### DIFF
--- a/jobs/JGDAS_ENKF_ARCHIVE
+++ b/jobs/JGDAS_ENKF_ARCHIVE
@@ -2,31 +2,12 @@
 
 source "${HOMEgfs}/ush/preamble.sh"
 
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base earc"
-for config in ${configs}; do
-    . "${EXPDIR}"/config."${config}"
-    status=$?
-    [[ ${status} -ne 0 ]] && exit "${status}"
-done
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env earc
-status=$?
-[[ ${status} -ne 0 ]] && exit "${status}"
-
 ##############################################
 # Obtain unique process id (pid) and make temp directory
 ##############################################
-export pid=${pid:-$$}
-export DATA=${DATA:-${DATAROOT}/${jobid:?}}
-mkdir -p "${DATA}"
-cd "${DATA}"
+export DATA=${DATA:-${DATAROOT}/${jobid}}
+mkdir -p ${DATA}
+cd ${DATA}
 
 
 ##############################################
@@ -40,8 +21,29 @@ setpdy.sh
 ##############################################
 # Determine Job Output Name on System
 ##############################################
+export pid=${pid:-$$}
 export pgmout="OUTPUT.${pid}"
 export pgmerr=errfile
+
+
+#############################
+# Source relevant config files
+#############################
+export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
+configs="base earc"
+for config in ${configs}; do
+    . ${EXPDIR}/config.${config}
+    status=$?
+    [[ ${status} -ne 0 ]] && exit "${status}"
+done
+
+
+##########################################
+# Source machine runtime environment
+##########################################
+. ${HOMEgfs}/env/${machine}.env earc
+status=$?
+[[ ${status} -ne 0 ]] && exit "${status}"
 
 
 ##############################################
@@ -61,7 +63,17 @@ status=$?
 
 ###############################################################
 
-echo "ENDED NORMALLY."
+##############################################
+# End JOB SPECIFIC work
+##############################################
+
+##############################################
+# Final processing
+##############################################
+if [ -e "${pgmout}" ] ; then
+  cat ${pgmout}
+fi
+
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGDAS_ENKF_ARCHIVE
+++ b/jobs/JGDAS_ENKF_ARCHIVE
@@ -7,7 +7,7 @@ source "${HOMEgfs}/ush/preamble.sh"
 ##############################################
 export DATA=${DATA:-${DATAROOT}/${jobid}}
 mkdir -p "${DATA}"
-cd "${DATA}"
+cd "${DATA}" || (echo "${DATA} does not exist. ABORT!"; exit 1)
 
 
 ##############################################

--- a/jobs/JGDAS_ENKF_ARCHIVE
+++ b/jobs/JGDAS_ENKF_ARCHIVE
@@ -77,7 +77,7 @@ fi
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd "${DATAROOT}"
+cd "${DATAROOT}" || (echo "${DATAROOT} does not exist. ABORT!"; exit 1)
 [[ ${KEEPDATA} = "NO" ]] && rm -rf "${DATA}"
 
 exit 0

--- a/jobs/JGDAS_ENKF_ARCHIVE
+++ b/jobs/JGDAS_ENKF_ARCHIVE
@@ -6,8 +6,8 @@ source "${HOMEgfs}/ush/preamble.sh"
 # Obtain unique process id (pid) and make temp directory
 ##############################################
 export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
+mkdir -p "${DATA}"
+cd "${DATA}"
 
 
 ##############################################
@@ -32,7 +32,7 @@ export pgmerr=errfile
 export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
 configs="base earc"
 for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
+    . "${EXPDIR}/config.${config}"
     status=$?
     [[ ${status} -ne 0 ]] && exit "${status}"
 done
@@ -41,7 +41,7 @@ done
 ##########################################
 # Source machine runtime environment
 ##########################################
-. ${HOMEgfs}/env/${machine}.env earc
+. "${HOMEgfs}/env/${machine}.env" earc
 status=$?
 [[ ${status} -ne 0 ]] && exit "${status}"
 
@@ -51,13 +51,12 @@ status=$?
 ##############################################
 export CDATE=${CDATE:-${PDY}${cyc}}
 export CDUMP=${CDUMP:-${RUN:-"gdas"}}
-export COMPONENT="atmos"
 
 ###############################################################
 # Run archive script
 ###############################################################
 
-${SCRgfs}/exgdas_enkf_earc.sh
+"${SCRgfs}/exgdas_enkf_earc.sh"
 status=$?
 [[ ${status} -ne 0 ]] && exit "${status}"
 
@@ -70,8 +69,8 @@ status=$?
 ##############################################
 # Final processing
 ##############################################
-if [ -e "${pgmout}" ] ; then
-  cat ${pgmout}
+if [[ -e "${pgmout}" ]] ; then
+  cat "${pgmout}"
 fi
 
 

--- a/jobs/JGLOBAL_ARCHIVE
+++ b/jobs/JGLOBAL_ARCHIVE
@@ -7,7 +7,7 @@ source "${HOMEgfs}/ush/preamble.sh"
 ##############################################
 export DATA=${DATA:-${DATAROOT}/${jobid}}
 mkdir -p "${DATA}"
-cd "${DATA}"
+cd "${DATA}" || (echo "${DATA} does not exist. ABORT!"; exit 1)
 
 
 ##############################################

--- a/jobs/JGLOBAL_ARCHIVE
+++ b/jobs/JGLOBAL_ARCHIVE
@@ -2,31 +2,10 @@
 
 source "${HOMEgfs}/ush/preamble.sh"
 
-export RUN_ENVIR=${RUN_ENVIR:-"nco"}
-
-#############################################
-# Source relevant config files
-#############################################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base arch"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit "${status}"
-done
-
-##########################################
-# Source machine runtime environment
-##########################################
-. "${HOMEgfs}"/env/"${machine}".env arch
-status=$?
-[[ ${status} -ne 0 ]] && exit "${status}"
-
 ##############################################
 # Obtain unique process id (pid) and make temp directory
 ##############################################
-export pid=${pid:-$$}
-export DATA=${DATA:-${DATAROOT}/${jobid:?}}
+export DATA=${DATA:-${DATAROOT}/${jobid}}
 mkdir -p "${DATA}"
 cd "${DATA}"
 
@@ -42,8 +21,28 @@ setpdy.sh
 ##############################################
 # Determine Job Output Name on System
 ##############################################
+export pid=${pid:-$$}
 export pgmout="OUTPUT.${pid}"
 export pgmerr=errfile
+
+#############################################
+# Source relevant config files
+#############################################
+export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
+configs="base arch"
+for config in ${configs}; do
+    . ${EXPDIR}/config.${config}
+    status=$?
+    [[ ${status} -ne 0 ]] && exit "${status}"
+done
+
+
+##########################################
+# Source machine runtime environment
+##########################################
+. "${HOMEgfs}/env/${machine}.env" arch
+status=$?
+[[ ${status} -ne 0 ]] && exit "${status}"
 
 
 ##############################################
@@ -51,7 +50,7 @@ export pgmerr=errfile
 ##############################################
 export CDATE=${CDATE:-${PDY}${cyc}}
 export CDUMP=${CDUMP:-${RUN:-"gfs"}}
-export COMPONENT=${COMPONENT:-atmos}
+
 
 ###############################################################
 # Run archive script
@@ -61,9 +60,17 @@ ${GLOBALARCHIVESH:-${SCRgfs}/exglobal_archive.sh}
 status=$?
 [[ ${status} -ne 0 ]] && exit "${status}"
 
-###############################################################
+##############################################
+# End JOB SPECIFIC work
+##############################################
 
-echo "ENDED NORMALLY."
+##############################################
+# Final processing
+##############################################
+if [ -e "${pgmout}" ] ; then
+  cat ${pgmout}
+fi
+
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGLOBAL_ARCHIVE
+++ b/jobs/JGLOBAL_ARCHIVE
@@ -75,7 +75,7 @@ fi
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd "${DATAROOT}"
+cd "${DATAROOT}" || (echo "${DATAROOT} does not exist. ABORT!"; exit 1)
 [[ ${KEEPDATA} = "NO" ]] && rm -rf "${DATA}"
 
 exit 0

--- a/jobs/JGLOBAL_ARCHIVE
+++ b/jobs/JGLOBAL_ARCHIVE
@@ -67,8 +67,8 @@ status=$?
 ##############################################
 # Final processing
 ##############################################
-if [ -e "${pgmout}" ] ; then
-  cat ${pgmout}
+if [[ -e "${pgmout}" ]] ; then
+  cat "${pgmout}"
 fi
 
 

--- a/jobs/rocoto/aeroanlfinal.sh
+++ b/jobs/rocoto/aeroanlfinal.sh
@@ -8,5 +8,8 @@ source "$HOMEgfs/ush/preamble.sh"
 status=$?
 [[ $status -ne 0 ]] && exit $status
 
+export job="aeroanlfinal"
+export jobid="${job}.$$"
+
 ###############################################################
 echo "Do nothing for now"

--- a/jobs/rocoto/aeroanlinit.sh
+++ b/jobs/rocoto/aeroanlinit.sh
@@ -8,5 +8,8 @@ source "$HOMEgfs/ush/preamble.sh"
 status=$?
 [[ $status -ne 0 ]] && exit $status
 
+export job="aeroanlinit"
+export jobid="${job}.$$"
+
 ###############################################################
 echo "Do nothing for now"

--- a/jobs/rocoto/aeroanlrun.sh
+++ b/jobs/rocoto/aeroanlrun.sh
@@ -8,5 +8,8 @@ source "$HOMEgfs/ush/preamble.sh"
 status=$?
 [[ $status -ne 0 ]] && exit $status
 
+export job="aeroanlrun"
+export jobid="${job}.$$"
+
 ###############################################################
 echo "Do nothing for now"

--- a/jobs/rocoto/arch.sh
+++ b/jobs/rocoto/arch.sh
@@ -8,6 +8,9 @@ source "${HOMEgfs}/ush/preamble.sh"
 status=$?
 [[ ${status} -ne 0 ]] && exit "${status}"
 
+export job="arch"
+export jobid="${job}.$$"
+
 ###############################################################
 # Execute the JJOB
 "${HOMEgfs}"/jobs/JGLOBAL_ARCHIVE

--- a/jobs/rocoto/earc.sh
+++ b/jobs/rocoto/earc.sh
@@ -8,9 +8,12 @@ source "${HOMEgfs}/ush/preamble.sh"
 status=$?
 [[ ${status} -ne 0 ]] && exit "${status}"
 
+export job="earc"
+export jobid="${job}.$$"
+
 ###############################################################
 # Execute the JJOB
-"${HOMEgfs}"/jobs/JENKFGDAS_ARCHIVE
+${HOMEgfs}/jobs/JGDAS_ENKF_ARCHIVE
 status=$?
 
 

--- a/jobs/rocoto/earc.sh
+++ b/jobs/rocoto/earc.sh
@@ -4,7 +4,7 @@ source "${HOMEgfs}/ush/preamble.sh"
 
 ###############################################################
 # Source FV3GFS workflow modules
-. "${HOMEgfs}"/ush/load_fv3gfs_modules.sh
+. "${HOMEgfs}/ush/load_fv3gfs_modules.sh"
 status=$?
 [[ ${status} -ne 0 ]] && exit "${status}"
 
@@ -13,7 +13,7 @@ export jobid="${job}.$$"
 
 ###############################################################
 # Execute the JJOB
-${HOMEgfs}/jobs/JGDAS_ENKF_ARCHIVE
+"${HOMEgfs}/jobs/JGDAS_ENKF_ARCHIVE"
 status=$?
 
 

--- a/jobs/rocoto/gldas.sh
+++ b/jobs/rocoto/gldas.sh
@@ -8,6 +8,9 @@ source "$HOMEgfs/ush/preamble.sh"
 status=$?
 [[ $status -ne 0 ]] && exit $status
 
+export job="gldas"
+export jobid="${job}.$$"
+
 ###############################################################
 # Execute the JJOB. GLDAS only runs once per day.
 

--- a/jobs/rocoto/ocnanalpost.sh
+++ b/jobs/rocoto/ocnanalpost.sh
@@ -8,6 +8,9 @@ module purge
 module use "${HOMEgfs}/sorc/gdas.cd/modulefiles"
 module load GDAS/"${machine,,}"
 
+export job="ocnanalpost"
+export jobid="${job}.$$"
+
 ###############################################################
 # Execute the JJOB
 "${HOMEgfs}"/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_POST

--- a/jobs/rocoto/ocnanalprep.sh
+++ b/jobs/rocoto/ocnanalprep.sh
@@ -8,6 +8,9 @@ module purge
 module use "${HOMEgfs}/sorc/gdas.cd/modulefiles"
 module load "GDAS/${machine,,}"
 
+export job="ocnanalprep"
+export jobid="${job}.$$"
+
 ###############################################################
 # Execute the JJOB
 "${HOMEgfs}"/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP

--- a/jobs/rocoto/ocnanalrun.sh
+++ b/jobs/rocoto/ocnanalrun.sh
@@ -8,6 +8,9 @@ module purge
 module use "${HOMEgfs}/sorc/gdas.cd/modulefiles"
 module load GDAS/"${machine,,}"
 
+export job="ocnanalrun"
+export jobid="${job}.$$"
+
 ###############################################################
 # Execute the JJOB
 "${HOMEgfs}"/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_RUN

--- a/scripts/exgdas_enkf_earc.sh
+++ b/scripts/exgdas_enkf_earc.sh
@@ -7,7 +7,7 @@ source "${HOMEgfs}/ush/preamble.sh"
 ##############################################
 export n=$((10#${ENSGRP}))
 export CDUMP_ENKF=$(echo "${EUPD_CYC:-"gdas"}" | tr a-z A-Z)
-export ARCH_LIST="${ROTDIR}/enkf${CDUMP}.${PDY}/${cyc}/${COMPONENT}/earc${ENSGRP}"
+export ARCH_LIST="${ROTDIR}/enkf${CDUMP}.${PDY}/${cyc}/atmos/earc${ENSGRP}"
 
 # ICS are restarts and always lag INC by $assim_freq hours.
 EARCINC_CYC=${ARCH_CYC}
@@ -122,13 +122,13 @@ if [ "${ENSGRP}" -eq 0 ]; then
     [[ ! -d ${ARCDIR} ]] && mkdir -p "${ARCDIR}"
     cd "${ARCDIR}"
 
-    nb_copy "${ROTDIR}"/enkf"${CDUMP}"."${PDY}"/"${cyc}"/"${COMPONENT}"/"${CDUMP}".t"${cyc}"z.enkfstat         enkfstat."${CDUMP}"."${CDATE}"
-    nb_copy "${ROTDIR}"/enkf"${CDUMP}"."${PDY}"/"${cyc}"/"${COMPONENT}"/"${CDUMP}".t"${cyc}"z.gsistat.ensmean  gsistat."${CDUMP}"."${CDATE}".ensmean
+    nb_copy "${ROTDIR}/enkf${CDUMP}.${PDY}/${cyc}/atmos/${CDUMP}.t${cyc}z.enkfstat"        "enkfstat.${CDUMP}.${CDATE}"
+    nb_copy "${ROTDIR}/enkf${CDUMP}.${PDY}/${cyc}/atmos/${CDUMP}.t${cyc}z.gsistat.ensmean" "gsistat.${CDUMP}.${CDATE}.ensmean"
 
     if [ "${CDUMP_ENKF}" != "GDAS" ]; then
-      nb_copy "${ROTDIR}"/enkfgfs."${PDY}"/"${cyc}"/"${COMPONENT}"/"${CDUMP}".t"${cyc}"z.enkfstat enkfstat.gfs."${CDATE}"
-      nb_copy "${ROTDIR}"/enkfgfs."${PDY}"/"${cyc}"/"${COMPONENT}"/"${CDUMP}".t"${cyc}"z.gsistat.ensmean gsistat.gfs."${CDATE}".ensmean
-        fi
+      nb_copy "${ROTDIR}/enkfgfs.${PDY}/${cyc}/atmos/${CDUMP}.t${cyc}z.enkfstat"        "enkfstat.gfs.${CDATE}"
+      nb_copy "${ROTDIR}/enkfgfs.${PDY}/${cyc}/atmos/${CDUMP}.t${cyc}z.gsistat.ensmean" "gsistat.gfs.${CDATE}.ensmean"
+    fi
 
 fi
 
@@ -152,7 +152,7 @@ if [ "${ENSGRP}" -eq 0 ]; then
         # Loop over GDAS and GFS EnKF directories separately.
         clist="gdas gfs"
         for ctype in ${clist}; do
-            COMIN_ENS="${ROTDIR}/enkf${ctype}.${gPDY}/${gcyc}/${COMPONENT}"
+            COMIN_ENS="${ROTDIR}/enkf${ctype}.${gPDY}/${gcyc}/atmos"
             if [ -d "${COMIN_ENS}" ]; then
                 rocotolog="${EXPDIR}/logs/${GDATE}.log"
                 if [ -f "${rocotolog}" ]; then


### PR DESCRIPTION
**Description**
Some of the pre-job scripts (`jobs/rocoto/*`) were not defining `job` and `jobid` before calling the j-job.

Also refactors the archive j-jobs to match the new j-job structure.

Fixes #1169 

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
Being tested by @XianwuXue-NOAA as part of Early cycle EnKF work.
  
**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
