### PR TITLE
allow ocean vrfy jjob script to access eva yaml generators

### DIFF
--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_VRFY
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_VRFY
@@ -16,7 +16,7 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "ocnanalprep" -c "base ocnanal ocnanal
 export COMOUT=${COMOUT:-${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ocean}
 
 # Add UFSDA to PYTHONPATH
-export PYTHONPATH=${HOMEgfs}/sorc/gdas.cd/ush/:${PYTHONPATH}
+export PYTHONPATH=${HOMEgfs}/sorc/gdas.cd/ush/:${HOMEgfs}/sorc/gdas.cd/ush/eva:${PYTHONPATH}
 
 ###############################################################
 # Run relevant script


### PR DESCRIPTION


**Description**

Adds `gdas.cd/ush/eva` to `PYTHONPATH` in `jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_VRFY` towards fixing https://github.com/NOAA-EMC/GDASApp/issues/202

Needed to merge https://github.com/NOAA-EMC/GDASApp/pull/365

**Type of change**

- [ ] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

SOCA ctests on Hera
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
