### PR TITLE
Update archive job memory request value for R&Ds

### DIFF
--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -605,7 +605,10 @@ elif [[ ${step} = "arch" || ${step} = "earc" || ${step} = "getic" ]]; then
     eval "export npe_${step}=1"
     eval "export npe_node_${step}=1"
     eval "export nth_${step}=1"
-    eval "export memory_${step}=50GB"
+    eval "export memory_${step}=2048M"
+    if [[ "${machine}" = "WCOSS2" ]]; then
+      eval "export memory_${step}=50GB"
+    fi
 
 elif [ ${step} = "coupled_ic" ]; then
 


### PR DESCRIPTION
**Description**

This PR reverts memory request back to 2048M on R&Ds. Keeps 50GB setting for WCOSS2.

Resolves #1144

**Type of change**

Adjustment to resolve over-request for archive job memory on R&Ds.

**How Has This Been Tested?**

- [x] Clone and build tests on Hera and Orion
- [x] Cycled tests on Hera and Orion
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
