### PR TITLE
Correct issue in linking final restart files

### DIFF
--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -209,22 +209,20 @@ FV3_GFS_predet(){
     RSTDIR_ATM=${RSTDIR_ATM:-${ROTDIR}/${CDUMP}.${PDY}/${cyc}/atmos/RERUN_RESTART}
     if [ ! -d $RSTDIR_ATM ]; then mkdir -p $RSTDIR_ATM ; fi
     $NLN $RSTDIR_ATM RESTART
-    if [[ $(( ${FHMAX_GFS} % ${restart_interval_gfs} )) == 0 ]]; then
-      # The final restart written at the end doesn't include the valid date
-      # Create links that keep the same name pattern for these files
-      VDATE=$($NDATE +$FHMAX_GFS $CDATE)
-      vPDY=$(echo $VDATE | cut -c1-8)
-      vcyc=$(echo $VDATE | cut -c9-10)
-      files="coupler.res fv_core.res.nc"
-      for tile in {1..6}; do
-        for base in ca_data fv_core.res fv_srf_wnd.res fv_tracer.res phy_data sfc_data; do
-          files="${files} ${base}.tile${tile}.nc"
-        done
+    # The final restart written at the end doesn't include the valid date
+    # Create links that keep the same name pattern for these files
+    VDATE=$($NDATE +$FHMAX_GFS $CDATE)
+    vPDY=$(echo $VDATE | cut -c1-8)
+    vcyc=$(echo $VDATE | cut -c9-10)
+    files="coupler.res fv_core.res.nc"
+    for tile in {1..6}; do
+      for base in ca_data fv_core.res fv_srf_wnd.res fv_tracer.res phy_data sfc_data; do
+        files="${files} ${base}.tile${tile}.nc"
       done
-      for file in $files; do
-        $NLN $RSTDIR_ATM/$file $RSTDIR_ATM/${vPDY}.${vcyc}0000.$file
-      done
-    fi
+    done
+    for file in $files; do
+      $NLN $RSTDIR_ATM/$file $RSTDIR_ATM/${vPDY}.${vcyc}0000.$file
+    done
   else
     mkdir -p $DATA/RESTART
   fi


### PR DESCRIPTION
**Description**

Redo to fix a bug in forecast_predet.sh, because when run cycled model, the interval_restart_gfs=0, it will cause the condition failed and will not run the following statements, which will cause gmemdir is not set values in the forecast_postdet.sh. Therefore, I delete the condition to solve this issue.

Fixes #1284

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
Yes, tested on Hera
<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--
- [ ] Clone and Build tests on WCOSS Dell P3
- [ ] Cycled test on Orion
- [ ] Forecast-only test on Hera
-->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
