### PR TITLE
Stop wiping data at beginning of bmat vrfy j-job

### DIFF
--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_BMAT_VRFY
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_BMAT_VRFY
@@ -1,8 +1,7 @@
 #!/bin/bash
 export STRICT="NO"
 source "${HOMEgfs}/ush/preamble.sh"
-
-
+WIPE_DATA="NO"
 export DATA="${DATAROOT}/${RUN}ocnanal_${cyc}"
 source "${HOMEgfs}/ush/jjob_header.sh" -e "ocnanalrun" -c "base ocnanal ocnanalrun"
 


### PR DESCRIPTION
The ocean b-matrix verification job relies on data from the b-matrix job still residing in `$DATA`, but that directory was being wiped when this job began. Now setting `WIPE_DATA` to `NO` to prevent the deletion.

Closes [GDASApp/issues/318](https://github.com/NOAA-EMC/GDASApp/issues/318)