### PR TITLE
Use P8 settings for C384 atm by default

### DIFF
--- a/parm/config/config.defaults.s2sw
+++ b/parm/config/config.defaults.s2sw
@@ -14,25 +14,6 @@ FHOUT_HF_GFS=-1
 min_seaice="1.0e-6"
 use_cice_alb=".true."
 
-# config.ufs  # TODO: This is hard-wired for P8 and needs to be refactored.  For now, use case C384
-# TODO: Q. for @jessicameixner-noaa: can we make these defaults in config.ufs for C384?
-case "${CASE}" in
-  "C384")
-    DELTIM=300
-    layout_x_gfs=8
-    layout_y_gfs=8
-    WRITE_GROUP_GFS=1
-    WRTTASK_PER_GROUP_GFS=24
-    #The settings below will result in S2SWA running 35 days under 8 hours wallclock on hera
-    #layout_x_gfs=24
-    #layout_y_gfs=16
-    #WRTTASK_PER_GROUP_GFS=86
-    ;;
-  *)  # All other ${CASE}
-    echo "config.defaults.s2sw: Using default settings for CASE=${CASE}"
-    ;;
-esac
-
 # config.wave
 
 waveGRD='mx025'

--- a/parm/config/config.ufs
+++ b/parm/config/config.ufs
@@ -146,18 +146,18 @@ case "${fv3_res}" in
         export WRTTASK_PER_GROUP_GFS=64
         ;;
     "C384")
-        export DELTIM=200
+        export DELTIM=300
         export layout_x=6
         export layout_y=8
         export layout_x_gfs=8
-        export layout_y_gfs=12
+        export layout_y_gfs=8
         export nthreads_fv3=1
         export nthreads_fv3_gfs=2
         export cdmbgwd="1.1,0.72,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=2
         export WRTTASK_PER_GROUP=48
         export WRITE_GROUP_GFS=2
-        export WRTTASK_PER_GROUP_GFS=64
+        export WRTTASK_PER_GROUP_GFS=48
         ;;
     "C768")
         export DELTIM=150


### PR DESCRIPTION
**Description**
Switches the default C383 FV3 timestep to 300s and reduces the decomposition for gfs to 8×8 with 48 write tasks per group. These are the settings used by P8. MDAB has advised these settings can be used for non-P8 runs.

Fixes #1439 

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
- [ ] Cycled test on Orion
- [ ] Forecast-only test on Hera
  
**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
