### PR TITLE
Update hash for GDASApp to db2f998

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -50,7 +50,7 @@ protocol = git
 required = False
 
 [GDASApp]
-hash = 6aa55fa
+hash = db2f998
 local_path = sorc/gdas.cd
 repo_url = https://github.com/NOAA-EMC/GDASApp.git
 protocol = git

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -165,7 +165,7 @@ if [[ ${checkout_gsi} == "YES" ]]; then
 fi
 
 if [[ ${checkout_gdas} == "YES" ]]; then
-  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "fb56a55"; errs=$((errs + $?))
+  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "db2f998"; errs=$((errs + $?))
 fi
 
 if [[ ${checkout_gsi} == "YES" || ${checkout_gdas} == "YES" ]]; then

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -165,7 +165,7 @@ if [[ ${checkout_gsi} == "YES" ]]; then
 fi
 
 if [[ ${checkout_gdas} == "YES" ]]; then
-  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "6aa55fa"; errs=$((errs + $?))
+  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "fb56a55"; errs=$((errs + $?))
 fi
 
 if [[ ${checkout_gsi} == "YES" || ${checkout_gdas} == "YES" ]]; then


### PR DESCRIPTION
**Description**
When an update described below made a change to the HASH in the `${HOMEgfs}/sorc/checkout.sh` script for the corresponding GDASApp it was entered in error:

_3e73038c - Use V2 version of fix files needed for Thompson MP (#1422) (7 days ago) <Rahul Mahajan>_

Examining the GDASApp repo it should be confirmed that the correct HASH should be **db2f998**

Fixes #1441

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Clone on Orion
  
**Checklist**
- [x] My code follows the style guidelines of this project
