### PR TITLE
Fix checking for restart files

### DIFF
--- a/ush/forecast_det.sh
+++ b/ush/forecast_det.sh
@@ -40,7 +40,7 @@ FV3_GFS_det(){
   #-------------------------------------------------------
   # determine if restart IC exists to continue from a previous forecast
   RERUN="NO"
-  filecount=$(find "${RSTDIR_ATM}" -type f | wc -l)
+  filecount=$(find "${RSTDIR_ATM:-/dev/null}" -type f | wc -l)
   if [ ${CDUMP} = "gfs" -a ${rst_invt1} -gt 0 -a ${FHMAX} -gt ${rst_invt1} -a ${filecount} -gt 10 ]; then
     reverse=$(echo "${restart_interval[@]} " | tac -s ' ')
     for xfh in ${reverse} ; do

--- a/ush/forecast_det.sh
+++ b/ush/forecast_det.sh
@@ -40,7 +40,7 @@ FV3_GFS_det(){
   #-------------------------------------------------------
   # determine if restart IC exists to continue from a previous forecast
   RERUN="NO"
-  [[ ${CDUMP} = "gfs" ]] && filecount=$(find "${RSTDIR_ATM}" -type f | wc -l)
+  filecount=$(find "${RSTDIR_ATM}" -type f | wc -l)
   if [ ${CDUMP} = "gfs" -a ${rst_invt1} -gt 0 -a ${FHMAX} -gt ${rst_invt1} -a ${filecount} -gt 10 ]; then
     reverse=$(echo "${restart_interval[@]} " | tac -s ' ')
     for xfh in ${reverse} ; do


### PR DESCRIPTION
**Description**
Undoes the portion of PR #1179 that caused a new bug while attempting to fix #1140, without removing the linter fixes. Instead `/dev/null` is 'searched' if `${RSTDIR_ATM}` is not defined. That situation will always result in zero files found, ensuring a rerun is not triggered.

Fixes #1140 
Fixes #1185
Moots #1190 

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Cycled with early EnKF on Orion 
- [x] Full coupled on Orion
- [x] Forecast-only on Orion
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass with my changes
