### PR TITLE
Update GSI-Monitor hash to reflect recent assimilation changes

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -43,7 +43,7 @@ protocol = git
 required = False
 
 [GSI-Monitor]
-hash = 8cf16de
+hash = 45783e3
 local_path = sorc/gsi_monitor.fd
 repo_url = https://github.com/NOAA-EMC/GSI-monitor.git
 protocol = git

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -170,7 +170,7 @@ fi
 
 if [[ ${checkout_gsi} == "YES" || ${checkout_gdas} == "YES" ]]; then
   checkout "gsi_utils.fd"    "https://github.com/NOAA-EMC/GSI-Utils.git"   "322cc7b"; errs=$((errs + $?))
-  checkout "gsi_monitor.fd"  "https://github.com/NOAA-EMC/GSI-Monitor.git" "8cf16de"; errs=$((errs + $?))
+  checkout "gsi_monitor.fd"  "https://github.com/NOAA-EMC/GSI-Monitor.git" "45783e3"; errs=$((errs + $?))
   checkout "gldas.fd"        "https://github.com/NOAA-EMC/GLDAS.git"       "fd8ba62"; errs=$((errs + $?))
 fi
 


### PR DESCRIPTION
**Description**

This PR updates the hash of GSI-Monitor to [45783e3](https://github.com/NOAA-EMC/GSI-Monitor/commit/45783e324da02d7a3b95cfbde8d8dce193168ac0) to reflect recent assimilation changes in two fix files. See https://github.com/NOAA-EMC/GSI-Monitor/issues/77 & https://github.com/NOAA-EMC/GSI-Monitor/pull/78.

Resolves #1483

**Type of change**

Updated component hash.

**How Has This Been Tested?**

- [x] Clone and Build tests on Orion
- [x] Cycled test on Orion (1.5 cycle plumbing test)
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
