### PR TITLE
add cleanup of WCDA ocean, ice, and med direcories

### DIFF
--- a/scripts/exglobal_archive.sh
+++ b/scripts/exglobal_archive.sh
@@ -302,6 +302,9 @@ while [ "${GDATE}" -le "${GDATEEND}" ]; do
     gcyc=$(echo "${GDATE}" | cut -c9-10)
     COMIN="${ROTDIR}/${CDUMP}.${gPDY}/${gcyc}/atmos"
     COMINwave="${ROTDIR}/${CDUMP}.${gPDY}/${gcyc}/wave"
+    COMINocean="${ROTDIR}/${CDUMP}.${gPDY}/${gcyc}/ocean"
+    COMINice="${ROTDIR}/${CDUMP}.${gPDY}/${gcyc}/ice"
+    COMINmed="${ROTDIR}/${CDUMP}.${gPDY}/${gcyc}/med"
     COMINrtofs="${ROTDIR}/rtofs.${gPDY}"
     if [ -d "${COMIN}" ]; then
         rocotolog="${EXPDIR}/logs/${GDATE}.log"
@@ -312,6 +315,9 @@ while [ "${GDATE}" -le "${GDATEEND}" ]; do
             set_strict
             if [ "${rc}" -eq 0 ]; then
                 if [ -d "${COMINwave}" ]; then rm -rf "${COMINwave}" ; fi
+                if [ -d "${COMINocean}" ]; then rm -rf "${COMINocean}" ; fi
+                if [ -d "${COMINice}" ]; then rm -rf "${COMINice}" ; fi
+                if [ -d "${COMINmed}" ]; then rm -rf "${COMINmed}" ; fi
                 if [ -d "${COMINrtofs}" ] && [ "${GDATE}" -lt "${RTOFS_DATE}" ]; then rm -rf "${COMINrtofs}" ; fi
                 if [ "${CDUMP}" != "gdas" ] || [ "${DO_GLDAS}" = "NO" ] || [ "${GDATE}" -lt "${GLDAS_DATE}" ]; then
                     if [ "${CDUMP}" = "gdas" ]; then
@@ -346,6 +352,18 @@ while [ "${GDATE}" -le "${GDATEEND}" ]; do
 
     if [ -d "${COMINwave}" ]; then
         [[ ! "$(ls -A "${COMINwave}")" ]] && rm -rf "${COMINwave}"
+    fi
+
+    if [ -d "${COMINocean}" ]; then
+        [[ ! "$(ls -A "${COMINocean}")" ]] && rm -rf "${COMINocean}"
+    fi
+
+    if [ -d "${COMINice}" ]; then
+        [[ ! "$(ls -A "${COMINice}")" ]] && rm -rf "${COMINice}"
+    fi
+
+    if [ -d "${COMINmed}" ]; then
+        [[ ! "$(ls -A "${COMINmed}")" ]] && rm -rf "${COMINmed}"
     fi
 
     # Remove mdl gfsmos directory


### PR DESCRIPTION

**Description**

Addresses https://github.com/NOAA-EMC/global-workflow/issues/1385 - removes ocean, ice, and med directories as part of post-archive cleanup

File changed:
scripts/exglobal_archive.sh

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

Run for a cycle with WCDA setup on Hera
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
