### PR TITLE
Fix ocean anl path in staging

### DIFF
--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -88,7 +88,7 @@ def fill_COMROT_cycled(host, inputs):
         dst_med_dir = ''  # no mediator files for a "cold start"
         do_med = False
     dst_ocn_rst_dir = os.path.join('model_data', 'ocean', 'restart')
-    dst_ocn_anl_dir = os.path.join('model_data', 'ocean', 'analysis')
+    dst_ocn_anl_dir = os.path.join('analysis', 'ocean')
     dst_ice_dir = os.path.join('model_data', 'ice', 'restart')
     dst_atm_anl_dir = os.path.join('analysis', 'atmos')
 


### PR DESCRIPTION
**Description**
The path for ocean analysis files was not properly updated after analysis was moved out of model_data into its own directory. This is now corrected.

Fixes #1534

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Coupled warm-start experiment setup on Orion
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
