### PR TITLE
functionality of JGDAS_GLOBAL_OCEAN_ANALYSIS_POST removed to script script

### DIFF
--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_POST
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_POST
@@ -11,48 +11,25 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "ocnanalpost" -c "base ocnanalpost"
 ##############################################
 
 export COMOUT=${COMOUT:-${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ocean}
+export COMOUTice=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ice
 export CDATE=${CDATE:-${PDY}${cyc}}
 
 mkdir -p "${COMOUT}"
+mkdir -p "${COMOUTice}/RESTART"
+
+# Add UFSDA to PYTHONPATH
+ufsdaPATH="${HOMEgfs}/sorc/gdas.cd/ush/"
+PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${ufsdaPATH}"
+export PYTHONPATH
 
 ###############################################################
 # Run relevant script
 ###############################################################
 
-# Save some of the DA cycle output to COMOUT
-# TODO: Move to a dedicated script
-
-# Make a copy the IAU increment
-cp "${DATA}/inc.nc" "${COMOUT}/${CDUMP}.t${cyc}z.ocninc.nc"
-
-# TODO: Dump-splash of the sea-ice restart not done yet
-
-# Copy of the ioda output files, as is for now
-cp -r "${DATA}/diags" "${COMOUT}"
-
-# Copy of the diagonal of the background error for the cycle
-bdate=$(date -d "${CDATE:0:8} ${CDATE:8:2} - 3 hours" +"%Y-%m-%dT%H:00:00Z")
-cp "${DATA}/ocn.bkgerr_stddev.incr.${bdate}.nc" "${COMOUT}/${CDUMP}.t${cyc}z.ocn.bkgerr_stddev.nc"
-cp "${DATA}/ice.bkgerr_stddev.incr.${bdate}.nc" "${COMOUT}/${CDUMP}.t${cyc}z.ice.bkgerr_stddev.nc"
-
-# Copy the loacalization and correlation operators
-cp -rL "${DATA}/bump" "${COMOUT}/bump"
-
-# Copy the analysis in the middle of the window
-cdate=$(date -d "${CDATE:0:8} ${CDATE:8:2}" +"%Y-%m-%dT%H:00:00Z")
-cp "${DATA}/Data/ocn.3dvarfgat_pseudo.an.${cdate}.nc" "${COMOUT}/${CDUMP}.t${cyc}z.ocnana.nc"
-
-# Copy DA grid (computed for the start of the window)
-bcyc=$(((cyc - 3 + 24) % 24))
-cp "${DATA}/soca_gridspec.nc" "${COMOUT}/${CDUMP}.t${bcyc}z.ocngrid.nc"
-
-# Copy logs
-mkdir -p "${COMOUT}/logs"
-cp "${DATA}"/*.out "${COMOUT}/logs"
-
-# Copy var.yaml
-mkdir -p "${COMOUT}/yaml"
-cp "${DATA}"/*.yaml "${COMOUT}/yaml"
+EXSCRIPT=${GDASPREPPY:-${HOMEgfs}/sorc/gdas.cd/scripts/exgdas_global_marine_analysis_post.py}
+${EXSCRIPT}
+status=$?
+[[ ${status} -ne 0 ]] && exit "${status}"
 
 ##########################################
 # Remove the Temporary working directory


### PR DESCRIPTION

**Description**

Addresses first bullet of https://github.com/NOAA-EMC/global-workflow/issues/1480

Removes most of content of JGDAS_GLOBAL_OCEAN_ANALYSIS_POST to scripts/exgdas_global_marine_analysis_post.py in GDASApp, now just calls that script


**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

Tested with GDASApp soca ctests on Hera
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
