### PR TITLE
MOM6 backgrounds in cycled DA mode were hardcoded for IAU 

### DIFF
--- a/parm/parm_fv3diag/diag_table_da
+++ b/parm/parm_fv3diag/diag_table_da
@@ -2,15 +2,15 @@
 "fv3_history2d",  0,  "hours",  1,  "hours",  "time"
 "ocn_da%4yr%2mo%2dy%2hr",  0,  "hours",  1,  "hours",  "time",  1,  "hours",  "1901 1 1 0 0 0"
 
-"ocean_model",  "geolon",    "geolon",   "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
-"ocean_model",  "geolat",    "geolat",   "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
-"ocean_model",  "SSH",       "ave_ssh",  "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
-"ocean_model",  "MLD_0125",  "MLD",      "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
-"ocean_model",  "u",         "u",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
-"ocean_model",  "v",         "v",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
-"ocean_model",  "h",         "h",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
-"ocean_model",  "salt",      "Salt",     "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
-"ocean_model",  "temp",      "Temp",     "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "geolon",    "geolon",   "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
+"ocean_model",  "geolat",    "geolat",   "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
+"ocean_model",  "SSH",       "ave_ssh",  "ocn_da%4yr%2mo%2dy%2hr",  "all",  .true.,   "none",  2
+"ocean_model",  "MLD_0125",  "MLD",      "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
+"ocean_model",  "u",         "u",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
+"ocean_model",  "v",         "v",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
+"ocean_model",  "h",         "h",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
+"ocean_model",  "salt",      "Salt",     "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
+"ocean_model",  "temp",      "Temp",     "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
 
 "gfs_dyn",     "ucomp",       "ugrd",         "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "vcomp",       "vgrd",         "fv3_history",    "all",  .false.,  "none",  2

--- a/parm/parm_fv3diag/diag_table_da
+++ b/parm/parm_fv3diag/diag_table_da
@@ -2,15 +2,15 @@
 "fv3_history2d",  0,  "hours",  1,  "hours",  "time"
 "ocn_da%4yr%2mo%2dy%2hr",  0,  "hours",  1,  "hours",  "time",  1,  "hours",  "1901 1 1 0 0 0"
 
-"ocean_model",  "geolon",    "geolon",   "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
-"ocean_model",  "geolat",    "geolat",   "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
-"ocean_model",  "SSH",       "ave_ssh",  "ocn_da%4yr%2mo%2dy%2hr",  "all",  .true.,   "none",  2
-"ocean_model",  "MLD_0125",  "MLD",      "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
-"ocean_model",  "u",         "u",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
-"ocean_model",  "v",         "v",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
-"ocean_model",  "h",         "h",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
-"ocean_model",  "salt",      "Salt",     "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
-"ocean_model",  "temp",      "Temp",     "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
+"ocean_model",  "geolon",    "geolon",   "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "geolat",    "geolat",   "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "SSH",       "ave_ssh",  "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "MLD_0125",  "MLD",      "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "u",         "u",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "v",         "v",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "h",         "h",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "salt",      "Salt",     "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "temp",      "Temp",     "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
 
 "gfs_dyn",     "ucomp",       "ugrd",         "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "vcomp",       "vgrd",         "fv3_history",    "all",  .false.,  "none",  2

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -877,7 +877,6 @@ MOM6_postdet() {
     # Link output files for CDUMP = gdas
 
     # Save MOM6 backgrounds
-    local fhr="${FHMIN}"
     for fhr in ${OUTPUT_FH}; do
       local idatestr=$(date -d "${CDATE:0:8} ${CDATE:8:2} + ${fhr} hours" +%Y_%m_%d_%H)
       local fhr3=$(printf %03i "${fhr}")

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -878,9 +878,9 @@ MOM6_postdet() {
 
     # Save MOM6 backgrounds
     local fhr="${FHMIN}"
-    for fhr in $OUTPUT_FH; do
+    for fhr in ${OUTPUT_FH}; do
       local idatestr=$(date -d "${CDATE:0:8} ${CDATE:8:2} + ${fhr} hours" +%Y_%m_%d_%H)
-      local fhr3=$(printf %03i ${fhr})
+      local fhr3=$(printf %03i "${fhr}")
       $NLN "${COMOUTocean}/${CDUMP}.t${cyc}z.ocnf${fhr3}.nc" "${DATA}/ocn_da_${idatestr}.nc"
     done
   fi

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -876,15 +876,13 @@ MOM6_postdet() {
   elif [[ "${CDUMP}" =~ "gdas" ]]; then
     # Link output files for CDUMP = gdas
 
-    # MOM6 does not write out the first forecast hour, so start at FHOUT
-    local fhr="${FHOUT}"
-    while [[ "${fhr}" -le "${FHMAX}" ]]; do
+    # Save MOM6 backgrounds
+    local fhr="${FHMIN}"
+    for fhr in $OUTPUT_FH; do
       local idatestr=$(date -d "${CDATE:0:8} ${CDATE:8:2} + ${fhr} hours" +%Y_%m_%d_%H)
       local fhr3=$(printf %03i ${fhr})
       $NLN "${COMOUTocean}/${CDUMP}.t${cyc}z.ocnf${fhr3}.nc" "${DATA}/ocn_da_${idatestr}.nc"
-      local fhr=$((fhr + FHOUT))
     done
-
   fi
 
   mkdir -p "${COMOUTocean}/RESTART"


### PR DESCRIPTION
### Description
The ocean backgrounds linked to COMROT were wrong when not doing IAU. This is mainly a copy/paste work of what's done for the atmosphere.

### Testing
Tested in cycled/da mode at c48o500 and c384o025 

- fixes #1359 