### PR TITLE
Revert "Merge GFS v16.3 operational gsi scripts into develop branch"

### DIFF
--- a/jobs/JGDAS_ENKF_FCST
+++ b/jobs/JGDAS_ENKF_FCST
@@ -52,6 +52,7 @@ status=$?
 export CDATE=${CDATE:-${PDY}${cyc}}
 export CDUMP=${CDUMP:-${RUN:-"gdas"}}
 export COMPONENT="atmos"
+export rCDUMP="gdas"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -55,8 +55,8 @@ lupp=${lupp:-".true."}
 cnvw_option=${cnvw_option:-".false."}
 
 # Observation usage options
-cao_check=${cao_check:-".true."}
-ta2tb=${ta2tb:-".true."}
+cao_check=${cao_check:-".false."}
+ta2tb=${ta2tb:-".false."}
 
 # Diagnostic files options
 lobsdiag_forenkf=${lobsdiag_forenkf:-".false."}
@@ -426,7 +426,9 @@ ${NLN} ${RTMFIX}/NPOESS.VISsnow.EmisCoeff.bin  ./crtm_coeffs/NPOESS.VISsnow.Emis
 ${NLN} ${RTMFIX}/NPOESS.VISwater.EmisCoeff.bin ./crtm_coeffs/NPOESS.VISwater.EmisCoeff.bin
 ${NLN} ${RTMFIX}/FASTEM6.MWwater.EmisCoeff.bin ./crtm_coeffs/FASTEM6.MWwater.EmisCoeff.bin
 ${NLN} ${RTMFIX}/AerosolCoeff.bin              ./crtm_coeffs/AerosolCoeff.bin
-${NLN} ${RTMFIX}/CloudCoeff.GFDLFV3.-109z-1.bin ./crtm_coeffs/CloudCoeff.bin
+${NLN} ${RTMFIX}/CloudCoeff.bin                ./crtm_coeffs/CloudCoeff.bin
+#$NLN $RTMFIX/CloudCoeff.GFDLFV3.-109z-1.bin ./crtm_coeffs/CloudCoeff.bin
+
 
 ##############################################################
 # Observational data


### PR DESCRIPTION
Reverts NOAA-EMC/global-workflow#1158 due to issues it creates due to crtm version mismatches that can't be immediately corrected.