### PR TITLE
Update TC_tracker tag to v1.1.15.6 for Jet support

### DIFF
--- a/parm/config/config.vrfy
+++ b/parm/config/config.vrfy
@@ -66,7 +66,7 @@ fi
 # Cyclone genesis and cyclone track verification
 #-------------------------------------------------
 
-export ens_tracker_ver=v1.1.15.5
+export ens_tracker_ver=v1.1.15.6
 export HOMEens_tracker=$BASE_GIT/TC_tracker/${ens_tracker_ver}
 
 if [[ "${VRFYTRAK}" = "YES" ]]; then


### PR DESCRIPTION
**Description**

This PR updates the TC_tracker version to `v1.1.15.6` in `parm/config/config.vrfy`. This new tag includes the following updates:

- Jet support
- move R&D platforms to use EPIC hpc-stacks

Resolves #1463

**Type of change**

External package update.

**How Has This Been Tested?**

- [x] Clone and Build tests on all supported platforms
- [x] Cycled test on Hera, Orion, Jet
