### PR TITLE
GFSv16.3.6

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.3.5
+tag = gfsda.v16.3.6
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git

--- a/docs/Release_Notes.gfs.v16.3.6.md
+++ b/docs/Release_Notes.gfs.v16.3.6.md
@@ -26,7 +26,7 @@ The checkout script extracts the following GFS components:
 | --------- | ----------- | ----------------- |
 | MODEL     | GFS.v16.3.0   | Jun.Wang@noaa.gov |
 | GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
-| GSI       | gfsda.v16.3.6 | Emily.Liu@noaa.gov |
+| GSI       | gfsda.v16.3.6 | Andrew.Collard@noaa.gov |
 | UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
 | POST      | upp_v8.2.0 | Wen.Meng@noaa.gov |
 | WAFS      | gfs_wafs.v6.3.1 | Yali.Mao@noaa.gov |

--- a/docs/Release_Notes.gfs.v16.3.6.md
+++ b/docs/Release_Notes.gfs.v16.3.6.md
@@ -1,0 +1,127 @@
+GFS V16.3.6 RELEASE NOTES
+
+-------
+PRELUDE
+-------
+
+The GFSv16.3.5 is upgraded to GFSv16.3.6 to remove GMI from operational processing in the GSI.
+
+IMPLEMENTATION INSTRUCTIONS
+---------------------------
+
+The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub .com are used to manage the GFS code.  The SPA(s) handling the GFS implementation need to have permissions to clone VLab Gerrit repositories and private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are publicly readable and do not require access permissions.  Please proceed with the following steps to install the package on WCOSS2:
+
+```bash
+cd $PACKAGEROOT
+mkdir gfs.v16.3.6
+cd gfs.v16.3.6
+git clone -b EMC-v16.3.6 https://github.com/NOAA-EMC/global-workflow.git .
+cd sorc
+./checkout.sh -o
+```
+
+The checkout script extracts the following GFS components:
+
+| Component | Tag         | POC               |
+| --------- | ----------- | ----------------- |
+| MODEL     | GFS.v16.3.0   | Jun.Wang@noaa.gov |
+| GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
+| GSI       | gfsda.v16.3.6 | Emily.Liu@noaa.gov |
+| UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
+| POST      | upp_v8.2.0 | Wen.Meng@noaa.gov |
+| WAFS      | gfs_wafs.v6.3.1 | Yali.Mao@noaa.gov |
+
+To build all the GFS components, execute:
+```bash
+./build_all.sh
+```
+The `build_all.sh` script compiles all GFS components. Runtime output from the build for each package is written to log files in directory logs. To build an individual program, for instance, gsi, use `build_gsi.sh`.
+
+Next, link the executables, fix files, parm files, etc in their final respective locations by executing:
+```bash
+./link_fv3gfs.sh nco wcoss2
+```
+
+Lastly, link the ecf scripts by moving back up to the ecf folder and executing:
+```bash
+cd ../ecf
+./setup_ecf_links.sh
+```
+
+VERSION FILE CHANGES
+--------------------
+
+* `versions/run.ver` - change `version=v16.3.6` and `gfs_ver=v16.3.6`
+
+SORC CHANGES
+------------
+
+* No changes from GFS v16.3.5
+
+JOBS CHANGES
+------------
+
+* No changes from GFS v16.3.5
+
+PARM/CONFIG CHANGES
+-------------------
+
+* No changes from GFS v16.3.5
+
+SCRIPT CHANGES
+--------------
+
+* GSI - scripts/exglobal_atmos_analysis.sh
+
+FIX CHANGES
+-----------
+
+* No changes from GFS v16.3.5
+
+MODULE CHANGES
+--------------
+
+* No changes from GFS v16.3.5
+
+CHANGES TO FILE SIZES
+---------------------
+
+* No changes from GFS v16.3.5
+
+ENVIRONMENT AND RESOURCE CHANGES
+--------------------------------
+
+* No changes from GFS v16.3.5
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+---------------------------------------
+
+* Which production jobs should be tested as part of this implementation?
+  * GSI 
+* Does this change require a 30-day evaluation?
+  * No
+
+DISSEMINATION INFORMATION
+-------------------------
+
+* No changes from GFS v16.3.5
+
+HPSS ARCHIVE
+------------
+
+* No changes from GFS v16.3.5
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+---------------------------------
+
+* No changes from GFS v16.3.5
+
+DOCUMENTATION
+-------------
+
+* No changes from GFS v16.3.5
+
+PREPARED BY
+-----------
+Kate.Friedman@noaa.gov
+Andrew.Collard@noaa.gov

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -35,7 +35,7 @@ fi
 echo gsi checkout ...
 if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
-    git clone --recursive --branch gfsda.v16.3.5 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
+    git clone --recursive --branch gfsda.v16.3.6 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
     git submodule update --init
     cd ${topdir}

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.5
-export gfs_ver=v16.3.5
+export version=v16.3.6
+export gfs_ver=v16.3.6
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2


### PR DESCRIPTION
**Description**

This PR merges the GFSv16.3.6 release branch into the `dev/gfs.v16` branch upon the completion of the GFSv16.3.6 upgrade in WCOSS2 operations. Implemented into operations on February 9th during the 12z cycle (2023020912).

```
RFC 10562 - On WCOSS2, implement a modified GFS global analysis to remove
the use of GMI (Global Precipitation Measurement Microwave Imager) data. The
developer noticed an array overflow in the processing of GMI data on Hera
which may lead to a SEGFAULT for the GSI (Grid-Point Statistical 
Interpolation). Removing this data usage will prevent a potential operational
GSI crash.
```

Changes for v16.3.6:

1. Update GSI tag to `gfsda.v16.3.6`
2. Add release notes `docs/Release_Notes.gfs.v16.3.6.md`
3. Change `gfs_ver=v16.3.6`

**Type of change**

Production update.

**How Has This Been Tested?**

DA team tested before hand-off and NCO tested before implementation.

Resolves #1278
