### PR TITLE
Feature/soca remove cdate

### DIFF
--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_POST
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_POST
@@ -5,7 +5,7 @@ source "${HOMEgfs}/ush/preamble.sh"
 ##############################################
 # make temp directory
 ##############################################
-export DATA=${DATA:-${DATAROOT}/ocnanal_${PDY}${cyc}} 
+export DATA=${DATA:-${DATAROOT}/${RUN}ocnanal_${cyc}} 
 mkdir -p "${DATA}"
 cd "${DATA}" || (echo "${DATA} does not exist. ABORT!"; exit 1)
 

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_POST
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_POST
@@ -5,7 +5,7 @@ source "${HOMEgfs}/ush/preamble.sh"
 ##############################################
 # make temp directory
 ##############################################
-export DATA=${DATA:-${DATAROOT}/ocnanal_${CDATE}} # TODO (G): Switch to {cyc} when the downstream code is ready
+export DATA=${DATA:-${DATAROOT}/ocnanal_${PDY}${cyc}} 
 mkdir -p "${DATA}"
 cd "${DATA}" || (echo "${DATA} does not exist. ABORT!"; exit 1)
 

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
@@ -5,7 +5,7 @@ source "${HOMEgfs}/ush/preamble.sh"
 ##############################################
 # make temp directory
 ##############################################
-export DATA=${DATA:-${DATAROOT}/ocnanal_${CDATE}} # TODO (G): Switch to {cyc} when the downstream code is ready
+export DATA=${DATA:-${DATAROOT}/ocnanal_${PDY}${cyc}} 
 rm -rf "${DATA}"  # Ensure starting with a clean DATA
 mkdir -p "${DATA}"
 cd "${DATA}" || (echo "${DATA} does not exist. ABORT!"; exit 1)
@@ -50,7 +50,6 @@ status=$?
 ##############################################
 # Set variables used in the script
 ##############################################
-export CDATE=${CDATE:-${PDY}${cyc}}
 export CDUMP=${CDUMP:-${RUN:-"gfs"}}
 export COMPONENT="ocean"
 

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
@@ -5,7 +5,7 @@ source "${HOMEgfs}/ush/preamble.sh"
 ##############################################
 # make temp directory
 ##############################################
-export DATA=${DATA:-${DATAROOT}/ocnanal_${PDY}${cyc}} 
+export DATA=${DATA:-${DATAROOT}/${RUN}ocnanal_${cyc}} 
 rm -rf "${DATA}"  # Ensure starting with a clean DATA
 mkdir -p "${DATA}"
 cd "${DATA}" || (echo "${DATA} does not exist. ABORT!"; exit 1)

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_RUN
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_RUN
@@ -6,7 +6,7 @@ source "${HOMEgfs}/ush/preamble.sh"
 ##############################################
 # make temp directory
 ##############################################
-export DATA=${DATA:-${DATAROOT}/ocnanal_${CDATE}} # TODO (G): Switch to {cyc} when the downstream code is ready
+export DATA=${DATA:-${DATAROOT}/ocnanal_${PDY}${cyc}} # TODO (G): Switch to {cyc} when the downstream code is ready
 mkdir -p "${DATA}"
 cd "${DATA}" || (echo "${DATA} does not exist. ABORT!"; exit 1)
 

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_RUN
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_RUN
@@ -6,7 +6,7 @@ source "${HOMEgfs}/ush/preamble.sh"
 ##############################################
 # make temp directory
 ##############################################
-export DATA=${DATA:-${DATAROOT}/ocnanal_${PDY}${cyc}} # TODO (G): Switch to {cyc} when the downstream code is ready
+export DATA=${DATA:-${DATAROOT}/${RUN}ocnanal_${cyc}}
 mkdir -p "${DATA}"
 cd "${DATA}" || (echo "${DATA} does not exist. ABORT!"; exit 1)
 


### PR DESCRIPTION
**Description**

References to CDATE as exported variable replaced with `${PDY}${cyc}` in soca 

Files changed:

jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_POST
jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_RUN

Addresses GDASApp issue https://github.com/NOAA-EMC/GDASApp/issues/237

This will break GDASApp soca/global-workflow tests until GDASApp PR https://github.com/NOAA-EMC/GDASApp/pull/252 with (had to look this word up) concomitant changes is merged.

**Type of change**

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested?**

Tested with soca ctests on Orion 
  
**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
