### PR TITLE
Fix groupsize for early cycle EnKF rocoto task

### DIFF
--- a/workflow/rocoto/workflow_tasks.py
+++ b/workflow/rocoto/workflow_tasks.py
@@ -1241,7 +1241,7 @@ class Tasks:
 
         groups = self._get_hybgroups(self._base['NMEM_ENKF'], self._configs['efcs']['NMEM_EFCSGRP'])
 
-        if self.cdump == "gfs":
+        if self.cdump == "enkfgfs":
             groups = self._get_hybgroups(self._base['NMEM_EFCS'], self._configs['efcs']['NMEM_EFCSGRP_GFS'])
         cycledef = 'gdas_half,gdas' if self.cdump in ['enkfgdas'] else self.cdump.replace('enkf', '')
         resources = self.get_resource('efcs')


### PR DESCRIPTION
**Description**
When generating the rocoto tasks for enkfgfs, the different groupsize for gfs would not be picked up because the cdump comparison was not properly updated when the cdump/run was updated to include 'enkf'.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Experiment creation on Orion (tested during COM refactor)
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
