### PR TITLE
Update rocoto_viewer to replace deprecated getiterator call

### DIFF
--- a/workflow/rocoto_viewer.py
+++ b/workflow/rocoto_viewer.py
@@ -947,13 +947,13 @@ def get_tasklist(workflow_file):
                 task_cycledefs = cycle_noname
             if list_tasks:
                 print(f"{task_name}, {task_cycledefs}")
-                # dependancies = child.getiterator('dependency')
+                # dependancies = child.iter('dependency')
                 # for dependency in dependancies:
                 #    for them in dependency.getchildren():
                 #        print(them.attrib)
             tasks_ordered.append((task_name, task_cycledefs, log_file))
         elif child.tag == 'metatask':
-            all_metatasks_iterator = child.getiterator('metatask')
+            all_metatasks_iterator = child.iter('metatask')
             all_vars = dict()
             all_tasks = []
             for i, metatasks in enumerate(all_metatasks_iterator):


### PR DESCRIPTION
**Description**

Rocoto viewer was using a deprecated function `getiterator` that caused it to fail on python 3.8+. The replacement method `iter` is now used.

Fixes #522 

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Loaded the latest python and updated script and then it ran (may need more testing)

