### PR TITLE
fix name of MOM6 n restarts for future cycle points

### DIFF
--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -905,7 +905,7 @@ MOM6_postdet() {
     case ${OCNRES} in
       "025")
         for nn in $(seq 1 4); do
-          $NLN "${COMOUTocean}/RESTART/${idate:0:8}.${idate:8:2}0000.MOM.res_${nn}.nc" "${DATA}/MOM6_RESTART/MOM.res_${nn}.${idatestr}-00-00.nc"
+          $NLN "${COMOUTocean}/RESTART/${idate:0:8}.${idate:8:2}0000.MOM.res_${nn}.nc" "${DATA}/MOM6_RESTART/MOM.res.${idatestr}-00-00_${nn}.nc"
         done
         ;;
     esac


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

Script fix for C384 O0.25 3DVAR cycling. Original scripts had wrong naming structure for MOM *_res_${n}.nc restart files. 

Only one line in *ush/forecast_postdet.sh* was changed. 

This address issue numbers [https://github.com/NOAA-EMC/global-workflow/issues/947](https://github.com/NOAA-EMC/global-workflow/issues/947) and [https://github.com/NOAA-EMC/global-workflow/issues/1289](https://github.com/NOAA-EMC/global-workflow/issues/1289)
<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)


**How Has This Been Tested?**

This has been tested on hera with warm starts starting on 2020040106. The ICs can be found at
/scratch2/NCEPDEV/stmp3/Neil.Barton/ICs

The cycling test is with 3DVAR and without IAU. 

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--
- [ ] 3DVAR without IAU Cycled test on Hera
-->

Note, the gdasfcst task needs an additional node to run as the forecast fails due to memory issues. Adding one more node for these forecasts was not added to these scripts as a more eloquent way to address memory will be with esmf threading. 
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
