### PR TITLE
Fixed 'DEBUG' option in build_ufs.sh

### DIFF
--- a/sorc/build_ufs.sh
+++ b/sorc/build_ufs.sh
@@ -13,7 +13,7 @@ source "${cwd}/ufs_model.fd/tests/module-setup.sh"
 
 while getopts ":da:v" option; do
   case "${option}" in
-    d) BUILD_TYPE="Debug";;
+    d) BUILD_TYPE="DEBUG";;
     a) APP="${OPTARG}" ;;
     v) export BUILD_VERBOSE="YES";;
     :)


### PR DESCRIPTION
**Description**
When compiling the ufs_model with sorc/build_ufs.sh and the "-d" option, the model should be compiled with "--DEBUG=ON".   Line 16 of the code assigns "BUILD_TYPE" to "Debug" (mixed case) when option "-d" passed in, however, the logic test on line 31 tests for BUILD_TYPE = "DEBUG" (all caps), so the debug mode can never be invoked.

Fixes Issue [#1187](https://github.com/NOAA-EMC/global-workflow/issues/1187) 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
I tested the change to the script on Hera.  Code now compiles in DEBUG mode using "-d" option.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
