### PR TITLE
Use V2 version of fix files needed for Thompson MP.

### DIFF
--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -245,8 +245,8 @@ EOF
   if [ $imp_physics -eq 8 ]; then
     $NLN $FIX_AM/CCN_ACTIVATE.BIN  $DATA/CCN_ACTIVATE.BIN
     $NLN $FIX_AM/freezeH2O.dat     $DATA/freezeH2O.dat
-    $NLN $FIX_AM/qr_acr_qg.dat     $DATA/qr_acr_qg.dat
-    $NLN $FIX_AM/qr_acr_qs.dat     $DATA/qr_acr_qs.dat
+    $NLN $FIX_AM/qr_acr_qgV2.dat   $DATA/qr_acr_qgV2.dat
+    $NLN $FIX_AM/qr_acr_qsV2.dat   $DATA/qr_acr_qsV2.dat
   fi
 
   $NLN $FIX_AM/${O3FORC}                         $DATA/global_o3prdlos.f77


### PR DESCRIPTION
**Description**
It has been noted by some developers who look at the run log in realtime that the model takes a while during the calculation of Thompson tables.
Specifically see this part of the output from the forecast log:

```
   0: Calculating Thompson tables part 1 took      0.334 seconds.
   0: Calling radar_init took      0.000 seconds.
   0:    creating rain collecting graupel table
   0:  ThompMP: computing qr_acr_qg
   0:  Writing qr_acr_qgV2.dat in Thompson MP init
   0: Computing rain collecting graupel table took    203.539 seconds.
   0:    creating rain collecting snow table
   0:  ThompMP: computing qr_acr_qs
   0:  Writing qr_acr_qsV2.dat in Thompson MP init
   0: Computing rain collecting snow table took     36.694 seconds.
   0:    creating freezing of water drops table
   0: Computing freezing of water drops table took      2.084 seconds.
   0: Calculating Thompson tables part 2 took      2.084 seconds.
   0:   ... DONE microphysical lookup tables
```
These tables are already available in the `fix` space and are being used in the ufs-weather-model regression tests.

Fixes #1411 

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
The fix files now being linked are present in the `fix` directory and the model runs in the RT.
This is not expected to break existing functionality.

A forecast-only P8 test was run on Hera.  The above output is replaced with:
```
   0: Calculating Thompson tables part 1 took      0.335 seconds.
   0: Calling radar_init took      0.000 seconds.
   0:    creating rain collecting graupel table
   0: Computing rain collecting graupel table took      0.055 seconds.
   0:    creating rain collecting snow table
   0: Computing rain collecting snow table took      0.021 seconds.
   0:    creating freezing of water drops table
   0: Computing freezing of water drops table took      0.124 seconds.
   0: Calculating Thompson tables part 2 took      0.124 seconds.
   0:   ... DONE microphysical lookup tables
```

As seen, the look up tables provide significant speed up.
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [X] Any dependent changes have been merged and published
