### PR TITLE
Add Fit2Obs support for S4

### DIFF
--- a/modulefiles/module_base.s4.lua
+++ b/modulefiles/module_base.s4.lua
@@ -31,4 +31,7 @@ setenv("WGRIB2","wgrib2")
 prepend_path("MODULEPATH", pathJoin("/data/prod/glopara/git/prepobs/v1.0.1/modulefiles"))
 load(pathJoin("prepobs", "1.0.1"))
 
+prepend_path("MODULEPATH", pathJoin("/data/prod/glopara/git/Fit2Obs/v1.0.0/modulefiles"))
+load(pathJoin("fit2obs", "1.0.0"))
+
 whatis("Description: GFS run environment")


### PR DESCRIPTION
**Description**

Adds Fit2Obs support for S4 by adding the module use/load commands to the module_base.s4.lua modulefile.

Fixes #1489.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

- [x] Cycled test on S4
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- N/A I have commented my code, particularly in hard-to-understand areas
- N/A My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published