### PR TITLE
Add options while setting up Rocoto XML that are useful for CI

### DIFF
--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -156,6 +156,8 @@ Example:
 
    ./setup_xml.py /some_safe_disk_area/Joe.Schmo/expdir/test
 
+Additional options for setting up Rocoto are available with `setup_xml.py -h` that allow users to change the number of failed tries, number of concurrent cycles and tasks as well as Rocoto's verbosity levels.
+
 ****************************************
 Step 4: Confirm files from setup scripts
 ****************************************

--- a/workflow/rocoto/workflow_xml.py
+++ b/workflow/rocoto/workflow_xml.py
@@ -5,16 +5,19 @@ from distutils.spawn import find_executable
 from datetime import datetime
 from pygw.timetools import to_timedelta
 from collections import OrderedDict
+from typing import Dict
 from applications import AppConfig
 from rocoto.workflow_tasks import get_wf_tasks
 import rocoto.rocoto as rocoto
 
 
+
 class RocotoXML:
 
-    def __init__(self, app_config: AppConfig) -> None:
+    def __init__(self, app_config: AppConfig, rocoto: Dict) -> None:
 
         self._app_config = app_config
+        self.rocoto = rocoto
 
         self._base = self._app_config.configs['base']
 
@@ -60,7 +63,7 @@ class RocotoXML:
         entity['ROTDIR'] = self._base['ROTDIR']
         entity['JOBS_DIR'] = self._base['BASE_JOB']
 
-        entity['MAXTRIES'] = self._base.get('ROCOTO_MAXTRIES', 2)
+        entity['MAXTRIES'] = self.rocoto['maxtries']
 
         # Put them all in an XML key-value syntax
         strings = []
@@ -75,9 +78,9 @@ class RocotoXML:
         """
 
         scheduler = self._app_config.scheduler
-        cyclethrottle = self._base.get('ROCOTO_CYCLETHROTTLE', 3)
-        taskthrottle = self._base.get('ROCOTO_TASKTHROTTLE', 25)
-        verbosity = self._base.get('ROCOTO_VERBOSITY', 10)
+        cyclethrottle = self.rocoto['cyclethrottle']
+        taskthrottle =  self.rocoto['taskthrottle']
+        verbosity = self.rocoto['verbosity']
 
         expdir = self._base['EXPDIR']
 

--- a/workflow/rocoto/workflow_xml.py
+++ b/workflow/rocoto/workflow_xml.py
@@ -11,13 +11,12 @@ from rocoto.workflow_tasks import get_wf_tasks
 import rocoto.rocoto as rocoto
 
 
-
 class RocotoXML:
 
-    def __init__(self, app_config: AppConfig, rocoto: Dict) -> None:
+    def __init__(self, app_config: AppConfig, rocoto_config: Dict) -> None:
 
         self._app_config = app_config
-        self.rocoto = rocoto
+        self.rocoto_config = rocoto_config
 
         self._base = self._app_config.configs['base']
 
@@ -63,7 +62,7 @@ class RocotoXML:
         entity['ROTDIR'] = self._base['ROTDIR']
         entity['JOBS_DIR'] = self._base['BASE_JOB']
 
-        entity['MAXTRIES'] = self.rocoto['maxtries']
+        entity['MAXTRIES'] = self.rocoto_config['maxtries']
 
         # Put them all in an XML key-value syntax
         strings = []
@@ -78,9 +77,9 @@ class RocotoXML:
         """
 
         scheduler = self._app_config.scheduler
-        cyclethrottle = self.rocoto['cyclethrottle']
-        taskthrottle = self.rocoto['taskthrottle']
-        verbosity = self.rocoto['verbosity']
+        cyclethrottle = self.rocoto_config['cyclethrottle']
+        taskthrottle = self.rocoto_config['taskthrottle']
+        verbosity = self.rocoto_config['verbosity']
 
         expdir = self._base['EXPDIR']
 

--- a/workflow/rocoto/workflow_xml.py
+++ b/workflow/rocoto/workflow_xml.py
@@ -79,7 +79,7 @@ class RocotoXML:
 
         scheduler = self._app_config.scheduler
         cyclethrottle = self.rocoto['cyclethrottle']
-        taskthrottle =  self.rocoto['taskthrottle']
+        taskthrottle = self.rocoto['taskthrottle']
         verbosity = self.rocoto['verbosity']
 
         expdir = self._base['EXPDIR']

--- a/workflow/setup_xml.py
+++ b/workflow/setup_xml.py
@@ -28,6 +28,15 @@ def input_args():
     parser.add_argument('expdir', help='full path to experiment directory containing config files',
                         type=str, default=os.environ['PWD'])
 
+    parser.add_argument('--maxtries', help='maximum number of retries', type=int,
+                        default=2, required=False)
+    parser.add_argument('--cyclethrottle', help='maximum number of concurrent cycles', type=int,
+                        default=3, required=False)
+    parser.add_argument('--taskthrottle', help='maximum number of concurrent tasks', type=int,
+                        default=25, required=False)
+    parser.add_argument('--verbosity', help='verbosity level of Rocoto', type=int,
+                        default=10, required=False)
+
     args = parser.parse_args()
 
     return args
@@ -45,6 +54,10 @@ def check_expdir(cmd_expdir, cfg_expdir):
 if __name__ == '__main__':
 
     user_inputs = input_args()
+    rocoto_param_dict = {'maxtries': user_inputs['maxtries'],
+                         'cyclethrottle': user_inputs['cyclethrottle'],
+                         'taskthrottle': user_inputs['taskthrottle'],
+                         'verbosity': user_inputs['verbosity']}
 
     cfg = Configuration(user_inputs.expdir)
 
@@ -54,5 +67,5 @@ if __name__ == '__main__':
     app_config = AppConfig(cfg)
 
     # Create Rocoto Tasks and Assemble them into an XML
-    xml = RocotoXML(app_config)
+    xml = RocotoXML(app_config, rocoto_param_dict)
     xml.write()


### PR DESCRIPTION
**Description**
This PR adds options while setting up Rocoto XML for:
- maximum tries (default is 2)
- cyclethrottle (default is 3)
- taskthrottle (default is 25)
- verbosity (default is 10)

The defaults are unchanged.

Documentation is also updated to reflect the new options available to `setup_xml.py`

**Type of change**
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

**How Has This Been Tested?**
XML was created and found to be identical.
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [X] Any dependent changes have been merged and published
