### PR TITLE
Don't wipe $DATA before running ocean bmat

### DIFF
--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_BMAT
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_BMAT
@@ -1,7 +1,7 @@
 #!/bin/bash
 export STRICT="NO"
 source "${HOMEgfs}/ush/preamble.sh"
-
+WIPE_DATA="NO"
 
 export DATA="${DATAROOT}/${RUN}ocnanal_${cyc}"
 source "${HOMEgfs}/ush/jjob_header.sh" -e "ocnanalrun" -c "base ocnanal ocnanalrun"


### PR DESCRIPTION
**Description**

JGDAS_GLOBAL_OCEAN_ANALYSIS_BMAT reuses the rundir from JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP and so shouldn't wipe the data before running.

Necessary for https://github.com/NOAA-EMC/GDASApp/issues/288


**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Tested with soca ctests with GDASApp branch feature/add-soca-bmat-jjob on Hera - this PR is a dependency for the forthcoming associated GDASApp PR
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

