### PR TITLE
Reset modules properly at beginning of forecast job

### DIFF
--- a/jobs/rocoto/efcs.sh
+++ b/jobs/rocoto/efcs.sh
@@ -11,6 +11,7 @@ source "${HOMEgfs}/ush/preamble.sh"
 # TODO: clean this up
 source "${HOMEgfs}/ush/detect_machine.sh"
 set +x
+source "${HOMEgfs}/ush/module-setup.sh"
 module use "${HOMEgfs}/sorc/ufs_model.fd/tests"
 module load modules.ufs_model.lua
 # Workflow needs utilities from prod_util (setPDY.sh, ndate, etc.)

--- a/jobs/rocoto/fcst.sh
+++ b/jobs/rocoto/fcst.sh
@@ -11,6 +11,7 @@ source "${HOMEgfs}/ush/preamble.sh"
 # TODO: clean this up
 source "${HOMEgfs}/ush/detect_machine.sh"
 set +x
+source "${HOMEgfs}/ush/module-setup.sh"
 module use "${HOMEgfs}/sorc/ufs_model.fd/tests"
 module load modules.ufs_model.lua
 module load prod_util


### PR DESCRIPTION
**Description**
Following the PR last week that enabled ESMF threading, we had to replace `load_fv3gfs_modules.sh` with loading ufs-weather-model specific modules for the `fcst` and `efcs` jobs.

`module-setup.sh` is needed after `detect_machine.sh`.  Previously, both these functions were performed in `load_fv3gfs_modules.sh`.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

A dummy experiment was setup on hera (where the problem was discovered) and `fcst.sh` and `efcs.sh` were executed.
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [X] Any dependent changes have been merged and published
