### PR TITLE
Add mechanism to detect machine and clean module env.

### DIFF
--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+MACHINE_ID="UNKNOWN"  # Initialize
+
+# First detect w/ hostname
+case $(hostname -f) in
+
+  adecflow0[12].acorn.wcoss2.ncep.noaa.gov)  MACHINE_ID=wcoss2 ;; ### acorn
+  alogin0[12].acorn.wcoss2.ncep.noaa.gov)    MACHINE_ID=wcoss2 ;; ### acorn
+  clogin0[1-9].cactus.wcoss2.ncep.noaa.gov)  MACHINE_ID=wcoss2 ;; ### cactus01-9
+  clogin10.cactus.wcoss2.ncep.noaa.gov)      MACHINE_ID=wcoss2 ;; ### cactus10
+  dlogin0[1-9].dogwood.wcoss2.ncep.noaa.gov) MACHINE_ID=wcoss2 ;; ### dogwood01-9
+  dlogin10.dogwood.wcoss2.ncep.noaa.gov)     MACHINE_ID=wcoss2 ;; ### dogwood10
+
+  gaea9)               MACHINE_ID=gaea ;; ### gaea9
+  gaea1[0-6])          MACHINE_ID=gaea ;; ### gaea10-16
+  gaea9.ncrc.gov)      MACHINE_ID=gaea ;; ### gaea9
+  gaea1[0-6].ncrc.gov) MACHINE_ID=gaea ;; ### gaea10-16
+
+  hfe0[1-9]) MACHINE_ID=hera ;; ### hera01-9
+  hfe1[0-2]) MACHINE_ID=hera ;; ### hera10-12
+  hecflow01) MACHINE_ID=hera ;; ### heraecflow01
+
+  s4-submit.ssec.wisc.edu) MACHINE_ID=s4 ;; ### s4
+
+  fe[1-8]) MACHINE_ID=jet ;; ### jet01-8
+  tfe[12]) MACHINE_ID=jet ;; ### tjet1-2
+
+  Orion-login-[1-4].HPC.MsState.Edu) MACHINE_ID=orion ;; ### orion1-4
+
+  cheyenne[1-6].cheyenne.ucar.edu)     MACHINE_ID=cheyenne ;; ### cheyenne1-6
+  cheyenne[1-6].ib0.cheyenne.ucar.edu) MACHINE_ID=cheyenne ;; ### cheyenne1-6
+  chadmin[1-6].ib0.cheyenne.ucar.edu)  MACHINE_ID=cheyenne ;; ### cheyenne1-6
+
+  login[1-4].stampede2.tacc.utexas.edu) MACHINE_ID=stampede ;; ### stampede1-4
+
+  login0[1-2].expanse.sdsc.edu) MACHINE_ID=expanse ;; ### expanse1-2
+
+  discover3[1-5].prv.cube) MACHINE_ID=discover ;; ### discover31-35
+esac
+
+# Overwrite auto-detect with MACHINE if set
+MACHINE_ID=${MACHINE:-${MACHINE_ID}}
+
+# If MACHINE_ID is no longer UNKNNOWN, return it
+if [[ "${MACHINE_ID}" != "UNKNOWN" ]]; then
+  return
+fi
+
+# Try searching based on paths since hostname may not match on compute nodes
+if [[ -d /lfs/f1 ]] ; then
+  # We are on NOAA Cactus or Dogwood
+  MACHINE_ID=wcoss2
+elif [[ -d /lfs3 ]] ; then
+  # We are on NOAA Jet
+  MACHINE_ID=jet
+elif [[ -d /scratch1 ]] ; then
+  # We are on NOAA Hera
+  MACHINE_ID=hera
+elif [[ -d /work ]] ; then
+  # We are on MSU Orion
+  MACHINE_ID=orion
+elif [[ -d /glade ]] ; then
+  # We are on NCAR Yellowstone
+  MACHINE_ID=cheyenne
+elif [[ -d /lustre && -d /ncrc ]] ; then
+  # We are on GAEA.
+  MACHINE_ID=gaea
+elif [[ -d /data/prod ]] ; then
+  # We are on SSEC's S4
+  MACHINE_ID=s4
+else
+  echo WARNING: UNKNOWN PLATFORM 1>&2
+fi

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-MACHINE_ID="UNKNOWN"  # Initialize
-
 # First detect w/ hostname
 case $(hostname -f) in
 
@@ -37,6 +35,7 @@ case $(hostname -f) in
   login0[1-2].expanse.sdsc.edu) MACHINE_ID=expanse ;; ### expanse1-2
 
   discover3[1-5].prv.cube) MACHINE_ID=discover ;; ### discover31-35
+  *) MACHINE_ID=UNKNOWN ;;  # Unknown platform
 esac
 
 # Overwrite auto-detect with MACHINE if set

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -u
+
+if [[ $MACHINE_ID = jet* ]] ; then
+    # We are on NOAA Jet
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /apps/lmod/lmod/init/bash
+    fi
+    export LMOD_SYSTEM_DEFAULT_MODULES=contrib
+    module reset
+
+elif [[ $MACHINE_ID = hera* ]] ; then
+    # We are on NOAA Hera
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /apps/lmod/lmod/init/bash
+    fi
+    export LMOD_SYSTEM_DEFAULT_MODULES=contrib
+    module reset
+
+elif [[ $MACHINE_ID = orion* ]] ; then
+    # We are on Orion
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /apps/lmod/init/bash
+    fi
+    export LMOD_SYSTEM_DEFAULT_MODULES=contrib
+    module reset
+
+elif [[ $MACHINE_ID = s4* ]] ; then
+    # We are on SSEC Wisconsin S4
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /usr/share/lmod/lmod/init/bash
+    fi
+    export LMOD_SYSTEM_DEFAULT_MODULES=license_intel
+    module reset
+
+elif [[ $MACHINE_ID = wcoss2 ]]; then
+    # We are on WCOSS2
+    module reset
+
+elif [[ $MACHINE_ID = cheyenne* ]] ; then
+    # We are on NCAR Cheyenne
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /glade/u/apps/ch/modulefiles/default/localinit/localinit.sh
+    fi
+    module purge
+
+elif [[ $MACHINE_ID = stampede* ]] ; then
+    # We are on TACC Stampede
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /opt/apps/lmod/lmod/init/bash
+    fi
+    module purge
+
+elif [[ $MACHINE_ID = gaea* ]] ; then
+    # We are on GAEA.
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        # We cannot simply load the module command.  The GAEA
+        # /etc/profile modifies a number of module-related variables
+        # before loading the module command.  Without those variables,
+        # the module command fails.  Hence we actually have to source
+        # /etc/profile here.
+        source /etc/profile
+        __ms_source_etc_profile=yes
+    else
+        __ms_source_etc_profile=no
+    fi
+    module purge
+    # clean up after purge
+    unset _LMFILES_
+    unset _LMFILES_000
+    unset _LMFILES_001
+    unset LOADEDMODULES
+    module load modules
+    if [[ -d /opt/cray/ari/modulefiles ]] ; then
+        module use -a /opt/cray/ari/modulefiles
+    fi
+    if [[ -d /opt/cray/pe/ari/modulefiles ]] ; then
+        module use -a /opt/cray/pe/ari/modulefiles
+    fi
+    if [[ -d /opt/cray/pe/craype/default/modulefiles ]] ; then
+        module use -a /opt/cray/pe/craype/default/modulefiles
+    fi
+    if [[ -s /etc/opt/cray/pe/admin-pe/site-config ]] ; then
+        source /etc/opt/cray/pe/admin-pe/site-config
+    fi
+    if [[ "$__ms_source_etc_profile" == yes ]] ; then
+        source /etc/profile
+        unset __ms_source_etc_profile
+    fi
+
+elif [[ $MACHINE_ID = expanse* ]]; then
+    # We are on SDSC Expanse
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /etc/profile.d/modules.sh
+    fi
+    module purge
+    module load slurm/expanse/20.02.3
+
+elif [[ $MACHINE_ID = discover* ]]; then
+    # We are on NCCS discover
+    export SPACK_ROOT=/discover/nobackup/mapotts1/spack
+    export PATH=$PATH:$SPACK_ROOT/bin
+    . $SPACK_ROOT/share/spack/setup-env.sh
+
+else
+    echo WARNING: UNKNOWN PLATFORM 1>&2
+fi

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -u
 
-if [[ $MACHINE_ID = jet* ]] ; then
+if [[ ${MACHINE_ID} = jet* ]] ; then
     # We are on NOAA Jet
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /apps/lmod/lmod/init/bash
@@ -9,7 +9,7 @@ if [[ $MACHINE_ID = jet* ]] ; then
     export LMOD_SYSTEM_DEFAULT_MODULES=contrib
     module reset
 
-elif [[ $MACHINE_ID = hera* ]] ; then
+elif [[ ${MACHINE_ID} = hera* ]] ; then
     # We are on NOAA Hera
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /apps/lmod/lmod/init/bash
@@ -17,7 +17,7 @@ elif [[ $MACHINE_ID = hera* ]] ; then
     export LMOD_SYSTEM_DEFAULT_MODULES=contrib
     module reset
 
-elif [[ $MACHINE_ID = orion* ]] ; then
+elif [[ ${MACHINE_ID} = orion* ]] ; then
     # We are on Orion
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /apps/lmod/init/bash
@@ -25,7 +25,7 @@ elif [[ $MACHINE_ID = orion* ]] ; then
     export LMOD_SYSTEM_DEFAULT_MODULES=contrib
     module reset
 
-elif [[ $MACHINE_ID = s4* ]] ; then
+elif [[ ${MACHINE_ID} = s4* ]] ; then
     # We are on SSEC Wisconsin S4
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /usr/share/lmod/lmod/init/bash
@@ -33,25 +33,25 @@ elif [[ $MACHINE_ID = s4* ]] ; then
     export LMOD_SYSTEM_DEFAULT_MODULES=license_intel
     module reset
 
-elif [[ $MACHINE_ID = wcoss2 ]]; then
+elif [[ ${MACHINE_ID} = wcoss2 ]]; then
     # We are on WCOSS2
     module reset
 
-elif [[ $MACHINE_ID = cheyenne* ]] ; then
+elif [[ ${MACHINE_ID} = cheyenne* ]] ; then
     # We are on NCAR Cheyenne
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /glade/u/apps/ch/modulefiles/default/localinit/localinit.sh
     fi
     module purge
 
-elif [[ $MACHINE_ID = stampede* ]] ; then
+elif [[ ${MACHINE_ID} = stampede* ]] ; then
     # We are on TACC Stampede
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /opt/apps/lmod/lmod/init/bash
     fi
     module purge
 
-elif [[ $MACHINE_ID = gaea* ]] ; then
+elif [[ ${MACHINE_ID} = gaea* ]] ; then
     # We are on GAEA.
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         # We cannot simply load the module command.  The GAEA
@@ -83,12 +83,12 @@ elif [[ $MACHINE_ID = gaea* ]] ; then
     if [[ -s /etc/opt/cray/pe/admin-pe/site-config ]] ; then
         source /etc/opt/cray/pe/admin-pe/site-config
     fi
-    if [[ "$__ms_source_etc_profile" == yes ]] ; then
+    if [[ "${__ms_source_etc_profile}" == yes ]] ; then
         source /etc/profile
         unset __ms_source_etc_profile
     fi
 
-elif [[ $MACHINE_ID = expanse* ]]; then
+elif [[ ${MACHINE_ID} = expanse* ]]; then
     # We are on SDSC Expanse
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /etc/profile.d/modules.sh
@@ -96,11 +96,11 @@ elif [[ $MACHINE_ID = expanse* ]]; then
     module purge
     module load slurm/expanse/20.02.3
 
-elif [[ $MACHINE_ID = discover* ]]; then
+elif [[ ${MACHINE_ID} = discover* ]]; then
     # We are on NCCS discover
     export SPACK_ROOT=/discover/nobackup/mapotts1/spack
-    export PATH=$PATH:$SPACK_ROOT/bin
-    . $SPACK_ROOT/share/spack/setup-env.sh
+    export PATH=${PATH}:${SPACK_ROOT}/bin
+    . "${SPACK_ROOT}"/share/spack/setup-env.sh
 
 else
     echo WARNING: UNKNOWN PLATFORM 1>&2


### PR DESCRIPTION
**Description**

This PR:
- adds `detect_machine.sh` and `module-setup.sh` from ufs-weather-model with some improvements and modifications

Improvements include ability to detect machines from `compute` nodes.
The appending of `COMPILER` to `MACHINE_ID` is not done in `detect_machine.sh`

This work will be used for CI work as well as in the driver jobs. e.g. `rocoto/job_name.sh` or `ecf/job_name.ecf` in the future.

Use of `modulefiles/module-setup.sh.inc` should be deprecated going forward.  These will be removed in the future.

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
This PR just adds these files, so no testing of workflow is necessary.
The test of the scripts can be done via a simple script:
```bash
#!/bin/bash

set -eu
source ush/detect_machine.sh
echo $MACHINE_ID
source ush/module-setup.sh
module list
```
  
This was tested on Hera and Orion on the front end and compute nodes.

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
