### PR TITLE
Marine DA prep j-job needs more memory

### DIFF
--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -272,7 +272,7 @@ elif [[ "${step}" = "ocnanalprep" ]]; then
     export nth_ocnanalprep=1
     npe_node_ocnanalprep=$(echo "${npe_node_max} / ${nth_ocnanalprep}" | bc)
     export npe_node_ocnanalprep
-    export memory_ocnanalprep="3072M"
+    export memory_ocnanalprep="24GB"
 
 elif [[ "${step}" = "ocnanalbmat" ]]; then
    npes=16


### PR DESCRIPTION
The concatenation step runs out of memory in the marine-gdas prep step. This is not optimized and probably overkill, but 24GB should cover all cases.

- fixes #1389 