### PR TITLE
Updates to the MOM6 diag table used by the marine DA

### DIFF
--- a/parm/parm_fv3diag/diag_table_da
+++ b/parm/parm_fv3diag/diag_table_da
@@ -1,16 +1,16 @@
 "fv3_history",    0,  "hours",  1,  "hours",  "time"
 "fv3_history2d",  0,  "hours",  1,  "hours",  "time"
-"ocn_da%4yr%2mo%2dy%2hr",  0,  "hours",  1,  "hours",  "time",  1,  "hours",  "1901 1 1 0 0 0"
+"ocn_da%4yr%2mo%2dy%2hr", 1, "hours", 1, "hours", "time", 1,  "hours"
 
-"ocean_model",  "geolon",    "geolon",   "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
-"ocean_model",  "geolat",    "geolat",   "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
-"ocean_model",  "SSH",       "ave_ssh",  "ocn_da%4yr%2mo%2dy%2hr",  "all",  .true.,   "none",  2
-"ocean_model",  "MLD_0125",  "MLD",      "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
-"ocean_model",  "u",         "u",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
-"ocean_model",  "v",         "v",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
-"ocean_model",  "h",         "h",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
-"ocean_model",  "salt",      "Salt",     "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
-"ocean_model",  "temp",      "Temp",     "ocn_da%4yr%2mo%2dy%2hr",  "all",  .false.,  "none",  2
+"ocean_model",  "geolon",    "geolon",   "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "geolat",    "geolat",   "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "SSH",       "ave_ssh",  "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "MLD_0125",  "MLD",      "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "u",         "u",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "v",         "v",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "h",         "h",        "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "salt",      "Salt",     "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
+"ocean_model",  "temp",      "Temp",     "ocn_da%4yr%2mo%2dy%2hr",  "all",  "none",  "none",  2
 
 "gfs_dyn",     "ucomp",       "ugrd",         "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "vcomp",       "vgrd",         "fv3_history",    "all",  .false.,  "none",  2


### PR DESCRIPTION
### Description
Whatever I committed before did not work with the 1/4 deg MOM6 (see #1352). The corrections to the MOM6 DA diag table in this PR generates the needed background output for the 5 deg and 1/4 deg model.

- fixes #1352 

_Asking for forgiveness for the absence of the PR template, I have the bad habit of removing templates._

This work only affects the marine DA and its 2 users/developers.