### PR TITLE
Fix typo in wave awips gridded task def

### DIFF
--- a/workflow/rocoto/workflow_tasks.py
+++ b/workflow/rocoto/workflow_tasks.py
@@ -838,7 +838,7 @@ class Tasks:
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
-        resources = self.get_resource('waeawipsgridded')
+        resources = self.get_resource('waveawipsgridded')
         task = create_wf_task('waveawipsgridded', resources, cdump=self.cdump, envar=self.envars,
                               dependency=dependencies)
 


### PR DESCRIPTION
**Description**
The task name was misspelled in the task definition for gridded wave awips.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Workflow generation on Orion (tested while inadvertently creating the job during COM refactor work)
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
