### PR TITLE
ignore archiving sfluxgrbf00[124578] files when running WCDA

### DIFF
--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -341,13 +341,15 @@ if [[ ${type} = "gdas" ]]; then
     echo  "${dirname}${head}sfcf${fhr}.nc              " >>gdas.txt
     fh=$((fh+3))
   done
-  if [[ ${DO_JEDIOCNVAR} = "NO" ]]; then
-    flist="001 002 004 005 007 008"
-    for fhr in ${flist}; do
-      echo  "${dirname}${head}sfluxgrbf${fhr}.grib2      " >>gdas.txt
-      echo  "${dirname}${head}sfluxgrbf${fhr}.grib2.idx  " >>gdas.txt
-    done
-  fi
+  flist="001 002 004 005 007 008"
+  for fhr in ${flist}; do
+    file="${dirname}${head}sfluxgrbf${fhr}.grib2"
+    # Only add to list if file is present.
+    if [[ -s "${file}" ]]; then
+      echo  "${file}"      >>gdas.txt
+      echo  "${file}$.idx" >>gdas.txt
+    fi
+  done
   
 
 

--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -347,7 +347,7 @@ if [[ ${type} = "gdas" ]]; then
     # Only add to list if file is present.
     if [[ -s "${file}" ]]; then
       echo  "${file}"      >>gdas.txt
-      echo  "${file}$.idx" >>gdas.txt
+      echo  "${file}.idx"  >>gdas.txt
     fi
   done
   

--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -341,11 +341,13 @@ if [[ ${type} = "gdas" ]]; then
     echo  "${dirname}${head}sfcf${fhr}.nc              " >>gdas.txt
     fh=$((fh+3))
   done
-  flist="001 002 004 005 007 008"
-  for fhr in ${flist}; do
-    echo  "${dirname}${head}sfluxgrbf${fhr}.grib2      " >>gdas.txt
-    echo  "${dirname}${head}sfluxgrbf${fhr}.grib2.idx  " >>gdas.txt
-  done
+  if [[ ${DO_JEDIOCNVAR} = "NO" ]]; then
+    flist="001 002 004 005 007 008"
+    for fhr in ${flist}; do
+      echo  "${dirname}${head}sfluxgrbf${fhr}.grib2      " >>gdas.txt
+      echo  "${dirname}${head}sfluxgrbf${fhr}.grib2.idx  " >>gdas.txt
+    done
+  fi
   
 
 


### PR DESCRIPTION

**Description**

When running WCDA (S2S app), task gdasarch fails because sfluxgrb files for non-divisible-by-3 forecast hours are not in comrot. This change wraps this section of ush/hpssarch_gen.sh in an if/then block for DO_JEDIOCNVAR=NO to avoid this problem.

Addresses issue https://github.com/NOAA-EMC/global-workflow/issues/1418


**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Tested with cycling on Hera
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
