### PR TITLE
Allow increments to be added for ocean and ice cycling.

### DIFF
--- a/jobs/rocoto/ocnanalbmat.sh
+++ b/jobs/rocoto/ocnanalbmat.sh
@@ -13,7 +13,7 @@ export jobid="${job}.$$"
 
 ###############################################################
 # Execute the JJOB
-#"${HOMEgfs}"/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_BMAT
+"${HOMEgfs}"/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_BMAT
 echo "BMAT gets run here"
 status=$?
 exit "${status}"

--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -308,9 +308,6 @@ export imp_physics=@IMP_PHYSICS@
 export DO_JEDIVAR="NO"
 export DO_JEDIENS="NO"
 export DO_JEDIOCNVAR="NO"
-if [[ ${DO_JEDIOCNVAR} = "YES" ]]; then
-    export MOM_IAU=true
-fi
 
 # Hybrid related
 export DOHYBVAR="@DOHYBVAR@"

--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -308,6 +308,9 @@ export imp_physics=@IMP_PHYSICS@
 export DO_JEDIVAR="NO"
 export DO_JEDIENS="NO"
 export DO_JEDIOCNVAR="NO"
+if [[ ${DO_JEDIOCNVAR} = "YES" ]]; then
+    export MOM_IAU=true
+fi
 
 # Hybrid related
 export DOHYBVAR="@DOHYBVAR@"

--- a/parm/mom6/MOM_input_template_025
+++ b/parm/mom6/MOM_input_template_025
@@ -406,7 +406,7 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! radius, otherwise, if false, use Pedlosky's definition. These definitions
                                 ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
-INTERNAL_WAVE_SPEED_BETTER_EST = False !   [Boolean] default = True 
+INTERNAL_WAVE_SPEED_BETTER_EST = False !   [Boolean] default = True
                                 ! If true, use a more robust estimate of the first mode wave speed as the
                                 ! starting point for iterations.
 
@@ -731,7 +731,7 @@ NSTAR = 0.06                    !   [nondim] default = 0.2
                                 ! The portion of the buoyant potential energy imparted by surface fluxes that is
                                 ! available to drive entrainment at the base of mixed layer when that energy is
                                 ! positive.
-EPBL_MLD_BISECTION = True       !   [Boolean] default = False 
+EPBL_MLD_BISECTION = True       !   [Boolean] default = False
                                 ! If true, use bisection with the iterative determination of the self-consistent
                                 ! mixed layer depth.  Otherwise use the false position after a maximum and
                                 ! minimum bound have been evaluated and the returned value or bisection before
@@ -833,6 +833,30 @@ ENERGYSAVEDAYS = 1.00           !   [days] default = 1.0
 
 ! === module ocean_model_init ===
 
+! === module MOM_oda_incupd ===
+ODA_INCUPD = @[ODA_INCUPD]   ! [Boolean] default = False
+                             ! If true, oda incremental updates will be applied
+                             ! everywhere in the domain.
+ODA_INCUPD_FILE = "inc.nc"   ! The name of the file with the T,S,h increments.
+
+ODA_TEMPINC_VAR = "Temp"        ! default = "ptemp_inc"
+                                ! The name of the potential temperature inc. variable in
+				      	   ! ODA_INCUPD_FILE.
+ODA_SALTINC_VAR = "Salt"        ! default = "sal_inc"
+                                ! The name of the salinity inc. variable in
+                                ! ODA_INCUPD_FILE.
+ODA_THK_VAR = "h"               ! default = "h"
+                                ! The name of the int. depth inc. variable in
+                                ! ODA_INCUPD_FILE.
+ODA_INCUPD_UV = false           !
+!ODA_UINC_VAR = "u"             ! default = "u_inc"
+                                ! The name of the zonal vel. inc. variable in
+                                ! ODA_INCUPD_UV_FILE.
+!ODA_VINC_VAR = "v"             ! default = "v_inc"
+                                ! The name of the meridional vel. inc. variable in
+                                ! ODA_INCUPD_UV_FILE.
+ODA_INCUPD_NHOURS = @[ODA_INCUPD_NHOURS]            ! default=3.0
+
 ! === module MOM_surface_forcing ===
 OCEAN_SURFACE_STAGGER = "A"     ! default = "C"
                                 ! A case-insensitive character string to indicate the
@@ -868,8 +892,8 @@ LIQUID_RUNOFF_FROM_DATA = @[MOM6_RIVER_RUNOFF]  !   [Boolean] default = False
                                 ! the data_table using the component name 'OCN'.
 ! === module ocean_stochastics ===
 DO_SPPT   = @[DO_OCN_SPPT]      ! [Boolean] default = False
-                                ! If true perturb the diabatic tendencies in MOM_diabadic_driver 
-PERT_EPBL = @[PERT_EPBL]        ! [Boolean] default = False 
+                                ! If true perturb the diabatic tendencies in MOM_diabadic_driver
+PERT_EPBL = @[PERT_EPBL]        ! [Boolean] default = False
                                 ! If true perturb the KE dissipation and destruction in MOM_energetic_PBL
 ! === module MOM_restart ===
 RESTART_CHECKSUMS_REQUIRED = False

--- a/parm/mom6/MOM_input_template_025
+++ b/parm/mom6/MOM_input_template_025
@@ -892,7 +892,7 @@ LIQUID_RUNOFF_FROM_DATA = @[MOM6_RIVER_RUNOFF]  !   [Boolean] default = False
                                 ! the data_table using the component name 'OCN'.
 ! === module ocean_stochastics ===
 DO_SPPT   = @[DO_OCN_SPPT]      ! [Boolean] default = False
-                                ! If true perturb the diabatic tendencies in MOM_diabadic_driver
+                                ! If true perturb the diabatic tendencies in MOM_diabatic_driver
 PERT_EPBL = @[PERT_EPBL]        ! [Boolean] default = False
                                 ! If true perturb the KE dissipation and destruction in MOM_energetic_PBL
 ! === module MOM_restart ===

--- a/parm/mom6/MOM_input_template_025
+++ b/parm/mom6/MOM_input_template_025
@@ -837,7 +837,7 @@ ENERGYSAVEDAYS = 1.00           !   [days] default = 1.0
 ODA_INCUPD = @[ODA_INCUPD]   ! [Boolean] default = False
                              ! If true, oda incremental updates will be applied
                              ! everywhere in the domain.
-ODA_INCUPD_FILE = "inc.nc"   ! The name of the file with the T,S,h increments.
+ODA_INCUPD_FILE = "mom6_increment.nc"   ! The name of the file with the T,S,h increments.
 
 ODA_TEMPINC_VAR = "Temp"        ! default = "ptemp_inc"
                                 ! The name of the potential temperature inc. variable in

--- a/parm/mom6/MOM_input_template_050
+++ b/parm/mom6/MOM_input_template_050
@@ -864,7 +864,7 @@ RESTART_CHECKSUMS_REQUIRED = False
 ODA_INCUPD = @[ODA_INCUPD]   ! [Boolean] default = False
                              ! If true, oda incremental updates will be applied
                              ! everywhere in the domain.
-ODA_INCUPD_FILE = "inc.nc"   ! The name of the file with the T,S,h increments.
+ODA_INCUPD_FILE = "mom6_increment.nc"   ! The name of the file with the T,S,h increments.
 
 ODA_TEMPINC_VAR = "Temp"        ! default = "ptemp_inc"
                                 ! The name of the potential temperature inc. variable in

--- a/parm/mom6/MOM_input_template_050
+++ b/parm/mom6/MOM_input_template_050
@@ -419,7 +419,7 @@ GILL_EQUATORIAL_LD = True       !   [Boolean] default = False
                                 ! radius, otherwise, if false, use Pedlosky's definition. These definitions
                                 ! differ by a factor of 2 in front of the beta term in the denominator. Gill's
                                 ! is the more appropriate definition.
-INTERNAL_WAVE_SPEED_BETTER_EST = False !   [Boolean] default = True 
+INTERNAL_WAVE_SPEED_BETTER_EST = False !   [Boolean] default = True
                                 ! If true, use a more robust estimate of the first mode wave speed as the
                                 ! starting point for iterations.
 
@@ -757,7 +757,7 @@ MSTAR2_COEF1 = 0.29             !   [nondim] default = 0.3
 MSTAR2_COEF2 = 0.152            !   [nondim] default = 0.085
                                 ! Coefficient in computing mstar when only rotation limits the total mixing
                                 ! (used if EPBL_MSTAR_SCHEME = OM4)
-EPBL_MLD_BISECTION = True       !   [Boolean] default = False 
+EPBL_MLD_BISECTION = True       !   [Boolean] default = False
                                 ! If true, use bisection with the iterative determination of the self-consistent
                                 ! mixed layer depth.  Otherwise use the false position after a maximum and
                                 ! minimum bound have been evaluated and the returned value or bisection before
@@ -858,8 +858,32 @@ USE_NEUTRAL_DIFFUSION = True    !   [Boolean] default = False
                                 ! If true, enables the neutral diffusion module.
 
 ! === module ocean_model_init ===
-
 RESTART_CHECKSUMS_REQUIRED = False
+
+! === module MOM_oda_incupd ===
+ODA_INCUPD = @[ODA_INCUPD]   ! [Boolean] default = False
+                             ! If true, oda incremental updates will be applied
+                             ! everywhere in the domain.
+ODA_INCUPD_FILE = "inc.nc"   ! The name of the file with the T,S,h increments.
+
+ODA_TEMPINC_VAR = "Temp"        ! default = "ptemp_inc"
+                                ! The name of the potential temperature inc. variable in
+				      	   ! ODA_INCUPD_FILE.
+ODA_SALTINC_VAR = "Salt"        ! default = "sal_inc"
+                                ! The name of the salinity inc. variable in
+                                ! ODA_INCUPD_FILE.
+ODA_THK_VAR = "h"               ! default = "h"
+                                ! The name of the int. depth inc. variable in
+                                ! ODA_INCUPD_FILE.
+ODA_INCUPD_UV = false           !
+!ODA_UINC_VAR = "u"             ! default = "u_inc"
+                                ! The name of the zonal vel. inc. variable in
+                                ! ODA_INCUPD_UV_FILE.
+!ODA_VINC_VAR = "v"             ! default = "v_inc"
+                                ! The name of the meridional vel. inc. variable in
+                                ! ODA_INCUPD_UV_FILE.
+ODA_INCUPD_NHOURS = @[ODA_INCUPD_NHOURS]            ! default=3.0
+
 ! === module MOM_lateral_boundary_diffusion ===
 ! This module implements lateral diffusion of tracers near boundaries
 
@@ -913,8 +937,8 @@ LIQUID_RUNOFF_FROM_DATA = @[MOM6_RIVER_RUNOFF]  !   [Boolean] default = False
                                 ! the data_table using the component name 'OCN'.
 ! === module ocean_stochastics ===
 DO_SPPT   = @[DO_OCN_SPPT]      ! [Boolean] default = False
-                                ! If true perturb the diabatic tendencies in MOM_diabadic_driver 
-PERT_EPBL = @[PERT_EPBL]        ! [Boolean] default = False 
+                                ! If true perturb the diabatic tendencies in MOM_diabadic_driver
+PERT_EPBL = @[PERT_EPBL]        ! [Boolean] default = False
                                 ! If true perturb the KE dissipation and destruction in MOM_energetic_PBL
 ! === module MOM_restart ===
 

--- a/parm/mom6/MOM_input_template_050
+++ b/parm/mom6/MOM_input_template_050
@@ -937,7 +937,7 @@ LIQUID_RUNOFF_FROM_DATA = @[MOM6_RIVER_RUNOFF]  !   [Boolean] default = False
                                 ! the data_table using the component name 'OCN'.
 ! === module ocean_stochastics ===
 DO_SPPT   = @[DO_OCN_SPPT]      ! [Boolean] default = False
-                                ! If true perturb the diabatic tendencies in MOM_diabadic_driver
+                                ! If true perturb the diabatic tendencies in MOM_diabatic_driver
 PERT_EPBL = @[PERT_EPBL]        ! [Boolean] default = False
                                 ! If true perturb the KE dissipation and destruction in MOM_energetic_PBL
 ! === module MOM_restart ===

--- a/parm/mom6/MOM_input_template_100
+++ b/parm/mom6/MOM_input_template_100
@@ -832,7 +832,7 @@ ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
 ODA_INCUPD = @[ODA_INCUPD]   ! [Boolean] default = False
                              ! If true, oda incremental updates will be applied
                              ! everywhere in the domain.
-ODA_INCUPD_FILE = "inc.nc"   ! The name of the file with the T,S,h increments.
+ODA_INCUPD_FILE = "mom6_increment.nc"   ! The name of the file with the T,S,h increments.
 
 ODA_TEMPINC_VAR = "Temp"        ! default = "ptemp_inc"
                                 ! The name of the potential temperature inc. variable in

--- a/parm/mom6/MOM_input_template_100
+++ b/parm/mom6/MOM_input_template_100
@@ -878,7 +878,7 @@ FIX_USTAR_GUSTLESS_BUG = False  !   [Boolean] default = True
                                 ! velocity
 ! === module ocean_stochastics ===
 DO_SPPT   = @[DO_OCN_SPPT]      ! [Boolean] default = False
-                                ! If true perturb the diabatic tendencies in MOM_diabadic_driver
+                                ! If true perturb the diabatic tendencies in MOM_diabatic_driver
 PERT_EPBL = @[PERT_EPBL]        ! [Boolean] default = False
                                 ! If true perturb the KE dissipation and destruction in MOM_energetic_PBL
 

--- a/parm/mom6/MOM_input_template_100
+++ b/parm/mom6/MOM_input_template_100
@@ -76,7 +76,7 @@ SAVE_INITIAL_CONDS = False      !   [Boolean] default = False
                                 ! If true, write the initial conditions to a file given by IC_OUTPUT_FILE.
 
 ! === module MOM_oda_incupd ===
-ODA_INCUPD = @[MOM_IAU]         ! [Boolean] default = False
+ODA_INCUPD = @[ODA_INCUPD]         ! [Boolean] default = False
                                 ! If true, oda incremental updates will be applied
                                 ! everywhere in the domain.
 ODA_INCUPD_FILE = "mom6_increment.nc" ! The name of the file with the T,S,h increments.
@@ -97,7 +97,7 @@ ODA_UINC_VAR = "u_inc"          ! default = "u_inc"
 ODA_VINC_VAR = "v_inc"          ! default = "v_inc"
                                 ! The name of the meridional vel. inc. variable in
                                 ! ODA_INCUPD_UV_FILE.
-ODA_INCUPD_NHOURS = @[MOM_IAU_HRS] ! default=3.0
+ODA_INCUPD_NHOURS = @[ODA_INCUPD_NHOURS] ! default=3.0
                                 ! Number of hours for full update (0=direct insertion).
 
 ! === module MOM_domains ===
@@ -430,7 +430,7 @@ VISC_RES_FN_POWER = 2           !   [nondim] default = 100
                                 ! used, although even integers are more efficient to calculate.  Setting this
                                 ! greater than 100 results in a step-function being used. This function affects
                                 ! lateral viscosity, Kh, and not KhTh.
-INTERNAL_WAVE_SPEED_BETTER_EST = False !   [Boolean] default = True 
+INTERNAL_WAVE_SPEED_BETTER_EST = False !   [Boolean] default = True
                                 ! If true, use a more robust estimate of the first mode wave speed as the
                                 ! starting point for iterations.
 
@@ -829,6 +829,28 @@ ENERGYSAVEDAYS = 0.25           !   [days] default = 1.0
                                 ! other globally summed diagnostics.
 
 ! === module ocean_model_init ===
+ODA_INCUPD = @[ODA_INCUPD]   ! [Boolean] default = False
+                             ! If true, oda incremental updates will be applied
+                             ! everywhere in the domain.
+ODA_INCUPD_FILE = "inc.nc"   ! The name of the file with the T,S,h increments.
+
+ODA_TEMPINC_VAR = "Temp"        ! default = "ptemp_inc"
+                                ! The name of the potential temperature inc. variable in
+				      	   ! ODA_INCUPD_FILE.
+ODA_SALTINC_VAR = "Salt"        ! default = "sal_inc"
+                                ! The name of the salinity inc. variable in
+                                ! ODA_INCUPD_FILE.
+ODA_THK_VAR = "h"               ! default = "h"
+                                ! The name of the int. depth inc. variable in
+                                ! ODA_INCUPD_FILE.
+ODA_INCUPD_UV = false           !
+!ODA_UINC_VAR = "u"             ! default = "u_inc"
+                                ! The name of the zonal vel. inc. variable in
+                                ! ODA_INCUPD_UV_FILE.
+!ODA_VINC_VAR = "v"             ! default = "v_inc"
+                                ! The name of the meridional vel. inc. variable in
+                                ! ODA_INCUPD_UV_FILE.
+ODA_INCUPD_NHOURS = @[ODA_INCUPD_NHOURS]            ! default=3.0
 
 ! === module MOM_surface_forcing ===
 OCEAN_SURFACE_STAGGER = "A"     ! default = "C"

--- a/parm/mom6/MOM_input_template_500
+++ b/parm/mom6/MOM_input_template_500
@@ -492,7 +492,9 @@ MAXTRUNC = 1000                 !   [truncations save_interval-1] default = 0
                                 ! to stop if there is any truncation of velocities.
 
 ! === module ocean_model_init ===
-ODA_INCUPD = @[MOM_IAU]            ! [Boolean] default = False
+
+! === module MOM_oda_incupd ===
+ODA_INCUPD = @[ODA_INCUPD]   ! [Boolean] default = False
                              ! If true, oda incremental updates will be applied
                              ! everywhere in the domain.
 ODA_INCUPD_FILE = "inc.nc"   ! The name of the file with the T,S,h increments.
@@ -513,7 +515,7 @@ ODA_INCUPD_UV = false           !
 !ODA_VINC_VAR = "v"             ! default = "v_inc"
                                 ! The name of the meridional vel. inc. variable in
                                 ! ODA_INCUPD_UV_FILE.
-ODA_INCUPD_NHOURS = @[MOM_IAU_HRS]            ! default=3.0
+ODA_INCUPD_NHOURS = @[ODA_INCUPD_NHOURS]            ! default=3.0
 
 ! === module MOM_surface_forcing ===
 OCEAN_SURFACE_STAGGER = "A"     ! default = "C"

--- a/parm/mom6/MOM_input_template_500
+++ b/parm/mom6/MOM_input_template_500
@@ -497,7 +497,7 @@ MAXTRUNC = 1000                 !   [truncations save_interval-1] default = 0
 ODA_INCUPD = @[ODA_INCUPD]   ! [Boolean] default = False
                              ! If true, oda incremental updates will be applied
                              ! everywhere in the domain.
-ODA_INCUPD_FILE = "inc.nc"   ! The name of the file with the T,S,h increments.
+ODA_INCUPD_FILE = "mom6_increment.nc"   ! The name of the file with the T,S,h increments.
 
 ODA_TEMPINC_VAR = "Temp"        ! default = "ptemp_inc"
                                 ! The name of the potential temperature inc. variable in

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -769,6 +769,11 @@ MOM6_postdet() {
     ;;
   esac
 
+  # Link increment
+  if [[ "${MOM_IAU}" = "true" ]]; then
+      $NLN "${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ocean/${CDUMP}.t${cyc}z.ocninc.nc" "${DATA}/INPUT/inc.nc"
+  fi
+
   # Copy MOM6 fixed files
   $NCP -pf $FIXmom/$OCNRES/* $DATA/INPUT/
 

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -770,8 +770,13 @@ MOM6_postdet() {
   esac
 
   # Link increment
-  if [[ "${MOM_IAU}" = "true" ]]; then
+  if [[ "${DO_JEDIOCNVAR:-NO}" = "YES" ]]; then
+      if [[ ! -f "${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ocean/${CDUMP}.t${cyc}z.ocninc.nc" ]]; then
+          echo "FATAL ERROR: Ocean increment not found, ABORT!"
+          exit 111
+      fi
       $NLN "${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ocean/${CDUMP}.t${cyc}z.ocninc.nc" "${DATA}/INPUT/inc.nc"
+      export MOM_IAU="true"
   fi
 
   # Copy MOM6 fixed files

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -776,7 +776,7 @@ MOM6_postdet() {
           exit 111
       fi
       $NLN "${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ocean/${CDUMP}.t${cyc}z.ocninc.nc" "${DATA}/INPUT/inc.nc"
-      export MOM_IAU="true"
+      export ODA_INCUPD="true"
   fi
 
   # Copy MOM6 fixed files

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -775,7 +775,7 @@ MOM6_postdet() {
           echo "FATAL ERROR: Ocean increment not found, ABORT!"
           exit 111
       fi
-      $NLN "${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ocean/${CDUMP}.t${cyc}z.ocninc.nc" "${DATA}/INPUT/inc.nc"
+      $NLN "${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ocean/${CDUMP}.t${cyc}z.ocninc.nc" "${DATA}/INPUT/mom6_increment.nc"
       export ODA_INCUPD="true"
   fi
 

--- a/ush/load_ufsda_modules.sh
+++ b/ush/load_ufsda_modules.sh
@@ -1,7 +1,8 @@
 #! /usr/bin/env bash
 
 ###############################################################
-if [[ "${DEBUG_WORKFLOW:-NO}" == "NO" ]]; then
+export DEBUG_WORKFLOW="${DEBUG_WORKFLOW:-NO}"
+if [[ "${DEBUG_WORKFLOW}" == "NO" ]]; then
     echo "Loading modules quietly..."
     set +x
 fi

--- a/ush/load_ufsda_modules.sh
+++ b/ush/load_ufsda_modules.sh
@@ -1,7 +1,6 @@
 #! /usr/bin/env bash
 
 ###############################################################
-export DEBUG_WORKFLOW="${DEBUG_WORKFLOW:-NO}"
 if [[ "${DEBUG_WORKFLOW}" == "NO" ]]; then
     echo "Loading modules quietly..."
     set +x

--- a/ush/parsing_namelists_MOM6.sh
+++ b/ush/parsing_namelists_MOM6.sh
@@ -15,8 +15,8 @@ MOM6_ALLOW_LANDMASK_CHANGES=${MOM6_ALLOW_LANDMASK_CHANGES:-'False'}
 DO_OCN_SPPT=${DO_OCN_SPPT:-'False'}
 PERT_EPBL=${PERT_EPBL:-'False'}
 
-MOM_IAU=${MOM_IAU:-"false"}
-MOM_IAU_HRS=${MOM_IAU_HRS:-'3.0'}
+ODA_INCUPD=${ODA_INCUPD:-"false"}
+ODA_INCUPD_NHOURS=${ODA_INCUPD_NHOURS:-'3.0'}
 
 if [ $cplwav = ".true." ] ; then
   MOM6_USE_WAVES='True'
@@ -134,8 +134,8 @@ sed -e "s/@\[DT_THERM_MOM6\]/$DT_THERM_MOM6/g" \
     -e "s/@\[CHLCLIM\]/$CHLCLIM/g" \
     -e "s/@\[DO_OCN_SPPT\]/$OCN_SPPT/g" \
     -e "s/@\[PERT_EPBL\]/$PERT_EPBL/g" \
-    -e "s/@\[MOM_IAU_HRS\]/$MOM_IAU_HRS/g" \
-    -e "s/@\[MOM_IAU\]/$MOM_IAU/g" $DATA/INPUT/MOM_input_template_$OCNRES > $DATA/INPUT/MOM_input
+    -e "s/@\[ODA_INCUPD_NHOURS\]/$ODA_INCUPD_NHOURS/g" \
+    -e "s/@\[ODA_INCUPD\]/$ODA_INCUPD/g" $DATA/INPUT/MOM_input_template_$OCNRES > $DATA/INPUT/MOM_input
 rm $DATA/INPUT/MOM_input_template_$OCNRES
 
 #data table for runoff:

--- a/workflow/rocoto/workflow_tasks.py
+++ b/workflow/rocoto/workflow_tasks.py
@@ -649,9 +649,8 @@ class Tasks:
         dependencies = rocoto.create_dependency(dep=dep)
 
         if self.app_config.do_jediocnvar:
-            dep_dict = {'type': 'task', 'name': f'{self.cdump}ocnanalrun'}
-            dep = rocoto.add_dependency(dep_dict)
-            dependencies = rocoto.create_dependency(dep=dep)
+            dep_dict = {'type': 'task', 'name': f'{self.cdump}ocnanalpost'}
+            dependencies.append(rocoto.add_dependency(dep_dict))
 
         if self.app_config.do_gldas and self.cdump in ['gdas']:
             dep_dict = {'type': 'task', 'name': f'{self.cdump}gldas'}

--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -120,6 +120,14 @@ def fill_COMROT_cycled(host, inputs):
         makedirs_if_missing(dst_dir)
         link_files_from_src_to_dst(src_dir, dst_dir)
 
+        # First 1/2 cycle needs a MOM6 increment
+        incdir = f'{inputs.cdump}.{idatestr[:8]}/{idatestr[8:]}'
+        incfile = f'{inputs.cdump}.t{idatestr[8:]}z.ocninc.nc'
+        src_file = os.path.join(inputs.icsdir, incdir, 'ocean', incfile)
+        dst_file = os.path.join(comrot, incdir, 'ocean', incfile)
+        makedirs_if_missing(os.path.join(comrot, incdir, 'ocean'))
+        os.symlink(src_file, dst_file)
+
     # Link ice files
     if do_ice:
         detdir = f'{inputs.cdump}.{rdatestr[:8]}/{rdatestr[8:]}'


### PR DESCRIPTION
# Description
Motivation: WCDA cycling. Long description for very few updates.

### Summary of changes:
- Removed forgotten commented out call to the B-mat `j-job` in ```jobs/rocoto/ocnanalbmat.sh``` ... oops
- `MOM6` IAU is now triggered with the `DO_JEDIOCNVAR` switch. Direct insertion can be achieved with the same IAU module.
- Link to the `JEDI/SOCA` increment in `ush/forecast_postdet.sh`
- Fixed a dependency bug in `workflow/rocoto/workflow_tasks.py`
- MOM6 Increment is required in `ICSDIR` for the first 1/2 cycle, changes reflected in  ```workflow/setup_expt.py``` 

### Dependencies
Nothing major, just 1 obs `yaml` updated to the new `ioda` format so we have obs to cycle with.
[GDASApp/pull/349](https://github.com/NOAA-EMC/GDASApp/pull/349)


- Fixes [#346](https://github.com/NOAA-EMC/GDASApp/issues/346)
- Fixes [#350](https://github.com/NOAA-EMC/GDASApp/issues/350)


### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested
It only works on `Hera` and with the develop branch of the `GDASApp` repository.
It was tested over 1.5 cycle. I ran out of obs for the GSI and our `ioda` concatenation tool is broken since the merge of the "new naming convention", so we can't do `00z` cycles.

### To reproduce
Edit `config.base`:
```bash
export DOIAU="NO"
export DO_JEDIOCNVAR="YES"
export l4densvar=".false."
export lwrite4danl=".false."
export DO_METP="NO"
```

Resource files needed for a warm start, stored in `ICSDIR`: 
```/scratch2/NCEPDEV/ocean/Guillaume.Vernieres/runs/wcda-tutorial/ICSDIR```, same as @aerorahul 's but with the addition of a MOM6 incr (all zeros)

Create a yaml list of obs `obs_list.yaml`:
```yaml
observers:
- <path to gw>/sorc/gdas.cd/parm/soca/obs/config/adt_j3_egm2008.yaml
```

Configure the ocean/ice DA in `ocnanal.yaml`, the default will be broken until we resolve our obs database issues:
```yaml
ocnanal:
  SOCA_INPUT_FIX_DIR: /scratch2/NCEPDEV/ocean/Guillaume.Vernieres/data/static/72x35x25/soca
  CASE_ANL: 'C24'
  COMIN_OBS: '/scratch2/NCEPDEV/ocean/Guillaume.Vernieres/runs/r2d2-v2-v3'   # Temporary obs file in ioda-v3
  SOCA_OBS_LIST:  <path to your>/obs_list.yaml
  SOCA_NINNER: 1
  R2D2_OBS_SRC: 'gdas_marine'
  R2D2_OBS_DUMP: 's2s_v1'
  SABER_BLOCKS_YAML: ''
  NICAS_RESOL: 1
  NICAS_GRID_SIZE: 15000
```
Setup the experiment:
```bash
./setup_expt.py cycled --app S2S --pslot wcda --configdir $CONFIGDIR --idate 2021032312 --edate 2021032318 --resdet 48 --gfs_cyc 0 --comrot $COMROT --expdir $EXPDIR --nens 0 --start 'warm' --icsdir <path to>/ICSDIR/C48O500 --yaml ocnanal.yaml
```

Generate the `xml` files:
```bash
setup_xml.py $EXPDIR/wcda
```
  
**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
