### PR TITLE
Feature/args schema

### DIFF
--- a/ush/python/pygw/src/pygw/exceptions.py
+++ b/ush/python/pygw/src/pygw/exceptions.py
@@ -6,9 +6,14 @@ from collections.abc import Callable
 
 from pygw.logger import Logger, logit
 
+# ----
+
 logger = Logger(level="error", colored_log=True)
 
-__all__ = ["WorkflowException", "msg_except_handle"]
+__all__ = ["InputArgsException", "SchemaExcception",
+           "WorkflowException", "msg_except_handle"]
+
+# ----
 
 
 class WorkflowException(Exception):
@@ -43,6 +48,31 @@ class WorkflowException(Exception):
         logger.error(msg=msg)
         super().__init__()
 
+# ----
+
+
+class InputArgsException(WorkflowException):
+    """
+    Description
+    -----------
+
+    This is the base-class for exceptions encountered within
+    pygw/inputargs.py; it is a sub-class of WorkflowException.
+
+    """
+
+
+# ----
+
+class SchemaException(WorkflowException):
+    """
+    Description
+    -----------
+
+    This is the base-class for exceptions encountered within
+    pygw/schema.py; it is a sub-class of WorkflowException.
+
+    """
 
 # ----
 

--- a/ush/python/pygw/src/pygw/schema.py
+++ b/ush/python/pygw/src/pygw/schema.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+
+# ----
+
+"""
+Module
+------
+
+    schema.py
+
+Description
+-----------
+
+    This module provides various schema evaluation interfaces and/or
+    check applications.
+
+Functions
+---------
+
+    validate(cls_schema, cls_opts)
+
+        This function validates the calling class schema; if the
+        respective schema is not validated an exception will be
+        raised; otherwise this function is passive.
+
+Requirements
+------------
+
+schema; https://github.com/keleshev/schema
+
+Author(s)
+---------
+
+    Henry R. Winterbottom; 20 March 2023
+
+History
+-------
+
+    2023-03-20: Henry Winterbottom -- Initial implementation.
+
+"""
+
+
+from typing import Dict
+
+from pygw.exceptions import SchemaException
+from pygw.logger import Logger, logit
+from schema import Schema
+
+# ----
+
+logger = Logger(level="info", colored_log=True)
+
+__all__ = ["validate_opts"]
+
+# ----
+
+
+@logit(logger)
+def validate_opts(cls_schema: Dict, cls_opts: Dict) -> None:
+    """
+    Description
+    -----------
+
+    This function validates the calling class schema; if the
+    respective schema is not validated an exception will be raised;
+    otherwise this function is passive.
+
+    Parameters
+    ----------
+
+    cls_schema: dict
+
+        A Python dictionary containing the calling class schema.
+
+    cls_opts: dict
+
+        A Python dictionary containing the options (i.e., parameter
+        arguments, keyword arguments, etc.,) passed to the respective
+        calling class.
+
+    Raises
+    ------
+
+    SchemaException:
+
+        * raised if an exception is encountered while validating the
+          schema.
+
+    """
+
+    # Define the schema object.
+    schema = Schema([cls_schema])
+
+    # Check that the specified options (`cls_opts`) are valid; proceed
+    # accordingly.
+    try:
+
+        # Validate the schema.
+        schema.validate([cls_opts])
+
+    except Exception as errmsg:
+
+        msg = f"Schema validation failed with error {errmsg}. Aborting!!!"
+        raise SchemaException(msg=msg) from errmsg

--- a/ush/python/pygw/src/tests/test_schema.py
+++ b/ush/python/pygw/src/tests/test_schema.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+
+# ----
+
+"""
+Module
+------
+
+    test_schema.py
+
+Description
+-----------
+
+    This module provides a series of unit-tests for the pygw.schema
+    module.
+
+Usage
+-----
+
+    pytest tests/test_schema.py
+
+Functions
+---------
+
+    test_schema_float()
+
+        This function provides a unit test for the schema module; a
+        float-value will be passed to the schema validator that
+        accepts only string or integer instances; in order to pass,
+        this unit test must raise a a SchemaException.
+
+    test_schema_int()
+
+        This function provides a unit test for the schema module; a
+        integer-value is passed to the schema.
+
+    test_schema_opt()
+
+        This function provides a unit test for the schema module; a
+        integer-value and an optional string value `opt_var` are
+        passed to the schema.
+
+    test_schema_str()
+
+        This function provides a unit test for the schema module; a
+        string is passed to the schema.
+
+Requirements
+------------
+
+schema; https://github.com/keleshev/schema
+
+Author(s)
+---------
+
+    Henry R. Winterbottom; 20 March 2023
+
+History
+-------
+
+    2023-03-20: Henry Winterbottom -- Initial implementation.
+
+"""
+
+# ----
+
+from pygw.exceptions import SchemaException
+from pygw.logger import Logger, logit
+from pygw.schema import validate_opts
+from schema import Optional, Or
+
+# ----
+
+base_logger = Logger(level="info", colored_log=True)
+
+# ----
+
+# Define the schema.
+CLS_SCHEMA = {
+    "check_var": Or(str, int),
+    Optional("opt_var"): str,
+}
+
+# ----
+
+
+@logit(base_logger)
+def test_schema_float() -> None:
+    """
+    Description
+    -----------
+
+    This function provides a unit test for the schema module; a
+    float-value will be passed to the schema validator that accepts
+    only string or integer instances; in order to pass, this unit test
+    must raise a a SchemaException.
+
+    """
+
+    # Define the option values to be evaluated within the context of
+    # the specified schema.
+    cls_opts = {"check_var": 0.0000}
+
+    # Evaluate the schema.
+    try:
+        validate_opts(cls_schema=CLS_SCHEMA, cls_opts=cls_opts)
+
+    except SchemaException:
+        pass
+
+
+# ----
+
+
+@logit(base_logger)
+def test_schema_int() -> None:
+    """
+    Description
+    -----------
+
+    This function provides a unit test for the schema module; a
+    integer-value is passed to the schema.
+
+    """
+
+    # Define the option values to be evaluated within the context of
+    # the specified schema.
+    cls_opts = {"check_var": 1}
+
+    # Evaluate the schema.
+    validate_opts(cls_schema=CLS_SCHEMA, cls_opts=cls_opts)
+
+    assert True
+
+
+# ----
+
+
+@logit(base_logger)
+def test_schema_opt() -> None:
+    """
+    Description
+    -----------
+
+    This function provides a unit test for the schema module; a
+    integer-value and an optional string value `opt_var` are passed to
+    the schema.
+
+    """
+
+    # Define the option values to be evaluated within the context of
+    # the specified schema.
+    cls_opts = {"check_var": 1, "opt_var": "I am an optional string."}
+
+    # Evaluate the schema.
+    validate_opts(cls_schema=CLS_SCHEMA, cls_opts=cls_opts)
+
+    assert True
+
+
+# ----
+
+
+@logit(base_logger)
+def test_schema_string() -> None:
+    """
+    Description
+    -----------
+
+    This function provides a unit test for the schema module; a
+    string is passed to the schema.
+
+    """
+
+    # Define the option values to be evaluated within the context of
+    # the specified schema.
+    cls_opts = {"check_var": "I am a string."}
+
+    # Evaluate the schema.
+    validate_opts(cls_schema=CLS_SCHEMA, cls_opts=cls_opts)
+
+    assert True

--- a/ush/python/pygw/src/tests/test_schema.py
+++ b/ush/python/pygw/src/tests/test_schema.py
@@ -93,7 +93,7 @@ def test_schema_float() -> None:
     This function provides a unit test for the schema module; a
     float-value will be passed to the schema validator that accepts
     only string or integer instances; in order to pass, this unit test
-    must raise a a SchemaException.
+    must raise a SchemaException.
 
     """
 
@@ -106,7 +106,9 @@ def test_schema_float() -> None:
         validate_opts(cls_schema=CLS_SCHEMA, cls_opts=cls_opts)
 
     except SchemaException:
-        pass
+        return
+
+    assert False
 
 
 # ----


### PR DESCRIPTION
This PR provides an interface to the [schema](https://github.com/keleshev/schema) package. The intention of this PR is as follows:

- A means of evaluating application (e.g., GFS, GSI, JEDI, etc.,) options such that they conform to the expectations of the respective application(s);
- A means to improve the robustness of `scripts` level application scripts which may require command line arguments; the schema interface can be used to check that the arguments are correctly formatted (i.e., valid) prior to entering the task level (e.g., `ush`); an example can be seen as follows:

```
def main() -> None:

    # Define the schema attributes.
    cls_schema = {
        "yaml_file": str,
        "cycle": Or(str, int),
        "expt_name": str,
        "work_path": str,
    }

    # Collect the command line arguments.
    cls_opts = **some_options_passed_to_script**
    check_schema(cls_schema=cls_schema, cls_opts=cls_opts)
    
    # If the schema is valid, run the application; if the schema is not
    # valid, raise a SchemaException.
    task = SomeTask()
    task.run()
```
In the above example, if any of the dictionary keys are not provided to the script via either the command-line (at the `scripts` level) or by some other means, an exception will raised. Further, if the `cycle` attribute provided to the script is neither a `str` or `int`, an exception will also be raised.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

A series of unit-tests have been provided in `pygw/tests/test_schema.py`; all tests pass.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

**Note**

This update requires that the [schema](https://github.com/keleshev/schema)  package is added to the respective Python stacks. Further, this PR will be used as a basis to establish the aforementioned script-level options in a future PR.
