### PR TITLE
Enable staging ics for cycled experiments.

### DIFF
--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -60,23 +60,41 @@ def fill_COMROT_cycled(host, inputs):
 
     if inputs.icsdir is not None:
         # Link ensemble member initial conditions
-        enkfdir = f'enkf{inputs.cdump}.{idatestr[:8]}/{idatestr[8:]}'
-        makedirs_if_missing(os.path.join(comrot, enkfdir))
-        for ii in range(1, inputs.nens + 1):
-            makedirs_if_missing(os.path.join(comrot, enkfdir, f'mem{ii:03d}'))
-            os.symlink(os.path.join(inputs.icsdir, idatestr, f'C{inputs.resens}', f'mem{ii:03d}', 'RESTART'),
-                       os.path.join(comrot, enkfdir, f'mem{ii:03d}', 'RESTART'))
+        if inputs.nens > 0:
+            enkfdir = f'enkf{inputs.cdump}.{idatestr[:8]}/{idatestr[8:]}'
+            makedirs_if_missing(os.path.join(comrot, enkfdir))
+
+            # Link atmospheric files (ocean, ice, coming TBD ...)
+            for ii in range(1, inputs.nens + 1):
+                memdir = f'atmos/mem{ii:03d}'
+                dst_dir = os.path.join(comrot, enkfdir, memdir, 'INPUT')
+                src_dir = os.path.join(inputs.icsdir, enkfdir, memdir, 'INPUT')
+                makedirs_if_missing(dst_dir)
+                files = os.listdir(src_dir)
+                for fname in files:
+                    os.symlink(os.path.join(src_dir, fname),
+                               os.path.join(dst_dir, fname))
 
         # Link deterministic initial conditions
         detdir = f'{inputs.cdump}.{idatestr[:8]}/{idatestr[8:]}'
         makedirs_if_missing(os.path.join(comrot, detdir))
-        os.symlink(os.path.join(inputs.icsdir, idatestr, f'C{inputs.resdet}', 'control', 'RESTART'),
-                   os.path.join(comrot, detdir, 'RESTART'))
+
+        # Link atmospheric files (ocean, ice, TBD ...)
+        dst_dir = os.path.join(comrot, detdir, 'atmos/INPUT')
+        src_dir = os.path.join(inputs.icsdir, detdir, 'atmos/INPUT')
+        makedirs_if_missing(dst_dir)
+        files = os.listdir(src_dir)
+        for fname in files:
+            os.symlink(os.path.join(src_dir, fname),
+                       os.path.join(dst_dir, fname))
 
         # Link bias correction and radiance diagnostics files
-        for fname in ['abias', 'abias_pc', 'abias_air', 'radstat']:
-            os.symlink(os.path.join(inputs.icsdir, idatestr, f'{inputs.cdump}.t{idatestr[8:]}z.{fname}'),
-                       os.path.join(comrot, detdir, f'{inputs.cdump}.t{idatestr[8:]}z.{fname}'))
+        src_dir = os.path.join(inputs.icsdir, detdir, 'atmos')
+        dst_dir = os.path.join(comrot, detdir, 'atmos')
+        for ftype in ['abias', 'abias_pc', 'abias_air', 'radstat']:
+            fname = f'{inputs.cdump}.t{idatestr[8:]}z.{ftype}'
+            os.symlink(os.path.join(src_dir, f'{fname}'),
+                       os.path.join(dst_dir, f'{fname}'))
 
     return
 
@@ -85,6 +103,7 @@ def fill_COMROT_forecasts(host, inputs):
     """
     Implementation of 'fill_COMROT' for forecast-only mode
     """
+    print('forecast-only mode treats ICs differently and cannot be staged here')
     return
 
 


### PR DESCRIPTION
**Description**
This PR allows users to fill the ROTDIR for cycled initial conditions if the user provides the path to initial conditions.
The initial conditions need to be stored in the same directory structure they are in ROTDIR.

To use, simply add the `--icsdir /pathto/my/staged/ics` to `setup_expt.py cycled`.

The forecast-only mode uses `--icsdir` differently and one cannot use this functionality unless the jobs `coupled_ic.sh` and `getic.sh` are consolidated.  Work may also be needed in the forecast script where initial conditions are copied from ICSDIR directly.

**Type of change**

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
`setup_expt.py` was executed on Orion and the resulting experiment directory and ROTDIR were verified.
An example for Orion as executed is shown below:

```
./setup_expt.py cycled --pslot pyfcst02 --resdet 96 --expdir $stmp2/gwWork/EXPDIR --comrot $stmp2/gwWork/ROTDIR --idate 2021122018 --edate 2021122200 --nens 0 --gfs_cyc 1 --app ATM --icsdir /work2/noaa/stmp/rmahajan/work/ICSDIR/C96C48/half
```
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
