### PR TITLE
Remove extra 'enkf' from folder/file names in archive scripts.

### DIFF
--- a/scripts/exgdas_enkf_earc.sh
+++ b/scripts/exgdas_enkf_earc.sh
@@ -7,7 +7,7 @@ source "${HOMEgfs}/ush/preamble.sh"
 ##############################################
 export n=$((10#${ENSGRP}))
 export CDUMP_ENKF=$(echo "${EUPD_CYC:-"gdas"}" | tr a-z A-Z)
-export ARCH_LIST="${ROTDIR}/${CDUMP}.${PDY}/${cyc}/earc${ENSGRP}"
+export ARCH_LIST="${ROTDIR}/${RUN}.${PDY}/${cyc}/earc${ENSGRP}"
 
 # ICS are restarts and always lag INC by $assim_freq hours.
 EARCINC_CYC=${ARCH_CYC}
@@ -20,10 +20,10 @@ fi
 mkdir -p "${ARCH_LIST}"
 cd "${ARCH_LIST}"
 
-"${HOMEgfs}"/ush/hpssarch_gen.sh "${CDUMP}"
+"${HOMEgfs}"/ush/hpssarch_gen.sh "${RUN}"
 status=$?
 if [ "${status}" -ne 0 ]; then
-   echo "${HOMEgfs}/ush/hpssarch_gen.sh ${CDUMP} failed, ABORT!"
+   echo "${HOMEgfs}/ush/hpssarch_gen.sh ${RUN} failed, ABORT!"
    exit "${status}"
 fi
 
@@ -65,27 +65,27 @@ if (( 10#${ENSGRP} > 0 )) && [[ ${HPSSARCH} = "YES" || ${LOCALARCH} = "YES" ]]; 
 
    if [ "${CDATE}" -gt "${SDATE}" ]; then # Don't run for first half cycle
 
-     ${TARCMD} -P -cvf "${ATARDIR}/${CDATE}/${CDUMP}_grp${ENSGRP}.tar" $(cat "${ARCH_LIST}/${CDUMP}_grp${n}.txt")
+     ${TARCMD} -P -cvf "${ATARDIR}/${CDATE}/${RUN}_grp${ENSGRP}.tar" $(cat "${ARCH_LIST}/${RUN}_grp${n}.txt")
      status=$?
      if [ "${status}" -ne 0 ] && [ "${CDATE}" -ge "${firstday}" ]; then
-         echo "$(echo "${TARCMD}" | tr 'a-z' 'A-Z') ${CDATE} ${CDUMP}_grp${ENSGRP}.tar failed"
+         echo "$(echo "${TARCMD}" | tr 'a-z' 'A-Z') ${CDATE} ${RUN}_grp${ENSGRP}.tar failed"
          exit "${status}"
      fi
 
      if [ "${SAVEWARMICA}" = "YES" ] && [ "${cyc}" -eq "${EARCINC_CYC}" ]; then
-       ${TARCMD} -P -cvf "${ATARDIR}/${CDATE}/${CDUMP}_restarta_grp${ENSGRP}.tar" $(cat "${ARCH_LIST}/${CDUMP}_restarta_grp${n}.txt")
+       ${TARCMD} -P -cvf "${ATARDIR}/${CDATE}/${RUN}_restarta_grp${ENSGRP}.tar" $(cat "${ARCH_LIST}/${RUN}_restarta_grp${n}.txt")
        status=$?
        if [ "${status}" -ne 0 ]; then
-           echo "$(echo "${TARCMD}" | tr 'a-z' 'A-Z') ${CDATE} ${CDUMP}_restarta_grp${ENSGRP}.tar failed"
+           echo "$(echo "${TARCMD}" | tr 'a-z' 'A-Z') ${CDATE} ${RUN}_restarta_grp${ENSGRP}.tar failed"
            exit "${status}"
        fi
      fi
 
      if [ "${SAVEWARMICB}" = "YES" ] && [ "${cyc}" -eq "${EARCICS_CYC}" ]; then
-       ${TARCMD} -P -cvf "${ATARDIR}/${CDATE}/${CDUMP}_restartb_grp${ENSGRP}.tar" $(cat "${ARCH_LIST}/${CDUMP}_restartb_grp{n}.txt")
+       ${TARCMD} -P -cvf "${ATARDIR}/${CDATE}/${RUN}_restartb_grp${ENSGRP}.tar" $(cat "${ARCH_LIST}/${RUN}_restartb_grp{n}.txt")
        status=$?
        if [ "${status}" -ne 0 ]; then
-           echo "$(echo "${TARCMD}" | tr 'a-z' 'A-Z') ${CDATE} ${CDUMP}_restartb_grp${ENSGRP}.tar failed"
+           echo "$(echo "${TARCMD}" | tr 'a-z' 'A-Z') ${CDATE} ${RUN}_restartb_grp${ENSGRP}.tar failed"
            exit "${status}"
        fi
      fi
@@ -109,10 +109,10 @@ if [ "${ENSGRP}" -eq 0 ]; then
         fi
 
         set +e
-        ${TARCMD} -P -cvf "${ATARDIR}/${CDATE}/${CDUMP}.tar" $(cat "${ARCH_LIST}/${CDUMP}.txt")
+        ${TARCMD} -P -cvf "${ATARDIR}/${CDATE}/${RUN}.tar" $(cat "${ARCH_LIST}/${RUN}.txt")
         status=$?
         if [ "${status}" -ne 0 ] && [ "${CDATE}" -ge "${firstday}" ]; then
-            echo "$(echo "${TARCMD}" | tr 'a-z' 'A-Z') ${CDATE} ${CDUMP}.tar failed"
+            echo "$(echo "${TARCMD}" | tr 'a-z' 'A-Z') ${CDATE} ${RUN}.tar failed"
             exit "${status}"
         fi
         set_strict
@@ -122,12 +122,12 @@ if [ "${ENSGRP}" -eq 0 ]; then
     [[ ! -d ${ARCDIR} ]] && mkdir -p "${ARCDIR}"
     cd "${ARCDIR}"
 
-    nb_copy "${ROTDIR}/${CDUMP}.${PDY}/${cyc}/${CDUMP}.t${cyc}z.enkfstat"        "enkfstat.${CDUMP}.${CDATE}"
-    nb_copy "${ROTDIR}/${CDUMP}.${PDY}/${cyc}/${CDUMP}.t${cyc}z.gsistat.ensmean" "gsistat.${CDUMP}.${CDATE}.ensmean"
+    nb_copy "${ROTDIR}/${RUN}.${PDY}/${cyc}/${RUN}.t${cyc}z.enkfstat"        "enkfstat.${RUN}.${CDATE}"
+    nb_copy "${ROTDIR}/${RUN}.${PDY}/${cyc}/${RUN}.t${cyc}z.gsistat.ensmean" "gsistat.${RUN}.${CDATE}.ensmean"
 
     if [ "${CDUMP_ENKF}" != "GDAS" ]; then
-      nb_copy "${ROTDIR}/enkfgfs.${PDY}/${cyc}/${CDUMP}.t${cyc}z.enkfstat"        "enkfstat.gfs.${CDATE}"
-      nb_copy "${ROTDIR}/enkfgfs.${PDY}/${cyc}/${CDUMP}.t${cyc}z.gsistat.ensmean" "gsistat.gfs.${CDATE}.ensmean"
+      nb_copy "${ROTDIR}/enkfgfs.${PDY}/${cyc}/${RUN}.t${cyc}z.enkfstat"        "enkfstat.gfs.${CDATE}"
+      nb_copy "${ROTDIR}/enkfgfs.${PDY}/${cyc}/${RUN}.t${cyc}z.gsistat.ensmean" "gsistat.gfs.${CDATE}.ensmean"
     fi
 
 fi

--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -420,50 +420,50 @@ if [ ${type} = "enkfgdas" -o ${type} = "enkfgfs" ]; then
 ##NTARS2=$((NTARS/2))  # number of earc groups to include analysis/increments
   NTARS2=${NTARS}
 
-  dirpath="enkf${CDUMP}.${PDY}/${cyc}/"
+  dirpath="${RUN}.${PDY}/${cyc}/"
   dirname="./${dirpath}"
-  head="${CDUMP}.t${cyc}z."
+  head="${RUN}.t${cyc}z."
 
   #..................
-  rm -f enkf${CDUMP}.txt
-  touch enkf${CDUMP}.txt
+  rm -f ${RUN}.txt
+  touch ${RUN}.txt
 
-  echo  "${dirname}${head}enkfstat                   " >>enkf${CDUMP}.txt
-  echo  "${dirname}${head}gsistat.ensmean            " >>enkf${CDUMP}.txt
+  echo  "${dirname}${head}enkfstat                   " >>${RUN}.txt
+  echo  "${dirname}${head}gsistat.ensmean            " >>${RUN}.txt
   if [[ -s ${ROTDIR}/${dirpath}${head}cnvstat.ensmean ]]; then
-       echo  "${dirname}${head}cnvstat.ensmean       " >>enkf${CDUMP}.txt
+       echo  "${dirname}${head}cnvstat.ensmean       " >>${RUN}.txt
   fi
   if [[ -s ${ROTDIR}/${dirpath}${head}oznstat.ensmean ]]; then
-       echo  "${dirname}${head}oznstat.ensmean       " >>enkf${CDUMP}.txt
+       echo  "${dirname}${head}oznstat.ensmean       " >>${RUN}.txt
   fi
   if [[ -s ${ROTDIR}/${dirpath}${head}radstat.ensmean ]]; then
-       echo  "${dirname}${head}radstat.ensmean       " >>enkf${CDUMP}.txt
+       echo  "${dirname}${head}radstat.ensmean       " >>${RUN}.txt
   fi
   for FHR in $nfhrs; do  # loop over analysis times in window
      if [ $FHR -eq 6 ]; then
         if [ -s $ROTDIR/${dirpath}${head}atmanl.ensmean.nc ]; then
-            echo  "${dirname}${head}atmanl.ensmean.nc      " >>enkf${CDUMP}.txt
+            echo  "${dirname}${head}atmanl.ensmean.nc      " >>${RUN}.txt
 	fi
         if [ -s $ROTDIR/${dirpath}${head}atminc.ensmean.nc ]; then
-            echo  "${dirname}${head}atminc.ensmean.nc      " >>enkf${CDUMP}.txt
+            echo  "${dirname}${head}atminc.ensmean.nc      " >>${RUN}.txt
         fi
      else
         if [ -s $ROTDIR/${dirpath}${head}atma00${FHR}.ensmean.nc ]; then
-	    echo  "${dirname}${head}atma00${FHR}.ensmean.nc      " >>enkf${CDUMP}.txt
+	    echo  "${dirname}${head}atma00${FHR}.ensmean.nc      " >>${RUN}.txt
         fi
         if [ -s $ROTDIR/${dirpath}${head}atmi00${FHR}.ensmean.nc ]; then
-            echo  "${dirname}${head}atmi00${FHR}.ensmean.nc      " >>enkf${CDUMP}.txt
+            echo  "${dirname}${head}atmi00${FHR}.ensmean.nc      " >>${RUN}.txt
         fi
      fi 
   done # loop over FHR
   for fstep in eobs ecen esfc eupd efcs epos ; do
-   echo  "logs/${CDATE}/${CDUMP}${fstep}*.log        " >>enkf${CDUMP}.txt
+   echo  "logs/${CDATE}/${RUN}${fstep}*.log        " >>${RUN}.txt
   done
 
 # eomg* are optional jobs
-  for log in ${ROTDIR}/logs/${CDATE}/${CDUMP}eomg*.log; do
+  for log in ${ROTDIR}/logs/${CDATE}/${RUN}eomg*.log; do
      if [[ -s "${log}" ]]; then
-        echo  "logs/${CDATE}/${CDUMP}eomg*.log        " >>enkf${CDUMP}.txt
+        echo  "logs/${CDATE}/${RUN}eomg*.log        " >>${RUN}.txt
      fi
      break
   done
@@ -473,10 +473,10 @@ if [ ${type} = "enkfgdas" -o ${type} = "enkfgfs" ]; then
   fh=3
   while [ $fh -le 9 ]; do
       fhr=$(printf %03i $fh)
-      echo  "${dirname}${head}atmf${fhr}.ensmean.nc       " >>enkf${CDUMP}.txt
-      echo  "${dirname}${head}sfcf${fhr}.ensmean.nc       " >>enkf${CDUMP}.txt
+      echo  "${dirname}${head}atmf${fhr}.ensmean.nc       " >>${RUN}.txt
+      echo  "${dirname}${head}sfcf${fhr}.ensmean.nc       " >>${RUN}.txt
       if [ -s $ROTDIR/${dirpath}${head}atmf${fhr}.ensspread.nc ]; then
-          echo  "${dirname}${head}atmf${fhr}.ensspread.nc     " >>enkf${CDUMP}.txt
+          echo  "${dirname}${head}atmf${fhr}.ensspread.nc     " >>${RUN}.txt
       fi
       fh=$((fh+3))
   done
@@ -486,82 +486,82 @@ if [ ${type} = "enkfgdas" -o ${type} = "enkfgfs" ]; then
   while [[ ${n} -le ${NTARS} ]]; do
   #...........................
 
-  rm -f enkf${CDUMP}_grp${n}.txt
-  rm -f enkf${CDUMP}_restarta_grp${n}.txt
-  rm -f enkf${CDUMP}_restartb_grp${n}.txt
-  touch enkf${CDUMP}_grp${n}.txt
-  touch enkf${CDUMP}_restarta_grp${n}.txt
-  touch enkf${CDUMP}_restartb_grp${n}.txt
+  rm -f ${RUN}_grp${n}.txt
+  rm -f ${RUN}_restarta_grp${n}.txt
+  rm -f ${RUN}_restartb_grp${n}.txt
+  touch ${RUN}_grp${n}.txt
+  touch ${RUN}_restarta_grp${n}.txt
+  touch ${RUN}_restartb_grp${n}.txt
 
   m=1
   while [[ ${m} -le ${NMEM_EARCGRP} ]]; do
     nm=$(((n-1)*NMEM_EARCGRP+m))
     mem=$(printf %03i $nm)
-    dirpath="enkf${CDUMP}.${PDY}/${cyc}/mem${mem}/atmos/"
+    dirpath="${RUN}.${PDY}/${cyc}/mem${mem}/atmos/"
     dirname="./${dirpath}"
-    head="${CDUMP}.t${cyc}z."
+    head="${RUN}.t${cyc}z."
 
     #---
     for FHR in $nfhrs; do  # loop over analysis times in window
       if [ $FHR -eq 6 ]; then
          if [ $n -le $NTARS2 ]; then
             if [ -s $ROTDIR/${dirpath}${head}atmanl.nc ] ; then
-                echo "${dirname}${head}atmanl.nc      " >>enkf${CDUMP}_grp${n}.txt
+                echo "${dirname}${head}atmanl.nc      " >>${RUN}_grp${n}.txt
             fi
 	    if [ -s $ROTDIR/${dirpath}${head}ratminc.nc ] ; then
-		echo "${dirname}${head}ratminc.nc      " >>enkf${CDUMP}_grp${n}.txt
+		echo "${dirname}${head}ratminc.nc      " >>${RUN}_grp${n}.txt
 	    fi
          fi
          if [ -s $ROTDIR/${dirpath}${head}ratminc.nc ] ; then
-             echo "${dirname}${head}ratminc.nc      " >>enkf${CDUMP}_restarta_grp${n}.txt
+             echo "${dirname}${head}ratminc.nc      " >>${RUN}_restarta_grp${n}.txt
          fi
 
       else
          if [ $n -le $NTARS2 ]; then
              if [ -s $ROTDIR/${dirpath}${head}atma00${FHR}.nc ] ; then
-                 echo "${dirname}${head}atma00${FHR}.nc      " >>enkf${CDUMP}_grp${n}.txt
+                 echo "${dirname}${head}atma00${FHR}.nc      " >>${RUN}_grp${n}.txt
              fi
              if [ -s $ROTDIR/${dirpath}${head}ratmi00${FHR}.nc ] ; then
-                 echo "${dirname}${head}ratmi00${FHR}.nc      " >>enkf${CDUMP}_grp${n}.txt
+                 echo "${dirname}${head}ratmi00${FHR}.nc      " >>${RUN}_grp${n}.txt
              fi
          fi
          if [ -s $ROTDIR/${dirpath}${head}ratmi00${FHR}.nc ] ; then
-             echo "${dirname}${head}ratmi00${FHR}.nc      " >>enkf${CDUMP}_restarta_grp${n}.txt
+             echo "${dirname}${head}ratmi00${FHR}.nc      " >>${RUN}_restarta_grp${n}.txt
          fi
 
       fi 
-      echo "${dirname}${head}atmf00${FHR}.nc       " >>enkf${CDUMP}_grp${n}.txt
+      echo "${dirname}${head}atmf00${FHR}.nc       " >>${RUN}_grp${n}.txt
       if [ $FHR -eq 6 ]; then
-	  echo "${dirname}${head}sfcf00${FHR}.nc       " >>enkf${CDUMP}_grp${n}.txt
+	  echo "${dirname}${head}sfcf00${FHR}.nc       " >>${RUN}_grp${n}.txt
       fi
     done # loop over FHR
 
     if [[ lobsdiag_forenkf = ".false." ]] ; then
-       echo "${dirname}${head}gsistat              " >>enkf${CDUMP}_grp${n}.txt
+       echo "${dirname}${head}gsistat              " >>${RUN}_grp${n}.txt
        if [[ -s ${ROTDIR}/${dirpath}${head}cnvstat ]] ; then
-          echo "${dirname}${head}cnvstat           " >>enkf${CDUMP}_grp${n}.txt
+          echo "${dirname}${head}cnvstat           " >>${RUN}_grp${n}.txt
        fi
        if [[ -s ${ROTDIR}/${dirpath}${head}radstat ]]; then
-          echo "${dirname}${head}radstat           " >>enkf${CDUMP}_restarta_grp${n}.txt
+          echo "${dirname}${head}radstat           " >>${RUN}_restarta_grp${n}.txt
        fi
        if [[ -s ${ROTDIR}/${dirpath}${head}cnvstat ]]; then
-          echo "${dirname}${head}cnvstat           " >>enkf${CDUMP}_restarta_grp${n}.txt
+          echo "${dirname}${head}cnvstat           " >>${RUN}_restarta_grp${n}.txt
        fi
-       echo "${dirname}${head}abias                " >>enkf${CDUMP}_restarta_grp${n}.txt
-       echo "${dirname}${head}abias_air            " >>enkf${CDUMP}_restarta_grp${n}.txt
-       echo "${dirname}${head}abias_int            " >>enkf${CDUMP}_restarta_grp${n}.txt
-       echo "${dirname}${head}abias_pc             " >>enkf${CDUMP}_restarta_grp${n}.txt
+       echo "${dirname}${head}abias                " >>${RUN}_restarta_grp${n}.txt
+       echo "${dirname}${head}abias_air            " >>${RUN}_restarta_grp${n}.txt
+       echo "${dirname}${head}abias_int            " >>${RUN}_restarta_grp${n}.txt
+       echo "${dirname}${head}abias_pc             " >>${RUN}_restarta_grp${n}.txt
     fi
     #---
-    echo "${dirname}RESTART/*0000.sfcanl_data.tile1.nc  " >>enkf${CDUMP}_restarta_grp${n}.txt
-    echo "${dirname}RESTART/*0000.sfcanl_data.tile2.nc  " >>enkf${CDUMP}_restarta_grp${n}.txt
-    echo "${dirname}RESTART/*0000.sfcanl_data.tile3.nc  " >>enkf${CDUMP}_restarta_grp${n}.txt
-    echo "${dirname}RESTART/*0000.sfcanl_data.tile4.nc  " >>enkf${CDUMP}_restarta_grp${n}.txt
-    echo "${dirname}RESTART/*0000.sfcanl_data.tile5.nc  " >>enkf${CDUMP}_restarta_grp${n}.txt
-    echo "${dirname}RESTART/*0000.sfcanl_data.tile6.nc  " >>enkf${CDUMP}_restarta_grp${n}.txt
+    echo "${dirname}RESTART/*0000.sfcanl_data.tile1.nc  " >>${RUN}_restarta_grp${n}.txt
+    echo "${dirname}RESTART/*0000.sfcanl_data.tile2.nc  " >>${RUN}_restarta_grp${n}.txt
+    echo "${dirname}RESTART/*0000.sfcanl_data.tile3.nc  " >>${RUN}_restarta_grp${n}.txt
+    echo "${dirname}RESTART/*0000.sfcanl_data.tile4.nc  " >>${RUN}_restarta_grp${n}.txt
+    echo "${dirname}RESTART/*0000.sfcanl_data.tile5.nc  " >>${RUN}_restarta_grp${n}.txt
+    echo "${dirname}RESTART/*0000.sfcanl_data.tile6.nc  " >>${RUN}_restarta_grp${n}.txt
 
     #---
-    echo "${dirname}RESTART                     " >>enkf${CDUMP}_restartb_grp${n}.txt
+    echo "${dirname}RESTART                     " >>${RUN}_restartb_grp${n}.txt
 
     m=$((m+1))
   done


### PR DESCRIPTION
**Description**

The archiving scripts have had preceding `enkf`s removed and `$CDUMP` has been replaced with `$RUN` throughout the scripts.  This fixes #1353 and partially addresses #1299.

Fixes #1353
Refs #1299 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--
- [x] Clone and Build tests on S4
- [x] Cycled test on S4
- [ ] Forecast-only test on Hera (if warranted)
-->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes