### PR TITLE
update GDASApp hash to d34f616

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -50,7 +50,7 @@ protocol = git
 required = False
 
 [GDASApp]
-hash = db2f998
+hash = d34f616
 local_path = sorc/gdas.cd
 repo_url = https://github.com/NOAA-EMC/GDASApp.git
 protocol = git

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -165,7 +165,7 @@ if [[ ${checkout_gsi} == "YES" ]]; then
 fi
 
 if [[ ${checkout_gdas} == "YES" ]]; then
-  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "db2f998"; errs=$((errs + $?))
+  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "d34f616"; errs=$((errs + $?))
 fi
 
 if [[ ${checkout_gsi} == "YES" || ${checkout_gdas} == "YES" ]]; then


### PR DESCRIPTION
**Description**
Recent g-w PRs have enhanced UFS-DA functionality.   To fully exercise this enhanced functionality the GDASApp hash in `Externals.cfg` and `sorc/checkout.sh` needs to be updated.   This PR updates the GDASApp hash in both files.

Fixes #1505

**Type of change**
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
- [x] Clone and Build tests on Hera

`feature/update_gdasapp` has been cloned on Hera and `./checkout.sh -u` executed.   `git status` in `gdas.cd` confirms that hash [d34f616](https://github.com/NOAA-EMC/GDASApp/commit/d34f616f5f48b3db0b15dd34687d70d54a087614) was checked out.   This is correct.
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

