### PR TITLE
Fix workflow generation post times for early cycle

### DIFF
--- a/workflow/rocoto/workflow_tasks.py
+++ b/workflow/rocoto/workflow_tasks.py
@@ -1276,7 +1276,7 @@ class Tasks:
             fhmin = epos['FHMIN_ENKF']
             fhmax = epos['FHMAX_ENKF']
             fhout = epos['FHOUT_ENKF']
-            if self.cdump == "gfs":
+            if self.cdump == "enkfgfs":
                 fhmax = epos['FHMAX_ENKF_GFS']
                 fhout = epos['FHOUT_ENKF_GFS']
             fhrs = range(fhmin, fhmax + fhout, fhout)


### PR DESCRIPTION
In PR #1309 a setting was overlooked that controls what hours have post tasks created for the early cycle.

Fixes #1328

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
Tested on WCOSS2
<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--
- [ ] Clone and Build tests on WCOSS Dell P3
- [ ] Cycled test on Orion
- [ ] Forecast-only test on Hera
-->
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] have performed a self-review of my own code
