### PR TITLE
Move GDASApp hash to stable version

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -50,7 +50,7 @@ protocol = git
 required = False
 
 [GDASApp]
-hash = d34f616
+hash = aaf7caa
 local_path = sorc/gdas.cd
 repo_url = https://github.com/NOAA-EMC/GDASApp.git
 protocol = git

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -165,7 +165,7 @@ if [[ ${checkout_gsi} == "YES" ]]; then
 fi
 
 if [[ ${checkout_gdas} == "YES" ]]; then
-  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "d34f616"; errs=$((errs + $?))
+  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "aaf7caa"; errs=$((errs + $?))
 fi
 
 if [[ ${checkout_gsi} == "YES" || ${checkout_gdas} == "YES" ]]; then


### PR DESCRIPTION
**Description**
Changes the GDASApp hash to a more stable version than the tip of develop.

See post-merge conversation in #1506

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Checkout with GDASApp

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
