### PR TITLE
Update obsproc package version to v1.1.2

### DIFF
--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -77,7 +77,7 @@ export MODE="@MODE@" # cycled/forecast-only
 export FIXgsi="${HOMEgfs}/fix/gsi"
 export HOMEfv3gfs="${HOMEgfs}/sorc/fv3gfs.fd"
 export HOMEpost="${HOMEgfs}"
-export HOMEobsproc="${BASE_GIT}/obsproc/v1.0.2"
+export HOMEobsproc="${BASE_GIT}/obsproc/v1.1.2"
 
 # CONVENIENT utility scripts and other environment parameters
 export NCP="/bin/cp -p"

--- a/parm/config/config.base.nco.static
+++ b/parm/config/config.base.nco.static
@@ -65,7 +65,7 @@ export REALTIME="YES"
 export FIXgsi="$HOMEgfs/fix/gsi"
 export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
 export HOMEpost="$HOMEgfs"
-export HOMEobsproc="/lfs/h1/ops/prod/packages/obsproc.v1.0.2"
+export HOMEobsproc="/lfs/h1/ops/prod/packages/obsproc.v1.1.2"
 
 # CONVENIENT utility scripts and other environment parameters
 export NCP="/bin/cp -p"


### PR DESCRIPTION
**Description**

The obsproc package updated to `v1.1.2` in operations with the GFSv16.3 upgrade. Update both versions of config.base `HOMEobsproc` path to move obsproc to the newer version.

New obsproc version only changes results if used for newer dates (after GFSv16.3 went into operations - new dump data). Older dates reproduce prior obsproc version.

Closes #1291

**Type of change**

Regular update of external package version.

**How Has This Been Tested?**

- [x] Cloned and built `obsproc.v1.1.2` on supported platforms (see issue #1291 for locations)
- [x] Cycled test on Orion - reproduced control run using `develop`
