### PR TITLE
Have aerostat tar file extract to basename only

### DIFF
--- a/ush/python/pygfs/task/aero_analysis.py
+++ b/ush/python/pygfs/task/aero_analysis.py
@@ -143,7 +143,8 @@ class AerosolAnalysis(Analysis):
         # open tar file for writing
         with tarfile.open(aerostat, "w") as archive:
             for diagfile in diags:
-                archive.add(f"{diagfile}.gz")
+                diaggzip = f"{diagfile}.gz"
+                archive.add(diaggzip, arcname=os.path.basename(diaggzip))
 
         # copy full YAML from executable to ROTDIR
         src = os.path.join(self.task_config['DATA'], f"{self.task_config['CDUMP']}.t{self.runtime_config['cyc']:02d}z.aerovar.yaml")


### PR DESCRIPTION
**Description**

Closes #1423 

This bugfix makes it so that when the aerosol diags are extracted, they are extracted to the directory directly and not a full directory tree to where the runtime directory was located.

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Tested it manually on Orion to ensure that the newly created tarball is structured as intended.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
