### PR TITLE
Revert to Cory's commit in ufsda_modules.sh

### DIFF
--- a/ush/load_ufsda_modules.sh
+++ b/ush/load_ufsda_modules.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 ###############################################################
-if [[ "${DEBUG_WORKFLOW}" == "NO" ]]; then
+if [[ "${DEBUG_WORKFLOW:-NO}" == "NO" ]]; then
     echo "Loading modules quietly..."
     set +x
 fi


### PR DESCRIPTION
@CoryMartin-NOAA pointed to an issue in PR#1308 which I thought I took care of but apparently did not merge properly.
This bugfix PR reverts [load_ufsda_modules.sh#L4](https://github.com/NOAA-EMC/global-workflow/blob/3bfcb8975acab6a14634d95189b6b10379e37afc/ush/load_ufsda_modules.sh#L4) to @CoryMartin-NOAA 's latest commit.