### PR TITLE
Initialize variable filecount in forecast_det.sh

### DIFF
--- a/ush/forecast_det.sh
+++ b/ush/forecast_det.sh
@@ -40,6 +40,7 @@ FV3_GFS_det(){
   #-------------------------------------------------------
   # determine if restart IC exists to continue from a previous forecast
   RERUN="NO"
+  filecount=0
   [[ ${CDUMP} = "gfs" ]] && filecount=$(find "${RSTDIR_ATM}" -type f | wc -l)
   if [ ${CDUMP} = "gfs" -a ${rst_invt1} -gt 0 -a ${FHMAX} -gt ${rst_invt1} -a ${filecount} -gt 10 ]; then
     reverse=$(echo "${restart_interval[@]} " | tac -s ' ')


### PR DESCRIPTION
Provide a fix to initialize variable filecount in forecast_det.sh. 
Fix issue #1140 

**Description**
The filecount in script forecast_det.sh need to be initialized. 

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [X] Cycled test on WCOSS
- [X] Forecast-only test on Hera
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
