### PR TITLE
Remove para module paths for ncdiag on WCOSS2

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -29,7 +29,7 @@ protocol = git
 required = True
 
 [GSI-EnKF]
-hash = 31b8b29
+hash = 113e307
 local_path = sorc/gsi_enkf.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -43,7 +43,7 @@ protocol = git
 required = False
 
 [GSI-Monitor]
-hash = c64cc47
+hash = 8cf16de
 local_path = sorc/gsi_monitor.fd
 repo_url = https://github.com/NOAA-EMC/GSI-monitor.git
 protocol = git

--- a/modulefiles/module_base.wcoss2.lua
+++ b/modulefiles/module_base.wcoss2.lua
@@ -26,15 +26,10 @@ load(pathJoin("prod_util", "2.0.9"))
 load(pathJoin("grib_util", "1.2.3"))
 load(pathJoin("bufr_dump", "1.0.0"))
 load(pathJoin("util_shared", "1.4.0"))
-load(pathJoin("crtm", "2.4.0"))
 load(pathJoin("g2tmpl", "1.9.1"))
+load(pathJoin("ncdiag", "1.0.0"))
+load(pathJoin("crtm", "2.4.0"))
 load(pathJoin("wgrib2", "2.0.7"))
-
-pushenv("HPC_OPT", "/apps/ops/para/libs")
-append_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/compiler/intel/19.1.3.304")
-append_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/mpi/intel/19.1.3.304/cray-mpich/8.1.7")
-
-load("ncdiag/1.0.0")
 
 prepend_path("MODULEPATH", pathJoin("/lfs/h2/emc/global/save/emc.global/git/prepobs/v1.0.1/modulefiles"))
 load(pathJoin("prepobs", "1.0.1"))

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -170,7 +170,7 @@ fi
 
 if [[ ${checkout_gsi} == "YES" || ${checkout_gdas} == "YES" ]]; then
   checkout "gsi_utils.fd"    "https://github.com/NOAA-EMC/GSI-Utils.git"   "322cc7b"; errs=$((errs + $?))
-  checkout "gsi_monitor.fd"  "https://github.com/NOAA-EMC/GSI-Monitor.git" "c64cc47"; errs=$((errs + $?))
+  checkout "gsi_monitor.fd"  "https://github.com/NOAA-EMC/GSI-Monitor.git" "8cf16de"; errs=$((errs + $?))
   checkout "gldas.fd"        "https://github.com/NOAA-EMC/GLDAS.git"       "fd8ba62"; errs=$((errs + $?))
 fi
 

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -161,7 +161,7 @@ checkout "ufs_model.fd"    "https://github.com/ufs-community/ufs-weather-model" 
 checkout "verif-global.fd" "https://github.com/NOAA-EMC/EMC_verif-global.git"   "c267780"                    ; errs=$((errs + $?))
 
 if [[ ${checkout_gsi} == "YES" ]]; then
-  checkout "gsi_enkf.fd" "https://github.com/NOAA-EMC/GSI.git" "31b8b29" "NO"; errs=$((errs + $?))
+  checkout "gsi_enkf.fd" "https://github.com/NOAA-EMC/GSI.git" "113e307" "NO"; errs=$((errs + $?))
 fi
 
 if [[ ${checkout_gdas} == "YES" ]]; then


### PR DESCRIPTION
**Description**

This PR updates the `ncdiag` module for WCOSS2 from the para version to the newly implemented prod version. The `module_base.wcoss2.lua` modulefile is updated. New hashes for GSI (`113e307`) and GSI-Monitor (`8cf16de`) for the same update are included. Also moved the `crtm/2.4.0` module down to be consistent with the module load order we have in our other modulefiles.

Resolves #1426

**Type of change**

Operational update maintenance.

**How Has This Been Tested?**

- [x] Clone and build tests on WCOSS2-Cactus
- [x] Cycled C96C48L127 test on WCOSS2
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
