### PR TITLE
Fix incorrect ocean history tmpl during workflow generation

### DIFF
--- a/workflow/rocoto/workflow_tasks.py
+++ b/workflow/rocoto/workflow_tasks.py
@@ -547,7 +547,7 @@ class Tasks:
 
         dump_suffix = self._base["DUMP_SUFFIX"]
         dmpdir = self._base["DMPDIR"]
-        ocean_hist_path = self._template_to_rocoto_cycstring(self._base["COM_OCEAN_HISTORY"])
+        ocean_hist_path = self._template_to_rocoto_cycstring(self._base["COM_OCEAN_HISTORY_TMPL"])
 
         deps = []
         data = f'{ocean_hist_path}/gdas.t@Hz.ocnf009.nc'


### PR DESCRIPTION
**Description**
The trailing '_TMPL' was accidentally ommited from the ocean history template used during workflow generation.

Fixes #1532

**Type of change**

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Cycled S2S workflow generated on Orion
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
