### PR TITLE
Marine DA bug fix and cycling of the verify task

### DIFF
--- a/jobs/rocoto/ocnanalchkpt.sh
+++ b/jobs/rocoto/ocnanalchkpt.sh
@@ -1,0 +1,18 @@
+#! /usr/bin/env bash
+
+source "${HOMEgfs}/ush/preamble.sh"
+
+###############################################################
+# Source UFSDA workflow modules
+. "${HOMEgfs}/ush/load_ufsda_modules.sh"
+status=$?
+[[ ${status} -ne 0 ]] && exit "${status}"
+
+export job="ocnanalchkpt"
+export jobid="${job}.$$"
+
+###############################################################
+# Execute the JJOB
+"${HOMEgfs}"/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_CHKPT
+status=$?
+exit "${status}"

--- a/parm/config/config.ocnanalvrfy
+++ b/parm/config/config.ocnanalvrfy
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+########## config.ocnanalvrfy ##########
+# Pre Ocn Analysis specific
+
+echo "BEGIN: config.ocnanalvrfy"
+
+# Get task specific resources
+. "${EXPDIR}/config.resources" ocnanalvrfy
+echo "END: config.ocnanalvrfy"

--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -20,8 +20,7 @@ if [[ $# -ne 1 ]]; then
     echo "wavegempak waveawipsbulls waveawipsgridded"
     echo "postsnd awips gempak"
     echo "wafs wafsgrib2 wafsblending wafsgrib20p25 wafsblending0p25 wafsgcip"
-    echo "ocnanalprep ocnanalbmat ocnanalrun ocnanalchkpt ocnanalpost"
-
+    echo "ocnanalprep ocnanalbmat ocnanalrun ocnanalchkpt ocnanalpost ocnanalvrfy"
     exit 1
 
 fi
@@ -228,7 +227,7 @@ elif [[ "${step}" = "landanlinit" || "${step}" = "landanlrun"  || "${step}" = "l
    export layout_x
    export layout_y
 
-   if [[ "${step}" = "landanlinit" || "${step}" = "landanlfinal" ]]; then 
+   if [[ "${step}" = "landanlinit" || "${step}" = "landanlfinal" ]]; then
        declare -x "wtime_${step}"="00:10:00"
        declare -x "npe_${step}"=1
        declare -x "nth_${step}"=1
@@ -396,6 +395,15 @@ elif [[ "${step}" = "ocnanalpost" ]]; then
     export nth_ocnanalpost=1
     npe_node_ocnanalpost=$(echo "${npe_node_max} / ${nth_ocnanalpost}" | bc)
     export npe_node_ocnanalpost
+
+elif [[ "${step}" = "ocnanalvrfy" ]]; then
+
+    export wtime_ocnanalvrfy="00:35:00"
+    export npe_ocnanalvrfy=1
+    export nth_ocnanalvrfy=1
+    npe_node_ocnanalvrfy=$(echo "${npe_node_max} / ${nth_ocnanalvrfy}" | bc)
+    export npe_node_ocnanalvrfy
+    export memory_ocnanalvrfy="24GB"
 
 elif [[ ${step} = "anal" ]]; then
 

--- a/workflow/applications.py
+++ b/workflow/applications.py
@@ -184,7 +184,8 @@ class AppConfig:
             configs += ['anal', 'analdiag']
 
         if self.do_jediocnvar:
-            configs += ['ocnanalprep', 'ocnanalbmat', 'ocnanalrun', 'ocnanalchkpt', 'ocnanalpost']
+            configs += ['ocnanalprep', 'ocnanalbmat', 'ocnanalrun', 'ocnanalchkpt', 'ocnanalpost', 'ocnanalvrfy']
+
         if self.do_ocean:
             configs += ['ocnpost']
 
@@ -362,7 +363,7 @@ class AppConfig:
 
         if self.do_jediocnvar:
             gdas_gfs_common_tasks_before_fcst += ['ocnanalprep', 'ocnanalbmat', 'ocnanalrun',
-                                                  'ocnanalchkpt', 'ocnanalpost']
+                                                  'ocnanalchkpt', 'ocnanalpost', 'ocnanalvrfy']
 
         gdas_gfs_common_tasks_before_fcst += ['sfcanl', 'analcalc']
 

--- a/workflow/rocoto/workflow_tasks.py
+++ b/workflow/rocoto/workflow_tasks.py
@@ -14,7 +14,7 @@ class Tasks:
     VALID_TASKS = ['aerosol_init', 'coupled_ic', 'getic', 'init',
                    'prep', 'anal', 'sfcanl', 'analcalc', 'analdiag', 'gldas', 'arch',
                    'atmanlinit', 'atmanlrun', 'atmanlfinal',
-                   'ocnanalprep', 'ocnanalbmat', 'ocnanalrun', 'ocnanalchkpt', 'ocnanalpost',
+                   'ocnanalprep', 'ocnanalbmat', 'ocnanalrun', 'ocnanalchkpt', 'ocnanalpost', 'ocnanalvrfy',
                    'earc', 'ecen', 'echgres', 'ediag', 'efcs',
                    'eobs', 'eomg', 'epos', 'esfc', 'eupd',
                    'atmensanlinit', 'atmensanlrun', 'atmensanlfinal',
@@ -625,6 +625,22 @@ class Tasks:
 
         resources = self.get_resource('ocnanalpost')
         task = create_wf_task('ocnanalpost',
+                              resources,
+                              cdump=self.cdump,
+                              envar=self.envars,
+                              dependency=dependencies)
+
+        return task
+
+    def ocnanalvrfy(self):
+
+        deps = []
+        dep_dict = {'type': 'task', 'name': f'{self.cdump}ocnanalpost'}
+        deps.append(rocoto.add_dependency(dep_dict))
+        dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
+
+        resources = self.get_resource('ocnanalvrfy')
+        task = create_wf_task('ocnanalvrfy',
                               resources,
                               cdump=self.cdump,
                               envar=self.envars,


### PR DESCRIPTION
**Description**
The title says it all. 
This PR addresses a few items of issue #1480:
- item 2: Allow for the verify j-job to be launched within a cycle
- item 4: Adds the forgotten rocoto script ```jobs/rocoto/ocnanalchkpt.sh```

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
This was tested before the merge of [PR #1421](https://github.com/NOAA-EMC/global-workflow/pull/1421). The code changes submitted in this PR are the remaining differences between our working branch and develop.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
