### PR TITLE
Stop checking for restarts on non-GFS CDUMPs

### DIFF
--- a/ush/forecast_det.sh
+++ b/ush/forecast_det.sh
@@ -19,55 +19,55 @@ FV3_GFS_det(){
   res_latlon_dynamics="''"
 
   # Determine if this is a warm start or cold start
-  if [ -f $gmemdir/RESTART/${sPDY}.${scyc}0000.coupler.res ]; then
+  if [[ -f "${gmemdir}"/RESTART/"${sPDY}"."${scyc}"0000.coupler.res ]]; then
     export warm_start=".true."
   fi
 
   # turn IAU off for cold start
   DOIAU_coldstart=${DOIAU_coldstart:-"NO"}
-  if [ $DOIAU = "YES" -a $warm_start = ".false." ] || [ $DOIAU_coldstart = "YES" -a $warm_start = ".true." ]; then
+  if [[ "${DOIAU}" = "YES" ]] && [[ ${warm_start} = ".false." ]] || [[ "${DOIAU_coldstart}" = "YES" ]] && [[ ${warm_start} = ".true." ]]; then
     export DOIAU="NO"
-    echo "turning off IAU since warm_start = $warm_start"
+    echo "turning off IAU since warm_start = ${warm_start}"
     DOIAU_coldstart="YES"
     IAU_OFFSET=0
-    sCDATE=$CDATE
-    sPDY=$PDY
-    scyc=$cyc
-    tPDY=$sPDY
-    tcyc=$cyc
+    sCDATE=${CDATE}
+    sPDY=${PDY}
+    scyc=${cyc}
+    tPDY=${sPDY}
+    tcyc=${cyc}
   fi
 
   #-------------------------------------------------------
   # determine if restart IC exists to continue from a previous forecast
   RERUN="NO"
-  filecount=$(find $RSTDIR_ATM -type f | wc -l)
-  if [ $CDUMP = "gfs" -a $rst_invt1 -gt 0 -a $FHMAX -gt $rst_invt1 -a $filecount -gt 10 ]; then
+  [[ ${CDUMP} = "gfs" ]] && filecount=$(find "${RSTDIR_ATM}" -type f | wc -l)
+  if [[ "${CDUMP}" = "gfs" ]] && [[ "${rst_invt1}" -gt 0 ]] && [[ "${FHMAX}" -gt "${rst_invt1}" ]] && [[ "${filecount}" -gt 10 ]]; then
     reverse=$(echo "${restart_interval[@]} " | tac -s ' ')
-    for xfh in $reverse ; do
+    for xfh in ${reverse} ; do
       yfh=$((xfh-(IAU_OFFSET/2)))
-      SDATE=$($NDATE +$yfh $CDATE)
-      PDYS=$(echo $SDATE | cut -c1-8)
-      cycs=$(echo $SDATE | cut -c9-10)
-      flag1=$RSTDIR_ATM/${PDYS}.${cycs}0000.coupler.res
-      flag2=$RSTDIR_ATM/coupler.res
+      SDATE=$(${NDATE} +${yfh} "${CDATE}")
+      PDYS=$(echo "${SDATE}" | cut -c1-8)
+      cycs=$(echo "${SDATE}" | cut -c9-10)
+      flag1=${RSTDIR_ATM}/${PDYS}.${cycs}0000.coupler.res
+      flag2=${RSTDIR_ATM}/coupler.res
 
       #make sure that the wave restart files also exist if cplwav=true
       waverstok=".true."
-      if [ $cplwav = ".true." ]; then
-        for wavGRD in $waveGRD ; do
-          if [ ! -f ${RSTDIR_WAVE}/${PDYS}.${cycs}0000.restart.${wavGRD} ]; then
+      if [[ "${cplwav}" = ".true." ]]; then
+        for wavGRD in ${waveGRD} ; do
+          if [[ ! -f "${RSTDIR_WAVE}"/"${PDYS}"."${cycs}"0000.restart."${wavGRD}" ]]; then
             waverstok=".false."
           fi
         done
       fi
 
-      if [ -s $flag1 -a $waverstok = ".true." ]; then
-        CDATE_RST=$SDATE
-        [[ $RERUN = "YES" ]] && break
-        mv $flag1 ${flag1}.old
-        if [ -s $flag2 ]; then mv $flag2 ${flag2}.old ;fi
+      if [[ -s "${flag1}" ]] && [[ ${waverstok} = ".true." ]]; then
+        CDATE_RST=${SDATE}
+        [[ ${RERUN} = "YES" ]] && break
+        mv "${flag1}" "${flag1}".old
+        if [[ -s "${flag2}" ]]; then mv "${flag2}" "${flag2}".old ;fi
         RERUN="YES"
-        [[ $xfh = $rst_invt1 ]] && RERUN="NO"
+        [[ ${xfh} = ${rst_invt1} ]] && RERUN="NO"
       fi
     done
   fi

--- a/ush/forecast_det.sh
+++ b/ush/forecast_det.sh
@@ -19,7 +19,7 @@ FV3_GFS_det(){
   res_latlon_dynamics="''"
 
   # Determine if this is a warm start or cold start
-  if [[ -f "${gmemdir}"/RESTART/"${sPDY}"."${scyc}"0000.coupler.res ]]; then
+  if [[ -f "${gmemdir}/RESTART/${sPDY}.${scyc}0000.coupler.res" ]]; then
     export warm_start=".true."
   fi
 
@@ -55,7 +55,7 @@ FV3_GFS_det(){
       waverstok=".true."
       if [[ "${cplwav}" = ".true." ]]; then
         for wavGRD in ${waveGRD} ; do
-          if [[ ! -f "${RSTDIR_WAVE}"/"${PDYS}"."${cycs}"0000.restart."${wavGRD}" ]]; then
+          if [[ ! -f "${RSTDIR_WAVE}/${PDYS}.${cycs}0000.restart.${wavGRD}" ]]; then
             waverstok=".false."
           fi
         done
@@ -64,8 +64,8 @@ FV3_GFS_det(){
       if [[ -s "${flag1}" ]] && [[ ${waverstok} = ".true." ]]; then
         CDATE_RST=${SDATE}
         [[ ${RERUN} = "YES" ]] && break
-        mv "${flag1}" "${flag1}".old
-        if [[ -s "${flag2}" ]]; then mv "${flag2}" "${flag2}".old ;fi
+        mv "${flag1}" "${flag1}.old"
+        if [[ -s "${flag2}" ]]; then mv "${flag2}" "${flag2}.old" ;fi
         RERUN="YES"
         [[ ${xfh} = ${rst_invt1} ]] && RERUN="NO"
       fi

--- a/ush/forecast_det.sh
+++ b/ush/forecast_det.sh
@@ -25,7 +25,7 @@ FV3_GFS_det(){
 
   # turn IAU off for cold start
   DOIAU_coldstart=${DOIAU_coldstart:-"NO"}
-  if [[ "${DOIAU}" = "YES" ]] && [[ ${warm_start} = ".false." ]] || [[ "${DOIAU_coldstart}" = "YES" ]] && [[ ${warm_start} = ".true." ]]; then
+  if [ ${DOIAU} = "YES" -a ${warm_start} = ".false." ] || [ ${DOIAU_coldstart} = "YES" -a ${warm_start} = ".true." ]; then
     export DOIAU="NO"
     echo "turning off IAU since warm_start = ${warm_start}"
     DOIAU_coldstart="YES"
@@ -41,7 +41,7 @@ FV3_GFS_det(){
   # determine if restart IC exists to continue from a previous forecast
   RERUN="NO"
   [[ ${CDUMP} = "gfs" ]] && filecount=$(find "${RSTDIR_ATM}" -type f | wc -l)
-  if [[ "${CDUMP}" = "gfs" ]] && [[ "${rst_invt1}" -gt 0 ]] && [[ "${FHMAX}" -gt "${rst_invt1}" ]] && [[ "${filecount}" -gt 10 ]]; then
+  if [ ${CDUMP} = "gfs" -a ${rst_invt1} -gt 0 -a ${FHMAX} -gt ${rst_invt1} -a ${filecount} -gt 10 ]; then
     reverse=$(echo "${restart_interval[@]} " | tac -s ' ')
     for xfh in ${reverse} ; do
       yfh=$((xfh-(IAU_OFFSET/2)))


### PR DESCRIPTION
**Description**
The forecast was attempting to check `RSTDIR_ATM` for restart files, but that variable is not defined for gdas, resulting in an unbound variable error. Because the error occurred in a subshell, the error had no impact on the execution, just an unwanted error message in the log. Now that directory is only checked when the `$CDUMP` is 'gfs'.

Also fixes some linter warnings.

Fixes #1140 

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Forecast-only test on Hera
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
