### PR TITLE
Update RTD GFS operational status version to v16.3.6

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Status
 ======
 
 * State of develop (HEAD) branch: GFSv17+ development
-* State of operations: GFS v16.3.5 `tag: [gfs.v16.3.5] <https://github.com/NOAA-EMC/global-workflow/releases/tag/gfs.v16.3.5>`_
+* State of operations (dev/gfs.v16 branch): GFS v16.3.6 `tag: [gfs.v16.3.6] <https://github.com/NOAA-EMC/global-workflow/releases/tag/gfs.v16.3.6>`_
 
 =============
 Code managers


### PR DESCRIPTION
**Description**

Update the status of operations to the newly implemented v16.3.6 version on the read-the-docs main page.

Refs #1278

**Type of change**

Documentation update.
