### PR TITLE
Minor gefs upgrade for exwave_nawips.sh to replace mv to cpfs

### DIFF
--- a/scripts/exwave_nawips.sh
+++ b/scripts/exwave_nawips.sh
@@ -152,7 +152,7 @@ EOF
          chgrp rstprod $GEMGRD
          chmod 750 $GEMGRD
        fi
-       mv $GEMGRD $COMOUT/gempak/$GEMGRD
+       cpfs $GEMGRD $COMOUT/gempak/$GEMGRD
        if [ $SENDDBN = "YES" ] ; then
            $DBNROOT/bin/dbn_alert MODEL ${DBN_ALERT_TYPE} $job \
              $COMOUT/gempak/$GEMGRD

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -87,7 +87,7 @@ if [[ ! -d gsd_prep_chem.fd ]] ; then
     rc=$?
     ((err+=$rc))
     cd gsd_prep_chem.fd
-    git checkout gefs_v12.3.5
+    git checkout gefs_v12.3.3
     cd ${topdir}
 else
     echo 'Skip.  Directory gsd_prep_chem.fd already exists.'


### PR DESCRIPTION
Replacing mv to cpfs to resolve mag_gefswave_processor
  occasionally failed to open wave/gempak files

Change tag of GSD-prep-chem back to gefs_v12.3.3

Fixes #1366

<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Tested by NCO on dogwood and I also ran tests on Cactus

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--
- [ ] Clone and Build tests on WCOSS Dell P3
- [ ] Cycled test on Orion
- [ ] Forecast-only test on Hera
-->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
