### PR TITLE
Purge ICSDIR

### DIFF
--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -74,7 +74,7 @@ The following command examples include variables for reference but users should 
 
    cd workflow
    ./setup_expt.py forecast-only --idate $IDATE --edate $EDATE [--app $APP] [--start $START] [--gfs_cyc $GFS_CYC] [--resdet $RESDET]
-     [--pslot $PSLOT] [--configdir $CONFIGDIR] [--comrot $COMROT] [--expdir $EXPDIR] [--icsdir $ICSDIR]
+     [--pslot $PSLOT] [--configdir $CONFIGDIR] [--comrot $COMROT] [--expdir $EXPDIR]
 
 where:
 
@@ -97,10 +97,6 @@ where:
    * ``$GFS_CYC`` is the forecast frequency (0 = none, 1 = 00z only [default], 2 = 00z & 12z, 4 = all cycles)
    * ``$COMROT`` is the path to your experiment output directory. DO NOT include PSLOT folder at end of path, it’ll be built for you. [default: $HOME (but do not use default due to limited space in home directories normally, provide a path to a larger scratch space)]
    * ``$EXPDIR`` is the path to your experiment directory where your configs will be placed and where you will find your workflow monitoring files (i.e. rocoto database and xml file). DO NOT include PSLOT folder at end of path, it will be built for you. [default: $HOME]
-   * ``$ICSDIR`` is the path to the initial conditions. This is handled differently depending on whether ``$APP`` is S2S or not.
-
-      - If ``$APP`` is ATM or ATMW, this setting is currently ignored
-      - If ``$APP`` is S2S or S2SW, ICs are copied from the central location to this location and the argument is required
 
 Examples:
 
@@ -109,21 +105,21 @@ Atm-only:
 ::
 
    cd workflow
-   ./setup_expt.py forecast-only --pslot test --idate 2020010100 --edate 2020010118 --resdet 384 --gfs_cyc 4 --comrot /some_large_disk_area/Joe.Schmo/comrot --expdir /some_safe_disk_area/Joe.Schmo/expdir 
+   ./setup_expt.py forecast-only --pslot test --idate 2020010100 --edate 2020010118 --resdet 384 --gfs_cyc 4 --comrot /some_large_disk_area/Joe.Schmo/comrot --expdir /some_safe_disk_area/Joe.Schmo/expdir
 
 Coupled:
 
 ::
 
    cd workflow
-   ./setup_expt.py forecast-only --app S2SW --pslot coupled_test --idate 2013040100 --edate 2013040100 --resdet 384 --comrot /some_large_disk_area/Joe.Schmo/comrot --expdir /some_safe_disk_area/Joe.Schmo/expdir --icsdir /some_large_disk_area/Joe.Schmo/icsdir
+   ./setup_expt.py forecast-only --app S2SW --pslot coupled_test --idate 2013040100 --edate 2013040100 --resdet 384 --comrot /some_large_disk_area/Joe.Schmo/comrot --expdir /some_safe_disk_area/Joe.Schmo/expdir
 
 Coupled with aerosols:
 
 ::
 
    cd workflow
-   ./setup_expt.py forecast-only --app S2SWA --pslot coupled_test --idate 2013040100 --edate 2013040100 --resdet 384 --comrot /some_large_disk_area/Joe.Schmo/comrot --expdir /some_safe_disk_area/Joe.Schmo/expdir --icsdir /some_large_disk_area/Joe.Schmo/icsdir
+   ./setup_expt.py forecast-only --app S2SWA --pslot coupled_test --idate 2013040100 --edate 2013040100 --resdet 384 --comrot /some_large_disk_area/Joe.Schmo/comrot --expdir /some_safe_disk_area/Joe.Schmo/expdir
 
 ****************************************
 Step 2: Set user and experiment settings
@@ -164,13 +160,13 @@ Example:
 Step 4: Confirm files from setup scripts
 ****************************************
 
-You will now have a rocoto xml file in your EXPDIR ($PSLOT.xml) and a crontab file generated for your use. Rocoto uses CRON as the scheduler. If you do not have a crontab file you may not have had the rocoto module loaded. To fix this load a rocoto module and then rerun setup_xml.py script again. Follow directions for setting up the rocoto cron on the platform the experiment is going to run on.  
+You will now have a rocoto xml file in your EXPDIR ($PSLOT.xml) and a crontab file generated for your use. Rocoto uses CRON as the scheduler. If you do not have a crontab file you may not have had the rocoto module loaded. To fix this load a rocoto module and then rerun setup_xml.py script again. Follow directions for setting up the rocoto cron on the platform the experiment is going to run on.
 
 ^^^^^^^^^^^^^^^^^
 Cycled experiment
 ^^^^^^^^^^^^^^^^^
 
-Scripts that will be used: 
+Scripts that will be used:
 
    * ``workflow/setup_expt.py``
    * ``workflow/setup_xml.py``
@@ -289,5 +285,4 @@ Example:
 Step 4: Confirm files from setup scripts
 ****************************************
 
-You will now have a rocoto xml file in your EXPDIR ($PSLOT.xml) and a crontab file generated for your use. Rocoto uses CRON as the scheduler. If you do not have a crontab file you may not have had the rocoto module loaded. To fix this load a rocoto module and then rerun ``setup_xml.py`` script again. Follow directions for setting up the rocoto cron on the platform the experiment is going to run on.  
-
+You will now have a rocoto xml file in your EXPDIR ($PSLOT.xml) and a crontab file generated for your use. Rocoto uses CRON as the scheduler. If you do not have a crontab file you may not have had the rocoto module loaded. To fix this load a rocoto module and then rerun ``setup_xml.py`` script again. Follow directions for setting up the rocoto cron on the platform the experiment is going to run on.

--- a/jobs/rocoto/coupled_ic.sh
+++ b/jobs/rocoto/coupled_ic.sh
@@ -89,6 +89,11 @@ case $OCNRES in
       fi
     done
   ;;
+  *)
+    echo "FATAL ERROR: Unsupported ocean resolution ${OCNRES}"
+    rc=1
+    err=$((err + rc))
+  ;;
 esac
 
 # Stage ice initial conditions to ROTDIR (cold start as these are SIS2 generated)
@@ -106,7 +111,7 @@ err=$((err + rc))
 if [[ "${DO_WAVE}" = "YES" ]]; then
   WAVdir="${ROTDIR}/${CDUMP}.${PDY}/${cyc}/wave/restart"
   [[ ! -d "${WAVdir}" ]] && mkdir -p "${WAVdir}"
-  for grdID in "${waveGRD}"; do
+  for grdID in ${waveGRD}; do  # TODO: check if this is a bash array; if so adjust
     source="${BASE_CPLIC}/${CPL_WAVIC}/${PDY}${cyc}/wav/${grdID}/${PDY}.${cyc}0000.restart.${grdID}"
     target="${WAVdir}/${PDY}.${cyc}0000.restart.${grdID}"
     ${NCP} "${source}" "${target}"

--- a/jobs/rocoto/coupled_ic.sh
+++ b/jobs/rocoto/coupled_ic.sh
@@ -4,19 +4,17 @@ source "$HOMEgfs/ush/preamble.sh"
 
 ###############################################################
 ## Abstract:
-## Create FV3 initial conditions from GFS intitial conditions
-## RUN_ENVIR : runtime environment (emc | nco)
+## Copy initial conditions from BASE_CPLIC to ROTDIR for coupled forecast-only runs
 ## HOMEgfs   : /full/path/to/workflow
 ## EXPDIR : /full/path/to/config/files
-## CDATE  : current date (YYYYMMDDHH)
 ## CDUMP  : cycle name (gdas / gfs)
 ## PDY    : current date (YYYYMMDD)
 ## cyc    : current cycle (HH)
 ###############################################################
 
 ###############################################################
-# Source FV3GFS workflow modules
-. $HOMEgfs/ush/load_fv3gfs_modules.sh
+# Source workflow modules
+. "${HOMEgfs}/ush/load_fv3gfs_modules.sh"  # TODO: Do we need any modules for this job??
 status=$?
 [[ $status -ne 0 ]] && exit $status
 err=0
@@ -24,93 +22,107 @@ err=0
 ###############################################################
 # Source relevant configs
 configs="base coupled_ic wave"
-for config in $configs; do
-    . $EXPDIR/config.${config}
+for config in ${configs}; do
+    . ${EXPDIR}/config.${config}
     status=$?
-    [[ $status -ne 0 ]] && exit $status
+    [[ ${status} -ne 0 ]] && exit ${status}
 done
 
 ###############################################################
 # Source machine runtime environment
-. $BASE_ENV/${machine}.env config.coupled_ic
+. ${BASE_ENV}/${machine}.env config.coupled_ic
 status=$?
-[[ $status -ne 0 ]] && exit $status
+[[ ${status} -ne 0 ]] && exit ${status}
 
-# Create ICSDIR if needed
-[[ ! -d $ICSDIR/$CDATE ]] && mkdir -p $ICSDIR/$CDATE
-[[ ! -d $ICSDIR/$CDATE/atmos ]] && mkdir -p $ICSDIR/$CDATE/atmos
-[[ ! -d $ICSDIR/$CDATE/ocn ]] && mkdir -p $ICSDIR/$CDATE/ocn
-[[ ! -d $ICSDIR/$CDATE/ice ]] && mkdir -p $ICSDIR/$CDATE/ice
+###############################################################
+# Locally scoped variables and functions
+GDATE=$(date -d "${PDY} ${cyc} - ${assim_freq} hours" +%Y%m%d%H)
+gPDY="${GDATE:0:8}"
+gcyc="${GDATE:8:2}"
 
-if [ $ICERES = '025' ]; then
-  ICERESdec="0.25"
-fi 
-if [ $ICERES = '050' ]; then         
- ICERESdec="0.50"        
-fi 
+error_message(){
+    echo "FATAL ERROR: Unable to copy ${1} to ${2} (Error code ${3})"
+}
 
-# Setup ATM initial condition files
-cp -r $BASE_CPLIC/$CPL_ATMIC/$CDATE/$CDUMP/*  $ICSDIR/$CDATE/atmos/
+###############################################################
+# Start staging
+
+# Stage the FV3 initial conditions to ROTDIR (cold start)
+ATMdir="${ROTDIR}/${CDUMP}.${PDY}/${cyc}/atmos/INPUT"
+[[ ! -d "${ATMdir}" ]] && mkdir -p "${ATMdir}"
+source="${BASE_CPLIC}/${CPL_ATMIC}/${PDY}${cyc}/${CDUMP}/${CASE}/INPUT/gfs_ctrl.nc"
+target="${ATMdir}/gfs_ctrl.nc"
+${NCP} "${source}" "${target}"
 rc=$?
-if [[ $rc -ne 0 ]] ; then
-  echo "FATAL: Unable to copy $BASE_CPLIC/$CPL_ATMIC/$CDATE/$CDUMP/* to $ICSDIR/$CDATE/atmos/ (Error code $rc)" 
-fi
+[[ ${rc} -ne 0 ]] && error_message "${source}" "${target}" "${rc}"
 err=$((err + rc))
-
-
-# Setup Ocean IC files 
-cp -r $BASE_CPLIC/$CPL_OCNIC/$CDATE/ocn/$OCNRES/MOM*.nc  $ICSDIR/$CDATE/ocn/
-rc=$?
-if [[ $rc -ne 0 ]] ; then
-  echo "FATAL: Unable to copy $BASE_CPLIC/$CPL_OCNIC/$CDATE/ocn/$OCNRES/MOM*.nc to $ICSDIR/$CDATE/ocn/ (Error code $rc)"
-fi
-err=$((err + rc))
-
-#Setup Ice IC files 
-cp $BASE_CPLIC/$CPL_ICEIC/$CDATE/ice/$ICERES/cice5_model_${ICERESdec}.res_$CDATE.nc $ICSDIR/$CDATE/ice/cice_model_${ICERESdec}.res_$CDATE.nc
-rc=$?
-if [[ $rc -ne 0 ]] ; then
-  echo "FATAL: Unable to copy $BASE_CPLIC/$CPL_ICEIC/$CDATE/ice/$ICERES/cice5_model_${ICERESdec}.res_$CDATE.nc to $ICSDIR/$CDATE/ice/cice_model_${ICERESdec}.res_$CDATE.nc (Error code $rc)"
-fi
-err=$((err + rc))
-
-if [ $DO_WAVE = "YES" ]; then
-  [[ ! -d $ICSDIR/$CDATE/wav ]] && mkdir -p $ICSDIR/$CDATE/wav
-  for grdID in $waveGRD
-  do
-    cp $BASE_CPLIC/$CPL_WAVIC/$CDATE/wav/$grdID/*restart.$grdID $ICSDIR/$CDATE/wav/
+for ftype in gfs_data sfc_data; do
+  for tt in $(seq 1 6); do
+    source="${BASE_CPLIC}/${CPL_ATMIC}/${PDY}${cyc}/${CDUMP}/${CASE}/INPUT/${ftype}.tile${tt}.nc"
+    target="${ATMdir}/${ftype}.tile${tt}.nc"
+    ${NCP} "${source}" "${target}"
     rc=$?
-    if [[ $rc -ne 0 ]] ; then
-      echo "FATAL: Unable to copy $BASE_CPLIC/$CPL_WAVIC/$CDATE/wav/$grdID/*restart.$grdID to $ICSDIR/$CDATE/wav/ (Error code $rc)" 
-    fi
+    [[ ${rc} -ne 0 ]] && error_message "${source}" "${target}" "${rc}"
+    err=$((err + rc))
+  done
+done
+
+# Stage ocean initial conditions to ROTDIR (warm start), Not sure if there exists a "cold start" for ocean
+OCNdir="${ROTDIR}/${CDUMP}.${gPDY}/${gcyc}/ocean/RESTART"
+[[ ! -d "${OCNdir}" ]] && mkdir -p "${OCNdir}"
+source="${BASE_CPLIC}/${CPL_OCNIC}/${PDY}${cyc}/ocn/${OCNRES}/MOM.res.nc"
+target="${OCNdir}/${PDY}.${cyc}0000.MOM.res.nc"
+${NCP} "${source}" "${target}"
+rc=$?
+[[ ${rc} -ne 0 ]] && error_message "${source}" "${target}" "${rc}"
+err=$((err + rc))
+case $OCNRES in
+  "025")
+    for nn in $(seq 1 4); do
+      source="${BASE_CPLIC}/${CPL_OCNIC}/${PDY}${cyc}/ocn/${OCNRES}/MOM.res_${nn}.nc"
+      if [[ -f "${source}" ]]; then
+        target="${OCNdir}/${PDY}.${cyc}0000.MOM.res_${nn}.nc"
+        ${NCP} "${source}" "${target}"
+        rc=$?
+        [[ ${rc} -ne 0 ]] && error_message "${source}" "${target}" "${rc}"
+        err=$((err + rc))
+      fi
+    done
+  ;;
+esac
+
+# Stage ice initial conditions to ROTDIR (cold start as these are SIS2 generated)
+ICEdir="${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ice/RESTART"
+[[ ! -d "${ICEdir}" ]] && mkdir -p "${ICEdir}"
+ICERESdec=$(echo "${ICERES}" | awk '{printf "%0.2f", $1/100}')
+source="${BASE_CPLIC}/${CPL_ICEIC}/${PDY}${cyc}/ice/${ICERES}/cice5_model_${ICERESdec}.res_${PDY}${cyc}.nc"
+target="${ICEdir}/${PDY}.${cyc}0000.cice_model.res.nc"
+${NCP} "${source}" "${target}"
+rc=$?
+[[ ${rc} -ne 0 ]] && error_message "${source}" "${target}" "${rc}"
+err=$((err + rc))
+
+# Stage the WW3 initial conditions to ROTDIR (unsure if these should be treated as warm start or cold start)
+if [[ "${DO_WAVE}" = "YES" ]]; then
+  WAVdir="${ROTDIR}/${CDUMP}.${PDY}/${cyc}/wave/restart"
+  [[ ! -d "${WAVdir}" ]] && mkdir -p "${WAVdir}"
+  for grdID in "${waveGRD}"; do
+    source="${BASE_CPLIC}/${CPL_WAVIC}/${PDY}${cyc}/wav/${grdID}/${PDY}.${cyc}0000.restart.${grdID}"
+    target="${WAVdir}/${PDY}.${cyc}0000.restart.${grdID}"
+    ${NCP} "${source}" "${target}"
+    rc=$?
+    [[ ${rc} -ne 0 ]] && error_message "${source}" "${target}" "${rc}"
     err=$((err + rc))
   done
 fi
 
-# Stage the FV3 initial conditions to ROTDIR
-export OUTDIR="$ICSDIR/$CDATE/atmos/$CASE/INPUT"
-COMOUT="$ROTDIR/$CDUMP.$PDY/$cyc/atmos"
-[[ ! -d $COMOUT ]] && mkdir -p $COMOUT
-cd $COMOUT || exit 99
-rm -rf INPUT
-$NLN $OUTDIR .
-
-#Stage the WW3 initial conditions to ROTDIR 
-if [ $DO_WAVE = "YES" ]; then
-  export OUTDIRw="$ICSDIR/$CDATE/wav"
-  COMOUTw="$ROTDIR/$CDUMP.$PDY/$cyc/wave/restart"
-  [[ ! -d $COMOUTw ]] && mkdir -p $COMOUTw
-  cd $COMOUTw || exit 99
-  $NLN $OUTDIRw/* .
+###############################################################
+# Check for errors and exit if any of the above failed
+if  [[ "${err}" -ne 0 ]] ; then
+  echo "FATAL ERROR: Unable to copy ICs from ${BASE_CPLIC} to ${ROTDIR}; ABORT!"
+  exit "${err}"
 fi
-
-if  [[ $err -ne 0 ]] ; then 
-  echo "Fatal Error: ICs are not properly set-up" 
-  exit $err 
-fi 
 
 ##############################################################
 # Exit cleanly
-
-
 exit 0

--- a/jobs/rocoto/coupled_ic.sh
+++ b/jobs/rocoto/coupled_ic.sh
@@ -13,13 +13,6 @@ source "$HOMEgfs/ush/preamble.sh"
 ###############################################################
 
 ###############################################################
-# Source workflow modules
-. "${HOMEgfs}/ush/load_fv3gfs_modules.sh"  # TODO: Do we need any modules for this job??
-status=$?
-[[ $status -ne 0 ]] && exit $status
-err=0
-
-###############################################################
 # Source relevant configs
 configs="base coupled_ic wave"
 for config in ${configs}; do
@@ -67,7 +60,7 @@ for ftype in gfs_data sfc_data; do
   done
 done
 
-# Stage ocean initial conditions to ROTDIR (warm start), Not sure if there exists a "cold start" for ocean
+# Stage ocean initial conditions to ROTDIR (warm start)
 OCNdir="${ROTDIR}/${CDUMP}.${gPDY}/${gcyc}/ocean/RESTART"
 [[ ! -d "${OCNdir}" ]] && mkdir -p "${OCNdir}"
 source="${BASE_CPLIC}/${CPL_OCNIC}/${PDY}${cyc}/ocn/${OCNRES}/MOM.res.nc"
@@ -107,7 +100,7 @@ rc=$?
 [[ ${rc} -ne 0 ]] && error_message "${source}" "${target}" "${rc}"
 err=$((err + rc))
 
-# Stage the WW3 initial conditions to ROTDIR (unsure if these should be treated as warm start or cold start)
+# Stage the WW3 initial conditions to ROTDIR (warm start; TODO: these should be placed in $RUN.$gPDY/$gcyc)
 if [[ "${DO_WAVE}" = "YES" ]]; then
   WAVdir="${ROTDIR}/${CDUMP}.${PDY}/${cyc}/wave/restart"
   [[ ! -d "${WAVdir}" ]] && mkdir -p "${WAVdir}"

--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -111,7 +111,6 @@ fi
 export DATAROOT="${STMP}/RUNDIRS/${PSLOT}"  # TODO: set via prod_envir in Ops
 export RUNDIR="${DATAROOT}"  # TODO: Should be removed; use DATAROOT instead
 export ARCDIR="${NOSCRUB}/archive/${PSLOT}"
-export ICSDIR="@ICSDIR@"
 export ATARDIR="@ATARDIR@"
 
 # Commonly defined parameters in JJOBS

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -758,20 +758,16 @@ MOM6_postdet() {
   OCNRES=${OCNRES:-"025"}  # TODO: remove from here and lift higher
 
   # Copy MOM6 ICs
-  if [[ "${MODE}" = 'cycled' ]]; then  # TODO: remove this block after ICSDIR is corrected for forecast-only
-    $NLN "${ROTDIR}/${CDUMP}.${gPDY}/${gcyc}/ocean/RESTART/${PDY}.${cyc}0000.MOM.res.nc" "${DATA}/INPUT/MOM.res.nc"
-    case $OCNRES in
-      "025")
-        for nn in $(seq 1 4); do
-          if [[ -f "${ROTDIR}/${CDUMP}.${gPDY}/${gcyc}/ocean/RESTART/${PDY}.${cyc}0000.MOM.res_${nn}.nc" ]]; then
-            $NLN "${ROTDIR}/${CDUMP}.${gPDY}/${gcyc}/ocean/RESTART/${PDY}.${cyc}0000.MOM.res_${nn}.nc" "${DATA}/INPUT/MOM.res_${nn}.nc"
-          fi
-        done
-      ;;
-    esac
-  else
-    $NCP -pf "${ICSDIR}/${CDATE}"/ocn/MOM*.nc "${DATA}/INPUT/"  # TODO: Update files in ICSDIR to reflect COM structure naming convention
-  fi
+  $NLN "${ROTDIR}/${CDUMP}.${gPDY}/${gcyc}/ocean/RESTART/${PDY}.${cyc}0000.MOM.res.nc" "${DATA}/INPUT/MOM.res.nc"
+  case $OCNRES in
+    "025")
+      for nn in $(seq 1 4); do
+        if [[ -f "${ROTDIR}/${CDUMP}.${gPDY}/${gcyc}/ocean/RESTART/${PDY}.${cyc}0000.MOM.res_${nn}.nc" ]]; then
+          $NLN "${ROTDIR}/${CDUMP}.${gPDY}/${gcyc}/ocean/RESTART/${PDY}.${cyc}0000.MOM.res_${nn}.nc" "${DATA}/INPUT/MOM.res_${nn}.nc"
+        fi
+      done
+    ;;
+  esac
 
   # Copy MOM6 fixed files
   $NCP -pf $FIXmom/$OCNRES/* $DATA/INPUT/
@@ -1012,11 +1008,10 @@ CICE_postdet() {
   export MESH_OCN_ICE=${MESH_OCN_ICE:-"mesh.mx${ICERES}.nc"}
 
   # Copy/link CICE IC to DATA
-  if [[ "${MODE}" = 'cycled' ]]; then  # TODO: remove this block after ICSDIR is corrected for forecast-only
+  if [[ "${warm_start}" = ".true." ]]; then
     $NLN "${ROTDIR}/${CDUMP}.${gPDY}/${gcyc}/ice/RESTART/${PDY}.${cyc}0000.cice_model.res.nc" "${DATA}/cice_model.res.nc"
-  else
-    ICERESdec=$(echo "${ICERES}" | awk '{printf "%0.2f", $1/100}')
-    $NCP -p $ICSDIR/$CDATE/ice/cice_model_${ICERESdec}.res_$CDATE.nc $DATA/cice_model.res.nc
+  else # cold start are typically SIS2 restarts obtained from somewhere else e.g. CPC
+    $NLN "${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ice/RESTART/${PDY}.${cyc}0000.cice_model.res.nc" "${DATA}/cice_model.res.nc"
   fi
   # TODO: add a check for the restarts to exist, if not, exit eloquently
   rm -f "${DATA}/ice.restart_file"

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -42,7 +42,6 @@ common_predet(){
   CDATE=${CDATE:-2017032500}
   DATA=${DATA:-$pwd/fv3tmp$$}    # temporary running directory
   ROTDIR=${ROTDIR:-$pwd}         # rotating archive directory
-  ICSDIR=${ICSDIR:-$pwd}         # cold start initial conditions
 }
 
 DATM_predet(){
@@ -102,7 +101,6 @@ FV3_GFS_predet(){
   FIXfv3=${FIXfv3:-$FIX_DIR/orog}
   DATA=${DATA:-$pwd/fv3tmp$$}    # temporary running directory
   ROTDIR=${ROTDIR:-$pwd}         # rotating archive directory
-  ICSDIR=${ICSDIR:-$pwd}         # cold start initial conditions
   DMPDIR=${DMPDIR:-$pwd}         # global dumps for seaice, snow and sst analysis
 
   # Model resolution specific parameters

--- a/workflow/rocoto/workflow_xml.py
+++ b/workflow/rocoto/workflow_xml.py
@@ -57,9 +57,6 @@ class RocotoXML:
 
         entity['PSLOT'] = self._base['PSLOT']
 
-        if self._app_config.mode in ['forecast-only']:
-            entity['ICSDIR'] = self._base['ICSDIR']
-
         entity['ROTDIR'] = self._base['ROTDIR']
         entity['JOBS_DIR'] = self._base['BASE_JOB']
 

--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -220,7 +220,6 @@ def edit_baseconfig(host, inputs):
         "@CASECTL@": f'C{inputs.resdet}',
         "@EXPDIR@": inputs.expdir,
         "@ROTDIR@": inputs.comrot,
-        "@ICSDIR@": inputs.icsdir,
         "@EXP_WARM_START@": inputs.warm_start,
         "@MODE@": inputs.mode,
         "@gfs_cyc@": inputs.gfs_cyc,
@@ -296,7 +295,6 @@ def input_args():
         Setup files and directories to start a GFS parallel.\n
         Create EXPDIR, copy config files.\n
         Create COMROT experiment directory structure,
-        link initial condition files from $ICSDIR to $COMROT
         """
 
     parser = ArgumentParser(description=description,
@@ -322,7 +320,6 @@ def input_args():
         subp.add_argument('--idate', help='starting date of experiment, initial conditions must exist!',
                           required=True, type=lambda dd: to_datetime(dd))
         subp.add_argument('--edate', help='end date experiment', required=True, type=lambda dd: to_datetime(dd))
-        subp.add_argument('--icsdir', help='full path to initial condition directory', type=str, required=False, default=None)
         subp.add_argument('--configdir', help='full path to directory containing the config files',
                           type=str, required=False, default=os.path.join(_top, 'parm/config'))
         subp.add_argument('--cdump', help='CDUMP to start the experiment',
@@ -338,6 +335,7 @@ def input_args():
     ufs_apps = ['ATM', 'ATMA', 'ATMW', 'S2S', 'S2SW']
 
     # cycled mode additional arguments
+    cycled.add_argument('--icsdir', help='full path to initial condition directory', type=str, required=False, default=None)
     cycled.add_argument('--resens', help='resolution of the ensemble model forecast',
                         type=int, required=False, default=192)
     cycled.add_argument('--nens', help='number of ensemble members',
@@ -350,9 +348,6 @@ def input_args():
                            choices=ufs_apps + ['S2SWA'], required=False, default='ATM')
 
     args = parser.parse_args()
-
-    if args.mode in ['forecast-only'] and args.app in ['S2S', 'S2SW'] and args.icsdir is None:
-        raise SyntaxError("An IC directory must be specified with --icsdir when running the S2S or S2SW app in forecast-only mode")
 
     # Add an entry for warm_start = .true. or .false.
     if args.start in ['warm']:

--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -354,7 +354,6 @@ def input_args():
         args.warm_start = ".true."
     elif args.start in ['cold']:
         args.warm_start = ".false."
-    print(args.warm_start)
 
     return args
 


### PR DESCRIPTION
**Description**

This PR:
- updates `coupled_ic.sh` job to copy initial conditions from `BASE_CPLIC` directly to `ROTDIR` in the names that the workflow expects and conforms to the naming convention within the workflow
- obsoletes the need and use of `ICSDIR` in forecast-only experiments which served as a intermediate space for staging initial conditions.
- updates the documentation section for `forecast-only`

This is a non-breaking change.

A change in documentation is required as the instructions for setting up the coupled forecast-only experiment no longer needs to pass the argument `--icsdir` to `setup_expt.py`.

Fixes #1276 

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

**How Has This Been Tested?**

- [X] Coupled forecast-only P8 test on Hera.  The forecast was only run for 24 hours as the work in this script is in the initialization of the model to validate all the ICs are indeed found.  The test was successful.
See `EXPDIR: /scratch1/NCEPDEV/stmp2/Rahul.Mahajan/EXPDIR/ffs2sw` for details
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [X] Any dependent changes have been merged and published
