### PR TITLE
Fix warm-start IC staging

### DIFF
--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -73,7 +73,7 @@ def fill_COMROT_cycled(host, inputs):
     rdatestr = datetime_to_YMDH(inputs.idate - to_timedelta('T06H'))
     idatestr = datetime_to_YMDH(inputs.idate)
 
-    if os.path.isdir(os.path.join(inputs.icsdir, 'model_data', 'atmos')):
+    if os.path.isdir(os.path.join(inputs.icsdir, f'{inputs.cdump}.{rdatestr[:8]}', rdatestr[8:], 'model_data', 'atmos')):
         flat_structure = False
     else:
         flat_structure = True
@@ -94,7 +94,7 @@ def fill_COMROT_cycled(host, inputs):
 
     if flat_structure:
         # ICs are in the old flat COM structure
-        if inputs.start in ['warm']:  # This is warm start experiment (only meaningful for atmos)
+        if inputs.start in ['warm']:  # This is warm start experiment
             src_atm_dir = os.path.join('atmos', 'RESTART')
             src_med_dir = os.path.join('med', 'RESTART')
         elif inputs.start in ['cold']:  # This is a cold start experiment
@@ -154,7 +154,7 @@ def fill_COMROT_cycled(host, inputs):
     if do_ocean:
         detdir = f'{inputs.cdump}.{rdatestr[:8]}/{rdatestr[8:]}'
         dst_dir = os.path.join(comrot, detdir, dst_ocn_rst_dir)
-        src_dir = os.path.join(inputs.icsdir, detdir, 'ocean', src_ocn_rst_dir)
+        src_dir = os.path.join(inputs.icsdir, detdir, src_ocn_rst_dir)
         makedirs_if_missing(dst_dir)
         link_files_from_src_to_dst(src_dir, dst_dir)
 
@@ -169,16 +169,16 @@ def fill_COMROT_cycled(host, inputs):
     # Link ice files
     if do_ice:
         detdir = f'{inputs.cdump}.{rdatestr[:8]}/{rdatestr[8:]}'
-        dst_dir = os.path.join(comrot, detdir, 'ice', dst_ice_dir)
-        src_dir = os.path.join(inputs.icsdir, detdir, 'ice', src_ice_dir)
+        dst_dir = os.path.join(comrot, detdir, dst_ice_dir)
+        src_dir = os.path.join(inputs.icsdir, detdir, src_ice_dir)
         makedirs_if_missing(dst_dir)
         link_files_from_src_to_dst(src_dir, dst_dir)
 
     # Link mediator files
     if do_med:
         detdir = f'{inputs.cdump}.{rdatestr[:8]}/{rdatestr[8:]}'
-        dst_dir = os.path.join(comrot, detdir, 'med', dst_med_dir)
-        src_dir = os.path.join(inputs.icsdir, detdir, 'med', src_med_dir)
+        dst_dir = os.path.join(comrot, detdir, dst_med_dir)
+        src_dir = os.path.join(inputs.icsdir, detdir, src_med_dir)
         makedirs_if_missing(dst_dir)
         link_files_from_src_to_dst(src_dir, dst_dir)
 

--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -188,8 +188,8 @@ def fill_COMROT_cycled(host, inputs):
             detdir = f'{inputs.cdump}.{rdatestr[:8]}/{rdatestr[8:]}'
         elif inputs.start in ['cold']:
             detdir = f'{inputs.cdump}.{idatestr[:8]}/{idatestr[8:]}'
-        dst_dir = os.path.join(comrot, detdir, 'chem', chem_dir)
-        src_dir = os.path.join(inputs.icsdir, detdir, 'chem', chem_dir)
+        dst_dir = os.path.join(comrot, detdir, chem_dir)
+        src_dir = os.path.join(inputs.icsdir, detdir, chem_dir)
         makedirs_if_missing(dst_dir)
         link_files_from_src_to_dst(src_dir, dst_dir)
 


### PR DESCRIPTION
**Description**
The incorrect path was used for staging coupled components during the COM refactor update (#1421). These are now corrected.

Fixes #1528 

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
cycled test with the coupled UFS (S2S).
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
