### PR TITLE
Use fracoro data for all new UFS applications

### DIFF
--- a/parm/config/config.init
+++ b/parm/config/config.init
@@ -17,7 +17,7 @@ export GDASINIT_DIR=${UFS_DIR}/util/gdas_init
 export CRES_HIRES=$CASE
 export CRES_ENKF=$CASE_ENKF
 
-export RUNICSH=${GDASINIT_DIR}/run_v16.chgres.sh
+export RUNICSH=${GDASINIT_DIR}/run_v17.chgres.sh
 if [ "${RETRO:-"NO"}" = "YES" ] || [ "$CDUMP" = "gdas" ]; then
   export RUNICSH=${GDASINIT_DIR}/run_v16retro.chgres.sh
 fi

--- a/scripts/exgdas_atmos_gldas.sh
+++ b/scripts/exgdas_atmos_gldas.sh
@@ -86,12 +86,8 @@ mkdir -p "${RUNDIR}/input"
 ln -fs "${GDAS}" "${RUNDIR}/input/GDAS"
 ln -fs "${EXECgldas:?}/gldas_model" "${RUNDIR}/LIS"
 
-# Set FIXgldas subfolder based on FRAC_GRID value
-if [[ "${FRAC_GRID:-".true."}" = ".true." ]] ; then
-  ln -fs "${FIXgldas}/frac_grid/FIX_T${JCAP}" "${RUNDIR}/FIX"
-else
-  ln -fs "${FIXgldas}/nonfrac_grid/FIX_T${JCAP}" "${RUNDIR}/FIX"
-fi
+# Set FIXgldas subfolder
+ln -fs "${FIXgldas}/frac_grid/FIX_T${JCAP}" "${RUNDIR}/FIX"
 
 #---------------------------------------------------------------
 ### 1) Get gdas 6-tile netcdf restart file and gdas forcing data

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -164,10 +164,6 @@ EOF
 
   #--------------------------------------------------------------------------
   # Grid and orography data
-  for n in $(seq 1 $ntiles); do
-    $NLN $FIXfv3/$CASE/${CASE}_grid.tile${n}.nc     $DATA/INPUT/${CASE}_grid.tile${n}.nc
-    $NLN $FIXfv3/$CASE/${CASE}_oro_data.tile${n}.nc $DATA/INPUT/oro_data.tile${n}.nc
-  done
 
   if [ $cplflx = ".false." ] ; then
     $NLN $FIXfv3/$CASE/${CASE}_mosaic.nc $DATA/INPUT/grid_spec.nc
@@ -175,20 +171,12 @@ EOF
     $NLN $FIXfv3/$CASE/${CASE}_mosaic.nc $DATA/INPUT/${CASE}_mosaic.nc
   fi
 
-  # Fractional grid related
-  if [ $FRAC_GRID = ".true." ]; then
-    OROFIX=${OROFIX:-"${FIX_DIR}/orog/${CASE}.mx${OCNRES}_frac"}
-    FIX_SFC=${FIX_SFC:-"${OROFIX}/fix_sfc"}
-    for n in $(seq 1 $ntiles); do
-      $NLN ${OROFIX}/oro_${CASE}.mx${OCNRES}.tile${n}.nc $DATA/INPUT/oro_data.tile${n}.nc
-    done
-  else
-    OROFIX=${OROFIX:-"${FIXfv3}/${CASE}"}
-    FIX_SFC=${FIX_SFC:-"${OROFIX}/fix_sfc"}
-    for n in $(seq 1 $ntiles); do
-      $NLN ${OROFIX}/${CASE}_oro_data.tile${n}.nc $DATA/INPUT/oro_data.tile${n}.nc
-    done
-  fi
+  OROFIX=${OROFIX:-"${FIX_DIR}/orog/${CASE}.mx${OCNRES}_frac"}
+  FIX_SFC=${FIX_SFC:-"${OROFIX}/fix_sfc"}
+  for n in $(seq 1 $ntiles); do
+    $NLN ${OROFIX}/oro_${CASE}.mx${OCNRES}.tile${n}.nc $DATA/INPUT/oro_data.tile${n}.nc
+    $NLN ${OROFIX}/${CASE}_grid.tile${n}.nc     $DATA/INPUT/${CASE}_grid.tile${n}.nc
+  done
 
   export CCPP_SUITE=${CCPP_SUITE:-"FV3_GFS_v16"}
   _suite_file=$HOMEgfs/sorc/ufs_model.fd/FV3/ccpp/suites/suite_${CCPP_SUITE}.xml


### PR DESCRIPTION
**Description**

The new fracoro data should be used for all new UFS applications no matter if it uses frac_grid or not. 

Most problems in Issue[#863](https://github.com/NOAA-EMC/global-workflow/issues/863) have been resolved. However, one problem remains, e.g., the latest fix, mask and oro datasets (fracoro) created by Shan/Mike/Helin should work for both fractional and non-fractional grid. 

Related to the changes in UFS_UTILS. A PR[#714](https://github.com/ufs-community/UFS_UTILS/pull/741) in UFS_UTILS has been created. 

Fixes #863 

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

The Forecast-only tests were successful on Orion.   The tests are: Atmosphere-only C96 for FRAC_GRID on and off, respectively; Coupled c384 for GRAC_GRID on and off, respectively. However, the test for GLDAS is not done.

- [ ] Clone and Build tests on WCOSS Dell P3
- [ ] Cycled test on Orion
- [ ] Forecast-only test on Hera
  
**Checklist**
This PR requires an upstream UFS_UTILS PR[#741](https://github.com/ufs-community/UFS_UTILS/pull/741). 
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
