### PR TITLE
Feature/argparser.py

### DIFF
--- a/ush/python/pygw/src/pygw/argsparse.py
+++ b/ush/python/pygw/src/pygw/argsparse.py
@@ -1,0 +1,210 @@
+"""
+Module
+------
+
+    argsparse.py
+
+Description
+-----------
+
+    This module contains classes and methods to parse and
+    appropriately format argumenst passed to a caller script.
+
+Classes
+-------
+
+    ArgsParser()
+
+        This is the base-class object for all command line argument(s)
+        parsing.
+
+Author(s)
+---------
+
+    Henry R. Winterbottom; 27 March 2023
+
+History
+-------
+
+    2023-03-27: Henry Winterbottom -- Initial implementation.
+
+"""
+
+# ----
+
+# pylint: disable=too-many-branches
+# pylint: disable=unnecessary-list-index-lookup
+
+# ----
+
+from argparse import ArgumentParser
+from dataclasses import dataclass
+from typing import Union
+
+from pygw.attrdict import AttrDict
+from pygw.logger import Logger
+
+# ----
+
+logger = Logger(level="info", colored_log="True")
+
+# ----
+
+__author__ = "Henry R. Winterbottom"
+__maintainer__ = "Henry R. Winterbottom"
+__email__ = "henry.winterbottom@noaa.gov"
+
+# ----
+
+
+@dataclass
+class ArgsParse:
+    """
+    Description
+    -----------
+
+    This is the base-class object for all command line argument(s)
+    parsing.
+
+    Returns
+    -------
+
+    args_obj: object
+
+        A Python object containing the command-line arguments; if no
+        command-line arguments have been passed to the caller script,
+        the returned value is NoneType.
+
+    """
+
+    def __check__(self, args_obj: AttrDict) -> AttrDict:
+        """
+        Description
+        -----------
+
+        This method checks that the argument values are formatted
+        correctly; this method is necessary due to the Python
+        interpretter assuming that all arguments passed via the Python
+        `sys` module are formatted as strings.
+
+        Parameters
+        ----------
+
+        in_dict: object
+
+            A Python object containing the argument values to be
+            evaluated and formatted as neccessary.
+
+        Returns
+        -------
+
+        out_dict: object
+
+            A Python object containing the formatted argument values.
+
+        """
+
+        # Define local function to sort and format the input Python
+        # dictionary upon entry.
+        def sorted_by_keys(in_dict):
+
+            out_dict = AttrDict()
+            for (key, value) in sorted(in_dict.items(), key=lambda key: key):
+
+                if isinstance(value, dict):
+                    setattr(out_dict, key, sorted_by_keys(value))
+
+                else:
+                    test_value = value
+
+                    # Check if the key and value pair is a boolean
+                    # type argument and proceed accordingly.
+                    if isinstance(test_value, bool):
+                        if test_value:
+                            value = True
+
+                        if not test_value:
+                            value = False
+
+                    # Check if the key and value pair is a string type
+                    # argument and proceed accordingly.
+                    if isinstance(test_value, str):
+                        try:
+                            dummy = float(test_value)
+                            if "." in test_value:
+                                value = float(test_value)
+                            else:
+                                value = int(test_value)
+
+                        except ValueError:
+                            if test_value.lower() == "none":
+                                value = None
+
+                            elif test_value.lower() == "true":
+                                value = True
+
+                            elif test_value.lower() == "false":
+                                value = False
+
+                            else:
+                                value = str(test_value)
+
+                    # Update the output dictionary key and value pair.
+                    setattr(out_dict, key, value)
+
+            return out_dict
+
+        # Define the formatted output dictionary.
+        out_dict = sorted_by_keys(in_dict=args_obj)
+
+        return out_dict
+
+    def run(self) -> Union[None, AttrDict]:
+        """
+        Description
+        -----------
+
+        This method collects the arguments passed from the command
+        line to the respective caller script and builds a Python
+        object containing the respective arguments.
+
+        """
+
+        # Collect the command-line argument key and value pairs.
+        (_, args) = ArgumentParser().parse_known_args()
+        (arg_keys, arg_values) = ([item.strip("-")
+                                   for item in args[::2]], args[1::2])
+
+        # Build/define the Python object to contain the argument(s)
+        # attributes; proceed accordingly.
+        if len(arg_keys) == 0:
+
+            # If the number of command-line arguments is 0, set the
+            # base-class attribute to NoneType.
+            msg = (
+                "No command line arguments have been specified; "
+                "setting arguments object to NoneType."
+            )
+            logger.warning(msg=msg)
+
+            args_obj = None
+
+        else:
+
+            # If the number of command-line arguments is non-zero,
+            # build the command line arguments object.
+            args_obj = AttrDict()
+
+            for (idx, _) in enumerate(arg_keys):
+
+                # Define the argument attributes.
+                msg = f"Command line argument {arg_keys[idx]} is {arg_values[idx]}"
+                logger.info(msg=msg)
+
+                setattr(args_obj, arg_keys[idx], arg_values[idx])
+
+            # Check that the command line arguments have the
+            # appropriate format upon exit.
+            args_obj = self.__check__(args_obj=args_obj)
+
+        return args_obj

--- a/ush/python/pygw/src/tests/test_argsparse.py
+++ b/ush/python/pygw/src/tests/test_argsparse.py
@@ -1,0 +1,101 @@
+"""
+Module
+------
+
+    test_argsparse.py
+
+Description
+-----------
+
+    The following unit tests contain functions to evaluate
+    command-line argument applications.
+
+Functions
+---------
+
+    main()
+
+        This is the dummy function to collect and return command line
+        arguments via a Python AttrDict object.
+
+    test_argsparse_args()
+
+        This function tests the ArgsParse.run() method for command
+        line argument instances.
+
+Author(s)
+---------
+
+    Henry R. Winterbottom; 27 March 2023
+
+History
+-------
+
+    2023-03-27: Henry Winterbottom -- Initial implementation.
+
+"""
+
+# ----
+
+from unittest.mock import patch
+
+from pygw.argsparse import ArgsParse
+
+# ----
+
+__author__ = "Henry R. Winterbottom"
+__maintainer__ = "Henry R. Winterbottom"
+__email__ = "henry.winterbottom@noaa.gov"
+
+# ----
+
+
+def main() -> None:
+    """
+    Description
+    -----------
+
+    This is the dummy function to collect and return command line
+    arguments via a Python AttrDict object.
+
+    """
+
+    # Parse (any) command line argument values.
+    args_obj = ArgsParse().run()
+
+    return args_obj
+
+
+# ----
+
+
+def test_argsparse_args() -> None:
+    """
+    Description
+    -----------
+
+    This function tests the ArgsParse.run() method for command line
+    argument instances.
+
+    """
+
+    # Test argument parser with a single argument.
+    with patch("sys.argv", ["main", "--filepath", "/path/to/file"]):
+        args_obj = main()
+
+        assert args_obj.filepath == "/path/to/file"
+        assert isinstance(args_obj.filepath, str)
+        assert not isinstance(args_obj.filepath, int)
+
+    # Test the argument parser with multiple arguments.
+    with patch("sys.argv", ["main", "--filepath", "/path/to/file", "--intarg", "2"]):
+        args_obj = main()
+
+        assert args_obj.filepath == "/path/to/file"
+        assert args_obj.intarg == "2"
+
+    # Test the argument parser with no arguments.
+    with patch("sys.argv", ["main"]):
+        args_obj = main()
+
+        assert args_obj is None

--- a/ush/python/pygw/src/tests/test_argsparse.py
+++ b/ush/python/pygw/src/tests/test_argsparse.py
@@ -87,12 +87,14 @@ def test_argsparse_args() -> None:
         assert isinstance(args_obj.filepath, str)
         assert not isinstance(args_obj.filepath, int)
 
-    # Test the argument parser with multiple arguments.
+    # Test the argument parser with multiple arguments; note that the
+    # Python interpretor assumes that all attributes collected via
+    # the sys instance are formatted as strings.
     with patch("sys.argv", ["main", "--filepath", "/path/to/file", "--intarg", "2"]):
         args_obj = main()
 
         assert args_obj.filepath == "/path/to/file"
-        assert args_obj.intarg == "2"
+        assert args_obj.intarg == 2
 
     # Test the argument parser with no arguments.
     with patch("sys.argv", ["main"]):


### PR DESCRIPTION
**Description**

This PR provides an interface for command line arguments to be passed to driver (sometimes refererenced as caller) scripts to be used by applications within the global workflow.

**Use Case**

The current global-workflow infrastructure assumes that the configuration object is defined by the contents of the run-time environment established by the global-workflow configuration beneath `parm/config`. This PR implements a methodology for a driver or caller script (`exglobal_some_task.py`, below) to receive arguments passed via the command line in order to define a similar object -- most often specific to the application. Although not imperative at the moment, providing an interface as described below will allow for simpler implementations as refactoring continues.

Consider the following example.

``python exglobal_some_task.py``

In this instance the global-workflow application will behave as usual and define the configuration object by casting `os.environ` as a Python dictionary. However, as the global-workflow refactor evolves, passing YAML-formatted configurations specific to the respective application becomes more attractive and should be considered. The contents within this PR allow such functionality as demonstrated in the following example.

``python exglobal_some_task.py  --yaml_file /path/to/yaml_file``

The driver script (`exglobal_some_task.py`) can read the YAML-formatted file and make use of it as necessary. Further, in the context of the current global-workflow, the configuration object defined by the casting of `os.environ` dictionary could be replaced by this new functionality while defaulting to the `os.environ` if the `yaml_file` (or any command-line) attribute is not specified. 

The additional advantage of this innovation is that the caller script (i.e., `exglobal_some_task.py`) does not require modification for new command line arguments. Consider the following code snippet.

```
from somewhere import SomeTask
from pygw.argsparse import ArgsParser

main() -> None:
   
        config = ArgsParser.run()
   
        task = SomeTask()
        task.run(config)
```

In the example above, all command-line arguments, no matter the number and/or type, are captured by the `ArgsParser.run` instance. However, for the current state of global-workflow development, the following configuration should be implemented.

```
import os

from somewhere import SomeTask
from pygw.argsparse import ArgsParser
from pygw.configuration import cast_strdict_as_dtypedict

main() -> None:
   
        config = ArgsParser.run()
        if config is None:
                 config = cast_strdict_as_dtypedict(os.environ)
   
        task = SomeTask(config)
        task.run()
```

In this example, if no command line values are passed, the configuration will default to the configuration defined by the casting of `os.environ` as Python dictionary.

In addition to the command line parsing application, a helper function is included in `pygw.argsparse.py` to ensure that the arguments are formatted correctly. This is necessary since the Python interpreter assumes that all arguments passed via the `argsparse.Arguments` class are formatted as strings upon entry. Further/future extensions of this capability could involve the use of schemas to evaluate command line value validity.

**Type of change**

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

All unit-tests for `pygw` pass.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
