### PR TITLE
Add utility to compare Fortran namelists

### DIFF
--- a/ush/compare_f90nml.py
+++ b/ush/compare_f90nml.py
@@ -85,5 +85,5 @@ if __name__ == "__main__":
 
     msg = f"comparing: {nml1} | {nml2}"
     print(msg)
-    print("-"*len(msg))
+    print("-" * len(msg))
     compare_dicts(dict1, dict2)

--- a/ush/compare_f90nml.py
+++ b/ush/compare_f90nml.py
@@ -1,18 +1,23 @@
 #!/usr/bin/env python3
 
 import json
+import f90nml
 from typing import Dict
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
-try:
-    import f90nml
-except (ImportError, ModuleNotFoundError):
-    raise ModuleNotFoundError(f"f90nml not found on this system, ABORT!")
 
 
 def get_dict_from_nml(filename: str) -> Dict:
     """
     Read a F90 namelist and convert to a dictionary.
     This method uses json to convert OrderedDictionary into regular dictionary
+    Parameters
+    ----------
+    filename: str
+              Name of the F90 namelist
+    Returns
+    -------
+    dictionary: Dict
+                F90 namelist returned as a dictionary
     """
     return json.loads(json.dumps(f90nml.read(filename).todict()))
 
@@ -26,6 +31,18 @@ def compare_dicts(dict1: Dict, dict2: Dict, path: str = "") -> None:
     If a matching key is not found, it is set to as UNDEFINED.
     Note: A reverse match is not performed in this method.  For reverse matching, use the -r option in the main driver.
     Note: This is a recursive method to handle nested dictionaries.
+    Parameters
+    ----------
+    dict1: Dict
+           First dictionary
+    dict2: Dict
+           Second dictionary
+    path:  str (optional)
+           default: ""
+           key (if nested dictionary)
+    Returns
+    -------
+    None
     """
 
     result = dict()
@@ -44,17 +61,24 @@ def compare_dicts(dict1: Dict, dict2: Dict, path: str = "") -> None:
                 result[tt] = dict()
             result[tt][kk] = [dict1[kk], 'UNDEFINED']
 
-    def _print_diffs(diffs: Dict) -> None:
+    def _print_diffs(diff_dict: Dict) -> None:
         """
         Print the differences between the two dictionaries to stdout
+        Parameters
+        ----------
+        diff_dict: Dict
+                   Dictionary containing differences
+        Returns
+        -------
+        None
         """
-        for path in diffs.keys():
+        for path in diff_dict.keys():
             print(f"{path}:")
-            max_len = len(max(diffs[path], key=len))
-            for kk in diffs[path].keys():
-                items = diffs[path][kk]
+            max_len = len(max(diff_dict[path], key=len))
+            for kk in diff_dict[path].keys():
+                items = diff_dict[path][kk]
                 print(
-                    f"{kk:>{max_len+2}} : {' | '.join(map(str, diffs[path][kk]))}")
+                    f"{kk:>{max_len+2}} : {' | '.join(map(str, diff_dict[path][kk]))}")
 
     _print_diffs(result)
 

--- a/ush/compare_f90nml.py
+++ b/ush/compare_f90nml.py
@@ -86,16 +86,15 @@ def compare_dicts(dict1: Dict, dict2: Dict, path: str = "") -> None:
 if __name__ == "__main__":
 
     parser = ArgumentParser(
-        description=("Compare two Fortran namelists and display differences"),
+        description=("Compare two Fortran namelists and display differences (left_namelist - right_namelist)"),
         formatter_class=ArgumentDefaultsHelpFormatter)
-    parser.add_argument('-n', '--namelists', help='name of two namelists to compare (namelist1 - namelist2)',
-                        type=str, nargs=2,
-                        metavar=('namelist1', 'namelist2'), required=True)
-    parser.add_argument('-r', '--reverse', help='reverse diff (namelist2 - namelist1)',
+    parser.add_argument('left_namelist', type=str, help="Left namelist to compare")
+    parser.add_argument('right_namelist', type=str, help="Right namelist to compare")
+    parser.add_argument('-r', '--reverse', help='reverse diff (right_namelist - left_namelist)',
                         action='store_true', required=False)
     args = parser.parse_args()
 
-    nml1, nml2 = args.namelists
+    nml1, nml2 = args.left_namelist, args.right_namelist
     if args.reverse:
         nml2, nml1 = nml1, nml2
 

--- a/ush/compare_f90nml.py
+++ b/ush/compare_f90nml.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import json
+from typing import Dict
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+try:
+    import f90nml
+except (ImportError, ModuleNotFoundError):
+    raise ModuleNotFoundError(f"f90nml not found on this system, ABORT!")
+
+
+def get_dict_from_nml(filename: str) -> Dict:
+    """
+    Read a F90 namelist and convert to a dictionary.
+    This method uses json to convert OrderedDictionary into regular dictionary
+    """
+    return json.loads(json.dumps(f90nml.read(filename).todict()))
+
+
+def compare_dicts(dict1: Dict, dict2: Dict, path: str = "") -> None:
+    """
+    Compare 2 dictionaries.
+    This is done by looping over keys in dictionary 1 and searching for them
+    in dictionary 2.
+    If a matching key is found, the values are compared.
+    If a matching key is not found, it is set to as UNDEFINED.
+    Note: A reverse match is not performed in this method.  For reverse matching, use the -r option in the main driver.
+    Note: This is a recursive method to handle nested dictionaries.
+    """
+
+    result = dict()
+    for kk in dict1.keys():
+        if kk in dict2.keys():
+            if type(dict1[kk]) is dict:
+                compare_dicts(dict1[kk], dict2[kk],
+                              f"{path} -> {kk}" if path else kk)
+            else:
+                if dict1[kk] != dict2[kk]:
+                    if path not in result:
+                        result[path] = dict()
+                    result[path][kk] = [dict1[kk], dict2[kk]]
+        else:
+            if path:
+                if path not in result:
+                    result[path] = dict()
+                result[path][kk] = [dict1[kk], 'UNDEFINED']
+            else:
+                if kk not in result:
+                    result[kk] = dict()
+                    result[kk][kk] = ['UNDEFINED']
+
+    def _print_diffs(diffs: Dict) -> None:
+        """
+        Print the differences between the two dictionaries to stdout
+        """
+        for path in diffs.keys():
+            print(f"{path}:")
+            max_len = len(max(diffs[path], key=len))
+            for kk in diffs[path].keys():
+                items = diffs[path][kk]
+                print(
+                    f"{kk:>{max_len+2}} : {' | '.join(map(str, diffs[path][kk]))}")
+
+    _print_diffs(result)
+
+
+if __name__ == "__main__":
+
+    parser = ArgumentParser(
+        description=("Compare two Fortran namelists and display differences"),
+        formatter_class=ArgumentDefaultsHelpFormatter)
+    parser.add_argument('-n', '--namelists', help='name of two namelists to compare (namelist1 - namelist2)',
+                        type=str, nargs=2,
+                        metavar=('namelist1', 'namelist2'), required=True)
+    parser.add_argument('-r', '--reverse', help='reverse diff (namelist2 - namelist1)',
+                        action='store_true', required=False)
+    args = parser.parse_args()
+
+    nml1, nml2 = args.namelists
+    if args.reverse:
+        nml2, nml1 = nml1, nml2
+
+    dict1 = get_dict_from_nml(nml1)
+    dict2 = get_dict_from_nml(nml2)
+
+    msg = f"comparing: {nml1} | {nml2}"
+    print(msg)
+    print("-"*len(msg))
+    compare_dicts(dict1, dict2)

--- a/ush/compare_f90nml.py
+++ b/ush/compare_f90nml.py
@@ -29,25 +29,20 @@ def compare_dicts(dict1: Dict, dict2: Dict, path: str = "") -> None:
     """
 
     result = dict()
-    for kk in dict1.keys():
-        if kk in dict2.keys():
-            if type(dict1[kk]) is dict:
-                compare_dicts(dict1[kk], dict2[kk],
-                              f"{path} -> {kk}" if path else kk)
+    for kk in dict1.keys():  # Loop over all keys of first dictionary
+        if kk in dict2.keys():  # kk is present in dict2
+            if isinstance(dict1[kk], dict):  # nested dictionary, go deeper
+                compare_dicts(dict1[kk], dict2[kk], path=kk)
             else:
                 if dict1[kk] != dict2[kk]:
                     if path not in result:
                         result[path] = dict()
                     result[path][kk] = [dict1[kk], dict2[kk]]
-        else:
-            if path:
-                if path not in result:
-                    result[path] = dict()
-                result[path][kk] = [dict1[kk], 'UNDEFINED']
-            else:
-                if kk not in result:
-                    result[kk] = dict()
-                    result[kk][kk] = ['UNDEFINED']
+        else:  # kk is *not* present in dict2
+            tt = path if path else kk
+            if tt not in result:
+                result[tt] = dict()
+            result[tt][kk] = [dict1[kk], 'UNDEFINED']
 
     def _print_diffs(diffs: Dict) -> None:
         """


### PR DESCRIPTION
**Description**
Often times it is necessary to compare Fortran namelists between a UFS-weather-model regression test and a global-workflow experiment, or in other example applications.

This PR adds a simple utility that loads two namelists and spits out the differences between them.  The differences are calculated as a departure from the first namelist.
This utility leverages `f90nml` (approved for use on WCOSS2)

The usage is as follows:
```
❯❯❯ python3 compare_f90nml.py -h
usage: compare_f90nml.py [-h] [-r] left_namelist right_namelist

Compare two Fortran namelists and display differences (left_namelist - right_namelist)

positional arguments:
  left_namelist   Left namelist to compare
  right_namelist  Right namelist to compare

options:
  -h, --help      show this help message and exit
  -r, --reverse   reverse diff (right_namelist - left_namelist) (default: False)
```

The comparison is done as follows:
- Both namelists are loaded
- We loop over the keys of `left_namelist`.  We look for the same key in the `right_namelist`.  If the key is found, the values are compared.  If the key is not found, a note is made that the key is undefined in `right_namelist`.
- Differences in the values are printed to screen.
- 
The `-r | --reverse` reverses the `namelists`.  This allows the user to use `right_namelist` as the reference.

If differences are found, they are shown as follows (examples of `input.nml` from the `control_p8` and `cpld_control_p8` regression tests of the ufs-weather-model)
```
❯❯❯ python3 compare_f90nml.py control_p8.nml cpld_control_p8.nml
comparing: control_p8.nml | cpld_control_p8.nml
-----------------------------------------------
atmos_model_nml:
  ccpp_suite : FV3_GFS_v17_p8 | FV3_GFS_v17_coupled_p8
fms_nml:
  domains_stack_size : 3000000 | 8000000
fv_core_nml:
  dnats : 0 | 2
gfs_physics_nml:
    min_seaice : 0.15 | 1e-06
  use_cice_alb : False | True
     nstf_name : [2, 1, 0, 0, 0] | [2, 0, 0, 0, 0]
        cplchm : False | True
        cplflx : False | True
        cplice : False | True
        cplwav : False | True
    cplwav2atm : False | True
```

**Type of change**
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
As shown above in comparing 2 namelists from ufs-weather-model regression tests.
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
