### PR TITLE
Enable ESMF threading in the ufs-weather-model forecast

### DIFF
--- a/env/HERA.env
+++ b/env/HERA.env
@@ -190,13 +190,7 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    if [[ "${CDUMP}" =~ "gfs" ]]; then
-        nprocs="npe_${step}_gfs"
-    else
-        nprocs="npe_${step}"
-    fi
-    export APRUN_UFS="${launcher} -n ${!nprocs}"
-    unset nprocs
+    export APRUN_UFS="${launcher}"
 
 elif [[ "${step}" = "post" ]]; then
 

--- a/env/HERA.env
+++ b/env/HERA.env
@@ -190,7 +190,7 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    nprocs="npe_${step}"
+    [[ "${CDUMP}" =~ "gfs" ]] && nprocs="npe_${step}_gfs" || nprocs="npe_${step}"
     export APRUN_UFS="${launcher} -n ${!nprocs}"
     unset nprocs
 

--- a/env/HERA.env
+++ b/env/HERA.env
@@ -188,43 +188,11 @@ elif [[ "${step}" = "eupd" ]]; then
     export USE_CFP=${USE_CFP:-"YES"}
     export APRUNCFP="${launcher} -n \$ncmd ${mpmd_opt}"
 
-elif [[ "${step}" = "fcst" ]]; then
+elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    #PEs and PEs/node can differ for GFS and GDAS forecasts if threading differs
-    if [[ ${CDUMP} == "gfs" ]]; then
-        npe_fcst=${npe_fcst_gfs}
-        npe_node_fcst=${npe_node_fcst_gfs}
-        nth_fv3=${nth_fv3_gfs}
-    fi
-
-    nth_max=$((npe_node_max / npe_node_fcst))
-
-    export NTHREADS_FV3=${nth_fv3:-${nth_max}}
-    [[ ${NTHREADS_FV3} -gt ${nth_max} ]] && export NTHREADS_FV3=${nth_max}
-    export cores_per_node=${npe_node_max}
-    export APRUN_FV3="${launcher} -n ${npe_fcst}"
-
-    export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
-    [[ ${NTHREADS_REGRID_NEMSIO} -gt ${nth_max} ]] && export NTHREADS_REGRID_NEMSIO=${nth_max}
-    export APRUN_REGRID_NEMSIO="${launcher} -n ${LEVS}"
-
-    export NTHREADS_REMAP=${nth_remap:-2}
-    [[ ${NTHREADS_REMAP} -gt ${nth_max} ]] && export NTHREADS_REMAP=${nth_max}
-    export APRUN_REMAP="${launcher} -n ${npe_remap:-${npe_fcst}}"
-    export I_MPI_DAPL_UD="enable"
-
-elif [[ "${step}" = "efcs" ]]; then
-
-    nth_max=$((npe_node_max / npe_node_efcs))
-
-    export NTHREADS_FV3=${nth_efcs:-${nth_max}}
-    [[ ${NTHREADS_FV3} -gt ${nth_max} ]] && export NTHREADS_FV3=${nth_max}
-    export cores_per_node=${npe_node_max}
-    export APRUN_FV3="${launcher} -n ${npe_efcs}"
-
-    export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
-    [[ ${NTHREADS_REGRID_NEMSIO} -gt ${nth_max} ]] && export NTHREADS_REGRID_NEMSIO=${nth_max}
-    export APRUN_REGRID_NEMSIO="${launcher} -n ${LEVS}"
+    nprocs="npe_${step}"
+    export APRUN_UFS="${launcher} -n ${!nprocs}"
+    unset nprocs
 
 elif [[ "${step}" = "post" ]]; then
 

--- a/env/HERA.env
+++ b/env/HERA.env
@@ -190,7 +190,11 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    [[ "${CDUMP}" =~ "gfs" ]] && nprocs="npe_${step}_gfs" || nprocs="npe_${step}"
+    if [[ "${CDUMP}" =~ "gfs" ]]; then
+        nprocs="npe_${step}_gfs"
+    else
+        nprocs="npe_${step}"
+    fi
     export APRUN_UFS="${launcher} -n ${!nprocs}"
     unset nprocs
 

--- a/env/HERA.env
+++ b/env/HERA.env
@@ -190,7 +190,18 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    export APRUN_UFS="${launcher}"
+    if [[ "${CDUMP}" =~ "gfs" ]]; then
+        nprocs="npe_${step}_gfs"
+        ppn="npe_node_${step}_gfs" || ppn="npe_node_${step}"
+    else
+        nprocs="npe_${step}"
+        ppn="npe_node_${step}"
+    fi
+    (( nnodes = (${!nprocs}+${!ppn}-1)/${!ppn} ))
+    (( ntasks = nnodes*${!ppn} ))
+    # With ESMF threading, the model wants to use the full node
+    export APRUN_UFS="${launcher} -n ${ntasks}"
+    unset nprocs ppn nnodes ntasks
 
 elif [[ "${step}" = "post" ]]; then
 

--- a/env/JET.env
+++ b/env/JET.env
@@ -118,7 +118,18 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    export APRUN_UFS="${launcher}"
+    if [[ "${CDUMP}" =~ "gfs" ]]; then
+        nprocs="npe_${step}_gfs"
+        ppn="npe_node_${step}_gfs" || ppn="npe_node_${step}"
+    else
+        nprocs="npe_${step}"
+        ppn="npe_node_${step}"
+    fi
+    (( nnodes = (${!nprocs}+${!ppn}-1)/${!ppn} ))
+    (( ntasks = nnodes*${!ppn} ))
+    # With ESMF threading, the model wants to use the full node
+    export APRUN_UFS="${launcher} -n ${ntasks}"
+    unset nprocs ppn nnodes ntasks
 
 elif [[ "${step}" = "post" ]]; then
 

--- a/env/JET.env
+++ b/env/JET.env
@@ -118,13 +118,7 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    if [[ "${CDUMP}" =~ "gfs" ]]; then
-        nprocs="npe_${step}_gfs"
-    else
-        nprocs="npe_${step}"
-    fi
-    export APRUN_UFS="${launcher} ${!nprocs}"
-    unset nprocs
+    export APRUN_UFS="${launcher}"
 
 elif [[ "${step}" = "post" ]]; then
 

--- a/env/JET.env
+++ b/env/JET.env
@@ -1,4 +1,4 @@
-#!/bin/ksh -x
+#! /usr/bin/env bash
 
 if [[ $# -ne 1 ]]; then
 
@@ -116,43 +116,11 @@ elif [[ "${step}" = "eupd" ]]; then
     [[ ${NTHREADS_ENKF} -gt ${nth_max} ]] && export NTHREADS_ENKF=${nth_max}
     export APRUN_ENKF="${launcher} ${npe_enkf:-${npe_eupd:-${PBS_NP}}}"
 
-elif [[ "${step}" = "fcst" ]]; then
+elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    #PEs and PEs/node can differ for GFS and GDAS forecasts if threading differs
-    if [[ ${CDUMP} == "gfs" ]]; then
-        npe_fcst=${npe_fcst_gfs}
-        npe_node_fcst=${npe_node_fcst_gfs}
-        nth_fv3=${nth_fv3_gfs}
-    fi
-
-    nth_max=$((npe_node_max / npe_node_fcst))
-
-    export NTHREADS_FV3=${nth_fv3:-${nth_max}}
-    [[ ${NTHREADS_FV3} -gt ${nth_max} ]] && export NTHREADS_FV3=${nth_max}
-    export cores_per_node=${npe_node_max}
-    export APRUN_FV3="${launcher}"
-
-    export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
-    [[ ${NTHREADS_REGRID_NEMSIO} -gt ${nth_max} ]] && export NTHREADS_REGRID_NEMSIO=${nth_max}
-    export APRUN_REGRID_NEMSIO="${launcher} ${LEVS}"
-
-    export NTHREADS_REMAP=${nth_remap:-2}
-    [[ ${NTHREADS_REMAP} -gt ${nth_max} ]] && export NTHREADS_REMAP=${nth_max}
-    export APRUN_REMAP="${launcher} ${npe_remap:-${npe_fcst:-${PBS_NP}}}"
-    export I_MPI_DAPL_UD="enable"
-
-elif [[ "${step}" = "efcs" ]]; then
-
-    nth_max=$((npe_node_max / npe_node_efcs))
-
-    export NTHREADS_FV3=${nth_fv3:-${nth_max}}
-    [[ ${NTHREADS_FV3} -gt ${nth_max} ]] && export NTHREADS_FV3=${nth_max}
-    export cores_per_node=${npe_node_max}
-    export APRUN_FV3="${launcher} ${npe_fv3:-${npe_efcs:-${PBS_NP}}}"
-
-    export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
-    [[ ${NTHREADS_REGRID_NEMSIO} -gt ${nth_max} ]] && export NTHREADS_REGRID_NEMSIO=${nth_max}
-    export APRUN_REGRID_NEMSIO="${launcher} ${LEVS}"
+    nprocs="npe_${step}"
+    export APRUN_UFS="${launcher} ${!nprocs}"
+    unset nprocs
 
 elif [[ "${step}" = "post" ]]; then
 

--- a/env/JET.env
+++ b/env/JET.env
@@ -118,7 +118,11 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    [[ "${CDUMP}" =~ "gfs" ]] && nprocs="npe_${step}_gfs" || nprocs="npe_${step}"
+    if [[ "${CDUMP}" =~ "gfs" ]]; then
+        nprocs="npe_${step}_gfs"
+    else
+        nprocs="npe_${step}"
+    fi
     export APRUN_UFS="${launcher} ${!nprocs}"
     unset nprocs
 

--- a/env/JET.env
+++ b/env/JET.env
@@ -118,7 +118,7 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    nprocs="npe_${step}"
+    [[ "${CDUMP}" =~ "gfs" ]] && nprocs="npe_${step}_gfs" || nprocs="npe_${step}"
     export APRUN_UFS="${launcher} ${!nprocs}"
     unset nprocs
 

--- a/env/ORION.env
+++ b/env/ORION.env
@@ -188,13 +188,7 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    if [[ "${CDUMP}" =~ "gfs" ]]; then
-        nprocs="npe_${step}_gfs"
-    else
-        nprocs="npe_${step}"
-    fi
-    export APRUN_UFS="${launcher} -n ${!nprocs}"
-    unset nprocs
+    export APRUN_UFS="${launcher}"
 
 elif [[ "${step}" = "post" ]]; then
 

--- a/env/ORION.env
+++ b/env/ORION.env
@@ -188,7 +188,7 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    nprocs="npe_${step}"
+    [[ "${CDUMP}" =~ "gfs" ]] && nprocs="npe_${step}_gfs" || nprocs="npe_${step}"
     export APRUN_UFS="${launcher} -n ${!nprocs}"
     unset nprocs
 

--- a/env/ORION.env
+++ b/env/ORION.env
@@ -188,7 +188,11 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    [[ "${CDUMP}" =~ "gfs" ]] && nprocs="npe_${step}_gfs" || nprocs="npe_${step}"
+    if [[ "${CDUMP}" =~ "gfs" ]]; then
+        nprocs="npe_${step}_gfs"
+    else
+        nprocs="npe_${step}"
+    fi
     export APRUN_UFS="${launcher} -n ${!nprocs}"
     unset nprocs
 

--- a/env/ORION.env
+++ b/env/ORION.env
@@ -188,7 +188,19 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    export APRUN_UFS="${launcher}"
+    export OMP_STACKSIZE=512M
+    if [[ "${CDUMP}" =~ "gfs" ]]; then
+        nprocs="npe_${step}_gfs"
+        ppn="npe_node_${step}_gfs" || ppn="npe_node_${step}"
+    else
+        nprocs="npe_${step}"
+        ppn="npe_node_${step}"
+    fi
+    (( nnodes = (${!nprocs}+${!ppn}-1)/${!ppn} ))
+    (( ntasks = nnodes*${!ppn} ))
+    # With ESMF threading, the model wants to use the full node
+    export APRUN_UFS="${launcher} -n ${ntasks}"
+    unset nprocs ppn nnodes ntasks
 
 elif [[ "${step}" = "post" ]]; then
 

--- a/env/ORION.env
+++ b/env/ORION.env
@@ -186,43 +186,11 @@ elif [[ "${step}" = "eupd" ]]; then
     [[ ${NTHREADS_ENKF} -gt ${nth_max} ]] && export NTHREADS_ENKF=${nth_max}
     export APRUN_ENKF="${launcher} -n ${npe_enkf:-${npe_eupd}}"
 
-elif [[ "${step}" = "fcst" ]]; then
+elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    #PEs and PEs/node can differ for GFS and GDAS forecasts if threading differs
-    if [[ ${CDUMP} == "gfs" ]]; then
-        npe_fcst=${npe_fcst_gfs}
-        npe_node_fcst=${npe_node_fcst_gfs}
-        nth_fv3=${nth_fv3_gfs}
-    fi
-
-    nth_max=$((npe_node_max / npe_node_fcst))
-
-    export NTHREADS_FV3=${nth_fv3:-${nth_max}}
-    [[ ${NTHREADS_FV3} -gt ${nth_max} ]] && export NTHREADS_FV3=${nth_max}
-    export cores_per_node=${npe_node_max}
-    export APRUN_FV3="${launcher} -n ${npe_fcst}"
-
-    export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
-    [[ ${NTHREADS_REGRID_NEMSIO} -gt ${nth_max} ]] && export NTHREADS_REGRID_NEMSIO=${nth_max}
-    export APRUN_REGRID_NEMSIO="${launcher} -n ${LEVS}"
-
-    export NTHREADS_REMAP=${nth_remap:-2}
-    [[ ${NTHREADS_REMAP} -gt ${nth_max} ]] && export NTHREADS_REMAP=${nth_max}
-    export APRUN_REMAP="${launcher} -n ${npe_remap:-${npe_fcst}}"
-    export I_MPI_DAPL_UD="enable"
-
-elif [[ "${step}" = "efcs" ]]; then
-
-    nth_max=$((npe_node_max / npe_node_efcs))
-
-    export NTHREADS_FV3=${nth_efcs:-${nth_max}}
-    [[ ${NTHREADS_FV3} -gt ${nth_max} ]] && export NTHREADS_FV3=${nth_max}
-    export cores_per_node=${npe_node_max}
-    export APRUN_FV3="${launcher} -n ${npe_efcs}"
-
-    export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
-    [[ ${NTHREADS_REGRID_NEMSIO} -gt ${nth_max} ]] && export NTHREADS_REGRID_NEMSIO=${nth_max}
-    export APRUN_REGRID_NEMSIO="${launcher} -n ${LEVS}"
+    nprocs="npe_${step}"
+    export APRUN_UFS="${launcher} -n ${!nprocs}"
+    unset nprocs
 
 elif [[ "${step}" = "post" ]]; then
 
@@ -306,7 +274,7 @@ elif [[ "${step}" = "gempak" ]]; then
         npe_gempak=${npe_gempak_gfs}
         npe_node_gempak=${npe_node_gempak_gfs}
     fi
-    
+
     nth_max=$((npe_node_max / npe_node_gempak))
 
     export NTHREADS_GEMPAK=${nth_gempak:-1}

--- a/env/S4.env
+++ b/env/S4.env
@@ -174,7 +174,18 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    export APRUN_UFS="${launcher}"
+    if [[ "${CDUMP}" =~ "gfs" ]]; then
+        nprocs="npe_${step}_gfs"
+        ppn="npe_node_${step}_gfs" || ppn="npe_node_${step}"
+    else
+        nprocs="npe_${step}"
+        ppn="npe_node_${step}"
+    fi
+    (( nnodes = (${!nprocs}+${!ppn}-1)/${!ppn} ))
+    (( ntasks = nnodes*${!ppn} ))
+    # With ESMF threading, the model wants to use the full node
+    export APRUN_UFS="${launcher} -n ${ntasks}"
+    unset nprocs ppn nnodes ntasks
 
 elif [[ "${step}" = "post" ]]; then
 

--- a/env/S4.env
+++ b/env/S4.env
@@ -174,13 +174,7 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    if [[ "${CDUMP}" =~ "gfs" ]]; then
-        nprocs="npe_${step}_gfs"
-    else
-        nprocs="npe_${step}"
-    fi
-    export APRUN_UFS="${launcher} -n ${!nprocs}"
-    unset nprocs
+    export APRUN_UFS="${launcher}"
 
 elif [[ "${step}" = "post" ]]; then
 

--- a/env/S4.env
+++ b/env/S4.env
@@ -174,7 +174,7 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    nprocs="npe_${step}"
+    [[ "${CDUMP}" =~ "gfs" ]] && nprocs="npe_${step}_gfs" || nprocs="npe_${step}"
     export APRUN_UFS="${launcher} -n ${!nprocs}"
     unset nprocs
 

--- a/env/S4.env
+++ b/env/S4.env
@@ -174,7 +174,11 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    [[ "${CDUMP}" =~ "gfs" ]] && nprocs="npe_${step}_gfs" || nprocs="npe_${step}"
+    if [[ "${CDUMP}" =~ "gfs" ]]; then
+        nprocs="npe_${step}_gfs"
+    else
+        nprocs="npe_${step}"
+    fi
     export APRUN_UFS="${launcher} -n ${!nprocs}"
     unset nprocs
 

--- a/env/S4.env
+++ b/env/S4.env
@@ -172,43 +172,11 @@ elif [[ "${step}" = "eupd" ]]; then
     export USE_CFP=${USE_CFP:-"YES"}
     export APRUNCFP="${launcher} -n \$ncmd ${mpmd_opt}"
 
-elif [[ "${step}" = "fcst" ]]; then
+elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    #PEs and PEs/node can differ for GFS and GDAS forecasts if threading differs
-    if [[ ${CDUMP} == "gfs" ]]; then
-        npe_fcst=${npe_fcst_gfs}
-        npe_node_fcst=${npe_node_fcst_gfs}
-        nth_fv3=${nth_fv3_gfs}
-    fi
-
-    nth_max=$((npe_node_max / npe_node_fcst))
-
-    export NTHREADS_FV3=${nth_fv3:-${nth_max}}
-    [[ ${NTHREADS_FV3} -gt ${nth_max} ]] && export NTHREADS_FV3=${nth_max}
-    export cores_per_node=${npe_node_max}
-    export APRUN_FV3="${launcher} -n ${npe_fcst}"
-
-    export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
-    [[ ${NTHREADS_REGRID_NEMSIO} -gt ${nth_max} ]] && export NTHREADS_REGRID_NEMSIO=${nth_max}
-    export APRUN_REGRID_NEMSIO="${launcher} -n ${LEVS}"
-
-    export NTHREADS_REMAP=${nth_remap:-2}
-    [[ ${NTHREADS_REMAP} -gt ${nth_max} ]] && export NTHREADS_REMAP=${nth_max}
-    export APRUN_REMAP="${launcher} -n ${npe_remap:-${npe_fcst}}"
-    export I_MPI_DAPL_UD="enable"
-
-elif [[ "${step}" = "efcs" ]]; then
-
-    nth_max=$((npe_node_max / npe_node_efcs))
-
-    export NTHREADS_FV3=${nth_efcs:-${nth_max}}
-    [[ ${NTHREADS_FV3} -gt ${nth_max} ]] && export NTHREADS_FV3=${nth_max}
-    export cores_per_node=${npe_node_max}
-    export APRUN_FV3="${launcher} -n ${npe_efcs}"
-
-    export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
-    [[ ${NTHREADS_REGRID_NEMSIO} -gt ${nth_max} ]] && export NTHREADS_REGRID_NEMSIO=${nth_max}
-    export APRUN_REGRID_NEMSIO="${launcher} -n ${LEVS}"
+    nprocs="npe_${step}"
+    export APRUN_UFS="${launcher} -n ${!nprocs}"
+    unset nprocs
 
 elif [[ "${step}" = "post" ]]; then
 

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -179,9 +179,10 @@ elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
         nprocs="npe_${step}"
         ppn="npe_node_${step}"
     fi
-    (( ntasks = (${!nprocs}+${!ppn}-1)/${!ppn} ))
+    (( nnodes = (${!nprocs}+${!ppn}-1)/${!ppn} ))
+    (( ntasks = ${nnodes}*${!ppn} ))
     export APRUN_UFS="${launcher} -n ${ntasks} -ppn ${!ppn} --cpu-bind depth --depth 1"
-    unset nprocs ppn ntasks
+    unset nprocs ppn nnodes ntasks
 
     # TODO: Why are fcst and efcs so different on WCOSS2?
     # TODO: Compare these with the ufs-weather-model regression test job card at:

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -170,49 +170,27 @@ elif [[ "${step}" = "eupd" ]]; then
     export USE_CFP=${USE_CFP:-"YES"}
     export APRUNCFP="${launcher} -np \$ncmd ${mpmd_opt}"
 
-#elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
-#
-#    nprocs="npe_${step}"
-#    ppn="npe_node_${step}"
-#    export APRUN_UFS="${launcher} -n ${!nprocs} -ppn ${!ppn} --cpu-bind depth --depth 1"
-#    unset nprocs ppn
-# TODO: Why are fcst and efcs so different on WCOSS2?
-# TODO: Compare these with the ufs-weather-model regression test job card at:
-# https://github.com/ufs-community/ufs-weather-model/blob/develop/tests/fv3_conf/fv3_qsub.IN_wcoss2
-elif [[ "${step}" = "fcst" ]]; then
+elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    export OMP_PLACES=cores
-    export OMP_STACKSIZE=2048M
+    nprocs="npe_${step}"
+    ppn="npe_node_${step}"
+    [[ "${CDUMP}" =~ "gfs" ]] && nprocs="npe_${step}_gfs" || nprocs="npe_${step}"
+    [[ "${CDUMP}" =~ "gfs" ]] && ppn="npe_node_${step}_gfs" || ppn="npe_node_${step}"
+    export APRUN_UFS="${launcher} -n ${!nprocs} -ppn ${!ppn} --cpu-bind depth --depth 1"
+    unset nprocs ppn
+
+    # TODO: Why are fcst and efcs so different on WCOSS2?
+    # TODO: Compare these with the ufs-weather-model regression test job card at:
+    # https://github.com/ufs-community/ufs-weather-model/blob/develop/tests/fv3_conf/fv3_qsub.IN_wcoss2
     export FI_OFI_RXM_RX_SIZE=40000
     export FI_OFI_RXM_TX_SIZE=40000
-
-    #PEs and PEs/node can differ for GFS and GDAS forecasts if threading differs
-    if [[ ${CDUMP} == "gfs" ]]; then
-        npe_fcst=${npe_fcst_gfs}
-        npe_node_fcst=${npe_node_fcst_gfs}
-        nth_fv3=${nth_fv3_gfs}
+    if [[ "${step}}" = "fcst" ]]; then
+        export OMP_PLACES=cores
+        export OMP_STACKSIZE=2048M
+    elif [[ "${step}}" = "efcs" ]]; then
+        export MPICH_MPIIO_HINTS="*:romio_cb_write=disable"
+        export FI_OFI_RXM_SAR_LIMIT=3145728
     fi
-
-    nth_max=$((npe_node_max / npe_node_fcst))
-
-    export NTHREADS_FV3=${nth_fv3:-${nth_max}}
-    [[ ${NTHREADS_FV3} -gt ${nth_max} ]] && export NTHREADS_FV3=${nth_max}
-    export APRUN_UFS="${launcher} -n ${npe_fcst} -ppn ${npe_node_fcst} --cpu-bind depth --depth ${NTHREADS_FV3}"
-
-    export I_MPI_DAPL_UD="enable"
-
-elif [[ "${step}" = "efcs" ]]; then
-
-    export MPICH_MPIIO_HINTS="*:romio_cb_write=disable"
-    export FI_OFI_RXM_SAR_LIMIT=3145728
-    export FI_OFI_RXM_RX_SIZE=40000
-    export FI_OFI_RXM_TX_SIZE=40000
-
-    nth_max=$((npe_node_max / npe_node_efcs))
-
-    export NTHREADS_FV3=${nth_efcs:-${nth_max}}
-    [[ ${NTHREADS_FV3} -gt ${nth_max} ]] && export NTHREADS_FV3=${nth_max}
-    export APRUN_UFS="${launcher} -n ${npe_fv3:-${npe_efcs}} -ppn ${npe_node_efcs} --cpu-bind depth --depth ${NTHREADS_FV3}"
 
 elif [[ "${step}" = "post" ]]; then
 

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -172,10 +172,13 @@ elif [[ "${step}" = "eupd" ]]; then
 
 elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
-    nprocs="npe_${step}"
-    ppn="npe_node_${step}"
-    [[ "${CDUMP}" =~ "gfs" ]] && nprocs="npe_${step}_gfs" || nprocs="npe_${step}"
-    [[ "${CDUMP}" =~ "gfs" ]] && ppn="npe_node_${step}_gfs" || ppn="npe_node_${step}"
+    if [[ "${CDUMP}" =~ "gfs" ]]; then
+        nprocs="npe_${step}_gfs"
+        ppn="npe_node_${step}_gfs" || ppn="npe_node_${step}"
+    else
+        nprocs="npe_${step}"
+        ppn="npe_node_${step}"
+    fi
     export APRUN_UFS="${launcher} -n ${!nprocs} -ppn ${!ppn} --cpu-bind depth --depth 1"
     unset nprocs ppn
 

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -170,6 +170,15 @@ elif [[ "${step}" = "eupd" ]]; then
     export USE_CFP=${USE_CFP:-"YES"}
     export APRUNCFP="${launcher} -np \$ncmd ${mpmd_opt}"
 
+#elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
+#
+#    nprocs="npe_${step}"
+#    ppn="npe_node_${step}"
+#    export APRUN_UFS="${launcher} -n ${!nprocs} -ppn ${!ppn} --cpu-bind depth --depth 1"
+#    unset nprocs ppn
+# TODO: Why are fcst and efcs so different on WCOSS2?
+# TODO: Compare these with the ufs-weather-model regression test job card at:
+# https://github.com/ufs-community/ufs-weather-model/blob/develop/tests/fv3_conf/fv3_qsub.IN_wcoss2
 elif [[ "${step}" = "fcst" ]]; then
 
     export OMP_PLACES=cores
@@ -188,16 +197,8 @@ elif [[ "${step}" = "fcst" ]]; then
 
     export NTHREADS_FV3=${nth_fv3:-${nth_max}}
     [[ ${NTHREADS_FV3} -gt ${nth_max} ]] && export NTHREADS_FV3=${nth_max}
-    export cores_per_node=${npe_node_max}
-    export APRUN_FV3="${launcher} -n ${npe_fcst} -ppn ${npe_node_fcst} --cpu-bind depth --depth ${NTHREADS_FV3}"
+    export APRUN_UFS="${launcher} -n ${npe_fcst} -ppn ${npe_node_fcst} --cpu-bind depth --depth ${NTHREADS_FV3}"
 
-    export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
-    [[ ${NTHREADS_REGRID_NEMSIO} -gt ${nth_max} ]] && export NTHREADS_REGRID_NEMSIO=${nth_max}
-    export APRUN_REGRID_NEMSIO="${launcher} -n ${LEVS}"
-
-    export NTHREADS_REMAP=${nth_remap:-2}
-    [[ ${NTHREADS_REMAP} -gt ${nth_max} ]] && export NTHREADS_REMAP=${nth_max}
-    export APRUN_REMAP="${launcher} -n ${npe_remap:-${npe_fcst}}"
     export I_MPI_DAPL_UD="enable"
 
 elif [[ "${step}" = "efcs" ]]; then
@@ -211,12 +212,7 @@ elif [[ "${step}" = "efcs" ]]; then
 
     export NTHREADS_FV3=${nth_efcs:-${nth_max}}
     [[ ${NTHREADS_FV3} -gt ${nth_max} ]] && export NTHREADS_FV3=${nth_max}
-    export cores_per_node=${npe_node_max}
-    export APRUN_FV3="${launcher} -n ${npe_fv3:-${npe_efcs}} -ppn ${npe_node_efcs} --cpu-bind depth --depth ${NTHREADS_FV3}"
-
-    export NTHREADS_REGRID_NEMSIO=${nth_regrid_nemsio:-1}
-    [[ ${NTHREADS_REGRID_NEMSIO} -gt ${nth_max} ]] && export NTHREADS_REGRID_NEMSIO=${nth_max}
-    export APRUN_REGRID_NEMSIO="${launcher} -n ${LEVS}"
+    export APRUN_UFS="${launcher} -n ${npe_fv3:-${npe_efcs}} -ppn ${npe_node_efcs} --cpu-bind depth --depth ${NTHREADS_FV3}"
 
 elif [[ "${step}" = "post" ]]; then
 

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -180,7 +180,8 @@ elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
         ppn="npe_node_${step}"
     fi
     (( nnodes = (${!nprocs}+${!ppn}-1)/${!ppn} ))
-    (( ntasks = ${nnodes}*${!ppn} ))
+    (( ntasks = nnodes*${!ppn} ))
+    # With ESMF threading, the model wants to use the full node
     export APRUN_UFS="${launcher} -n ${ntasks} -ppn ${!ppn} --cpu-bind depth --depth 1"
     unset nprocs ppn nnodes ntasks
 

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -184,10 +184,10 @@ elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
     # https://github.com/ufs-community/ufs-weather-model/blob/develop/tests/fv3_conf/fv3_qsub.IN_wcoss2
     export FI_OFI_RXM_RX_SIZE=40000
     export FI_OFI_RXM_TX_SIZE=40000
-    if [[ "${step}}" = "fcst" ]]; then
+    if [[ "${step}" = "fcst" ]]; then
         export OMP_PLACES=cores
         export OMP_STACKSIZE=2048M
-    elif [[ "${step}}" = "efcs" ]]; then
+    elif [[ "${step}" = "efcs" ]]; then
         export MPICH_MPIIO_HINTS="*:romio_cb_write=disable"
         export FI_OFI_RXM_SAR_LIMIT=3145728
     fi

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -179,8 +179,9 @@ elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
         nprocs="npe_${step}"
         ppn="npe_node_${step}"
     fi
-    export APRUN_UFS="${launcher} -n ${!nprocs} -ppn ${!ppn} --cpu-bind depth --depth 1"
-    unset nprocs ppn
+    (( ntasks = (${!nprocs}+${!ppn}-1)/${!ppn} ))
+    export APRUN_UFS="${launcher} -n ${ntasks} -ppn ${!ppn} --cpu-bind depth --depth 1"
+    unset nprocs ppn ntasks
 
     # TODO: Why are fcst and efcs so different on WCOSS2?
     # TODO: Compare these with the ufs-weather-model regression test job card at:

--- a/jobs/rocoto/efcs.sh
+++ b/jobs/rocoto/efcs.sh
@@ -4,9 +4,17 @@ source "${HOMEgfs}/ush/preamble.sh"
 
 ###############################################################
 # Source FV3GFS workflow modules
-. ${HOMEgfs}/ush/load_fv3gfs_modules.sh
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+#. ${HOMEgfs}/ush/load_fv3gfs_modules.sh
+#status=$?
+#[[ ${status} -ne 0 ]] && exit ${status}
+
+set +x
+module use "${HOMEgfs}/sorc/ufs_model.fd/tests"
+module load modules.ufs_model.lua
+# Workflow needs utilities from prod_util (setPDY.sh, ndate, etc.)
+module load prod_util
+module list
+set_trace
 
 export job="efcs"
 export jobid="${job}.$$"

--- a/jobs/rocoto/efcs.sh
+++ b/jobs/rocoto/efcs.sh
@@ -8,12 +8,18 @@ source "${HOMEgfs}/ush/preamble.sh"
 #status=$?
 #[[ ${status} -ne 0 ]] && exit ${status}
 
+# TODO: clean this up
+source "${HOMEgfs}/ush/detect_machine.sh"
 set +x
 module use "${HOMEgfs}/sorc/ufs_model.fd/tests"
 module load modules.ufs_model.lua
 # Workflow needs utilities from prod_util (setPDY.sh, ndate, etc.)
 module load prod_util
+if [[ "${MACHINE_ID}" = "wcoss2" ]]; then
+  module load cray-pals
+fi
 module list
+unset MACHINE_ID
 set_trace
 
 export job="efcs"

--- a/jobs/rocoto/fcst.sh
+++ b/jobs/rocoto/fcst.sh
@@ -4,9 +4,16 @@ source "${HOMEgfs}/ush/preamble.sh"
 
 ###############################################################
 # Source FV3GFS workflow modules
-. ${HOMEgfs}/ush/load_fv3gfs_modules.sh
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+#. ${HOMEgfs}/ush/load_fv3gfs_modules.sh
+#status=$?
+#[[ ${status} -ne 0 ]] && exit ${status}
+
+set +x
+module use "${HOMEgfs}/sorc/ufs_model.fd/tests"
+module load modules.ufs_model.lua
+module load prod_util
+module list
+set_trace
 
 export job="fcst"
 export jobid="${job}.$$"

--- a/jobs/rocoto/fcst.sh
+++ b/jobs/rocoto/fcst.sh
@@ -8,11 +8,17 @@ source "${HOMEgfs}/ush/preamble.sh"
 #status=$?
 #[[ ${status} -ne 0 ]] && exit ${status}
 
+# TODO: clean this up
+source "${HOMEgfs}/ush/detect_machine.sh"
 set +x
 module use "${HOMEgfs}/sorc/ufs_model.fd/tests"
 module load modules.ufs_model.lua
 module load prod_util
+if [[ "${MACHINE_ID}" = "wcoss2" ]]; then
+  module load cray-pals
+fi
 module list
+unset MACHINE_ID
 set_trace
 
 export job="fcst"

--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -252,10 +252,10 @@ export gfs_cyc=@gfs_cyc@ # 0: no GFS cycle, 1: 00Z only, 2: 00Z and 12Z only, 4:
 # GFS output and frequency
 export FHMIN_GFS=0
 
-export FHMAX_GFS_00=${FHMAX_GFS_00:-384}
-export FHMAX_GFS_06=${FHMAX_GFS_06:-384}
-export FHMAX_GFS_12=${FHMAX_GFS_12:-384}
-export FHMAX_GFS_18=${FHMAX_GFS_18:-384}
+export FHMAX_GFS_00=${FHMAX_GFS_00:-120}
+export FHMAX_GFS_06=${FHMAX_GFS_06:-120}
+export FHMAX_GFS_12=${FHMAX_GFS_12:-120}
+export FHMAX_GFS_18=${FHMAX_GFS_18:-120}
 export FHMAX_GFS=$(eval echo \${FHMAX_GFS_${cyc}})
 
 export FHOUT_GFS=${FHOUT_GFS:-3}

--- a/parm/config/config.defaults.s2sw
+++ b/parm/config/config.defaults.s2sw
@@ -27,7 +27,6 @@ case "${CASE}" in
     #layout_x_gfs=24
     #layout_y_gfs=16
     #WRTTASK_PER_GROUP_GFS=86
-    WRTIOBUF="32M"  # TODO: This value is for P8 w/ C384.  Why not update/set this as default in config.fv3 C384?
     ;;
   *)  # All other ${CASE}
     echo "config.defaults.s2sw: Using default settings for CASE=${CASE}"

--- a/parm/config/config.defaults.s2sw
+++ b/parm/config/config.defaults.s2sw
@@ -15,6 +15,7 @@ min_seaice="1.0e-6"
 use_cice_alb=".true."
 
 # config.ufs  # TODO: This is hard-wired for P8 and needs to be refactored.  For now, use case C384
+# TODO: Q. for @jessicameixner-noaa: can we make these defaults in config.ufs for C384?
 case "${CASE}" in
   "C384")
     DELTIM=300
@@ -27,10 +28,9 @@ case "${CASE}" in
     #layout_y_gfs=16
     #WRTTASK_PER_GROUP_GFS=86
     WRTIOBUF="32M"  # TODO: This value is for P8 w/ C384.  Why not update/set this as default in config.fv3 C384?
-    MEDPETS=300  # TODO: Use 300 instead of ATMPETS = layout_x * layout_y * 6
     ;;
-  "C768")
-    MEDPETS=300  
+  *)  # All other ${CASE}
+    echo "config.defaults.s2sw: Using default settings for CASE=${CASE}"
     ;;
 esac
 

--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -414,41 +414,42 @@ elif [ ${step} = "gldas" ]; then
     export npe_node_gaussian=$(echo "${npe_node_max} / ${nth_gaussian}" | bc)
     export is_exclusive=True
 
-elif [[ ${step} = "fcst" || ${step} = "efcs" ]]; then
+elif [[ "${step}" = "fcst" || "${step}" = "efcs" ]]; then
 
     export is_exclusive=True
 
-    if [[ ${step} == "fcst" ]]; then
+    if [[ "${step}" = "fcst" ]]; then
         _CDUMP_LIST=${CDUMP:-"gdas gfs"}
-    elif [[ ${step} == "efcs" ]]; then
+    elif [[ "${step}" = "efcs" ]]; then
         _CDUMP_LIST=${CDUMP:-"enkfgdas enkfgfs"}
     fi
 
     # During workflow creation, we need resources for all CDUMPs and CDUMP is undefined
     for _CDUMP in ${_CDUMP_LIST}; do
-        if [[ ${_CDUMP} =~ "gfs" ]]; then
+        if [[ "${_CDUMP}" =~ "gfs" ]]; then
           export layout_x=${layout_x_gfs}
           export layout_y=${layout_y_gfs}
           export WRITE_GROUP=${WRITE_GROUP_GFS}
           export WRTTASK_PER_GROUP=${WRTTASK_PER_GROUP_GFS}
           ntasks_fv3=${ntasks_fv3_gfs}
           ntasks_quilt=${ntasks_quilt_gfs}
-          nth_fv3=${nth_fv3_gfs}
+          nthreads_fv3=${nthreads_fv3_gfs}
         fi
 
         # PETS for the atmosphere dycore
-        (( FV3PETS = ntasks_fv3 ))
+        (( FV3PETS = ntasks_fv3 * nthreads_fv3 ))
 
         # PETS for quilting
-        if [[ ${QUILTING:-} == ".true." ]]; then
-          (( QUILTPETS = ntasks_quilt ))
+        if [[ "${QUILTING:-}" = ".true." ]]; then
+          (( QUILTPETS = ntasks_quilt * nthreads_fv3 ))
         else
           QUILTPETS=0
         fi
 
         # Total PETS for the atmosphere component
-        (( ATMPETS = FV3PETS + QUILTPETS))
-        export ATMPETS
+        ATMTHREADS=${nthreads_fv3}
+        (( ATMPETS = FV3PETS + QUILTPETS ))
+        export ATMPETS ATMTHREADS
 
         # Total PETS for the coupled model (starting w/ the atmosphere)
         NTASKS_TOT=${ATMPETS}
@@ -456,45 +457,49 @@ elif [[ ${step} = "fcst" || ${step} = "efcs" ]]; then
         # The mediator PETS can overlap with other components, usually it lands on the atmosphere tasks.
         # However, it is suggested limiting mediator PETS to 300, as it may cause the slow performance.
         # See https://docs.google.com/document/d/1bKpi-52t5jIfv2tuNHmQkYUe3hkKsiG_DG_s6Mnukog/edit
-        # TODO: Update reference with moved to RTD
+        # TODO: Update reference when moved to ufs-weather-model RTD
+        MEDTHREADS=${nthreads_mediator:-1}
         MEDPETS=${MEDPETS:-ATMPETS}
         [[ "${MEDPETS}" -gt 300 ]] && MEDPETS=300
-        export MEDPETS
+        export MEDPETS MEDTHREADS
 
-        if [[ ${DO_AERO} == "YES" ]]; then
-          (( CHMPETS = ntasks_fv3 ))
-          # GOCART shares the same grid and forecast tasks as FV3, do not add to NTASKS_TOT
-          export CHMPETS
+        if [[ "${DO_AERO}" = "YES" ]]; then
+          # GOCART shares the same grid and forecast tasks as FV3 (do not add write grid component tasks).
+          (( CHMTHREADS = ATMTHREADS ))
+          (( CHMPETS = FV3PETS ))
+          # Do not add to NTASKS_TOT
+          export CHMPETS CHMTHREADS
         fi
 
-        if [[ ${DO_WAVE} == "YES" ]]; then
-          (( WAVPETS = ntasks_ww3 ))
+        if [[ "${DO_WAVE}" = "YES" ]]; then
+          (( WAVPETS = ntasks_ww3 * nthreads_ww3 ))
+          (( WAVTHREADS = nthreads_ww3 ))
+          export WAVPETS WAVTHREADS
           (( NTASKS_TOT = NTASKS_TOT + WAVPETS ))
-          export WAVPETS
         fi
 
-        if [[ ${DO_OCN} == "YES" ]]; then
-          (( OCNPETS = ntasks_mom6 ))
+        if [[ "${DO_OCN}" = "YES" ]]; then
+          (( OCNPETS = ntasks_mom6 * nthreads_mom6 ))
+          (( OCNTHREADS = nthreads_mom6 ))
+          export OCNPETS OCNTHREADS
           (( NTASKS_TOT = NTASKS_TOT + OCNPETS ))
-          export OCNPETS
         fi
 
-        if [[ ${DO_ICE} == "YES" ]]; then
-          (( ICEPETS = ntasks_cice6 ))
+        if [[ "${DO_ICE}" = "YES" ]]; then
+          (( ICEPETS = ntasks_cice6 * nthreads_cice6 ))
+          (( ICETHREADS = nthreads_cice6 ))
+          export ICEPETS ICETHREADS
           (( NTASKS_TOT = NTASKS_TOT + ICEPETS ))
-          export ICEPETS
         fi
 
-        if [[ ${_CDUMP} =~ "gfs" ]]; then
+        if [[ "${_CDUMP}" =~ "gfs" ]]; then
           declare -x npe_${step}_gfs=${NTASKS_TOT}
-          threads=${nth_fv3_gfs:-2}
-          declare -x nth_${step}_gfs=${threads}
-          declare -x npe_node_${step}_gfs=$(echo "${npe_node_max} / ${threads}" | bc)
+          declare -x nth_${step}_gfs=1  # ESMF handles threading for the UFS-weather-model
+          declare -x npe_node_${step}_gfs=${npe_node_max}
         else
           declare -x npe_${step}=${NTASKS_TOT}
-          threads=${nth_fv3:-2}
-          declare -x nth_${step}=${threads}
-          declare -x npe_node_${step}=$(echo "${npe_node_max} / ${threads}" | bc)
+          declare -x nth_${step}=1  # ESMF handles threading for the UFS-weather-model
+          declare -x npe_node_${step}=${npe_node_max}
         fi
     done
 

--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -442,6 +442,9 @@ elif [[ "${step}" = "fcst" || "${step}" = "efcs" ]]; then
         # PETS for quilting
         if [[ "${QUILTING:-}" = ".true." ]]; then
           (( QUILTPETS = ntasks_quilt * nthreads_fv3 ))
+          (( WRTTASK_PER_GROUP = WRTTASK_PER_GROUP * nthreads_fv3 ))  # when threads are used, WRTTASKS_PER_GROUP = INCOMING_WRTTASKS_PER_GROUP * threads
+          # model_configure should be updated to reflect the number of threads used by calling this variable write_pets_per_group
+          export WRTTASK_PER_GROUP
         else
           QUILTPETS=0
         fi
@@ -517,6 +520,9 @@ elif [[ "${step}" = "fcst" || "${step}" = "efcs" ]]; then
         exit 1
         ;;
     esac
+
+    unset _CDUMP _CDUMP_LIST
+    unset NTASKS_TOT
 
 elif [ ${step} = "ocnpost" ]; then
 

--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -496,13 +496,13 @@ elif [[ "${step}" = "fcst" || "${step}" = "efcs" ]]; then
         fi
 
         if [[ "${_CDUMP}" =~ "gfs" ]]; then
-          declare -x npe_${step}_gfs=${NTASKS_TOT}
+          declare -x npe_${step}_gfs="${NTASKS_TOT}"
           declare -x nth_${step}_gfs=1  # ESMF handles threading for the UFS-weather-model
-          declare -x npe_node_${step}_gfs=${npe_node_max}
+          declare -x npe_node_${step}_gfs="${npe_node_max}"
         else
-          declare -x npe_${step}=${NTASKS_TOT}
+          declare -x npe_${step}="${NTASKS_TOT}"
           declare -x nth_${step}=1  # ESMF handles threading for the UFS-weather-model
-          declare -x npe_node_${step}=${npe_node_max}
+          declare -x npe_node_${step}="${npe_node_max}"
         fi
     done
 

--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -438,6 +438,7 @@ elif [[ "${step}" = "fcst" || "${step}" = "efcs" ]]; then
 
         # PETS for the atmosphere dycore
         (( FV3PETS = ntasks_fv3 * nthreads_fv3 ))
+        echo "FV3 using (nthreads, PETS) = (${nthreads_fv3}, ${FV3PETS})"
 
         # PETS for quilting
         if [[ "${QUILTING:-}" = ".true." ]]; then
@@ -448,11 +449,13 @@ elif [[ "${step}" = "fcst" || "${step}" = "efcs" ]]; then
         else
           QUILTPETS=0
         fi
+        echo "QUILT using (nthreads, PETS) = (${nthreads_fv3}, ${QUILTPETS})"
 
         # Total PETS for the atmosphere component
         ATMTHREADS=${nthreads_fv3}
         (( ATMPETS = FV3PETS + QUILTPETS ))
         export ATMPETS ATMTHREADS
+        echo "FV3ATM using (nthreads, PETS) = (${ATMTHREADS}, ${ATMPETS})"
 
         # Total PETS for the coupled model (starting w/ the atmosphere)
         NTASKS_TOT=${ATMPETS}
@@ -465,6 +468,7 @@ elif [[ "${step}" = "fcst" || "${step}" = "efcs" ]]; then
         MEDPETS=${MEDPETS:-ATMPETS}
         [[ "${MEDPETS}" -gt 300 ]] && MEDPETS=300
         export MEDPETS MEDTHREADS
+        echo "MEDIATOR using (threads, PETS) = (${MEDTHREADS}, ${MEDPETS})"
 
         if [[ "${DO_AERO}" = "YES" ]]; then
           # GOCART shares the same grid and forecast tasks as FV3 (do not add write grid component tasks).
@@ -472,12 +476,14 @@ elif [[ "${step}" = "fcst" || "${step}" = "efcs" ]]; then
           (( CHMPETS = FV3PETS ))
           # Do not add to NTASKS_TOT
           export CHMPETS CHMTHREADS
+          echo "GOCART using (threads, PETS) = (${CHMTHREADS}, ${CHMPETS})"
         fi
 
         if [[ "${DO_WAVE}" = "YES" ]]; then
           (( WAVPETS = ntasks_ww3 * nthreads_ww3 ))
           (( WAVTHREADS = nthreads_ww3 ))
           export WAVPETS WAVTHREADS
+          echo "WW3 using (threads, PETS) = (${WAVTHREADS}, ${WAVPETS})"
           (( NTASKS_TOT = NTASKS_TOT + WAVPETS ))
         fi
 
@@ -485,6 +491,7 @@ elif [[ "${step}" = "fcst" || "${step}" = "efcs" ]]; then
           (( OCNPETS = ntasks_mom6 * nthreads_mom6 ))
           (( OCNTHREADS = nthreads_mom6 ))
           export OCNPETS OCNTHREADS
+          echo "MOM6 using (threads, PETS) = (${OCNTHREADS}, ${OCNPETS})"
           (( NTASKS_TOT = NTASKS_TOT + OCNPETS ))
         fi
 
@@ -492,8 +499,11 @@ elif [[ "${step}" = "fcst" || "${step}" = "efcs" ]]; then
           (( ICEPETS = ntasks_cice6 * nthreads_cice6 ))
           (( ICETHREADS = nthreads_cice6 ))
           export ICEPETS ICETHREADS
+          echo "CICE6 using (threads, PETS) = (${ICETHREADS}, ${ICEPETS})"
           (( NTASKS_TOT = NTASKS_TOT + ICEPETS ))
         fi
+
+        echo "Total PETS for ${_CDUMP} = ${NTASKS_TOT}"
 
         if [[ "${_CDUMP}" =~ "gfs" ]]; then
           declare -x npe_${step}_gfs="${NTASKS_TOT}"
@@ -504,6 +514,7 @@ elif [[ "${step}" = "fcst" || "${step}" = "efcs" ]]; then
           declare -x nth_${step}=1  # ESMF handles threading for the UFS-weather-model
           declare -x npe_node_${step}="${npe_node_max}"
         fi
+
     done
 
     case "${CASE}" in

--- a/parm/config/config.ufs
+++ b/parm/config/config.ufs
@@ -55,7 +55,7 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-# Mediator is required if any of the components are not skipped
+# Mediator is required if any of the non-ATM components are used
 if [[ "${skip_mom6}" == "false" ]] || [[ "${skip_cice6}" == "false" ]] || [[ "${skip_ww3}" == "false" ]]; then
   skip_mediator=false
 fi

--- a/parm/config/config.ufs
+++ b/parm/config/config.ufs
@@ -25,6 +25,7 @@ fi
 skip_mom6=true
 skip_cice6=true
 skip_ww3=true
+skip_mediator=true
 
 # Loop through named arguments
 while [[ $# -gt 0 ]]; do
@@ -54,26 +55,31 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
+# Mediator is required if any of the components are not skipped
+if [[ "${skip_mom6}" == "false" ] || [ "${skip_cice6}" == "false" ] || [ "${skip_ww3}" == "false" ]]; then
+  skip_mediator=false
+fi
+
 case "${machine}" in
   "WCOSS2")
-    export npe_node_max=128
+    npe_node_max=128
     ;;
   "HERA" | "ORION")
-    export npe_node_max=40
+    npe_node_max=40
     ;;
   "JET")
     case "${PARTITION_BATCH}" in
       "xjet")
-        export npe_node_max=24
+        npe_node_max=24
         ;;
       "vjet" | "sjet")
-        export npe_node_max=16
+        npe_node_max=16
         ;;
       "kjet")
-        export npe_node_max=40
+        npe_node_max=40
         ;;
       *)
-        echo "FATAL ERROR: Unsupported PARTITION_BATCH = ${PARTITION_BATCH}, ABORT!"
+        echo "FATAL ERROR: Unsupported ${machine} PARTITION_BATCH = ${PARTITION_BATCH}, ABORT!"
         exit 1
         ;;
     esac
@@ -81,18 +87,19 @@ case "${machine}" in
   "S4")
     case "${PARTITION_BATCH}" in
       "s4")
-        export npe_node_max=32
+        npe_node_max=32
         ;;
       "ivy")
-        export npe_node_max=20
+        npe_node_max=20
         ;;
       *)
-        echo "FATAL ERROR: Unsupported PARTITION_BATCH = ${PARTITION_BATCH}, ABORT!"
+        echo "FATAL ERROR: Unsupported ${machine} PARTITION_BATCH = ${PARTITION_BATCH}, ABORT!"
         exit 1
         ;;
     esac
     ;;
 esac
+export npe_node_max
 
 # (Standard) Model resolution dependent variables
 case "${fv3_res}" in
@@ -102,8 +109,8 @@ case "${fv3_res}" in
         export layout_y=1
         export layout_x_gfs=1
         export layout_y_gfs=1
-        export nth_fv3=1
-        export nth_fv3_gfs=1
+        export nthreads_fv3=1
+        export nthreads_fv3_gfs=1
         export cdmbgwd="0.071,2.1,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=1
         export WRTTASK_PER_GROUP=2
@@ -117,8 +124,8 @@ case "${fv3_res}" in
         export layout_y=2
         export layout_x_gfs=2
         export layout_y_gfs=2
-        export nth_fv3=1
-        export nth_fv3_gfs=1
+        export nthreads_fv3=1
+        export nthreads_fv3_gfs=1
         export cdmbgwd="0.14,1.8,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=1
         export WRTTASK_PER_GROUP=4
@@ -132,8 +139,8 @@ case "${fv3_res}" in
         export layout_y=6
         export layout_x_gfs=4
         export layout_y_gfs=6
-        export nth_fv3=1
-        export nth_fv3_gfs=2
+        export nthreads_fv3=1
+        export nthreads_fv3_gfs=2
         export cdmbgwd="0.23,1.5,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=1
         export WRTTASK_PER_GROUP=64
@@ -147,8 +154,8 @@ case "${fv3_res}" in
         export layout_y=8
         export layout_x_gfs=8
         export layout_y_gfs=12
-        export nth_fv3=1
-        export nth_fv3_gfs=2
+        export nthreads_fv3=1
+        export nthreads_fv3_gfs=2
         export cdmbgwd="1.1,0.72,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=1
         export WRTTASK_PER_GROUP=48
@@ -162,8 +169,8 @@ case "${fv3_res}" in
         export layout_y=12
         export layout_x_gfs=12
         export layout_y_gfs=16
-        export nth_fv3=4
-        export nth_fv3_gfs=4
+        export nthreads_fv3=4
+        export nthreads_fv3_gfs=4
         export cdmbgwd="4.0,0.15,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=2
         export WRTTASK_PER_GROUP=64
@@ -177,8 +184,8 @@ case "${fv3_res}" in
         export layout_y=16
         export layout_x_gfs=8
         export layout_y_gfs=16
-        export nth_fv3=4
-        export nth_fv3_gfs=4
+        export nthreads_fv3=4
+        export nthreads_fv3_gfs=4
         export cdmbgwd="4.0,0.10,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=4
         export WRTTASK_PER_GROUP=64  # TODO: refine these numbers when a case is available
@@ -192,8 +199,8 @@ case "${fv3_res}" in
         export layout_y=32
         export layout_x_gfs=16
         export layout_y_gfs=32
-        export nth_fv3=4
-        export nth_fv3_gfs=4
+        export nthreads_fv3=4
+        export nthreads_fv3_gfs=4
         export cdmbgwd="4.0,0.05,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=4
         export WRTTASK_PER_GROUP=64  # TODO: refine these numbers when a case is available
@@ -220,18 +227,24 @@ export ntasks_quilt_gfs
 # Determine whether to use parallel NetCDF based on resolution
 case ${fv3_res} in
   "C48" | "C96" | "C192" | "C384")
-    export OUTPUT_FILETYPE_ATM="netcdf"
-    export OUTPUT_FILETYPE_SFC="netcdf"
+    OUTPUT_FILETYPE_ATM="netcdf"
+    OUTPUT_FILETYPE_SFC="netcdf"
     ;;
   "C768" | "C1152" | "C3072")
-    export OUTPUT_FILETYPE_ATM="netcdf_parallel"
-    export OUTPUT_FILETYPE_SFC="netcdf_parallel"
+    OUTPUT_FILETYPE_ATM="netcdf_parallel"
+    OUTPUT_FILETYPE_SFC="netcdf_parallel"
     ;;
 esac
+export OUTPUT_FILETYPE_ATM OUTPUT_FILETYPE_SFC
+
+# Mediator specific settings
+if [[ "${skip_mediator}" == "false" ]]; then
+  export nthreads_mediator=${nthreads_fv3}  # TODO: consult w/ @junwang-noaa how to optimize this in the context of nthreads_fv3 or should it be its own number?
+fi
 
 # MOM6 specific settings
 if [[ "${skip_mom6}" == "false" ]]; then
-  export nth_mom6=1
+  nthreads_mom6=1
   case "${mom6_res}" in
     "500")
       ntasks_mom6=8
@@ -286,7 +299,7 @@ if [[ "${skip_mom6}" == "false" ]]; then
       exit 1
       ;;
   esac
-  export ntasks_mom6
+  export nthreads_mom6 ntasks_mom6
   export OCNTIM
   export NX_GLB NY_GLB
   export DT_DYNAM_MOM6 DT_THERM_MOM6
@@ -303,7 +316,7 @@ if [[ "${skip_cice6}" == "false" ]]; then
     echo "FATAL ERROR: CICE6 cannot be configured without MOM6, ABORT!"
     exit 1
   fi
-  export nth_cice6=${mom6_res}  # CICE6 needs to run on same threads as MOM6
+  nthreads_cice6=${nthreads_mom6}  # CICE6 needs to run on same threads as MOM6
   case "${cice6_res}" in
     "500")
       ntasks_cice6=4
@@ -328,31 +341,32 @@ if [[ "${skip_cice6}" == "false" ]]; then
   esac
   # NX_GLB and NY_GLB are set in the MOM6 section above
   # CICE6 runs on the same domain decomposition as MOM6
-  export ntasks_cice6
+  export nthreads_cice6 ntasks_cice6
   export cice6_processor_shape
 fi
 
 # WW3 specific settings
 if [[ "${skip_ww3}" == "false" ]]; then
-  export nth_ww3=2
+  nthreads_ww3=2
   case "${ww3_res}" in
     "gnh_10m;aoc_9km;gsh_15m")
-      export ntasks_ww3=140
+      ntasks_ww3=140
       ;;
     "gwes_30m")
-      export ntasks_ww3=100
+      ntasks_ww3=100
       ;;
     "mx050")
-      export ntasks_ww3=240
+      ntasks_ww3=240
       ;;
     "mx025")
-      export ntasks_ww3=80
+      ntasks_ww3=80
       ;;
     *)
       echo "FATAL ERROR: Unsupported WW3 resolution = ${ww3_res}, ABORT!"
       exit 1
       ;;
   esac
+  export nthreads_ww3 nthreads_ww3
 fi
 
 echo "END: config.ufs"

--- a/parm/config/config.ufs
+++ b/parm/config/config.ufs
@@ -232,7 +232,7 @@ export OUTPUT_FILETYPE_ATM OUTPUT_FILETYPE_SFC
 
 # Mediator specific settings
 if [[ "${skip_mediator}" == "false" ]]; then
-  export nthreads_mediator=${nthreads_fv3}  # TODO: consult w/ @junwang-noaa how to optimize this in the context of nthreads_fv3 or should it be its own number?
+  export nthreads_mediator=${nthreads_fv3}  # Use same threads as FV3
 fi
 
 # MOM6 specific settings

--- a/parm/config/config.ufs
+++ b/parm/config/config.ufs
@@ -56,7 +56,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Mediator is required if any of the components are not skipped
-if [[ "${skip_mom6}" == "false" ] || [ "${skip_cice6}" == "false" ] || [ "${skip_ww3}" == "false" ]]; then
+if [ "${skip_mom6}" == "false" ] || [ "${skip_cice6}" == "false" ] || [ "${skip_ww3}" == "false" ]; then
   skip_mediator=false
 fi
 

--- a/parm/config/config.ufs
+++ b/parm/config/config.ufs
@@ -56,7 +56,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Mediator is required if any of the components are not skipped
-if [ "${skip_mom6}" == "false" ] || [ "${skip_cice6}" == "false" ] || [ "${skip_ww3}" == "false" ]; then
+if [[ "${skip_mom6}" == "false" ]] || [[ "${skip_cice6}" == "false" ]] || [[ "${skip_ww3}" == "false" ]]; then
   skip_mediator=false
 fi
 
@@ -366,7 +366,7 @@ if [[ "${skip_ww3}" == "false" ]]; then
       exit 1
       ;;
   esac
-  export nthreads_ww3 nthreads_ww3
+  export ntasks_ww3 nthreads_ww3
 fi
 
 echo "END: config.ufs"

--- a/parm/config/config.ufs
+++ b/parm/config/config.ufs
@@ -116,7 +116,6 @@ case "${fv3_res}" in
         export WRTTASK_PER_GROUP=2
         export WRITE_GROUP_GFS=1
         export WRTTASK_PER_GROUP_GFS=2
-        export WRTIOBUF="1M"
         ;;
     "C96")
         export DELTIM=600
@@ -131,7 +130,6 @@ case "${fv3_res}" in
         export WRTTASK_PER_GROUP=4
         export WRITE_GROUP_GFS=1
         export WRTTASK_PER_GROUP_GFS=4
-        export WRTIOBUF="4M"
         ;;
     "C192")
         export DELTIM=450
@@ -146,7 +144,6 @@ case "${fv3_res}" in
         export WRTTASK_PER_GROUP=64
         export WRITE_GROUP_GFS=2
         export WRTTASK_PER_GROUP_GFS=64
-        export WRTIOBUF="8M"
         ;;
     "C384")
         export DELTIM=200
@@ -157,11 +154,10 @@ case "${fv3_res}" in
         export nthreads_fv3=1
         export nthreads_fv3_gfs=2
         export cdmbgwd="1.1,0.72,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
-        export WRITE_GROUP=1
+        export WRITE_GROUP=2
         export WRTTASK_PER_GROUP=48
         export WRITE_GROUP_GFS=2
         export WRTTASK_PER_GROUP_GFS=64
-        export WRTIOBUF="16M"
         ;;
     "C768")
         export DELTIM=150
@@ -176,7 +172,6 @@ case "${fv3_res}" in
         export WRTTASK_PER_GROUP=64
         export WRITE_GROUP_GFS=4
         export WRTTASK_PER_GROUP_GFS=64
-        export WRTIOBUF="32M"
         ;;
     "C1152")
         export DELTIM=120
@@ -191,7 +186,6 @@ case "${fv3_res}" in
         export WRTTASK_PER_GROUP=64  # TODO: refine these numbers when a case is available
         export WRITE_GROUP_GFS=4
         export WRTTASK_PER_GROUP_GFS=64  # TODO: refine these numbers when a case is available
-        export WRTIOBUF="48M"
         ;;
     "C3072")
         export DELTIM=90
@@ -206,7 +200,6 @@ case "${fv3_res}" in
         export WRTTASK_PER_GROUP=64  # TODO: refine these numbers when a case is available
         export WRITE_GROUP_GFS=4
         export WRTTASK_PER_GROUP_GFS=64  # TODO: refine these numbers when a case is available
-        export WRTIOBUF="64M"
         ;;
     *)
         echo "FATAL ERROR: Unsupported FV3 resolution = ${fv3_res}, ABORT!"

--- a/scripts/exgdas_enkf_fcst.sh
+++ b/scripts/exgdas_enkf_fcst.sh
@@ -137,10 +137,6 @@ if [ $RECENTER_ENKF = "YES" ]; then
    export PREFIX_ATMINC="r"
 fi
 
-# APRUN for different executables
-export APRUN_FV3=${APRUN_FV3:-${APRUN:-""}}
-export NTHREADS_FV3=${NTHREADS_FV3:-${NTHREADS:-1}}
-
 ################################################################################
 # Run forecast for ensemble member
 rc=0

--- a/scripts/exglobal_forecast.sh
+++ b/scripts/exglobal_forecast.sh
@@ -179,8 +179,7 @@ if [ $esmf_profile ]; then
 fi
 
 $NCP $FCSTEXECDIR/$FCSTEXEC $DATA/.
-export OMP_NUM_THREADS=$NTHREADS_FV3
-$APRUN_FV3 $DATA/$FCSTEXEC 1>&1 2>&2
+$APRUN_UFS $DATA/$FCSTEXEC 1>&1 2>&2
 export ERR=$?
 export err=$ERR
 $ERRSCRIPT || exit $err

--- a/sorc/build_ufs.sh
+++ b/sorc/build_ufs.sh
@@ -36,5 +36,6 @@ CLEAN_AFTER=NO
 ./tests/compile.sh "${MACHINE_ID}" "${MAKE_OPT}" "${COMPILE_NR}" "${CLEAN_BEFORE}" "${CLEAN_AFTER}"
 mv "./tests/fv3_${COMPILE_NR}.exe" ./tests/ufs_model.x
 mv "./tests/modules.fv3_${COMPILE_NR}.lua" ./tests/modules.ufs_model.lua
+cp "./modulefiles/ufs_common.lua" ./tests/ufs_common.lua
 
 exit 0

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -135,14 +135,7 @@ FV3_GFS_predet(){
   PARM_POST=${PARM_POST:-$HOMEgfs/parm/post}
 
   # Model config options
-  APRUN_FV3=${APRUN_FV3:-${APRUN_FCST:-${APRUN:-""}}}
-  cores_per_node=${cores_per_node:-${npe_node_fcst:-24}}
   ntiles=${ntiles:-6}
-  if [ $MEMBER -lt 0 ]; then
-    NTASKS_TOT=${NTASKS_TOT:-${npe_fcst_gfs:-0}}
-  else
-    NTASKS_TOT=${NTASKS_TOT:-${npe_efcs:-0}}
-  fi
 
   TYPE=${TYPE:-"nh"}                  # choices:  nh, hydro
   MONO=${MONO:-"non-mono"}            # choices:  mono, non-mono

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -136,11 +136,6 @@ FV3_GFS_predet(){
 
   # Model config options
   APRUN_FV3=${APRUN_FV3:-${APRUN_FCST:-${APRUN:-""}}}
-  #the following NTHREAD_FV3 line is commented out because NTHREAD_FCST is not defined
-  #and because NTHREADS_FV3 gets overwritten by what is in the env/${macine}.env
-  #file and the value of npe_node_fcst is not correctly defined when using more than
-  #one thread and sets NTHREADS_FV3=1 even when the number of threads is appropraitely >1
-  #NTHREADS_FV3=${NTHREADS_FV3:-${NTHREADS_FCST:-${nth_fv3:-1}}}
   cores_per_node=${cores_per_node:-${npe_node_fcst:-24}}
   ntiles=${ntiles:-6}
   if [ $MEMBER -lt 0 ]; then

--- a/ush/load_fv3gfs_modules.sh
+++ b/ush/load_fv3gfs_modules.sh
@@ -40,6 +40,8 @@ else
   echo WARNING: UNKNOWN PLATFORM
 fi
 
+module list
+
 # Restore stack soft limit:
 ulimit -S -s "$ulimit_s"
 unset ulimit_s

--- a/ush/nems.configure.atm.IN
+++ b/ush/nems.configure.atm.IN
@@ -1,8 +1,12 @@
 # ESMF #
-logKindFlag:            @[esmf_logkind] 
+logKindFlag:            @[esmf_logkind]
+globalResourceControl:  true
 
 EARTH_component_list: ATM
-ATM_model:            fv3
+ATM_model:                      @[atm_model]
+ATM_petlist_bounds:             @[atm_petlist_bounds]
+ATM_omp_num_threads:            @[atm_omp_num_threads]
+
 runSeq::
   ATM
 ::

--- a/ush/nems.configure.atm_aero.IN
+++ b/ush/nems.configure.atm_aero.IN
@@ -3,7 +3,8 @@
 #############################################
 
 # ESMF #
- logKindFlag:            @[esmf_logkind]
+logKindFlag:            @[esmf_logkind]
+globalResourceControl:  true
 
 # EARTH #
 EARTH_component_list: ATM CHM
@@ -14,6 +15,7 @@ EARTH_attributes::
 # ATM #
 ATM_model:                      @[atm_model]
 ATM_petlist_bounds:             @[atm_petlist_bounds]
+ATM_omp_num_threads:            @[atm_omp_num_threads]
 ATM_attributes::
   Verbosity = max
 ::
@@ -21,6 +23,7 @@ ATM_attributes::
 # CHM #
 CHM_model:                      @[chm_model]
 CHM_petlist_bounds:             @[chm_petlist_bounds]
+CHM_omp_num_threads:            @[chm_omp_num_threads]
 CHM_attributes::
   Verbosity = max
 ::

--- a/ush/nems.configure.blocked_atm_wav.IN
+++ b/ush/nems.configure.blocked_atm_wav.IN
@@ -3,7 +3,8 @@
 #############################################
 
 # ESMF #
- logKindFlag:           @[esmf_logkind] 
+logKindFlag:           @[esmf_logkind]
+globalResourceControl: true
 
 # EARTH #
 EARTH_component_list: ATM WAV
@@ -14,6 +15,7 @@ EARTH_attributes::
 # ATM #
 ATM_model:                      @[atm_model]
 ATM_petlist_bounds:             @[atm_petlist_bounds]
+ATM_omp_num_threads:            @[atm_omp_num_threads]
 ATM_attributes::
   Verbosity = max
   DumpFields = true
@@ -22,6 +24,7 @@ ATM_attributes::
 # WAV #
 WAV_model:                      @[wav_model]
 WAV_petlist_bounds:             @[wav_petlist_bounds]
+WAV_omp_num_threads:            @[wav_omp_num_threads]
 WAV_attributes::
   Verbosity = max
 ::
@@ -31,7 +34,7 @@ WAV_attributes::
 # Run Sequence #
 runSeq::
   @@[coupling_interval_sec]
-    ATM -> WAV 
+    ATM -> WAV
     ATM
     WAV
   @

--- a/ush/nems.configure.cpld.IN
+++ b/ush/nems.configure.cpld.IN
@@ -3,7 +3,8 @@
 #############################################
 
 # ESMF #
-logKindFlag:            @[esmf_logkind] 
+logKindFlag:            @[esmf_logkind]
+globalResourceControl:  true
 
 # EARTH #
 EARTH_component_list: MED ATM OCN ICE
@@ -14,11 +15,13 @@ EARTH_attributes::
 # MED #
 MED_model:                      @[med_model]
 MED_petlist_bounds:             @[med_petlist_bounds]
+MED_omp_num_threads:            @[med_omp_num_threads]
 ::
 
 # ATM #
 ATM_model:                      @[atm_model]
 ATM_petlist_bounds:             @[atm_petlist_bounds]
+ATM_omp_num_threads:            @[atm_omp_num_threads]
 ATM_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]
@@ -29,6 +32,7 @@ ATM_attributes::
 # OCN #
 OCN_model:                      @[ocn_model]
 OCN_petlist_bounds:             @[ocn_petlist_bounds]
+OCN_omp_num_threads:            @[ocn_omp_num_threads]
 OCN_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]
@@ -40,6 +44,7 @@ OCN_attributes::
 # ICE #
 ICE_model:                      @[ice_model]
 ICE_petlist_bounds:             @[ice_petlist_bounds]
+ICE_omp_num_threads:            @[ice_omp_num_threads]
 ICE_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]

--- a/ush/nems.configure.cpld_aero_outerwave.IN
+++ b/ush/nems.configure.cpld_aero_outerwave.IN
@@ -3,7 +3,8 @@
 #############################################
 
 # ESMF #
-  logKindFlag:           @[esmf_logkind] 
+logKindFlag:           @[esmf_logkind]
+globalResourceControl: true
 
 # EARTH #
 EARTH_component_list: MED ATM CHM OCN ICE WAV
@@ -14,11 +15,13 @@ EARTH_attributes::
 # MED #
 MED_model:                      @[med_model]
 MED_petlist_bounds:             @[med_petlist_bounds]
+MED_omp_num_threads:            @[med_omp_num_threads]
 ::
 
 # ATM #
 ATM_model:                      @[atm_model]
 ATM_petlist_bounds:             @[atm_petlist_bounds]
+ATM_omp_num_threads:            @[atm_omp_num_threads]
 ATM_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]
@@ -29,6 +32,7 @@ ATM_attributes::
 # CHM #
 CHM_model:                      @[chm_model]
 CHM_petlist_bounds:             @[chm_petlist_bounds]
+CHM_omp_num_threads:            @[chm_omp_num_threads]
 CHM_attributes::
   Verbosity = 0
 ::
@@ -36,6 +40,7 @@ CHM_attributes::
 # OCN #
 OCN_model:                      @[ocn_model]
 OCN_petlist_bounds:             @[ocn_petlist_bounds]
+OCN_omp_num_threads:            @[ocn_omp_num_threads]
 OCN_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]
@@ -47,6 +52,7 @@ OCN_attributes::
 # ICE #
 ICE_model:                      @[ice_model]
 ICE_petlist_bounds:             @[ice_petlist_bounds]
+ICE_omp_num_threads:            @[ice_omp_num_threads]
 ICE_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]
@@ -61,6 +67,7 @@ ICE_attributes::
 # WAV #
 WAV_model:                      @[wav_model]
 WAV_petlist_bounds:             @[wav_petlist_bounds]
+WAV_omp_num_threads:            @[wav_omp_num_threads]
 WAV_attributes::
   Verbosity = 0
   OverwriteSlice = false

--- a/ush/nems.configure.cpld_aero_wave.IN
+++ b/ush/nems.configure.cpld_aero_wave.IN
@@ -3,7 +3,8 @@
 #############################################
 
 # ESMF #
-  logKindFlag:           @[esmf_logkind] 
+logKindFlag:           @[esmf_logkind]
+globalResourceControl: true
 
 # EARTH #
 EARTH_component_list: MED ATM CHM OCN ICE WAV
@@ -14,11 +15,13 @@ EARTH_attributes::
 # MED #
 MED_model:                      @[med_model]
 MED_petlist_bounds:             @[med_petlist_bounds]
+MED_omp_num_threads:            @[med_omp_num_threads]
 ::
 
 # ATM #
 ATM_model:                      @[atm_model]
 ATM_petlist_bounds:             @[atm_petlist_bounds]
+ATM_omp_num_threads:            @[atm_omp_num_threads]
 ATM_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]
@@ -29,6 +32,7 @@ ATM_attributes::
 # CHM #
 CHM_model:                      @[chm_model]
 CHM_petlist_bounds:             @[chm_petlist_bounds]
+CHM_omp_num_threads:            @[chm_omp_num_threads]
 CHM_attributes::
   Verbosity = 0
 ::
@@ -36,6 +40,7 @@ CHM_attributes::
 # OCN #
 OCN_model:                      @[ocn_model]
 OCN_petlist_bounds:             @[ocn_petlist_bounds]
+OCN_omp_num_threads:            @[ocn_omp_num_threads]
 OCN_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]
@@ -47,6 +52,7 @@ OCN_attributes::
 # ICE #
 ICE_model:                      @[ice_model]
 ICE_petlist_bounds:             @[ice_petlist_bounds]
+ICE_omp_num_threads:            @[ice_omp_num_threads]
 ICE_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]
@@ -61,6 +67,7 @@ ICE_attributes::
 # WAV #
 WAV_model:                      @[wav_model]
 WAV_petlist_bounds:             @[wav_petlist_bounds]
+WAV_omp_num_threads:            @[wav_omp_num_threads]
 WAV_attributes::
   Verbosity = 0
   OverwriteSlice = false

--- a/ush/nems.configure.cpld_outerwave.IN
+++ b/ush/nems.configure.cpld_outerwave.IN
@@ -4,6 +4,7 @@
 
 # ESMF #
 logKindFlag:            @[esmf_logkind]
+globalResourceControl:  true
 
 # EARTH #
 EARTH_component_list: MED ATM OCN ICE WAV
@@ -14,11 +15,13 @@ EARTH_attributes::
 # MED #
 MED_model:                      @[med_model]
 MED_petlist_bounds:             @[med_petlist_bounds]
+MED_omp_num_threads:            @[med_omp_num_threads]
 ::
 
 # ATM #
 ATM_model:                      @[atm_model]
 ATM_petlist_bounds:             @[atm_petlist_bounds]
+ATM_omp_num_threads:            @[atm_omp_num_threads]
 ATM_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]
@@ -29,6 +32,7 @@ ATM_attributes::
 # OCN #
 OCN_model:                      @[ocn_model]
 OCN_petlist_bounds:             @[ocn_petlist_bounds]
+OCN_omp_num_threads:            @[ocn_omp_num_threads]
 OCN_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]
@@ -40,6 +44,7 @@ OCN_attributes::
 # ICE #
 ICE_model:                      @[ice_model]
 ICE_petlist_bounds:             @[ice_petlist_bounds]
+ICE_omp_num_threads:            @[ice_omp_num_threads]
 ICE_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]
@@ -54,12 +59,13 @@ ICE_attributes::
 # WAV #
 WAV_model:                      @[wav_model]
 WAV_petlist_bounds:             @[wav_petlist_bounds]
+WAV_omp_num_threads:            @[wav_omp_num_threads]
 WAV_attributes::
   Verbosity = 0
   OverwriteSlice = false
   diro = "."
   logfile = wav.log
-  mesh_wav = @[MESH_WAV] 
+  mesh_wav = @[MESH_WAV]
   multigrid = @[MULTIGRID]
 ::
 

--- a/ush/nems.configure.cpld_wave.IN
+++ b/ush/nems.configure.cpld_wave.IN
@@ -4,6 +4,7 @@
 
 # ESMF #
 logKindFlag:            @[esmf_logkind]
+globalResourceControl:  true
 
 # EARTH #
 EARTH_component_list: MED ATM OCN ICE WAV
@@ -14,11 +15,13 @@ EARTH_attributes::
 # MED #
 MED_model:                      @[med_model]
 MED_petlist_bounds:             @[med_petlist_bounds]
+MED_omp_num_threads:            @[med_omp_num_threads]
 ::
 
 # ATM #
 ATM_model:                      @[atm_model]
 ATM_petlist_bounds:             @[atm_petlist_bounds]
+ATM_omp_num_threads:            @[atm_omp_num_threads]
 ATM_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]
@@ -29,6 +32,7 @@ ATM_attributes::
 # OCN #
 OCN_model:                      @[ocn_model]
 OCN_petlist_bounds:             @[ocn_petlist_bounds]
+OCN_omp_num_threads:            @[ocn_omp_num_threads]
 OCN_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]
@@ -40,6 +44,7 @@ OCN_attributes::
 # ICE #
 ICE_model:                      @[ice_model]
 ICE_petlist_bounds:             @[ice_petlist_bounds]
+ICE_omp_num_threads:            @[ice_omp_num_threads]
 ICE_attributes::
   Verbosity = 0
   DumpFields = @[DumpFields]
@@ -54,12 +59,13 @@ ICE_attributes::
 # WAV #
 WAV_model:                      @[wav_model]
 WAV_petlist_bounds:             @[wav_petlist_bounds]
+WAV_omp_num_threads:            @[wav_omp_num_threads]
 WAV_attributes::
   Verbosity = 0
   OverwriteSlice = false
   diro = "."
   logfile = wav.log
-  mesh_wav = @[MESH_WAV] 
+  mesh_wav = @[MESH_WAV]
   multigrid = @[MULTIGRID]
 ::
 

--- a/ush/nems.configure.leapfrog_atm_wav.IN
+++ b/ush/nems.configure.leapfrog_atm_wav.IN
@@ -3,7 +3,8 @@
 #############################################
 
 # ESMF #
- logKindFlag:            @[esmf_logkind]
+logKindFlag:            @[esmf_logkind]
+globalResourceControl:  true
 
 # EARTH #
 EARTH_component_list: ATM WAV
@@ -14,6 +15,7 @@ EARTH_attributes::
 # ATM #
 ATM_model:                      @[atm_model]
 ATM_petlist_bounds:             @[atm_petlist_bounds]
+ATM_omp_num_threads:            @[atm_omp_num_threads]
 ATM_attributes::
   Verbosity = max
   DumpFields = true
@@ -22,6 +24,7 @@ ATM_attributes::
 # WAV #
 WAV_model:                      @[wav_model]
 WAV_petlist_bounds:             @[wav_petlist_bounds]
+WAV_omp_num_threads:            @[wav_omp_num_threads]
 WAV_attributes::
   Verbosity = max
 ::
@@ -32,7 +35,7 @@ WAV_attributes::
 runSeq::
   @@[coupling_interval_slow_sec]
     ATM
-    ATM -> WAV 
+    ATM -> WAV
     WAV
   @
 ::

--- a/ush/nems_configure.sh
+++ b/ush/nems_configure.sh
@@ -46,13 +46,15 @@ fi
 local atm_petlist_bounds="0 $(( ${ATMPETS}-1 ))"
 local med_petlist_bounds="0 $(( ${MEDPETS}-1 ))"
 
-sed -i -e "s;@\[med_model\];cmeps;g" tmp1
 sed -i -e "s;@\[atm_model\];fv3;g" tmp1
-sed -i -e "s;@\[med_petlist_bounds\];${med_petlist_bounds};g" tmp1
 sed -i -e "s;@\[atm_petlist_bounds\];${atm_petlist_bounds};g" tmp1
+sed -i -e "s;@\[atm_omp_num_threads\];${ATMTHREADS};g" tmp1
+sed -i -e "s;@\[med_model\];cmeps;g" tmp1
+sed -i -e "s;@\[med_petlist_bounds\];${med_petlist_bounds};g" tmp1
+sed -i -e "s;@\[med_omp_num_threads\];${MEDTHREADS};g" tmp1
 sed -i -e "s;@\[esmf_logkind\];${esmf_logkind};g" tmp1
 
-if [[ ${cpl} = ".true." ]]; then
+if [[ "${cpl}" = ".true." ]]; then
   sed -i -e "s;@\[coupling_interval_slow_sec\];${CPL_SLOW};g" tmp1
 fi
 
@@ -63,7 +65,7 @@ if [[ "${cplflx}" = ".true." ]]; then
     local restart_interval_nems=${FHMAX}
   fi
 
-  # TODO: Should this be raised up to config.ufs?
+  # TODO: Should this be raised up to config.ufs or config.ocn?
   case "${OCNRES}" in
     "500") local eps_imesh="4.0e-1";;
     "100") local eps_imesh="2.5e-1";;
@@ -80,6 +82,7 @@ if [[ "${cplflx}" = ".true." ]]; then
 
   sed -i -e "s;@\[ocn_model\];mom6;g" tmp1
   sed -i -e "s;@\[ocn_petlist_bounds\];${ocn_petlist_bounds};g" tmp1
+  sed -i -e "s;@\[ocn_omp_num_threads\];${OCNTHREADS};g" tmp1
   sed -i -e "s;@\[DumpFields\];${DumpFields};g" tmp1
   sed -i -e "s;@\[cap_dbug_flag\];${cap_dbug_flag};g" tmp1
   sed -i -e "s;@\[use_coldstart\];${use_coldstart};g" tmp1
@@ -103,6 +106,7 @@ if [[ "${cplice}" = ".true." ]]; then
 
   sed -i -e "s;@\[ice_model\];cice6;g" tmp1
   sed -i -e "s;@\[ice_petlist_bounds\];${ice_petlist_bounds};g" tmp1
+  sed -i -e "s;@\[ice_omp_num_threads\];${ICETHREADS};g" tmp1
   sed -i -e "s;@\[MESH_OCN_ICE\];${mesh_ocn_ice};g" tmp1
   sed -i -e "s;@\[FHMAX\];${FHMAX_GFS};g" tmp1
 fi
@@ -115,6 +119,7 @@ if [[ "${cplwav}" = ".true." ]]; then
 
   sed -i -e "s;@\[wav_model\];ww3;g" tmp1
   sed -i -e "s;@\[wav_petlist_bounds\];${wav_petlist_bounds};g" tmp1
+  sed -i -e "s;@\[wav_omp_num_threads\];${WAVTHREADS};g" tmp1
   sed -i -e "s;@\[MESH_WAV\];${MESH_WAV};g" tmp1
   sed -i -e "s;@\[MULTIGRID\];${waveMULTIGRID};g" tmp1
 fi
@@ -125,6 +130,7 @@ if [[ "${cplchm}" = ".true." ]]; then
 
   sed -i -e "s;@\[chm_model\];gocart;g" tmp1
   sed -i -e "s;@\[chm_petlist_bounds\];${chm_petlist_bounds};g" tmp1
+  sed -i -e "s;@\[chm_omp_num_threads\];${CHMTHREADS};g" tmp1
   sed -i -e "s;@\[coupling_interval_fast_sec\];${CPL_FAST};g" tmp1
 fi
 


### PR DESCRIPTION
**Description**

This PR:
- enables the use of ESMF threading in the forecast model
- removes no longer necessary `NTHREADS_FV3` and such variables as threading is handled by ESMF internally
- updates various `${machine}.env` files to correct the `APRUN` statement for the UFS removing the threading calculation.
- `fcst.sh` and `efcs.sh` loads modules from the ufs-weather-model + `prod_util` instead of `module_base.${machine}.lua`.  This is a must on Orion.
- Fixes #1042 

Notes:
1. As a result of threading, the `WRTTASKS_PER_GROUP` in the `model_configure` will end up to be a multiple of the number of threads used in quilting.  At present, they are assumed to be the same as the threads for FV3.
2. The `WCOSS2.env` file needs a look at as the sections for steps `fcst` and `efcs` are different and very different when compared to the [job card](https://github.com/ufs-community/ufs-weather-model/blob/develop/tests/fv3_conf/fv3_qsub.IN_wcoss2) in the ufs-weather-model for WCOSS2. 

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

The following tests are being run on Hera
- [X] C96/C48 cycled test  -- Passed
- [x] C384 P8 test -- Passed
- [x] C48 S2S cycled test  -- Previous test passed

@WalterKolczynski-NOAA has agreed to run tests on Orion
- [x] C96/C48 cycled test
- [x] C384 P8 case

The following tests are being run on WCOSS2:
- [X] C384 P8 test -- passed

**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [X] Any dependent changes have been merged and published
