### PR TITLE
Add back in module load block in coupled_ic.sh

### DIFF
--- a/jobs/rocoto/coupled_ic.sh
+++ b/jobs/rocoto/coupled_ic.sh
@@ -13,6 +13,13 @@ source "$HOMEgfs/ush/preamble.sh"
 ###############################################################
 
 ###############################################################
+# Source FV3GFS workflow modules
+. ${HOMEgfs}/ush/load_fv3gfs_modules.sh
+status=$?
+[[ ${status} -ne 0 ]] && exit ${status}
+err=0
+
+###############################################################
 # Source relevant configs
 configs="base coupled_ic wave"
 for config in ${configs}; do


### PR DESCRIPTION
**Description**

This hotfix PR resolves bug introduced from removal of module load script block in coupled_ic.sh:
https://github.com/NOAA-EMC/global-workflow/commit/bdb0db77fdb3cc93a2eae981843499cd38724ba5#diff-a2ca8bb41122c95d1390f2136eb14b49952a67484329901b32bd421fe40e0dacL17-L22

Adding block back in for now and will then address errors produced by it more appropriately.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Made changes within `develop` clone on Orion and reran failing coupled_ic job to confirm bug fixed.
