### PR TITLE
Abstract common j-job tasks

### DIFF
--- a/jobs/JGDAS_ATMOS_ANALYSIS_DIAG
+++ b/jobs/JGDAS_ATMOS_ANALYSIS_DIAG
@@ -1,49 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base anal analdiag"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env anal
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base anal analdiag
 
 
 ##############################################

--- a/jobs/JGDAS_ATMOS_CHGRES_FORENKF
+++ b/jobs/JGDAS_ATMOS_CHGRES_FORENKF
@@ -1,49 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base anal echgres"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env anal
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base anal echgres
 
 
 ##############################################

--- a/jobs/JGDAS_ATMOS_GEMPAK
+++ b/jobs/JGDAS_ATMOS_GEMPAK
@@ -1,45 +1,12 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base gempak
 
-##########################################################
-# make temp directory
-##########################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-###########################################
-# Run setpdy and initialize PDY variables
-###########################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base gempak"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-###############################################################
-. ${BASE_ENV}/${machine}.env gempak
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+# TODO (#1219) This j-job is not part of the rocoto suite
 
 ################################
 # Set up the HOME directory
-################################
-export HOMEgfs=${HOMEgfs:-${PACKAGEROOT}/gfs.${gfs_ver}}  # TODO: remove these as they are already defined in config.base
 export EXECgfs=${EXECgfs:-${HOMEgfs}/exec}
 export PARMgfs=${PARMgfs:-${HOMEgfs}/parm}
 export PARMwmo=${PARMwmo:-${HOMEgfs}/parm/wmo}
@@ -67,8 +34,6 @@ export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 ###################################
 # Specify NET and RUN Name and model
 ####################################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gdas}
 export model=${model:-gdas}
 export COMPONENT="atmos"
 
@@ -83,7 +48,7 @@ if [ ${SENDCOM} = YES ] ; then
 fi
 
 
-# TODO: These actions belong in an ex-script not a j-job
+# TODO: These actions belong in an ex-script not a j-job (#1219)
 if [ -f ${DATA}/poescript ]; then
    rm ${DATA}/poescript
 fi

--- a/jobs/JGDAS_ATMOS_GEMPAK_META_NCDC
+++ b/jobs/JGDAS_ATMOS_GEMPAK_META_NCDC
@@ -1,28 +1,13 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/preamble.sh"
-
 ############################################
 # GDAS GEMPAK META NCDC PRODUCT GENERATION
 ############################################
 
-##########################################################
-# make temp directory
-##########################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
+# TODO (#1222) This j-job is not part of the rocoto
 
-###########################################
-# Run setpdy and initialize PDY variables
-###########################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
+source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base gempak
 
 ################################
 # Set up the HOME directory
@@ -46,8 +31,6 @@ cp ${FIXgempak}/datatype.tbl datatype.tbl
 ###################################
 # Specify NET and RUN Name and model
 ####################################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gdas}
 export COMPONENT="atmos"
 export MODEL=GDAS
 export GRID_NAME=gdas

--- a/jobs/JGDAS_ATMOS_GLDAS
+++ b/jobs/JGDAS_ATMOS_GLDAS
@@ -1,42 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs:?}/ush/preamble.sh"
-
-##############################################
-# Obtain unique process id (pid) and make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p "${DATA}"
-cd "${DATA}" || exit 1
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base gldas"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit "${status}"
-done
-
+source "${HOMEgfs}/ush/jjob_header.sh" base gldas
 
 if [[ "${cyc:?}" -ne "${gldas_cyc:?}" ]]; then
     echo "GLDAS only runs for ${gldas_cyc} cycle; Skip GLDAS step for cycle ${cyc}"
@@ -50,15 +15,6 @@ if [[ "${CDATE}" -le "$(${NDATE:?} +"${xtime}" "${SDATE:?}")" ]]; then
     echo "starting from ${SDATE}. This gldas cycle is skipped"
     exit 0
 fi
-
-##########################################
-# Source machine runtime environment
-##########################################
-# shellcheck disable=SC1090-SC1091
-. "${HOMEgfs}/env/${machine:?}.env" gldas
-# shellcheck disable=
-status=$?
-[[ ${status} -ne 0 ]] && exit "${status}"
 
 
 ##############################################

--- a/jobs/JGDAS_ATMOS_VERFOZN
+++ b/jobs/JGDAS_ATMOS_VERFOZN
@@ -4,36 +4,12 @@
 # Set up environment for GDAS Ozone Monitor job
 #############################################################
 source "${HOMEgfs}/ush/preamble.sh"
-
-###########################################################
-# make temp directories
-###########################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-####################################
-# Determine Job Output Name on System
-####################################
-export pid=$$
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
+source "${HOMEgfs}/ush/jjob_header.sh" base vrfy
 
 
 ###############################
 # Specify NET, RUN, and COMPONENT name
 ##############################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gdas}
 export COMPONENT="atmos"
 
 export OZNMON_SUFFIX=${OZNMON_SUFFIX:-${NET}}

--- a/jobs/JGDAS_ATMOS_VERFRAD
+++ b/jobs/JGDAS_ATMOS_VERFRAD
@@ -4,36 +4,8 @@
 # Set up environment for GDAS Radiance Monitor job
 #############################################################
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base vrfy
 
-###########################################################
-# make temp directories
-###########################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-####################################
-# Determine Job Output Name on System
-####################################
-export pid=$$
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-###############################
-# Specify NET, RUN, and COMPONENT name
-##############################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gdas}
 export COMPONENT="atmos"
 
 export RAD_DATA_IN=${DATA}

--- a/jobs/JGDAS_ATMOS_VMINMON
+++ b/jobs/JGDAS_ATMOS_VMINMON
@@ -4,36 +4,8 @@
 # GDAS Minimization Monitor (MinMon) job
 ###########################################################
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base vrfy
 
-###########################################################
-# make temp directories
-###########################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-####################################
-# Determine Job Output Name on System
-####################################
-export pid=$$
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-###############################
-# Specify NET, RUN, and COMPONENT name
-##############################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gdas}
 export COMPONENT="atmos"
 
 ###########################################################

--- a/jobs/JGDAS_ENKF_ARCHIVE
+++ b/jobs/JGDAS_ENKF_ARCHIVE
@@ -1,49 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# Obtain unique process id (pid) and make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p "${DATA}"
-cd "${DATA}" || (echo "${DATA} does not exist. ABORT!"; exit 1)
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base earc"
-for config in ${configs}; do
-    . "${EXPDIR}/config.${config}"
-    status=$?
-    [[ ${status} -ne 0 ]] && exit "${status}"
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. "${HOMEgfs}/env/${machine}.env" earc
-status=$?
-[[ ${status} -ne 0 ]] && exit "${status}"
+source "${HOMEgfs}/ush/jjob_header.sh" base earc
 
 
 ##############################################

--- a/jobs/JGDAS_ENKF_DIAG
+++ b/jobs/JGDAS_ENKF_DIAG
@@ -1,49 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base anal eobs analdiag ediag"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env eobs
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base anal eobs analdiag ediag
 
 
 ##############################################

--- a/jobs/JGDAS_ENKF_ECEN
+++ b/jobs/JGDAS_ENKF_ECEN
@@ -1,49 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# Obtain unique process id (pid) and make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base ecen"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env ecen
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base ecen
 
 
 ##############################################

--- a/jobs/JGDAS_ENKF_FCST
+++ b/jobs/JGDAS_ENKF_FCST
@@ -1,49 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base fcst efcs"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env efcs
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base fcst efcs
 
 
 ##############################################

--- a/jobs/JGDAS_ENKF_POST
+++ b/jobs/JGDAS_ENKF_POST
@@ -1,49 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base epos"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env epos
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base epos
 
 
 ##############################################

--- a/jobs/JGDAS_ENKF_SELECT_OBS
+++ b/jobs/JGDAS_ENKF_SELECT_OBS
@@ -1,49 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base anal eobs"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env eobs
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base anal eobs
 
 
 ##############################################

--- a/jobs/JGDAS_ENKF_SFC
+++ b/jobs/JGDAS_ENKF_SFC
@@ -1,49 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base esfc"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env esfc
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base esfc
 
 
 ##############################################

--- a/jobs/JGDAS_ENKF_UPDATE
+++ b/jobs/JGDAS_ENKF_UPDATE
@@ -1,49 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base anal eupd"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env eupd
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base anal eupd
 
 
 ##############################################

--- a/jobs/JGDAS_GLOBAL_ATMOS_ANALYSIS_POST
+++ b/jobs/JGDAS_GLOBAL_ATMOS_ANALYSIS_POST
@@ -1,49 +1,7 @@
 #!/bin/bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA} || (echo "${DATA} does not exist. ABORT!"; exit 1)
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base atmanal atmanalpost"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env atmanalpost
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base atmanal atmanalpost
 
 
 ##############################################

--- a/jobs/JGDAS_GLOBAL_ATMOS_ANALYSIS_PREP
+++ b/jobs/JGDAS_GLOBAL_ATMOS_ANALYSIS_PREP
@@ -1,49 +1,7 @@
 #!/bin/bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA} || (echo "${DATA} does not exist. ABORT!"; exit 1)
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base atmanal atmanalprep"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env atmanalprep
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base atmanal atmanalprep
 
 
 ##############################################

--- a/jobs/JGDAS_GLOBAL_ATMOS_ANALYSIS_RUN
+++ b/jobs/JGDAS_GLOBAL_ATMOS_ANALYSIS_RUN
@@ -1,49 +1,7 @@
 #!/bin/bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA} || (echo "${DATA} does not exist. ABORT!"; exit 1)
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base atmanal atmanalrun"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env atmanalrun
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base atmanal atmanalrun
 
 
 ##############################################

--- a/jobs/JGDAS_GLOBAL_ATMOS_ENSANAL_POST
+++ b/jobs/JGDAS_GLOBAL_ATMOS_ENSANAL_POST
@@ -1,49 +1,7 @@
 #!/bin/bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA} || (echo "${DATA} does not exist. ABORT!"; exit 1)
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base atmensanal atmensanalpost"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env atmensanalpost
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base atmensanal atmensanalpost
 
 
 ##############################################

--- a/jobs/JGDAS_GLOBAL_ATMOS_ENSANAL_PREP
+++ b/jobs/JGDAS_GLOBAL_ATMOS_ENSANAL_PREP
@@ -1,49 +1,7 @@
 #!/bin/bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA} || (echo "${DATA} does not exist. ABORT!"; exit 1)
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base atmensanal atmensanalprep"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env atmensanalprep
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base atmensanal atmensanalprep
 
 
 ##############################################

--- a/jobs/JGDAS_GLOBAL_ATMOS_ENSANAL_RUN
+++ b/jobs/JGDAS_GLOBAL_ATMOS_ENSANAL_RUN
@@ -1,49 +1,7 @@
 #!/bin/bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA} || (echo "${DATA} does not exist. ABORT!"; exit 1)
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base atmensanal atmensanalrun"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env atmensanalrun
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base atmensanal atmensanalrun
 
 
 ##############################################

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_POST
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_POST
@@ -1,41 +1,16 @@
 #!/bin/bash
 export STRICT="NO"
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${RUN}ocnanal_${cyc}} 
-mkdir -p "${DATA}"
-cd "${DATA}" || (echo "${DATA} does not exist. ABORT!"; exit 1)
+source "${HOMEgfs}/ush/jjob_header.sh" base ocnanalpost
 
 
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
+###############################################################
+# Run relevant script
+###############################################################
 
 
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
+# TODO (#982)
 
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base ocnanalpost"
-for config in ${configs}; do
-    . "${EXPDIR}/config.${config}"
-    status=$?
-    [[ "${status}" -ne 0 ]] && exit "${status}"
-done
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
@@ -1,50 +1,7 @@
 #!/bin/bash
 export STRICT="NO"
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${RUN}ocnanal_${cyc}} 
-rm -rf "${DATA}"  # Ensure starting with a clean DATA
-mkdir -p "${DATA}"
-cd "${DATA}" || (echo "${DATA} does not exist. ABORT!"; exit 1)
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base ocnanal ocnanalprep"
-for config in ${configs}; do
-    . "${EXPDIR}/config.${config}"
-    status=$?
-    [[ ${status} -ne 0 ]] && exit "${status}"
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. "${HOMEgfs}/env/${machine}.env" ocnanalprep
-status=$?
-[[ ${status} -ne 0 ]] && exit "${status}"
+source "${HOMEgfs}/ush/jjob_header.sh" base ocnanal ocnanalprep
 
 
 ##############################################

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_RUN
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_RUN
@@ -1,50 +1,7 @@
 #!/bin/bash
 export STRICT="NO"
 source "${HOMEgfs}/ush/preamble.sh"
-
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${RUN}ocnanal_${cyc}}
-mkdir -p "${DATA}"
-cd "${DATA}" || (echo "${DATA} does not exist. ABORT!"; exit 1)
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base ocnanal ocnanalrun"
-for config in ${configs}; do
-    . "${EXPDIR}/config.${config}"
-    status=$?
-    [[ ${status} -ne 0 ]] && exit "${status}"
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. "${HOMEgfs}/env/${machine}.env" ocnanalrun
-status=$?
-[[ ${status} -ne 0 ]] && exit "${status}"
+source "${HOMEgfs}/ush/jjob_header.sh" base ocnanal ocnanalrun
 
 
 ##############################################

--- a/jobs/JGFS_ATMOS_AWIPS_20KM_1P0DEG
+++ b/jobs/JGFS_ATMOS_AWIPS_20KM_1P0DEG
@@ -1,30 +1,11 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base awips
+
 
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
 
-###########################################
-# GFS_AWIPS_20KM AWIPS PRODUCT GENERATION
-###########################################
-
-#########################################################
-# obtain unique process id (pid) and make temp directory
-#########################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-######################################
-# Set up the cycle variable
-######################################
-export cycle="t${cyc}z"
-
-###########################################
-# Run setpdy and initialize PDY variables
-###########################################
-setpdy.sh
-. ./PDY
 
 ################################
 # Set up the HOME directory
@@ -40,8 +21,6 @@ export FIXgfs=${FIXgfs:-${HOMEgfs}/fix}
 ###################################
 # Specify NET and RUN Name and model
 ####################################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export model=${model:-gfs}
 export COMPONENT="atmos"
 
@@ -53,6 +32,7 @@ export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${gfs_ver}/${RUN}.${PDY})/${cyc}/
 export COMOUTwmo=${COMOUTwmo:-${COMOUT}/wmo}
 
 export SENDDBN=${SENDDBN:-NO}
+export SENDAWIP=${SENDAWIP:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
 if [ ${SENDCOM} = YES ] ; then

--- a/jobs/JGFS_ATMOS_AWIPS_G2
+++ b/jobs/JGFS_ATMOS_AWIPS_G2
@@ -1,35 +1,17 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/preamble.sh"
-
-export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
-
 ########################################
 # GFS_AWIPS_G2 AWIPS PRODUCT GENERATION
 ########################################
 
-##########################################################
-# obtain unique process id (pid) and make temp directory
-##########################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
+source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base awips
 
-######################################
-# Set up the cycle variable
-######################################
-export cycle="t${cyc}z"
-
-###########################################
-# Run setpdy and initialize PDY variables
-###########################################
-setpdy.sh
-. ./PDY
+export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
 
 ################################
 # Set up the HOME directory
 ################################
-export HOMEgfs=${HOMEgfs:-${PACKAGEROOT}/gfs.${gfs_ver}}
 export USHgfs=${USHgfs:-${HOMEgfs}/ush}
 export EXECgfs=${EXECgfs:-${HOMEgfs}/exec}
 export PARMgfs=${PARMgfs:-${HOMEgfs}/parm}
@@ -41,8 +23,6 @@ export UTILgfs=${UTILgfs:-${HOMEgfs}/util}
 ###################################
 # Specify NET and RUN Name and model
 ####################################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export model=${model:-gfs}
 export COMPONENT="atmos"
 
@@ -54,6 +34,7 @@ export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${gfs_ver}/${RUN}.${PDY})/${cyc}/
 export COMOUTwmo=${COMOUTwmo:-${COMOUT}/wmo}
 
 export SENDDBN=${SENDDBN:-NO}
+export SENDAWIP=${SENDAWIP:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
 if [ ${SENDCOM} = YES ] ; then

--- a/jobs/JGFS_ATMOS_CYCLONE_GENESIS
+++ b/jobs/JGFS_ATMOS_CYCLONE_GENESIS
@@ -1,63 +1,13 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base vrfy
 
+
+# TODO (#1220) Determine if this is still needed
 export RUN_ENVIR=${RUN_ENVIR:-"nco"}
 
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base vrfy"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env vrfy
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
-
-
-##############################################
-# Obtain unique process id (pid) and make temp directory
-##############################################
-if [ ${RUN_ENVIR} = "nco" ]; then
-    export DATA=${DATA:-${DATAROOT}/${jobid}}
-else
-    export job="gfs_cyclone_genesis"
-    export DATA="${DATAROOT}/${job}$$"
-    [[ -d ${DATA} ]] && rm -rf ${DATA}
-fi
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-####################################
-# Specify NET and RUN Name and model
-####################################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export COMPONENT="atmos"
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
 
 ##############################################
 # Set variables used in the exglobal script

--- a/jobs/JGFS_ATMOS_CYCLONE_TRACKER
+++ b/jobs/JGFS_ATMOS_CYCLONE_TRACKER
@@ -1,64 +1,13 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base vrfy
 
+
+# TODO (#1220) Determine if this is still needed
 export RUN_ENVIR=${RUN_ENVIR:-"nco"}
 
-#############################
-# Source relevant config files
-#############################
-EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base vrfy"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env vrfy
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
-
-
-##############################################
-# Obtain unique process id (pid) and make temp directory
-##############################################
-if [ ${RUN_ENVIR} = "nco" ]; then
-    export DATA=${DATA:-${DATAROOT}/${jobid}}
-else
-    export job="gfs_cyclone_tracker"
-    export DATA="${DATAROOT}/${job}$$"
-    [[ -d ${DATA} ]] && rm -rf ${DATA}
-fi
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-####################################
-# Specify NET and RUN Name and model
-####################################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export COMPONENT="atmos"
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
 
 
 ##############################################

--- a/jobs/JGFS_ATMOS_FBWIND
+++ b/jobs/JGFS_ATMOS_FBWIND
@@ -1,33 +1,16 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/preamble.sh"
+# TODO (#1221) This job is not part of the rocoto suite
 
 ############################################
 # GFS FBWIND PRODUCT GENERATION
 ############################################
-
-###########################################################
-# obtain unique process id (pid) and make temp directory
-###########################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-######################################
-# Set up the cycle variable
-######################################
-export cycle="t${cyc}z"
-
-###########################################
-# Run setpdy and initialize PDY variables
-###########################################
-setpdy.sh
-. ./PDY
+source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base 
 
 ################################
 # Set up the HOME directory
 ################################
-export HOMEgfs=${HOMEgfs:-${PACKAGEROOT}/gfs.${gfs_ver}}
 export USHgfs=${USHgfs:-${HOMEgfs}/ush}
 export EXECgfs=${EXECgfs:-${HOMEgfs}/exec}
 export PARMgfs=${PARMgfs:-${HOMEgfs}/parm}
@@ -39,8 +22,6 @@ export UTILgfs=${UTILgfs:-${HOMEgfs}/util}
 ###################################
 # Specify NET and RUN Name and model
 ####################################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export model=${model:-gfs}
 export COMPONENT="atmos"
 
@@ -57,8 +38,6 @@ export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 if [ ${SENDCOM} = YES ] ; then
   mkdir -m 775 -p ${COMOUT} ${COMOUTwmo}
 fi
-
-export pgmout=OUTPUT.$$
 
 
 ########################################################

--- a/jobs/JGFS_ATMOS_FSU_GENESIS
+++ b/jobs/JGFS_ATMOS_FSU_GENESIS
@@ -1,65 +1,11 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base vrfy
 
 export RUN_ENVIR=${RUN_ENVIR:-"nco"}
 
-#############################
-# Source relevant config files
-#############################
-EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base vrfy"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-##exit
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env vrfy
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
-
-
-##############################################
-# Obtain unique process id (pid) and make temp directory
-##############################################
-if [ ${RUN_ENVIR} = "nco" ]; then
-    export DATA=${DATA:-${DATAROOT}/${jobid}}
-else
-    export job="gfs_fsu_genesis"
-    export DATA="${DATAROOT}/${job}$$"
-    [[ -d ${DATA} ]] && rm -rf ${DATA}
-fi
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-####################################
-# Specify NET and RUN Name and model
-####################################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export COMPONENT="atmos"
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
 
 
 ##############################################

--- a/jobs/JGFS_ATMOS_GEMPAK
+++ b/jobs/JGFS_ATMOS_GEMPAK
@@ -1,45 +1,12 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base gempak
 
-##########################################################
-# make temp directory
-##########################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-###########################################
-# Run setpdy and initialize PDY variables
-###########################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-export pgmout=OUTPUT.$$
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base gempak"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env gempak
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
 
 ################################
 # Set up the HOME directory
 ################################
-export HOMEgfs=${HOMEgfs:-${PACKAGEROOT}/gfs.${gfs_ver}}  # TODO: These should be removed as they are defined in config.base
 export EXECgfs=${EXECgfs:-${HOMEgfs}/exec}
 export PARMgfs=${PARMgfs:-${HOMEgfs}/parm}
 export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
@@ -63,8 +30,6 @@ export DBN_ALERT_TYPE=${DBN_ALERT_TYPE:-GFS_GEMPAK}
 ###################################
 # Specify NET and RUN Name and model
 ####################################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export model=${model:-gfs}
 export COMPONENT="atmos"
 
@@ -149,7 +114,7 @@ chmod 775 ${DATA}/poescript
 export MP_PGMMODEL=mpmd
 export MP_CMDFILE=${DATA}/poescript
 
-ntasks=${NTASKS_GEMPAK:-$(cat ${DATA}/poescript | wc -l)}
+ntasks=$(cat ${DATA}/poescript | wc -l)
 ptile=${PTILE_GEMPAK:-4}
 threads=${NTHREADS_GEMPAK:-1}
 export OMP_NUM_THREADS=${threads}

--- a/jobs/JGFS_ATMOS_GEMPAK_META
+++ b/jobs/JGFS_ATMOS_GEMPAK_META
@@ -1,43 +1,26 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/preamble.sh"
+# TODO (#1222) This job is not part of the rocoto suite
 
 ############################################
 # GFS GEMPAK META PRODUCT GENERATION
 ############################################
+source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base
 
-export LAUNCH_MODE=MPI
 
 ###############################################
 # Set MP variables
 ###############################################
+export LAUNCH_MODE=MPI
 export OMP_NUM_THREADS=1
 export MP_LABELIO=yes
 export MP_PULSE=0
 export MP_DEBUG_NOTIMEOUT=yes
 
-##########################################################
-# obtain unique process id (pid) and make temp directory
-##########################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-######################################
-# Set up the cycle variable
-######################################
-export cycle="t${cyc}z"
-
-###########################################
-# Run setpdy and initialize PDY variables
-###########################################
-setpdy.sh
-. ./PDY
-
 ################################
 # Set up the HOME directory
 ################################
-export HOMEgfs=${HOMEgfs:-${PACKAGEROOT}/gfs.${gfs_ver}}
 export EXECgfs=${EXECgfs:-${HOMEgfs}/exec}
 export PARMgfs=${PARMgfs:-${HOMEgfs}/parm}
 export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
@@ -57,8 +40,6 @@ export fhinc=12
 ###################################
 # Specify NET and RUN Name and model
 ####################################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export model=${model:-gfs}
 export COMPONENT="atmos"
 
@@ -84,8 +65,6 @@ export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 if [ ${SENDCOM} = YES ] ; then
   mkdir -m 775 -p ${COMOUT}
 fi
-
-export pgmout=OUTPUT.$$
 
 
 ########################################################

--- a/jobs/JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF
+++ b/jobs/JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF
@@ -1,29 +1,17 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/preamble.sh"
+# TODO (#1222) This job is not part of the rocoto suite
 
 ############################################
 # GFS GEMPAK NCDC PRODUCT GENERATION
 ############################################
+source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base
 
-##########################################################
-# obtain unique process id (pid) and make temp directory
-##########################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-###########################################
-# Run setpdy and initialize PDY variables
-###########################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
 
 ################################
 # Set up the HOME directory
 ################################
-export HOMEgfs=${HOMEgfs:-${PACKAGEROOT}/gfs.${gfs_ver}}
 export EXECgfs=${EXECgfs:-${HOMEgfs}/exec}
 export PARMgfs=${PARMgfs:-${HOMEgfs}/parm}
 export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
@@ -56,8 +44,6 @@ export fstart=00
 ###################################
 # Specify NET and RUN Name and model
 ####################################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export model=${model:-gfs}
 export COMPONENT="atmos"
 

--- a/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
+++ b/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
@@ -1,33 +1,17 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/preamble.sh"
+# TODO (#1222) This job is not part of the rocoto suite
 
 ############################################
 # GFS_PGRB2_SPEC_GEMPAK PRODUCT GENERATION
 ############################################
+source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base
 
-#########################################################
-# obtain unique process id (pid) and make temp directory
-#########################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-######################################
-# Set up the cycle variable
-######################################
-export cycle="t${cyc}z"
-
-###########################################
-# Run setpdy and initialize PDY variables
-###########################################
-setpdy.sh
-. ./PDY
 
 ################################
 # Set up the HOME directory
 ################################
-export HOMEgfs=${HOMEgfs:-${PACKAGEROOT}/gfs.${gfs_ver}}
 export EXECgfs=${EXECgfs:-${HOMEgfs}/exec}
 export PARMgfs=${PARMgfs:-${HOMEgfs}/parm}
 export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
@@ -41,8 +25,6 @@ export SRCgfs=${SRCgfs:-${HOMEgfs}/scripts}
 ###################################
 # Specify NET and RUN Name and model
 ####################################
-export NET=gfs
-export RUN=gfs
 export COMPONENT="atmos"
 export finc=3
 export model=gfs
@@ -61,6 +43,8 @@ if [ ${SENDCOM} = YES ] ; then
   mkdir -m 775 -p ${COMOUT}
 fi
 
+
+# TODO - Assess what is going on with overwriting $DATA here (#1224)
 
 export DATA_HOLD=${DATA}
 

--- a/jobs/JGFS_ATMOS_PGRB2_SPEC_NPOESS
+++ b/jobs/JGFS_ATMOS_PGRB2_SPEC_NPOESS
@@ -1,35 +1,19 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/preamble.sh"
-
-export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
+# TODO (#1225) This job is not part of the rocoto suite
 
 ############################################
 # GFS PGRB2_SPECIAL_POST PRODUCT GENERATION
 ############################################
+source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base
 
-##########################################################
-# obtain unique process id (pid) and make temp directory
-##########################################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
 
-######################################
-# Set up the cycle variable
-######################################
-export cycle="t${cyc}z"
-
-###########################################
-# Run setpdy and initialize PDY variables
-###########################################
-setpdy.sh
-. ./PDY
 
 ################################
 # Set up the HOME directory
 ################################
-export HOMEgfs=${HOMEgfs:-${PACKAGEROOT}/gfs.${gfs_ver}}
 export USHgfs=${USHgfs:-${HOMEgfs}/ush}
 export EXECgfs=${EXECgfs:-${HOMEgfs}/exec}
 export PARMgfs=${PARMgfs:-${HOMEgfs}/parm}
@@ -41,8 +25,6 @@ export FIXgfs=${FIXgfs:-${HOMEgfs}/fix}
 ###################################
 # Specify NET and RUN Name and model
 ####################################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export model=${model:-gfs}
 export COMPONENT="atmos"
 
@@ -60,8 +42,8 @@ if [ ${SENDCOM} = YES ] ; then
   mkdir -m 775 -p ${COMOUT} ${COMOUTwmo}
 fi
 
-export pgmout=OUTPUT.$$
 
+# TODO - This should be in the ex-script (#1226)
 
 ####################################
 # Specify Forecast Hour Range

--- a/jobs/JGFS_ATMOS_POSTSND
+++ b/jobs/JGFS_ATMOS_POSTSND
@@ -1,48 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base postsnd"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env postsnd
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base postsnd
 
 
 ##############################################

--- a/jobs/JGFS_ATMOS_VMINMON
+++ b/jobs/JGFS_ATMOS_VMINMON
@@ -4,22 +4,13 @@
 # GFS Minimization Monitor (MinMon) job
 ###########################################################
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base vrfy
+
 
 ###############################
 # Specify NET and RUN name
 ##############################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export COMPONENT="atmos"
-
-
-###########################################################
-# obtain unique process id (pid) and make temp directories
-###########################################################
-export pid=$$
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
 
 
 ###########################################################
@@ -32,7 +23,6 @@ export m_job=${m_job:-${MINMON_SUFFIX}_mmDE}
 ##############################################
 # Specify Package Areas
 ##############################################
-export HOMEgfs=${HOMEgfs:-${NWROOT}/gfs.${gfs_ver}}
 export SCRgfs=${SCRgfs:-${HOMEgfs}/scripts}
 export M_FIXgfs=${M_FIXgfs:-${HOMEgfs}/fix/product}
 

--- a/jobs/JGLOBAL_ARCHIVE
+++ b/jobs/JGLOBAL_ARCHIVE
@@ -1,48 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# Obtain unique process id (pid) and make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p "${DATA}"
-cd "${DATA}" || (echo "${DATA} does not exist. ABORT!"; exit 1)
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-#############################################
-# Source relevant config files
-#############################################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base arch"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit "${status}"
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. "${HOMEgfs}/env/${machine}.env" arch
-status=$?
-[[ ${status} -ne 0 ]] && exit "${status}"
+source "${HOMEgfs}/ush/jjob_header.sh" base arch
 
 
 ##############################################

--- a/jobs/JGLOBAL_ATMOS_ANALYSIS
+++ b/jobs/JGLOBAL_ATMOS_ANALYSIS
@@ -1,49 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# Obtain unique process id (pid) and make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base anal"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env anal
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base anal
 
 
 ##############################################

--- a/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
+++ b/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
@@ -1,49 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# Obtain unique process id (pid) and make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base anal analcalc"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env analcalc
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base anal analcalc
 
 
 ##############################################

--- a/jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP
+++ b/jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP
@@ -1,43 +1,9 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base
 
 export RUN_ENVIR=${RUN_ENVIR:-"nco"}
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##############################################
-# Obtain unique process id (pid) and make temp directory
-##############################################
-export pid=${pid:-$$}
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
 
 export SENDDBN=${SENDDBN:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}

--- a/jobs/JGLOBAL_ATMOS_POST
+++ b/jobs/JGLOBAL_ATMOS_POST
@@ -1,49 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p "${DATA}"
-cd "${DATA}" || exit 1
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base post"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    (( status != 0 )) && exit "${status}"
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. "${HOMEgfs}/env/${machine}.env" post
-status=$?
-(( status != 0 )) && exit "${status}"
+source "${HOMEgfs}/ush/jjob_header.sh" base post
 
 
 ####################################

--- a/jobs/JGLOBAL_ATMOS_POST_MANAGER
+++ b/jobs/JGLOBAL_ATMOS_POST_MANAGER
@@ -1,60 +1,14 @@
 #! /usr/bin/env bash
 
+# TODO (#1227) This job is not used in the rocoto suite
+
 source "${HOMEgfs}/ush/preamble.sh"
-
-####################################
-# make temp directories
-####################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-###########################################
-# Run setpdy and initialize PDY variables
-###########################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-####################################
-# Determine Job Output Name on System
-####################################
-export pid=${pid:-$$}
-export jobid="${outid}.o${pid}"
-export pgmout="OUTPUT.${pid}"
-
-
-########################################
-# GFS post manager
-########################################
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base post"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env post
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base post
 
 
 ####################################
 # Specify NET and RUN Name and model
 ####################################
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export COMPONENT="atmos"
 
 

--- a/jobs/JGLOBAL_ATMOS_SFCANL
+++ b/jobs/JGLOBAL_ATMOS_SFCANL
@@ -1,48 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# Obtain unique process id (pid) and make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base sfcanl"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env sfcanl
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+source "${HOMEgfs}/ush/jjob_header.sh" base sfcanl
 
 
 ##############################################

--- a/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
+++ b/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
@@ -1,51 +1,10 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base prep
 
+# TODO (#1220) Evaluate if this is still needed
 export RUN_ENVIR=${RUN_ENVIR:-"nco"}
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base prep"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env prep
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
-
-
-##############################################
-# Obtain unique process id (pid) and make temp directory
-##############################################
-export pid=${pid:-$$}
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
 
 
 ##############################################

--- a/jobs/JGLOBAL_FORECAST
+++ b/jobs/JGLOBAL_FORECAST
@@ -1,51 +1,7 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base fcst"
-[[ ${DO_WAVE:-"NO"} = "YES" ]] && configs+=" wave"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env fcst
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
-
+source "${HOMEgfs}/ush/jjob_header.sh" base fcst
 
 ##############################################
 # Set variables used in the script

--- a/jobs/JGLOBAL_WAVE_GEMPAK
+++ b/jobs/JGLOBAL_WAVE_GEMPAK
@@ -1,35 +1,9 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base wavegempak
 
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export COMPONENT="wave"
-export machine=${machine:-WCOSS2}
 
 # Add default errchk = err_chk
 export errchk=${errchk:-err_chk}
@@ -38,14 +12,11 @@ export errchk=${errchk:-err_chk}
 # Set COM Paths
 export COMIN=${COMIN:-$(compath.py ${envir}/${NET}/${gfs_ver})/${RUN}.${PDY}/${cyc}/${COMPONENT}}
 export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${gfs_ver}/${RUN}.${PDY})/${cyc}/${COMPONENT}/gempak}
-#export pid=$$
-export pgmout="OUTPUT.$$"
 
 export DBN_ALERT_TYPE=GFS_WAVE_GEMPAK
 export SENDCOM=${SENDCOM:-YES}
 export SENDDBN=${SENDDBN:-YES}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
-
 
 if [ ${SENDCOM} = YES ] ; then
   mkdir -m 775 -p ${COMOUT}
@@ -64,6 +35,5 @@ cd ${DATAROOT}
 if [ "${KEEPDATA}" != "YES" ]; then
   rm -rf ${DATA}
 fi
-
 
 exit 0

--- a/jobs/JGLOBAL_WAVE_INIT
+++ b/jobs/JGLOBAL_WAVE_INIT
@@ -1,52 +1,8 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base wave waveinit
 
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base wave waveinit"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env waveinit
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
-
-# PATH for working directory
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export COMPONENT="wave"
 
 # Add default errchk = err_chk

--- a/jobs/JGLOBAL_WAVE_POST_BNDPNT
+++ b/jobs/JGLOBAL_WAVE_POST_BNDPNT
@@ -1,56 +1,9 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base wave wavepostsbs wavepostbndpnt
 
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base wave wavepostsbs wavepostbndpnt"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env wavepostbndpnt
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
-
-# PATH for working directory
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export COMPONENT="wave"
-
-export HOMEgefs=${HOMEgefs:-${PACKAGEROOT}/${NET}.${gefs_ver}}
-export HOMEgfs=${HOMEgfs:-${PACKAGEROOT}/${NET}.${gfs_ver}}
 
 # Add default errchk = err_chk
 export errchk=${errchk:-err_chk}

--- a/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
+++ b/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
@@ -1,55 +1,9 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base wave wavepostsbs wavepostbndpntbll
 
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base wave wavepostsbs wavepostbndpntbll"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env wavepostbndpntbll
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
-
-# PATH for working directory
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export COMPONENT="wave"
-
-export HOMEgefs=${HOMEgefs:-${PACKAGEROOT}/${NET}.${gefs_ver}}
 
 # Add default errchk = err_chk
 export errchk=${errchk:-err_chk}

--- a/jobs/JGLOBAL_WAVE_POST_PNT
+++ b/jobs/JGLOBAL_WAVE_POST_PNT
@@ -1,55 +1,9 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base wave wavepostsbs wavepostpnt
 
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base wave wavepostsbs wavepostpnt"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env wavepostpnt
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
-
-# PATH for working directory
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export COMPONENT="wave"
-
-export HOMEgefs=${HOMEgefs:-${PACKAGEROOT:-}/${NET}.${gefs_ver:-}}
 
 # Add default errchk = err_chk
 export errchk=${errchk:-err_chk}

--- a/jobs/JGLOBAL_WAVE_POST_SBS
+++ b/jobs/JGLOBAL_WAVE_POST_SBS
@@ -1,55 +1,9 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base wave wavepostsbs
 
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base wave wavepostsbs"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env wavepostsbs
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
-
-# PATH for working directory
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export COMPONENT="wave"
-
-export HOMEgefs=${HOMEgefs:-${PACKAGEROOT:-}/${NET}.${gefs_ver:-}}
 
 # Add default errchk = err_chk
 export errchk=${errchk:-err_chk}

--- a/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
+++ b/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
@@ -1,33 +1,8 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base waveawipsbulls
 
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export COMPONENT="wave"
 
 # Add default errchk = err_chk

--- a/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
+++ b/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
@@ -1,34 +1,8 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base waveawipsgridded
 
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-# PATH for working directory
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export COMPONENT="wave"
 
 # Add default errchk = err_chk

--- a/jobs/JGLOBAL_WAVE_PREP
+++ b/jobs/JGLOBAL_WAVE_PREP
@@ -1,52 +1,8 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" base wave waveprep
 
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-#############################
-# Source relevant config files
-#############################
-export EXPDIR=${EXPDIR:-${HOMEgfs}/parm/config}
-configs="base wave waveprep"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-##########################################
-# Source machine runtime environment
-##########################################
-. ${HOMEgfs}/env/${machine}.env waveprep
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
-
-# PATH for working directory
-export NET=${NET:-gfs}
-export RUN=${RUN:-gfs}
 export COMPONENT="wave"
 
 # Add default errchk = err_chk

--- a/jobs/rocoto/awips.sh
+++ b/jobs/rocoto/awips.sh
@@ -15,31 +15,20 @@ source "$HOMEgfs/ush/preamble.sh"
 ###############################################################
 
 ###############################################################
-echo
-echo "=============== BEGIN TO SOURCE FV3GFS WORKFLOW MODULES ==============="
-. $HOMEgfs/ush/load_fv3gfs_modules.sh
+# Source FV3GFS workflow modules
+source "${HOMEgfs}/ush/load_fv3gfs_modules.sh"
 status=$?
-[[ $status -ne 0 ]] && exit $status
+(( status != 0 )) && exit "${status}"
 
+export job="awips"
+export jobid="${job}.$$"
 
-###############################################################
-echo
-echo "=============== BEGIN TO SOURCE RELEVANT CONFIGS ==============="
-configs="base awips"
-for config in $configs; do
-    . $EXPDIR/config.${config}
-    status=$?
-    [[ $status -ne 0 ]] && exit $status
-done
+# TODO (#1228) - This script is doing more than just calling a j-job
+#   Also, this forces us to call the config files here instead of the j-job
+source "${HOMEgfs}/ush/jjob_header.sh" base awips
+
 
 fhrlst=$(echo $FHRLST | sed -e 's/_/ /g; s/f/ /g; s/,/ /g')
-
-###############################################################
-echo
-echo "=============== BEGIN TO SOURCE MACHINE RUNTIME ENVIRONMENT ==============="
-. $BASE_ENV/${machine}.env awips
-status=$?
-[[ $status -ne 0 ]] && exit $status
 
 ###############################################################
 export COMPONENT=${COMPONENT:-atmos}
@@ -94,14 +83,14 @@ for fhr in $fhrlst; do
             done
             
 	    export fcsthrs=$fhr3
-	    export job="jgfs_awips_f${fcsthrs}_20km_${cyc}"
-	    export DATA="${DATAROOT}/$job"
+	    # export job="jgfs_awips_f${fcsthrs}_20km_${cyc}"
+	    # export DATA="${DATAROOT}/$job"
 	    $AWIPS20SH
 	fi
 	
 	if [[ $(expr $fhr % 6) -eq 0 ]]; then
-	    export job="jgfs_awips_f${fcsthrs}_${cyc}"
-	    export DATA="${DATAROOT}/$job"
+	    # export job="jgfs_awips_f${fcsthrs}_${cyc}"
+	    # export DATA="${DATAROOT}/$job"
 	    $AWIPSG2SH
 	fi
     fi
@@ -131,12 +120,12 @@ for fhr in $fhrlst; do
             done
             
 	    export fcsthrs=$fhr3
-	    export job="jgfs_awips_f${fcsthrs}_20km_${cyc}"
-	    export DATA="${DATAROOT}/$job"
+	    # export job="jgfs_awips_f${fcsthrs}_20km_${cyc}"
+	    # export DATA="${DATAROOT}/$job"
 	    $AWIPS20SH
 	    
-	    export job="jgfs_awips_f${fcsthrs}_${cyc}"
-	    export DATA="${DATAROOT}/$job"
+	    # export job="jgfs_awips_f${fcsthrs}_${cyc}"
+	    # export DATA="${DATAROOT}/$job"
 	    $AWIPSG2SH
 	fi
     fi

--- a/jobs/rocoto/ecen.sh
+++ b/jobs/rocoto/ecen.sh
@@ -16,7 +16,7 @@ for fhr in ${fhrlst}; do
     export FHMIN_ECEN=${fhr}
     export FHMAX_ECEN=${fhr}
     export FHOUT_ECEN=${fhr}
-    export job=ecen${fhr}
+    export job=ecen
     export jobid="${job}.$$"
 
     ${HOMEgfs}/jobs/JGDAS_ENKF_ECEN

--- a/jobs/rocoto/epos.sh
+++ b/jobs/rocoto/epos.sh
@@ -8,6 +8,9 @@ source "${HOMEgfs}/ush/preamble.sh"
 status=$?
 [[ ${status} -ne 0 ]] && exit ${status}
 
+export job="epos"
+export jobid="${job}.$$"
+    
 ###############################################################
 # Loop over groups to Execute the JJOB
 fhrlst=$(echo ${FHRLST} | sed -e 's/_/ /g; s/f/ /g; s/,/ /g')
@@ -17,9 +20,6 @@ for fhr in ${fhrlst}; do
     export FHMIN_EPOS=${fhr}
     export FHMAX_EPOS=${fhr}
     export FHOUT_EPOS=${fhr}
-    export job=epos${fhr}
-    export jobid="${job}.$$"
-
     ${HOMEgfs}/jobs/JGDAS_ENKF_POST
     status=$?
     [[ ${status} -ne 0 ]] && exit ${status}

--- a/jobs/rocoto/gempak.sh
+++ b/jobs/rocoto/gempak.sh
@@ -1,23 +1,17 @@
 #! /usr/bin/env bash
 
-source "$HOMEgfs/ush/preamble.sh"
+source "${HOMEgfs}/ush/preamble.sh"
 
 ###############################################################
-echo
-echo "=============== BEGIN TO SOURCE FV3GFS WORKFLOW MODULES ==============="
-. $HOMEgfs/ush/load_fv3gfs_modules.sh
+. "${HOMEgfs}/ush/load_fv3gfs_modules.sh"
 status=$?
-[[ $status -ne 0 ]] && exit $status
+[[ ${status} -ne 0 ]] && exit ${status}
 
-export SENDCOM="YES"
-export COMPONENT=${COMPONENT:-atmos}
-
-export COMIN="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT"
-export COMOUT="$ROTDIR/$CDUMP.$PDY/$cyc/$COMPONENT/gempak"
+export job="gempak"
+export jobid="${job}.$$"
 
 # Execute the JJOB
-
-$HOMEgfs/jobs/JGFS_ATMOS_GEMPAK
+${HOMEgfs}/jobs/JGFS_ATMOS_GEMPAK
 
 status=$?
-exit $status
+exit ${status}

--- a/jobs/rocoto/post.sh
+++ b/jobs/rocoto/post.sh
@@ -13,6 +13,9 @@ source "${HOMEgfs}/ush/preamble.sh"
 status=$?
 [[ ${status} -ne 0 ]] && exit ${status}
 
+export job="post"
+export jobid="${job}.$$"
+
 export COMPONENT="atmos"
 
 if [ ${FHRGRP} = 'anl' ]; then
@@ -27,8 +30,6 @@ fi
 #---------------------------------------------------------------
 for fhr in ${fhrlst}; do
     export post_times=${fhr}
-    export job="post${post_times}"
-    export jobid="${job}.$$"
     ${HOMEgfs}/jobs/JGLOBAL_ATMOS_POST
     status=$?
     [[ ${status} -ne 0 ]] && exit ${status}

--- a/jobs/rocoto/vrfy.sh
+++ b/jobs/rocoto/vrfy.sh
@@ -2,56 +2,18 @@
 
 source "${HOMEgfs}/ush/preamble.sh"
 
-echo
-echo "=============== START TO SOURCE FV3GFS WORKFLOW MODULES ==============="
-. ${HOMEgfs}/ush/load_fv3gfs_modules.sh
+###############################################################
+# Source FV3GFS workflow modules
+source "${HOMEgfs}/ush/load_fv3gfs_modules.sh"
 status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+(( status != 0 )) && exit "${status}"
 
 export job="vrfy"
 export jobid="${job}.$$"
 
-
-##############################################
-# make temp directory
-##############################################
-export DATA="${DATA:-${DATAROOT}/${jobid}}"
-mkdir -p ${DATA}
-cd ${DATA}
-
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-##############################################
-# Determine Job Output Name on System
-##############################################
-export pid=${pid:-$$}
-export pgmout="OUTPUT.${pid}"
-export pgmerr=errfile
-
-
-###############################################################
-echo
-echo "=============== START TO SOURCE RELEVANT CONFIGS ==============="
-configs="base vrfy"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-###############################################################
-echo
-echo "=============== START TO SOURCE MACHINE RUNTIME ENVIRONMENT ==============="
-. ${BASE_ENV}/${machine}.env vrfy
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+# TODO (#235) - This job is calling multiple j-jobs and doing too much in general
+#   Also, this forces us to call the config files here instead of the j-job
+source "${HOMEgfs}/ush/jjob_header.sh" base vrfy
 
 ###############################################################
 export COMPONENT="atmos"

--- a/jobs/rocoto/waveawipsbulls.sh
+++ b/jobs/rocoto/waveawipsbulls.sh
@@ -3,34 +3,15 @@
 source "$HOMEgfs/ush/preamble.sh"
 
 ###############################################################
-echo
-echo "=============== START TO SOURCE FV3GFS WORKFLOW MODULES ==============="
-. $HOMEgfs/ush/load_fv3gfs_modules.sh
+# Source FV3GFS workflow modules
+source ${HOMEgfs}/ush/load_fv3gfs_modules.sh
 status=$?
-[[ $status -ne 0 ]] && exit $status
+[[ ${status} -ne 0 ]] && exit ${status}
+
+export job="waveawipsbulls"
+export jobid="${job}.$$"
 
 ###############################################################
-echo
-echo "=============== BEGIN TO SOURCE RELEVANT CONFIGS ==============="
-configs="base waveawipsbulls"
-for config in $configs; do
-    . $EXPDIR/config.${config}
-    status=$?
-    [[ $status -ne 0 ]] && exit $status
-done
-
-###############################################################
-echo
-echo "=============== BEGIN TO SOURCE MACHINE RUNTIME ENVIRONMENT ==============="
-. $BASE_ENV/${machine}.env waveawipsbulls
-status=$?
-[[ $status -ne 0 ]] && exit $status
-
-export DBNROOT=/dev/null
-
-###############################################################
-echo
-echo "=============== START TO RUN WAVE PRDGEN BULLS ==============="
 # Execute the JJOB
 $HOMEgfs/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
 status=$?

--- a/jobs/rocoto/waveawipsgridded.sh
+++ b/jobs/rocoto/waveawipsgridded.sh
@@ -3,37 +3,18 @@
 source "$HOMEgfs/ush/preamble.sh"
 
 ###############################################################
-echo
-echo "=============== START TO SOURCE FV3GFS WORKFLOW MODULES ==============="
-. $HOMEgfs/ush/load_fv3gfs_modules.sh
+# Source FV3GFS workflow modules
+source ${HOMEgfs}/ush/load_fv3gfs_modules.sh
 status=$?
-[[ $status -ne 0 ]] && exit $status
+[[ ${status} -ne 0 ]] && exit ${status}
+
+export job="waveawipsgridded"
+export jobid="${job}.$$"
 
 ###############################################################
-echo
-echo "=============== BEGIN TO SOURCE RELEVANT CONFIGS ==============="
-configs="base waveawipsgridded"
-for config in $configs; do
-    . $EXPDIR/config.${config}
-    status=$?
-    [[ $status -ne 0 ]] && exit $status
-done
-
-###############################################################
-echo
-echo "=============== BEGIN TO SOURCE MACHINE RUNTIME ENVIRONMENT ==============="
-. $BASE_ENV/${machine}.env waveawipsgridded
-status=$?
-[[ $status -ne 0 ]] && exit $status
-
-export DBNROOT=/dev/null
-
-###############################################################
-echo
-echo "=============== START TO RUN WAVE PRDGEN GRIDDED ==============="
 # Execute the JJOB
-$HOMEgfs/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
+${HOMEgfs}/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
 status=$?
 
 
-exit $status
+exit ${status}

--- a/jobs/rocoto/wavegempak.sh
+++ b/jobs/rocoto/wavegempak.sh
@@ -3,35 +3,13 @@
 source "$HOMEgfs/ush/preamble.sh"
 
 ###############################################################
-echo
-echo "=============== START TO SOURCE FV3GFS WORKFLOW MODULES ==============="
-. $HOMEgfs/ush/load_fv3gfs_modules.sh
+source $HOMEgfs/ush/load_fv3gfs_modules.sh
 status=$?
 [[ $status -ne 0 ]] && exit $status
 
 ###############################################################
-echo
-echo "=============== BEGIN TO SOURCE RELEVANT CONFIGS ==============="
-configs="base wavegempak"
-for config in $configs; do
-    . $EXPDIR/config.${config}
-    status=$?
-    [[ $status -ne 0 ]] && exit $status
-done
-
-###############################################################
-echo
-echo "=============== BEGIN TO SOURCE MACHINE RUNTIME ENVIRONMENT ==============="
-. $BASE_ENV/${machine}.env wavegempak
-status=$?
-[[ $status -ne 0 ]] && exit $status
-
-###############################################################
-echo
-echo "=============== START TO RUN WAVE GEMPAK ==============="
 # Execute the JJOB
 $HOMEgfs/jobs/JGLOBAL_WAVE_GEMPAK
 status=$?
-
 
 exit $status

--- a/jobs/rocoto/wavepostsbs.sh
+++ b/jobs/rocoto/wavepostsbs.sh
@@ -3,8 +3,7 @@
 source "${HOMEgfs}/ush/preamble.sh"
 
 ###############################################################
-echo
-echo "=============== START TO SOURCE FV3GFS WORKFLOW MODULES ==============="
+# Source FV3GFS workflow modules
 . ${HOMEgfs}/ush/load_fv3gfs_modules.sh
 status=$?
 [[ ${status} -ne 0 ]] && exit ${status}
@@ -13,8 +12,6 @@ export job="wavepostsbs"
 export jobid="${job}.$$"
 
 ###############################################################
-echo
-echo "=============== START TO RUN WAVE POST_SBS ==============="
 # Execute the JJOB
 ${HOMEgfs}/jobs/JGLOBAL_WAVE_POST_SBS
 status=$?

--- a/ush/jjob_header.sh
+++ b/ush/jjob_header.sh
@@ -1,0 +1,76 @@
+#! /usr/bin/env bash
+#
+# Universal header for global j-jobs
+#
+# Sets up and completes actions common to all j-jobs:
+# - Creates and moves to $DATA
+# - Runs `setpdy.sh`
+# - Sources configs provided as arguments
+# - Sources machine environment script
+# - Defines a few other variables
+#
+# The list of config files to source should be provided
+#   by providing the names as arguments, i.e.
+#   `jjob_header.sh base fcst` will source `config.base`
+#   and `config.fcst` from the $EXPDIR.
+#
+# Script requires the following variables to already be
+#   defined in the environment:
+#   - $HOMEgfs
+#   - $DATAROOT
+#   - $jobid
+#   - $PDY
+#   - $cyc
+#   - $machine
+#
+
+if (( $# < 1 )); then
+    echo "FATAL: Must specify a job name"
+fi
+configs=("$@")
+
+##############################################
+# make temp directory
+##############################################
+export DATA=${DATA:-"${DATAROOT}/${jobid}"}
+mkdir -p "${DATA}"
+cd "${DATA}" || ( echo "FATAL: ${DATA} does not exist"; exit 1 )
+
+
+##############################################
+# Run setpdy and initialize PDY variables
+##############################################
+export cycle="t${cyc}z"
+setpdy.sh
+source ./PDY
+
+
+##############################################
+# Determine Job Output Name on System
+##############################################
+export pid="${pid:-$$}"
+export pgmout="OUTPUT.${pid}"
+export pgmerr=errfile
+
+
+#############################
+# Source relevant config files
+#############################
+export EXPDIR="${EXPDIR:-${HOMEgfs}/parm/config}"
+for config in "${configs[@]}"; do
+    source "${EXPDIR}/config.${config}"
+    status=$?
+    if (( status != 0 )); then
+    	exit "${status}"
+    fi
+done
+
+
+##########################################
+# Source machine runtime environment
+##########################################
+source "${HOMEgfs}/env/${machine}.env" "${job}"
+status=$?
+if (( status != 0 )); then
+	exit "${status}"
+fi


### PR DESCRIPTION
**Description**
Takes all of the tasks that are common to all j-jobs and abstracts them out into a shared script that is sourced by each job:
- Set and create $DATA directory
- Call setpy and set $cycle
- Set pid, pgmout, and pgmerr
- Source config files
- Source machine environment file

The common j-job header script is called by passing a list of config files to source:
```
${HOMEgfs}/ush/jjob_header.sh [config1 [config2 [...]]]
```

Some pre j-job rocoto entry scripts (`jobs/rocoto/*`) are currently doing much more than they should be. These sometimes required extra finagling, usually pre-calling the jjob header in the rocoto script before it does something.

**Type of change**
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
- [x] Cycled test on Orion
- [ ] Cycled test on Hera
- [ ] Cycled test on WCOSS2
- [x] Coupled test on Orion
- [ ] Coupled test on Hera
- [ ] Couple test on WCOSS2

Post sounding (bufr) and gempak jobs complete successfully
AWIPS and WAFS failing for unrelated reasons
GDAS App jobs not tested
Some j-jobs are not called in the development workflow. TODOs an corresponding issues have been added to these.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

**Dependencies**
#1212
#1214
#1216
#1218
