### PR TITLE
Add dependency on gdasanal job to gdasfcst and gdasgldas jobs

### DIFF
--- a/ush/rocoto/setup_workflow.py
+++ b/ush/rocoto/setup_workflow.py
@@ -525,40 +525,36 @@ def get_gdasgfs_tasks(dict_configs, cdump='gdas'):
     # gldas
     if cdump in ['gdas'] and do_gldas in ['Y', 'YES']:
         deps1 = []
-        data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.loginc.txt'
-        dep_dict = {'type': 'data', 'data': data}
-        deps1.append(rocoto.add_dependency(dep_dict))
         dep_dict = {'type': 'task', 'name': f'{cdump}anal'}
         deps1.append(rocoto.add_dependency(dep_dict))
-        dependencies1 = rocoto.create_dependency(dep_condition='or', dep=deps1)
-
-        deps2 = []
-        deps2 = dependencies1
         dep_dict = {'type': 'cycleexist', 'offset': '-06:00:00'}
-        deps2.append(rocoto.add_dependency(dep_dict))
-        dependencies2 = rocoto.create_dependency(dep_condition='and', dep=deps2)
+        deps1.append(rocoto.add_dependency(dep_dict))
+        dependencies1 = rocoto.create_dependency(dep_condition='and', dep=deps1)
 
-        task = wfu.create_wf_task('gldas', cdump=cdump, envar=envars, dependency=dependencies2)
+        task = wfu.create_wf_task('gldas', cdump=cdump, envar=envars, dependency=dependencies1)
         dict_tasks[f'{cdump}gldas'] = task
 
     # fcst
     deps1 = []
-    #data = f'&ROTDIR;/{cdump}.@Y@m@d/@H/atmos/{cdump}.t@Hz.loginc.txt'
-    #dep_dict = {'type': 'data', 'data': data}
-    #deps1.append(rocoto.add_dependency(dep_dict))
     if cdump in ['gdas']:
-        dep_dict = {'type': 'cycleexist', 'condition': 'not', 'offset': '-06:00:00'}
-        deps1.append(rocoto.add_dependency(dep_dict))
+        deps3 = []
         if do_gldas in ['Y', 'YES']:
             dep_dict = {'type': 'task', 'name': f'{cdump}gldas'}
-            deps1.append(rocoto.add_dependency(dep_dict))
+            deps3.append(rocoto.add_dependency(dep_dict))
         else:
             dep_dict = {'type': 'task', 'name': f'{cdump}analcalc'}
-            deps1.append(rocoto.add_dependency(dep_dict))
+            deps3.append(rocoto.add_dependency(dep_dict))
+        dep_dict = {'type': 'task', 'name': f'{cdump}anal'}
+        deps3.append(rocoto.add_dependency(dep_dict))
+        dependencies3 = rocoto.create_dependency(dep_condition='and', dep=deps3)
+        deps1 = dependencies3
+        dep_dict = {'type': 'cycleexist', 'condition': 'not', 'offset': '-06:00:00'}
+        deps1.append(rocoto.add_dependency(dep_dict))
+        dependencies1 = rocoto.create_dependency(dep_condition='or', dep=deps1)
     elif cdump in ['gfs']:
         dep_dict = {'type': 'task', 'name': f'{cdump}anal'}
         deps1.append(rocoto.add_dependency(dep_dict))
-    dependencies1 = rocoto.create_dependency(dep_condition='or', dep=deps1)
+        dependencies1 = rocoto.create_dependency(dep=deps1)
 
     if do_wave in ['Y', 'YES'] and cdump in cdumps:
         deps2 = []


### PR DESCRIPTION
**Description**

This PR resolves the bug documented in issue #1320 with the `gdasfcst` job firing off before the `gdasanal` job has actually completed. The job dependencies for the `gdasgldas` and `gdasfcst` jobs are updated to add a dependency on the `gdasanal` job being complete. As part of restructuring the fcst dependency block in `setup_workflow.py`, this also updates the `gfsfcst` dependency to remove unneeded conditional.

Fixes #1320

Resulting gdasfcst job dependency in generated xml when `DO_WAVE=YES` and `DO_GLDAS=YES`:
```
        <dependency>
                <and>
                        <or>
                                <and>
                                        <taskdep task="gdasgldas"/>
                                        <taskdep task="gdasanal"/>
                                </and>
                                <not><cycleexistdep cycle_offset="-06:00:00"/></not>
                        </or>
                        <taskdep task="gdaswaveprep"/>
                </and>
        </dependency>
```

Resulting gdasfcst job dependency in generated xml when `DO_WAVE=NO` and `DO_GLDAS=YES`:
```
        <dependency>
                <or>
                        <and>
                                <taskdep task="gdasgldas"/>
                                <taskdep task="gdasanal"/>
                        </and>
                        <not><cycleexistdep cycle_offset="-06:00:00"/></not>
                </or>
        </dependency>
```

Resulting gdasfcst job dependency in generated xml when `DO_WAVE=NO` and `DO_GLDAS=NO`:
```
        <dependency>
                <or>
                        <and>
                                <taskdep task="gdasanalcalc"/>
                                <taskdep task="gdasanal"/>
                        </and>
                        <not><cycleexistdep cycle_offset="-06:00:00"/></not>
                </or>
        </dependency>
```

Comparing the above dependencies to prior ones would show the addition of a dependency on `gdasanal` for the `gdasgldas` (replacing the file dependency on the `loginc.txt` file) and `gdasfcst` jobs (with an `<and></and>` condition wrapped around it in the `gdasfcst` job. Dependencies are otherwise unchanged.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Ran `setup_workflow.py` to make sure generated xml had desired dependencies. Reran with `DO_WAVE=YES/NO` and `DO_GLDAS=YES/NO` to check different combinations.

@BrettHoover-NOAA also tested manual change in xml to show the gdasfcst job stopped firing off early.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
