### PR TITLE
Increase wallclock for diag jobs

### DIFF
--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -343,7 +343,7 @@ elif [ ${step} = "analcalc" ]; then
 
 elif [ ${step} = "analdiag" ]; then
 
-    export wtime_analdiag="00:10:00"
+    export wtime_analdiag="00:15:00"
     export npe_analdiag=96             # Should be at least twice npe_ediag
     export nth_analdiag=1
     export npe_node_analdiag=$(echo "${npe_node_max} / ${nth_analdiag}" | bc)
@@ -673,7 +673,7 @@ elif [[ ${step} = "eobs" || ${step} = "eomg" ]]; then
 
 elif [ ${step} = "ediag" ]; then
 
-    export wtime_ediag="00:06:00"
+    export wtime_ediag="00:15:00"
     export npe_ediag=48
     export nth_ediag=1
     export npe_node_ediag=$(echo "${npe_node_max} / ${nth_ediag}" | bc)


### PR DESCRIPTION
**Description**
Diag jobs were failing due to insufficient wall clock, so the wall clock is increased until a more complete review of the resources can be completed.

This is part of a package of PRs that were tested together as part of a j-job refactor.
    
Refs #1215

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Cycled test on Orion
- [x] Cycled test on Hera
- [x] Cycled test on WCOSS

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
