### PR TITLE
Rework arch job dependencies

### DIFF
--- a/workflow/rocoto/rocoto.py
+++ b/workflow/rocoto/rocoto.py
@@ -109,12 +109,14 @@ def create_task(task_dict: Dict[str, Any]) -> List[str]:
             strings.append(f'\t{e}\n')
         strings.append('\n')
 
-    if dependency is not None:
+    if len(dependency) > 0:
         strings.append('\t<dependency>\n')
         for d in dependency:
             strings.append(f'\t\t{d}\n')
         strings.append('\t</dependency>\n')
         strings.append('\n')
+    else:
+        print("WARNING: No dependencies for task " + taskname)
 
     strings.append('</task>\n')
 
@@ -293,7 +295,7 @@ def _traverse(o, tree_types=(list, tuple)):
         yield o
 
 
-def create_dependency(dep_condition=None, dep=None) -> List[str]:
+def create_dependency(dep_condition=None, dep=[]) -> List[str]:
     """
     create a compound dependency given a list of dependencies, and compounding condition
     the list of dependencies are created using add_dependency
@@ -309,10 +311,10 @@ def create_dependency(dep_condition=None, dep=None) -> List[str]:
 
     strings = []
 
-    if dep_condition is not None:
-        strings.append(f'<{dep_condition}>')
+    if len(dep) > 0:
+        if dep_condition is not None:
+            strings.append(f'<{dep_condition}>')
 
-    if dep[0] is not None:
         for d in dep:
             if dep_condition is None:
                 strings.append(f'{d}')
@@ -320,8 +322,8 @@ def create_dependency(dep_condition=None, dep=None) -> List[str]:
                 for e in _traverse(d):
                     strings.append(f'\t{e}')
 
-    if dep_condition is not None:
-        strings.append(f'</{dep_condition}>')
+        if dep_condition is not None:
+            strings.append(f'</{dep_condition}>')
 
     return strings
 

--- a/workflow/rocoto/rocoto.py
+++ b/workflow/rocoto/rocoto.py
@@ -78,7 +78,7 @@ def create_task(task_dict: Dict[str, Any]) -> List[str]:
     threads = resources_dict.get('threads', 1)
     log = task_dict.get('log', 'demo.log')
     envar = task_dict.get('envars', None)
-    dependency = task_dict.get('dependency', None)
+    dependency = task_dict.get('dependency', [])
 
     str_maxtries = str(maxtries)
     str_final = ' final="true"' if final else ''
@@ -109,13 +109,13 @@ def create_task(task_dict: Dict[str, Any]) -> List[str]:
             strings.append(f'\t{e}\n')
         strings.append('\n')
 
-    if len(dependency) > 0:
+    if dependency is not None and len(dependency) > 0:
         strings.append('\t<dependency>\n')
         for d in dependency:
             strings.append(f'\t\t{d}\n')
         strings.append('\t</dependency>\n')
         strings.append('\n')
-    else:
+    elif(taskname != "gfswaveinit"):
         print("WARNING: No dependencies for task " + taskname)
 
     strings.append('</task>\n')

--- a/workflow/rocoto/rocoto.py
+++ b/workflow/rocoto/rocoto.py
@@ -115,7 +115,7 @@ def create_task(task_dict: Dict[str, Any]) -> List[str]:
             strings.append(f'\t\t{d}\n')
         strings.append('\t</dependency>\n')
         strings.append('\n')
-    elif(taskname != "gfswaveinit"):
+    elif taskname != "gfswaveinit":
         print("WARNING: No dependencies for task " + taskname)
 
     strings.append('</task>\n')

--- a/workflow/rocoto/workflow_tasks.py
+++ b/workflow/rocoto/workflow_tasks.py
@@ -1035,6 +1035,11 @@ class Tasks:
             if self.app_config.mode in ['forecast-only']:  # TODO: fix ocnpost to run in cycled mode
                 dep_dict = {'type': 'metatask', 'name': f'{self.cdump}ocnpost'}
                 deps.append(rocoto.add_dependency(dep_dict))
+        # If all verification and ocean/wave coupling is off, add the gdas/gfs post metatask as a dependency
+        if len(deps) == 0:
+            dep_dict = {'type': 'metatask', 'name': f'{self.cdump}post'}
+            deps.append(rocoto.add_dependency(dep_dict))
+
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         cycledef = 'gdas_half,gdas' if self.cdump in ['gdas'] else self.cdump


### PR DESCRIPTION
**Description**
This reworks the dependencies for arch tasks so that if there are no verification tasks selected and it is an uncoupled experiment, a dependency for the cycle's post jobs is added.  It also fixes the dependency checks in rocoto.py to check for an empty list or string instead of checking the first element of a list, which may not exist if no dependencies are given.  Lastly, it issues a warning to the user if there are no dependencies for any job.

Fixes #1451

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
I created three test cases, each comparing develop against the current develop branch:

1. cycled test with `DO_VRFY=YES`: .xml files were identical excepting the creation time
2. cycled test with `DO_VRFY=NO` and `DO_METP=NO`: develop fails to create .xml while this branch succeeds and lists `{gdas|gfs}post` as dependencies
3. forecast only, uncoupled test with `DO_VRFY=NO`: develop fails and this branch succeeds with `{gdas|gfs}post` listed as dependencies
4. commented out the `post` dependencies in rocoto.py, [lines 1039-1041](https://github.com/DavidHuber-NOAA/global-workflow/blob/b9487d3d15a7832a5a1c95f613d5f949956e77b4/workflow/rocoto/workflow_tasks.py#L1039-L1041) and ran setup_xml.py with this branch and `DO_VRFY=NO`: the .xml file was generated successfully without any dependencies for the `*arch` jobs and a warning was produced, as expected.

A note from testing: when `DO_VRFY=NO`, the `*vrfy` jobs are still created in the resulting rocoto XML.  This doesn't seem like expected behavior and I can tackle it as part of this PR if desired.

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
