### PR TITLE
Use correct resources for GFS gempak

### DIFF
--- a/env/HERA.env
+++ b/env/HERA.env
@@ -293,7 +293,12 @@ elif [[ "${step}" = "awips" ]]; then
 elif [[ "${step}" = "gempak" ]]; then
 
     export CFP_MP="YES"
-    
+
+    if [[ ${CDUMP} == "gfs" ]]; then
+        npe_gempak=${npe_gempak_gfs}
+        npe_node_gempak=${npe_node_gempak_gfs}
+    fi
+
     nth_max=$((npe_node_max / npe_node_gempak))
 
     export NTHREADS_GEMPAK=${nth_gempak:-1}

--- a/env/ORION.env
+++ b/env/ORION.env
@@ -291,6 +291,11 @@ elif [[ "${step}" = "awips" ]]; then
 elif [[ "${step}" = "gempak" ]]; then
 
     export CFP_MP="YES"
+
+    if [[ ${CDUMP} == "gfs" ]]; then
+        npe_gempak=${npe_gempak_gfs}
+        npe_node_gempak=${npe_node_gempak_gfs}
+    fi
     
     nth_max=$((npe_node_max / npe_node_gempak))
 

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -299,6 +299,11 @@ elif [[ "${step}" = "awips" ]]; then
 
 elif [[ "${step}" = "gempak" ]]; then
 
+    if [[ ${CDUMP} == "gfs" ]]; then
+        npe_gempak=${npe_gempak_gfs}
+        npe_node_gempak=${npe_node_gempak_gfs}
+    fi
+
     nth_max=$((npe_node_max / npe_node_gempak))
 
     export NTHREADS_GEMPAK=${nth_gempak:-1}


### PR DESCRIPTION
**Description**
The GFS gempak job was using the GDAS settings instead of switching to the GFS settings for `npe` and `npe_node`.

This is part of a package of PRs that were tested together as part of a j-job refactor.

Fixes: #1213

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Cycled test on Orion
- [x] Cycled test on Hera
- [x] Cycled test on WCOSS2
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

** Dependencies **
This is part of a package of PRs that were tested together as part of a j-job refactor:
#1212 
