### PR TITLE
Update gsl-prep-chem tag to 12.3.5

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -87,7 +87,7 @@ if [[ ! -d gsd_prep_chem.fd ]] ; then
     rc=$?
     ((err+=$rc))
     cd gsd_prep_chem.fd
-    git checkout gefs_v12.3.3
+    git checkout gefs_v12.3.5
     cd ${topdir}
 else
     echo 'Skip.  Directory gsd_prep_chem.fd already exists.'


### PR DESCRIPTION
Updates the GSL prep-chem version for GEFS 12.3.5 to address changes in the input data.

See also https://github.com/NOAA-GSL/GSL-prep-chem/pull/6
Resolves #1324