### PR TITLE
Quiet generate_com

### DIFF
--- a/ush/preamble.sh
+++ b/ush/preamble.sh
@@ -120,6 +120,7 @@ function generate_com() {
     #       # Current cycle and COM for first member
     #       MEMDIR='mem001' YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_HISTORY
     #
+    if [[ ${DEBUG_WORKFLOW:-"NO"} == "NO" ]]; then set +x; fi
     local opts="-g"
     local OPTIND=1
     while getopts "rx" option; do
@@ -144,7 +145,9 @@ function generate_com() {
         value=$(echo "${!template}" | envsubst)
         # shellcheck disable=SC2086
         declare ${opts} "${com_var}"="${value}"
+        echo "generate_com :: ${com_var}=${value}"
     done
+    set_trace
 }
 # shellcheck disable=
 declare -xf generate_com


### PR DESCRIPTION
**Description**
Turns off trace for the duration of the generate_com function unless DEBUG_WORKFLOW is not set to "NO" (the default). In its place, the function will now echo the assignment.

Closes #1524

**Type of change**
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
- [x] Partial-cycle test on Orion (just to make sure log is correct)
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
