### PR TITLE
Update state of operations in RTD to GFSv16.3.7

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Status
 ======
 
 * State of develop (HEAD) branch: GFSv17+ development
-* State of operations (dev/gfs.v16 branch): GFS v16.3.6 `tag: [gfs.v16.3.6] <https://github.com/NOAA-EMC/global-workflow/releases/tag/gfs.v16.3.6>`_
+* State of operations (dev/gfs.v16 branch): GFS v16.3.7 `tag: [gfs.v16.3.7] <https://github.com/NOAA-EMC/global-workflow/releases/tag/gfs.v16.3.7>`_
 
 =============
 Code managers


### PR DESCRIPTION
**Description**

Update the "State of operations" blurb in `index.rst` to note the updated `GFSv16.3.7` operational version.

Closes #1368

**Type of change**

Documentation update for operational implementation.
