### PR TITLE
Enforce rstprod on relevant tarballs

### DIFF
--- a/scripts/exgdas_enkf_earc.sh
+++ b/scripts/exgdas_enkf_earc.sh
@@ -103,14 +103,18 @@ if [ "${ENSGRP}" -eq 0 ]; then
 
 #--set the archiving command and create local directories, if necessary
         TARCMD="htar"
+        HSICMD="hsi"
         if [[ ${LOCALARCH} = "YES" ]]; then
             TARCMD="tar"
+            HSICMD=""
             [ ! -d "${ATARDIR}"/"${CDATE}" ] && mkdir -p "${ATARDIR}"/"${CDATE}"
         fi
 
         set +e
-        ${TARCMD} -P -cvf "${ATARDIR}/${CDATE}/${RUN}.tar" $(cat "${ARCH_LIST}/${RUN}.txt")
+        ${TARCMD} -P -cvf "${ATARDIR}/${CDATE}/${RUN}.tar" $(cat "${ARCH_LIST}/${RUN}.txt")        
         status=$?
+        ${HSICMD} chgrp rstprod "${ATARDIR}/${CDATE}/${RUN}.tar"
+        ${HSICMD} chmod 640 "${ATARDIR}/${CDATE}/${RUN}.tar"
         if [ "${status}" -ne 0 ] && [ "${CDATE}" -ge "${firstday}" ]; then
             echo "$(echo "${TARCMD}" | tr 'a-z' 'A-Z') ${CDATE} ${RUN}.tar failed"
             exit "${status}"

--- a/scripts/exgdas_enkf_earc.sh
+++ b/scripts/exgdas_enkf_earc.sh
@@ -111,7 +111,7 @@ if [ "${ENSGRP}" -eq 0 ]; then
         fi
 
         set +e
-        ${TARCMD} -P -cvf "${ATARDIR}/${CDATE}/${RUN}.tar" $(cat "${ARCH_LIST}/${RUN}.txt")        
+        ${TARCMD} -P -cvf "${ATARDIR}/${CDATE}/${RUN}.tar" $(cat "${ARCH_LIST}/${RUN}.txt")
         status=$?
         ${HSICMD} chgrp rstprod "${ATARDIR}/${CDATE}/${RUN}.tar"
         ${HSICMD} chmod 640 "${ATARDIR}/${CDATE}/${RUN}.tar"

--- a/scripts/exglobal_archive.sh
+++ b/scripts/exglobal_archive.sh
@@ -109,8 +109,10 @@ if [[ ${HPSSARCH} = "YES" || ${LOCALARCH} = "YES" ]]; then
 
 # --set the archiving command and create local directories, if necessary
 TARCMD="htar"
+HSICMD="hsi"
 if [[ ${LOCALARCH} = "YES" ]]; then
    TARCMD="tar"
+   HSICMD=''
    [ ! -d "${ATARDIR}"/"${CDATE}" ] && mkdir -p "${ATARDIR}"/"${CDATE}"
    [ ! -d "${ATARDIR}"/"${CDATE_MOS}" ] && [ -d "${ROTDIR}"/gfsmos."${PDY_MOS}" ] && [ "${cyc}" -eq 18 ] && mkdir -p "${ATARDIR}"/"${CDATE_MOS}"
 fi
@@ -255,6 +257,13 @@ for targrp in ${targrp_list}; do
     set +e
     ${TARCMD} -P -cvf "${ATARDIR}"/"${CDATE}"/"${targrp}".tar $(cat "${ARCH_LIST}"/"${targrp}".txt)
     status=$?
+    case ${targrp} in
+    	'gdas'|'gdas_restarta')
+			${HSICMD} chgrp rstprod "${ATARDIR}/${CDATE}/${targrp}.tar"
+			${HSICMD} chmod 640 "${ATARDIR}/${CDATE}/${targrp}.tar"
+	 		;;
+		*) ;;
+	esac
     if [ "${status}" -ne 0 ] && [ "${CDATE}" -ge "${firstday}" ]; then
         echo "$(echo "${TARCMD}" | tr 'a-z' 'A-Z') ${CDATE} ${targrp}.tar failed"
         exit "${status}"


### PR DESCRIPTION
**Description**
Ensures that tarballs that contain restricted data are properly restricted to the rstprod group.

Fixes #1433

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Hera with HPSS archival
- [x]  Orion with local archival
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
