### PR TITLE
Fix ocean staging from flat structure

### DIFF
--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -103,7 +103,7 @@ def fill_COMROT_cycled(host, inputs):
             do_med = False
         # ocean and ice have the same filenames for warm and cold
         src_ocn_rst_dir = os.path.join('ocean', 'RESTART')
-        src_ocn_rst_dir = 'ocean'
+        src_ocn_anl_dir = 'ocean'
         src_ice_dir = os.path.join('ice', 'RESTART')
         src_atm_anl_dir = 'atmos'
     else:


### PR DESCRIPTION
**Description**
A typo led to the same variable being defined twice instead of the variable that was supposed to be defined.

Fixes #1530

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] S2S cycled experiment on Orion using a flat `--icsdir`
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
