### PR TITLE
Fix post sounding job

### DIFF
--- a/env/HERA.env
+++ b/env/HERA.env
@@ -270,6 +270,8 @@ elif [[ "${step}" = "init" ]]; then
 
 elif [[ "${step}" = "postsnd" ]]; then
 
+    export CFP_MP="YES"
+
     nth_max=$((npe_node_max / npe_node_postsnd))
 
     export NTHREADS_POSTSND=${nth_postsnd:-1}

--- a/env/HERA.env
+++ b/env/HERA.env
@@ -278,7 +278,7 @@ elif [[ "${step}" = "postsnd" ]]; then
 
     export NTHREADS_POSTSNDCFP=${nth_postsndcfp:-1}
     [[ ${NTHREADS_POSTSNDCFP} -gt ${nth_max} ]] && export NTHREADS_POSTSNDCFP=${nth_max}
-    export APRUN_POSTSNDCFP="${launcher} -n ${npe_postsnd} ${mpmd_opt}"
+    export APRUN_POSTSNDCFP="${launcher} -n ${npe_postsndcfp} ${mpmd_opt}"
 
 elif [[ "${step}" = "awips" ]]; then
 

--- a/env/ORION.env
+++ b/env/ORION.env
@@ -276,7 +276,7 @@ elif [[ "${step}" = "postsnd" ]]; then
 
     export NTHREADS_POSTSNDCFP=${nth_postsndcfp:-1}
     [[ ${NTHREADS_POSTSNDCFP} -gt ${nth_max} ]] && export NTHREADS_POSTSNDCFP=${nth_max}
-    export APRUN_POSTSNDCFP="${launcher} -n ${npe_postsnd} ${mpmd_opt}"
+    export APRUN_POSTSNDCFP="${launcher} -n ${npe_postsndcfp} ${mpmd_opt}"
 
 elif [[ "${step}" = "awips" ]]; then
 

--- a/env/ORION.env
+++ b/env/ORION.env
@@ -268,6 +268,8 @@ elif [[ "${step}" = "init" ]]; then
 
 elif [[ "${step}" = "postsnd" ]]; then
 
+    export CFP_MP="YES"
+
     nth_max=$((npe_node_max / npe_node_postsnd))
 
     export NTHREADS_POSTSND=${nth_postsnd:-1}

--- a/env/S4.env
+++ b/env/S4.env
@@ -270,6 +270,8 @@ elif [[ ${step} = "init" ]]; then
 
 elif [[ ${step} = "postsnd" ]]; then
 
+    export CFP_MP="YES"
+
     npe_node_postsnd=${npe_node_postsnd:-${npe_node_max}}
     nth_max=$((npe_node_max / npe_node_postsnd))
 

--- a/scripts/exgfs_atmos_postsnd.sh
+++ b/scripts/exgfs_atmos_postsnd.sh
@@ -142,7 +142,11 @@ for (( m = 1; m <10 ; m++ )); do
     echo "sh ${USHbufrsnd}/gfs_sndp.sh ${m} " >> poe_col
 done
 
-nl -n ln -v 0 poe_col > cmdfile
+if [[ ${CFP_MP:-"NO"} == "YES" ]]; then
+    nl -n ln -v 0 poe_col > cmdfile
+else
+    mv poe_col cmdfile
+fi
 
 cat cmdfile
 chmod +x cmdfile

--- a/scripts/exgfs_atmos_postsnd.sh
+++ b/scripts/exgfs_atmos_postsnd.sh
@@ -137,34 +137,19 @@ fi
 # Create Regional Collectives of BUFR data and 
 # add appropriate WMO Headers.
 ########################################
-collect=' 1 2 3 4 5 6 7 8 9'
-if [ $machine == "HERA" -o  $machine == "JET" ]; then
-for m in ${collect}
-do
-sh $USHbufrsnd/gfs_sndp.sh $m
-done
-
-################################################
-# Convert the bufr soundings into GEMPAK files
-################################################
-sh $USHbufrsnd/gfs_bfr2gpk.sh
-
-else
 rm -rf poe_col
-for m in ${collect}
-do
-echo "sh $USHbufrsnd/gfs_sndp.sh $m " >> poe_col
+for (( m = 1; m <10 ; m++ )); do
+    echo "sh ${USHbufrsnd}/gfs_sndp.sh ${m} " >> poe_col
 done
 
-mv poe_col cmdfile
+nl -n ln -v 0 poe_col > cmdfile
 
 cat cmdfile
 chmod +x cmdfile
 
 ${APRUN_POSTSNDCFP} cmdfile
 
-sh $USHbufrsnd/gfs_bfr2gpk.sh
-fi
+sh "${USHbufrsnd}/gfs_bfr2gpk.sh"
 
 
 ############## END OF SCRIPT #######################

--- a/ush/gfs_bufr.sh
+++ b/ush/gfs_bufr.sh
@@ -50,13 +50,12 @@ cat << EOF > gfsparm
 /
 EOF
 
-hh=${FSTART}
-while (( hh <= FEND )); do
-  hh2=$(printf %02i ${hh})
-  hh3=$(printf %03i ${hh})
+for (( hr = 10#${FSTART}; hr <= 10#${FEND}; hr = hr + 10#${FINT} )); do
+   hh2=$(printf %02i "${hr}")
+   hh3=$(printf %03i "${hr}")
 
-#---------------------------------------------------------
-# Make sure all files are available:
+   #---------------------------------------------------------
+   # Make sure all files are available:
    ic=0
    while (( ic < 1000 )); do
       if [ ! -f "${COMIN}/${RUN}.${cycle}.logf${hh3}.${logfm}" ]; then
@@ -71,11 +70,9 @@ while (( hh <= FEND )); do
          exit 2
       fi
    done
-#------------------------------------------------------------------
+   #------------------------------------------------------------------
    ln -sf "${COMIN}/${RUN}.${cycle}.atmf${hh3}.${atmfm}" "sigf${hh2}" 
    ln -sf "${COMIN}/${RUN}.${cycle}.sfcf${hh3}.${atmfm}" "flxf${hh2}"
-
-   hh=$((hh + FINT))
 done
 
 #  define input BUFR table file.


### PR DESCRIPTION
**Description**
A few minor errors were blocking the sounding job from completing successfully:
- CFP APRUN command was using incorrect number of PEs
- Updates were needed to run on Orion. Removed the machine-specific code for Hera and Jet so it runs the same on all machines, while refactoring it to use C-style loop.
- Bash base errors (see also #1195), which are now corrected, while refactoring to use C-style loop.

This is part of a package of PRs that were tested together as part of a j-job refactor.

Refs #1195
Fixes #1211

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Cycled test on Orion
- [x] Cycled test on Hera
- [x] Cycled test on WCOSS2

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
