### PR TITLE
Reorder post so all flux files are generated when running offline

### DIFF
--- a/scripts/exgfs_atmos_post.sh
+++ b/scripts/exgfs_atmos_post.sh
@@ -206,7 +206,7 @@ if [[ "${stime}" = "anl" ]]; then
           wafsgrid="latlon 0:1440:0.25 90:721:-0.25"
           ${WGRIB2} "${PGBOUT}" -set_grib_type same -new_grid_winds earth \
           -new_grid_interpolation bilinear -set_bitmap 1 \
-          -new_grid "${wafsgrid}" "${PGBOUT}.tmp"
+          -new_grid ${wafsgrid} "${PGBOUT}.tmp"
 
           if [[ "${SENDCOM}" = "YES" ]]; then
             cp "${PGBOUT}.tmp" "${COMOUT}/${PREFIX}wafs.0p25.anl"

--- a/scripts/exgfs_atmos_post.sh
+++ b/scripts/exgfs_atmos_post.sh
@@ -69,7 +69,7 @@ export TCYC=${TCYC:-".t${cyc}z."}
 export OUTPUT_FILE=${OUTPUT_FILE:-"nemsio"}
 export PREFIX=${PREFIX:-${RUN}${TCYC}}
 if (( OUTTYP == 4 )); then
-  if [ "${OUTPUT_FILE}" = "netcdf" ]; then
+  if [[ "${OUTPUT_FILE}" = "netcdf" ]]; then
     export SUFFIX=".nc"
   else
     export SUFFIX=".nemsio"
@@ -101,8 +101,8 @@ else
   export loganl="${COMIN}/${PREFIX}sanl"
 fi
 
-if [ "${stime}" = "anl" ]; then
-  if [ -f "${loganl}" ]; then
+if [[ "${stime}" = "anl" ]]; then
+  if [[ -f "${loganl}" ]]; then
     # add new environmental variables for running new ncep post
     # Validation date
     export VDATE=${PDY}${cyc}
@@ -113,7 +113,7 @@ if [ "${stime}" = "anl" ]; then
 
     # specify smaller control file for GDAS because GDAS does not
     # produce flux file, the default will be /nwprod/parm/gfs_cntrl.parm
-    if [ "${GRIBVERSION}" = 'grib2' ]; then
+    if [[ "${GRIBVERSION}" = 'grib2' ]]; then
       # use grib2 nomonic table in product g2tmpl directory as default 
       export POSTGRB2TBL=${POSTGRB2TBL:-${g2tmpl_ROOT}/share/params_grib2_tbl_new}
       export PostFlatFile=${PostFlatFile:-${PARMpost}/postxconfig-NT-GFS-ANL.txt}
@@ -138,31 +138,31 @@ if [ "${stime}" = "anl" ]; then
     ${POSTGPSH}
     export err=$?; err_chk
 
-    if [ "${GRIBVERSION}" = 'grib2' ]; then
+    if [[ "${GRIBVERSION}" = 'grib2' ]]; then
       mv "${PGBOUT}" "${PGBOUT2}"
     fi
 
     #  Process pgb files
-    if [ "${PGBF}" = 'YES' ]; then
+    if [[ "${PGBF}" = 'YES' ]]; then
       export FH=-1
       export downset=${downset:-2}
       ${GFSDOWNSH}
       export err=$?; err_chk
     fi
 
-    if [ "${SENDCOM}" = 'YES' ]; then
+    if [[ "${SENDCOM}" = 'YES' ]]; then
       export fhr3=anl
-      if [ "${GRIBVERSION}" = 'grib2' ]; then
+      if [[ "${GRIBVERSION}" = 'grib2' ]]; then
         MASTERANL=${PREFIX}master.grb2${fhr3}
         MASTERANLIDX=${PREFIX}master.grb2i${fhr3}
         cp "${PGBOUT2}" "${COMOUT}/${MASTERANL}"
         ${GRB2INDEX} "${PGBOUT2}" "${COMOUT}/${MASTERANLIDX}"
       fi
 
-      if [ "${SENDDBN}" = 'YES' ]; then
+      if [[ "${SENDDBN}" = 'YES' ]]; then
         "${DBNROOT}/bin/dbn_alert" MODEL GFS_MSC_sfcanl "${job}" "${COMOUT}/${PREFIX}sfcanl${SUFFIX}"
         "${DBNROOT}/bin/dbn_alert" MODEL GFS_SA "${job}" "${COMOUT}/${PREFIX}atmanl${SUFFIX}"
-        if [ "${PGBF}" = 'YES' ]; then
+        if [[ "${PGBF}" = 'YES' ]]; then
           "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_0P25 "${job}" "${COMOUT}/${PREFIX}pgrb2.0p25.anl"
           "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_0P25_WIDX "${job}" "${COMOUT}/${PREFIX}pgrb2.0p25.anl.idx"
           "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_0P25 "${job}" "${COMOUT}/${PREFIX}pgrb2b.0p25.anl"
@@ -185,7 +185,7 @@ if [ "${stime}" = "anl" ]; then
 
     ##########################  WAFS U/V/T analysis start ##########################
     # U/V/T on ICAO standard atmospheric pressure levels for WAFS verification
-    if [ "${WAFSF}" = "YES" ]; then
+    if [[ "${WAFSF}" = "YES" ]]; then
       if [[ "${RUN}" = "gfs" && "${GRIBVERSION}" = 'grib2' ]]; then
         export OUTTYP=${OUTTYP:-4}
 
@@ -206,9 +206,9 @@ if [ "${stime}" = "anl" ]; then
           wafsgrid="latlon 0:1440:0.25 90:721:-0.25"
           ${WGRIB2} "${PGBOUT}" -set_grib_type same -new_grid_winds earth \
           -new_grid_interpolation bilinear -set_bitmap 1 \
-          -new_grid ${wafsgrid} "${PGBOUT}.tmp"
+          -new_grid "${wafsgrid}" "${PGBOUT}.tmp"
 
-          if [ "${SENDCOM}" = "YES" ]; then
+          if [[ "${SENDCOM}" = "YES" ]]; then
             cp "${PGBOUT}.tmp" "${COMOUT}/${PREFIX}wafs.0p25.anl"
             ${WGRIB2} -s "${PGBOUT}.tmp" > "${COMOUT}/${PREFIX}wafs.0p25.anl.idx"
 
@@ -244,7 +244,7 @@ else   ## not_anl if_stime
     export pgm="postcheck"
     ic=1
     while (( ic <= SLEEP_LOOP_MAX )); do
-      if [ -f "${restart_file}${fhr}.txt" ]; then
+      if [[ -f "${restart_file}${fhr}.txt" ]]; then
         break
       else
         ic=$(( ic + 1 ))
@@ -288,11 +288,11 @@ else   ## not_anl if_stime
     export OUTTYP=${OUTTYP:-4}
     export GFSOUT="${PREFIX}gfsio${fhr}"
 
-    if [ "${GRIBVERSION}" = 'grib2' ]; then
+    if [[ "${GRIBVERSION}" = 'grib2' ]]; then
       export POSTGRB2TBL="${POSTGRB2TBL:-${g2tmpl_ROOT}/share/params_grib2_tbl_new}"
       export PostFlatFile="${PostFlatFile:-${PARMpost}/postxconfig-NT-GFS.txt}"
 
-      if [ "${RUN}" = "gfs" ]; then
+      if [[ "${RUN}" = "gfs" ]]; then
         export IGEN=${IGEN_GFS}
         if (( fhr > 0 )); then export IGEN=${IGEN_FCST} ; fi
       else
@@ -322,54 +322,54 @@ else   ## not_anl if_stime
     export PGBOUT2=pgbfile.grib2
     export PGIOUT2=pgifile.grib2.idx
     export FILTER=0 
-    if [ "${GRIBVERSION}" = 'grib2' ]; then
+    if [[ "${GRIBVERSION}" = 'grib2' ]]; then
       MASTERFL=${PREFIX}master.grb2f${fhr}
       MASTERFLIDX=${PREFIX}master.grb2if${fhr}
     fi
 
-    if [ "${INLINE_POST}" = ".false." ]; then
+    if [[ "${INLINE_POST}" = ".false." ]]; then
       ${POSTGPSH}
     else
       cp -p "${COMOUT}/${MASTERFL}" "${PGBOUT}" 
     fi
     export err=$?; err_chk
 
-    if [ "${GRIBVERSION}" = 'grib2' ]; then
+    if [[ "${GRIBVERSION}" = 'grib2' ]]; then
       mv "${PGBOUT}" "${PGBOUT2}"
     fi
 
     #  Process pgb files
-    if [ "${PGBF}" = 'YES' ]; then
+    if [[ "${PGBF}" = 'YES' ]]; then
       export FH=$(( 10#${fhr} + 0 ))
       export downset=${downset:-2}
       ${GFSDOWNSH}
       export err=$?; err_chk
     fi
 
-    if [ "${SENDCOM}" = "YES" ]; then
-      if [ "${GRIBVERSION}" = 'grib2' ]; then
-        if [ "${INLINE_POST}" = ".false." ]; then 
+    if [[ "${SENDCOM}" = "YES" ]]; then
+      if [[ "${GRIBVERSION}" = 'grib2' ]]; then
+        if [[ "${INLINE_POST}" = ".false." ]]; then 
           cp "${PGBOUT2}" "${COMOUT}/${MASTERFL}"
         fi
         ${GRB2INDEX} "${PGBOUT2}" "${COMOUT}/${MASTERFLIDX}"
       fi
 
-      if [ "${SENDDBN}" = 'YES' ]; then
-        if [ "${GRIBVERSION}" = 'grib2' ]; then
-          if [ "${PGBF}" = 'YES' ]; then
+      if [[ "${SENDDBN}" = 'YES' ]]; then
+        if [[ "${GRIBVERSION}" = 'grib2' ]]; then
+          if [[ "${PGBF}" = 'YES' ]]; then
             "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_0P25 "${job}" "${COMOUT}/${PREFIX}pgrb2.0p25.f${fhr}"
             "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_0P25_WIDX "${job}" "${COMOUT}/${PREFIX}pgrb2.0p25.f${fhr}.idx"
             "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_0P25 "${job}" "${COMOUT}/${PREFIX}pgrb2b.0p25.f${fhr}"
             "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_0P25_WIDX "${job}" "${COMOUT}/${PREFIX}pgrb2b.0p25.f${fhr}.idx"
 
-            if [ -s "${COMOUT}/${PREFIX}pgrb2.0p50.f${fhr}" ]; then
+            if [[ -s "${COMOUT}/${PREFIX}pgrb2.0p50.f${fhr}" ]]; then
               "${DBNROOT}/bin/dbn_alert"  MODEL GFS_PGB2_0P5 "${job}" "${COMOUT}/${PREFIX}pgrb2.0p50.f${fhr}"
               "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_0P5_WIDX "${job}" "${COMOUT}/${PREFIX}pgrb2.0p50.f${fhr}.idx"
               "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_0P5 "${job}" "${COMOUT}/${PREFIX}pgrb2b.0p50.f${fhr}"
               "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_0P5_WIDX "${job}" "${COMOUT}/${PREFIX}pgrb2b.0p50.f${fhr}.idx"
             fi
 
-            if [ -s "${COMOUT}/${PREFIX}pgrb2.1p00.f${fhr}" ]; then
+            if [[ -s "${COMOUT}/${PREFIX}pgrb2.1p00.f${fhr}" ]]; then
               "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_1P0 "${job}" "${COMOUT}/${PREFIX}pgrb2.1p00.f${fhr}"
               "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_1P0_WIDX "${job}" "${COMOUT}/${PREFIX}pgrb2.1p00.f${fhr}.idx"
               "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_1P0 "${job}" "${COMOUT}/${PREFIX}pgrb2b.1p00.f${fhr}"
@@ -400,21 +400,21 @@ else   ## not_anl if_stime
       export FLUXFL=${PREFIX}sfluxgrbf${fhr}.grib2
       FLUXFLIDX=${PREFIX}sfluxgrbf${fhr}.grib2.idx
 
-      #Add extra flux.1p00 file for coupled
-      if [ "${FLXGF}" = 'YES' ]; then                    
-        export FH=$(( 10#${fhr} + 0 ))
-        ${GFSDOWNSHF}
-        export err=$?; err_chk
-      fi   
-
-      if [ "${INLINE_POST}" = ".false." ]; then
+      if [[ "${INLINE_POST}" = ".false." ]]; then
         ${POSTGPSH}
         export err=$?; err_chk
         mv fluxfile "${COMOUT}/${FLUXFL}"
       fi
       ${WGRIB2} -s "${COMOUT}/${FLUXFL}" > "${COMOUT}/${FLUXFLIDX}"
 
-      if [ "${SENDDBN}" = 'YES' ]; then
+      #Add extra flux.1p00 file for coupled
+      if [[ "${FLXGF}" = 'YES' ]]; then
+        export FH=$(( 10#${fhr} + 0 ))
+        ${GFSDOWNSHF}
+        export err=$?; err_chk
+      fi
+
+      if [[ "${SENDDBN}" = 'YES' ]]; then
         "${DBNROOT}/bin/dbn_alert" MODEL GFS_SGB_GB2 "${job}" "${COMOUT}/${FLUXFL}"
         "${DBNROOT}/bin/dbn_alert" MODEL GFS_SGB_GB2_WIDX "${job}" "${COMOUT}/${FLUXFLIDX}"
       fi
@@ -422,7 +422,7 @@ else   ## not_anl if_stime
 
     # process satellite look alike separately so that master pgb gets out in time    
     # set outtyp to 2 because master post already generates gfs io files
-    if [ "${GOESF}" = "YES" ]; then
+    if [[ "${GOESF}" = "YES" ]]; then
       export OUTTYP=${OUTTYP:-4}
 
       # specify output file name from chgres which is input file name to nceppost 
@@ -436,7 +436,7 @@ else   ## not_anl if_stime
       export FIXCRTM="${FIXCRTM:-${CRTM_FIX}}"
       "${USHgfs}/link_crtm_fix.sh" "${FIXCRTM}"
 
-      if [ "${GRIBVERSION}" = 'grib2' ]; then 
+      if [[ "${GRIBVERSION}" = 'grib2' ]]; then 
         export PostFlatFile="${PARMpost}/postxconfig-NT-GFS-GOES.txt"
         export CTLFILE="${PARMpost}/postcntrl_gfs_goes.xml"
       fi
@@ -449,24 +449,24 @@ else   ## not_anl if_stime
       export JO=0
       export IGEN=0
 
-      if [ "${NET}" = "gfs" ]; then
+      if [[ "${NET}" = "gfs" ]]; then
         ${POSTGPSH}
         export err=$?; err_chk
       fi
 
-      if [ "${GRIBVERSION}" = 'grib2' ]; then
+      if [[ "${GRIBVERSION}" = 'grib2' ]]; then
         SPECIALFL="${PREFIX}special.grb2"
         SPECIALFLIDX="${PREFIX}special.grb2i"
       fi
       fhr3=${fhr}
 
-      if [ "${SENDCOM}" = "YES" ]; then
+      if [[ "${SENDCOM}" = "YES" ]]; then
         #       echo "$PDY$cyc$pad$fhr" > $COMOUT/${RUN}.t${cyc}z.master.control
 
         mv goesfile "${COMOUT}/${SPECIALFL}f${fhr}"
         mv goesifile "${COMOUT}/${SPECIALFLIDX}f${fhr}"
 
-        if [ "${SENDDBN}" = "YES" ]; then
+        if [[ "${SENDDBN}" = "YES" ]]; then
           "${DBNROOT}/bin/dbn_alert" MODEL GFS_SPECIAL_GB2 "${job}" "${COMOUT}/${SPECIALFL}f${fhr}"
         fi
       fi
@@ -509,8 +509,8 @@ else   ## not_anl if_stime
         if (( err != 0 )); then
           echo " *** GFS POST WARNING: WAFS output failed for f${fhr}, err=${err}"
         else
-          if [ -e "${PGBOUT}" ]; then
-            if [ "${SENDCOM}" = "YES" ]; then
+          if [[ -e "${PGBOUT}" ]]; then
+            if [[ "${SENDCOM}" = "YES" ]]; then
               cp "${PGBOUT}" "${COMOUT}/${PREFIX}wafs.grb2f${fhr}"
               cp "${PGIOUT}" "${COMOUT}/${PREFIX}wafs.grb2if${fhr}"
             fi

--- a/ush/inter_flux.sh
+++ b/ush/inter_flux.sh
@@ -43,22 +43,13 @@ else
 fi
 
 #---------------------------------------------------------------
-
-  if [ $INLINE_POST = ".false." ]; then
-    $WGRIB2 $PGBOUT $option1 $option21 $option22 $option23 $option24 \
+  $WGRIB2 $COMOUT/${FLUXFL} $option1 $option21 $option22 $option23 $option24 \
                           $option25 $option26 $option27 $option28 \
                           -new_grid $grid1p0  fluxfile_${fhr3}_1p00
-  else 
-    $WGRIB2 $COMOUT/${FLUXFL} $option1 $option21 $option22 $option23 $option24 \
-                          $option25 $option26 $option27 $option28 \
-                          -new_grid $grid1p0  fluxfile_${fhr3}_1p00
-  fi
   export err=$?; err_chk
-
 
   $WGRIB2 -s fluxfile_${fhr3}_1p00 > $COMOUT/${PREFIX}flux.1p00.f${fhr3}.idx
   cp fluxfile_${fhr3}_1p00  $COMOUT/${PREFIX}flux.1p00.f${fhr3}
-
 #---------------------------------------------------------------
 
 


### PR DESCRIPTION
**Description**
Post would fail when running without inline post because it would attempt to create 1p00 flux files before the flux file had been generated. `inter_flux.sh` also had to be updated to point at the correct file for offline post, which is now the same as inline.

Fixes #1157 

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
Tested and output verified.
- [X] Forecast-only test on Hera
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes