### PR TITLE
Add PYTHONPATH to soca ocean prep jjob

### DIFF
--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
@@ -33,7 +33,9 @@ mkdir -p "${COMOUT}"
 export COMIN_GES="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/ocean"
 
 # Add UFSDA to PYTHONPATH
-export PYTHONPATH=${HOMEgfs}/sorc/gdas.cd/ush/:${PYTHONPATH}
+ufsdaPATH="${HOMEgfs}/sorc/gdas.cd/ush/"
+PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${ufsdaPATH}"
+export PYTHONPATH
 
 ###############################################################
 # Run relevant script

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
@@ -32,6 +32,9 @@ mkdir -p "${COMOUT}"
 # COMIN_GES and COMIN_GES_ENS are used in script
 export COMIN_GES="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/ocean"
 
+# Add UFSDA to PYTHONPATH
+export PYTHONPATH=${HOMEgfs}/sorc/gdas.cd/ush/:${PYTHONPATH}
+
 ###############################################################
 # Run relevant script
 


### PR DESCRIPTION
**Description**

Adds the UFSDA location to PYTHONPATH in soca prep jjob so the path building is not done in script.

Addresses GDASApp issues https://github.com/NOAA-EMC/GDASApp/issues/242 and https://github.com/NOAA-EMC/GDASApp/pull/234

The issues require changes also to GDASApp, but this PR will not break GDASApp as is

**Type of change**


- [ ] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

Tested with soca/global-workflow GDASApp ctests on Hera

  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published - TBD
