### PR TITLE
Added method to define  defaults.

### DIFF
--- a/ush/python/pygfs/task/gfs_forecast.py
+++ b/ush/python/pygfs/task/gfs_forecast.py
@@ -71,3 +71,4 @@ class GFSForecast(Task):
 
         # Generate the input.nml.
         cfg = self.gfs.prepare_input_nml()
+        

--- a/ush/python/pygfs/task/gfs_forecast.py
+++ b/ush/python/pygfs/task/gfs_forecast.py
@@ -66,5 +66,8 @@ class GFSForecast(Task):
         self.gfs.generate_diag_table()
 
         # Generate the nems.configure.
-        self.gfs.prepare_nems_configure()
+        cfg = self.gfs.prepare_nems_configure()
         # TODO: Create nems.configure here.
+
+        # Generate the input.nml.
+        cfg = self.gfs.prepare_input_nml()

--- a/ush/python/pygfs/task/gfs_forecast.py
+++ b/ush/python/pygfs/task/gfs_forecast.py
@@ -71,4 +71,3 @@ class GFSForecast(Task):
 
         # Generate the input.nml.
         cfg = self.gfs.prepare_input_nml()
-        

--- a/ush/python/pygfs/ufswm/gfs.py
+++ b/ush/python/pygfs/ufswm/gfs.py
@@ -233,19 +233,107 @@ class GFS(UFS):
         self.parse_ufs_templates(diag_table + ".tmpl", diag_table, localconf)
 
     @logit(logger)
-    def prepare_model_configure(self):
+    def prepare_input_nml(self: UFS) -> AttrDict:
+        """
+        Description
+        -----------
+
+        Prepare `input.nml`.
+
+        Returns
+        -------
+
+        cfg: AttrDict
+
+            A Python dictionary containing the configuration
+            attributes relevant for `input.nml`. 
+
+        """
+
+        # Deine the configuration variables required to build the 
+        # `input.nml`` file.
+        cfg = AttrDict()
+
+        # TODO: Optional variables which may be set via `schema`. 
+        nml_var_dict = {"CCPP_SUITE": self._config.CCPP_SUITE,
+                        "MAX_OUTPUT_FIELDS": 300,
+                        "INPES": self._config.layout_x,
+                        "JNPES": self._config.layout_y,
+                        "NPX": self._config.npx,
+                        "NPY": self._config.npy,
+                        "NPZ": self._config.npz,
+                        "MAKE_NH": self._config.make_nh,
+                        "NA_INIT": self._config.na_init,
+                        "DNATS": self._config.dnats,
+                        "EXTERNAL_IC": self._config.external_ic,
+                        "NGGPS_IC": self._config.nggps_ic,
+                        "MOUNTAIN": self._config.mountain,
+                        "WARM_START": self._config.warm_start,
+                        "READ_INCREMENT": self._config.read_increment,
+                        "RES_LATLON_DYNAMICS": self._config.res_latlon_dynamics,
+                        "NPZP": self._config.NLEVS,
+                        "FHZERO": self._config.FHZER,
+                        "LDIAG3D": False, # TODO: default value
+                        "QDIAG3D": False, # TODO: default value
+                        "FHCYC": self._config.FHCYC,
+                        "IAER": self._config.IAER,
+                        "IOVR": 3, # TODO: default value
+                        "LHEATSTRG": False, # TODO: default value
+                        "LSEASPRAY": True, # TODO: default value 
+                        "RANDOM_CLDS": True, # TODO: default value
+                        "CNVCLD": True, # TODO: default value
+                        "IMFSHALCNV": 2, # TODO: default value
+                        "IMFDEEPCNV": 2, # TODO: default value
+                        "RAS": False, # TODO: default value
+                        "CDMBWD": [3.5, 0.25], # TODO: default value
+                        "CPLCHM": False, # TODO: default value
+                        "CPLWAV": False, # TODO: default value
+                        "CPLWAV2ATM": False, # TODO: default value
+                        "DO_SPPT": False, # TODO: default value
+                        "DO_SHUM": False, # TODO: default value
+                        "DO_SKEB": False, # TODO: default value
+                        "LNDP_TYPE": 2, # TODO: default value
+                        "N_VAR_LNDP": 0, # TODO: default value
+                        "FSCAV_AERO": "*0.0", # TODO: default value
+                        "DO_RRTMG": False, # TODO: default value
+                        "DOGP_CLDOPTICS_LUT": False, # TODO: default value
+                        "DOGP_LWSCAT": False, # TODO: default value
+                        "PROGSIGMA": True, # TODO: default value
+                        "FNALBC": self._config.FNALBC,
+                        "FNVETC": self._config.FNVETC,
+                        "FNSOTC": self._config.FNSOTC,
+                        "FNSMCC_control": self._config.FNSMCC,
+                        "FNMSKH_control": self._config.FNMSKH,
+                        "FNABSC": self._config.FNABSC,
+                        "STOCHINI": None, # TODO: This currently does not have a default value.
+                        "SKEB": self._config.SKEB,
+                        "SHUM": self._config.SHUM,
+                        "SPPT": self._config.SPPT,
+                        "LNDP_TYPE": self._config.lndp_type,
+                        "LNDP_MODEL_TYPE": None, # TODO: This currently does not have a default value.
+                        "LNDP_VAR_LIST": self._config.lndp_var_list,
+                        "LNDP_PRT_LIST": self._config.lndp_prt_list
+        }
+
+        for (key, value) in nml_var_dict.items():
+            setattr(cfg, key, value)
+
+        return cfg
+
+    @logit(logger)
+    def prepare_model_configure(self) -> None:
         """
         Prepare model_configure related attributes etc.
         """
         self.mdl_config()
 
     @logit(logger)
-    def prepare_nems_configure(self: UFS):
+    def prepare_nems_configure(self: UFS) -> AttrDict:
         """
         Description
         -----------
 
-        Prepare nems.configure.
+        Prepare `nems.configure`.
 
         Returns
         -------
@@ -258,7 +346,7 @@ class GFS(UFS):
         """
 
         # Define the configuration variables required to build the
-        # nems.configure.
+        # `nems.configure``.
         cfg = AttrDict()
 
         # TODO: Populate this dictionary as configurations are added.

--- a/ush/python/pygfs/ufswm/gfs.py
+++ b/ush/python/pygfs/ufswm/gfs.py
@@ -246,15 +246,15 @@ class GFS(UFS):
         cfg: AttrDict
 
             A Python dictionary containing the configuration
-            attributes relevant for `input.nml`. 
+            attributes relevant for `input.nml`.
 
         """
 
-        # Deine the configuration variables required to build the 
+        # Deine the configuration variables required to build the
         # `input.nml`` file.
         cfg = AttrDict()
 
-        # TODO: Optional variables which may be set via `schema`. 
+        # TODO: Optional variables which may be set via `schema`.
         nml_var_dict = {"CCPP_SUITE": self._config.CCPP_SUITE,
                         "MAX_OUTPUT_FIELDS": 300,
                         "INPES": self._config.layout_x,
@@ -273,47 +273,46 @@ class GFS(UFS):
                         "RES_LATLON_DYNAMICS": self._config.res_latlon_dynamics,
                         "NPZP": self._config.NLEVS,
                         "FHZERO": self._config.FHZER,
-                        "LDIAG3D": False, # TODO: default value
-                        "QDIAG3D": False, # TODO: default value
+                        "LDIAG3D": False,  # TODO: default value
+                        "QDIAG3D": False,  # TODO: default value
                         "FHCYC": self._config.FHCYC,
                         "IAER": self._config.IAER,
-                        "IOVR": 3, # TODO: default value
-                        "LHEATSTRG": False, # TODO: default value
-                        "LSEASPRAY": True, # TODO: default value 
-                        "RANDOM_CLDS": True, # TODO: default value
-                        "CNVCLD": True, # TODO: default value
-                        "IMFSHALCNV": 2, # TODO: default value
-                        "IMFDEEPCNV": 2, # TODO: default value
-                        "RAS": False, # TODO: default value
-                        "CDMBWD": [3.5, 0.25], # TODO: default value
-                        "CPLCHM": False, # TODO: default value
-                        "CPLWAV": False, # TODO: default value
-                        "CPLWAV2ATM": False, # TODO: default value
-                        "DO_SPPT": False, # TODO: default value
-                        "DO_SHUM": False, # TODO: default value
-                        "DO_SKEB": False, # TODO: default value
-                        "LNDP_TYPE": 2, # TODO: default value
-                        "N_VAR_LNDP": 0, # TODO: default value
-                        "FSCAV_AERO": "*0.0", # TODO: default value
-                        "DO_RRTMG": False, # TODO: default value
-                        "DOGP_CLDOPTICS_LUT": False, # TODO: default value
-                        "DOGP_LWSCAT": False, # TODO: default value
-                        "PROGSIGMA": True, # TODO: default value
+                        "IOVR": 3,  # TODO: default value
+                        "LHEATSTRG": False,  # TODO: default value
+                        "LSEASPRAY": True,  # TODO: default value
+                        "RANDOM_CLDS": True,  # TODO: default value
+                        "CNVCLD": True,  # TODO: default value
+                        "IMFSHALCNV": 2,  # TODO: default value
+                        "IMFDEEPCNV": 2,  # TODO: default value
+                        "RAS": False,  # TODO: default value
+                        "CDMBWD": [3.5, 0.25],  # TODO: default value
+                        "CPLCHM": False,  # TODO: default value
+                        "CPLWAV": False,  # TODO: default value
+                        "CPLWAV2ATM": False,  # TODO: default value
+                        "DO_SPPT": False,  # TODO: default value
+                        "DO_SHUM": False,  # TODO: default value
+                        "DO_SKEB": False,  # TODO: default value
+                        "N_VAR_LNDP": 0,  # TODO: default value
+                        "FSCAV_AERO": "*0.0",  # TODO: default value
+                        "DO_RRTMG": False,  # TODO: default value
+                        "DOGP_CLDOPTICS_LUT": False,  # TODO: default value
+                        "DOGP_LWSCAT": False,  # TODO: default value
+                        "PROGSIGMA": True,  # TODO: default value
                         "FNALBC": self._config.FNALBC,
                         "FNVETC": self._config.FNVETC,
                         "FNSOTC": self._config.FNSOTC,
                         "FNSMCC_control": self._config.FNSMCC,
                         "FNMSKH_control": self._config.FNMSKH,
                         "FNABSC": self._config.FNABSC,
-                        "STOCHINI": None, # TODO: This currently does not have a default value.
+                        "STOCHINI": None,  # TODO: This currently does not have a default value.
                         "SKEB": self._config.SKEB,
                         "SHUM": self._config.SHUM,
                         "SPPT": self._config.SPPT,
                         "LNDP_TYPE": self._config.lndp_type,
-                        "LNDP_MODEL_TYPE": None, # TODO: This currently does not have a default value.
+                        "LNDP_MODEL_TYPE": None,  # TODO: This currently does not have a default value.
                         "LNDP_VAR_LIST": self._config.lndp_var_list,
                         "LNDP_PRT_LIST": self._config.lndp_prt_list
-        }
+                        }
 
         for (key, value) in nml_var_dict.items():
             setattr(cfg, key, value)

--- a/ush/python/pygfs/ufswm/gfs.py
+++ b/ush/python/pygfs/ufswm/gfs.py
@@ -255,64 +255,65 @@ class GFS(UFS):
         cfg = AttrDict()
 
         # TODO: Optional variables which may be set via `schema`.
-        nml_var_dict = {"CCPP_SUITE": self._config.CCPP_SUITE,
-                        "MAX_OUTPUT_FIELDS": 300,
-                        "INPES": self._config.layout_x,
-                        "JNPES": self._config.layout_y,
-                        "NPX": self._config.npx,
-                        "NPY": self._config.npy,
-                        "NPZ": self._config.npz,
-                        "MAKE_NH": self._config.make_nh,
-                        "NA_INIT": self._config.na_init,
-                        "DNATS": self._config.dnats,
-                        "EXTERNAL_IC": self._config.external_ic,
-                        "NGGPS_IC": self._config.nggps_ic,
-                        "MOUNTAIN": self._config.mountain,
-                        "WARM_START": self._config.warm_start,
-                        "READ_INCREMENT": self._config.read_increment,
-                        "RES_LATLON_DYNAMICS": self._config.res_latlon_dynamics,
-                        "NPZP": self._config.NLEVS,
-                        "FHZERO": self._config.FHZER,
-                        "LDIAG3D": False,  # TODO: default value
-                        "QDIAG3D": False,  # TODO: default value
-                        "FHCYC": self._config.FHCYC,
-                        "IAER": self._config.IAER,
-                        "IOVR": 3,  # TODO: default value
-                        "LHEATSTRG": False,  # TODO: default value
-                        "LSEASPRAY": True,  # TODO: default value
-                        "RANDOM_CLDS": True,  # TODO: default value
-                        "CNVCLD": True,  # TODO: default value
-                        "IMFSHALCNV": 2,  # TODO: default value
-                        "IMFDEEPCNV": 2,  # TODO: default value
-                        "RAS": False,  # TODO: default value
-                        "CDMBWD": [3.5, 0.25],  # TODO: default value
-                        "CPLCHM": False,  # TODO: default value
-                        "CPLWAV": False,  # TODO: default value
-                        "CPLWAV2ATM": False,  # TODO: default value
-                        "DO_SPPT": False,  # TODO: default value
-                        "DO_SHUM": False,  # TODO: default value
-                        "DO_SKEB": False,  # TODO: default value
-                        "N_VAR_LNDP": 0,  # TODO: default value
-                        "FSCAV_AERO": "*0.0",  # TODO: default value
-                        "DO_RRTMG": False,  # TODO: default value
-                        "DOGP_CLDOPTICS_LUT": False,  # TODO: default value
-                        "DOGP_LWSCAT": False,  # TODO: default value
-                        "PROGSIGMA": True,  # TODO: default value
-                        "FNALBC": self._config.FNALBC,
-                        "FNVETC": self._config.FNVETC,
-                        "FNSOTC": self._config.FNSOTC,
-                        "FNSMCC_control": self._config.FNSMCC,
-                        "FNMSKH_control": self._config.FNMSKH,
-                        "FNABSC": self._config.FNABSC,
-                        "STOCHINI": None,  # TODO: This currently does not have a default value.
-                        "SKEB": self._config.SKEB,
-                        "SHUM": self._config.SHUM,
-                        "SPPT": self._config.SPPT,
-                        "LNDP_TYPE": self._config.lndp_type,
-                        "LNDP_MODEL_TYPE": None,  # TODO: This currently does not have a default value.
-                        "LNDP_VAR_LIST": self._config.lndp_var_list,
-                        "LNDP_PRT_LIST": self._config.lndp_prt_list
-                        }
+        nml_var_dict = {
+            "CCPP_SUITE": self._config.CCPP_SUITE,
+            "MAX_OUTPUT_FIELDS": 300,
+            "INPES": self._config.layout_x,
+            "JNPES": self._config.layout_y,
+            "NPX": self._config.npx,
+            "NPY": self._config.npy,
+            "NPZ": self._config.npz,
+            "MAKE_NH": self._config.make_nh,
+            "NA_INIT": self._config.na_init,
+            "DNATS": self._config.dnats,
+            "EXTERNAL_IC": self._config.external_ic,
+            "NGGPS_IC": self._config.nggps_ic,
+            "MOUNTAIN": self._config.mountain,
+            "WARM_START": self._config.warm_start,
+            "READ_INCREMENT": self._config.read_increment,
+            "RES_LATLON_DYNAMICS": self._config.res_latlon_dynamics,
+            "NPZP": self._config.NLEVS,
+            "FHZERO": self._config.FHZER,
+            "LDIAG3D": False,  # TODO: default value
+            "QDIAG3D": False,  # TODO: default value
+            "FHCYC": self._config.FHCYC,
+            "IAER": self._config.IAER,
+            "IOVR": 3,  # TODO: default value
+            "LHEATSTRG": False,  # TODO: default value
+            "LSEASPRAY": True,  # TODO: default value
+            "RANDOM_CLDS": True,  # TODO: default value
+            "CNVCLD": True,  # TODO: default value
+            "IMFSHALCNV": 2,  # TODO: default value
+            "IMFDEEPCNV": 2,  # TODO: default value
+            "RAS": False,  # TODO: default value
+            "CDMBWD": [3.5, 0.25],  # TODO: default value
+            "CPLCHM": False,  # TODO: default value
+            "CPLWAV": False,  # TODO: default value
+            "CPLWAV2ATM": False,  # TODO: default value
+            "DO_SPPT": False,  # TODO: default value
+            "DO_SHUM": False,  # TODO: default value
+            "DO_SKEB": False,  # TODO: default value
+            "N_VAR_LNDP": 0,  # TODO: default value
+            "FSCAV_AERO": "*0.0",  # TODO: default value
+            "DO_RRTMG": False,  # TODO: default value
+            "DOGP_CLDOPTICS_LUT": False,  # TODO: default value
+            "DOGP_LWSCAT": False,  # TODO: default value
+            "PROGSIGMA": True,  # TODO: default value
+            "FNALBC": self._config.FNALBC,
+            "FNVETC": self._config.FNVETC,
+            "FNSOTC": self._config.FNSOTC,
+            "FNSMCC_control": self._config.FNSMCC,
+            "FNMSKH_control": self._config.FNMSKH,
+            "FNABSC": self._config.FNABSC,
+            "STOCHINI": None,  # TODO: This currently does not have a default value.
+            "SKEB": self._config.SKEB,
+            "SHUM": self._config.SHUM,
+            "SPPT": self._config.SPPT,
+            "LNDP_TYPE": self._config.lndp_type,
+            "LNDP_MODEL_TYPE": None,  # TODO: This currently does not have a default value.
+            "LNDP_VAR_LIST": self._config.lndp_var_list,
+            "LNDP_PRT_LIST": self._config.lndp_prt_list,
+        }
 
         for (key, value) in nml_var_dict.items():
             setattr(cfg, key, value)

--- a/ush/python/pygfs/ufswm/ufs.py
+++ b/ush/python/pygfs/ufswm/ufs.py
@@ -143,6 +143,18 @@ class UFS:
                 with open(tt, "r") as fih:
                     fh.write(fih.read())
 
+    def input_nml_build(self, tmpl: str, target: str) -> None:
+        """ 
+        Description
+        -----------
+
+        This method prepares and builds the `input.nml` file for
+        the UFS forecast.
+
+
+        """
+        pass
+
     def mdl_config_defs(self) -> AttrDict:
         """
         Description
@@ -163,6 +175,7 @@ class UFS:
 
         cfg = AttrDict()
 
+        # TODO: This could be cleaned up via a dictionary.
         cfg.SYEAR = self._config.current_cycle.year
         cfg.SMONTH = self._config.current_cycle.month
         cfg.SDAY = self._config.current_cycle.day

--- a/ush/python/pygfs/ufswm/ufs.py
+++ b/ush/python/pygfs/ufswm/ufs.py
@@ -144,7 +144,7 @@ class UFS:
                     fh.write(fih.read())
 
     def input_nml_build(self, tmpl: str, target: str) -> None:
-        """ 
+        """
         Description
         -----------
 


### PR DESCRIPTION
**Description**

This PR adds a method to define the default values for the UFS `input.nml` file. 

Note that this PR does not (yet) introduce UFS forecast capabilities as the `input.nml` requires other bits to be defined appropriately. Thus, this is an intermediate step prior to full implementation.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

The Python dictionary `cfg` is defined as expected.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
