### PR TITLE
Enable ensemble forecast of coupled model

### DIFF
--- a/scripts/exgdas_enkf_fcst.sh
+++ b/scripts/exgdas_enkf_fcst.sh
@@ -155,7 +155,7 @@ for imem in $(seq $ENSBEG $ENSEND); do
    # Can't make these read-only because we are looping over members
    MEMDIR="${memchar}" YMD=${PDY} HH=${cyc} generate_com -x COM_ATMOS_RESTART COM_ATMOS_INPUT COM_ATMOS_ANALYSIS \
      COM_ATMOS_HISTORY COM_ATMOS_MASTER
-     
+
    RUN=${rCDUMP} MEMDIR="${memchar}" YMD="${gPDY}" HH="${gcyc}" generate_com -x COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
 
    if [[ ${DO_WAVE} == "YES" ]]; then
@@ -170,7 +170,7 @@ for imem in $(seq $ENSBEG $ENSEND); do
    fi
 
    if [[ ${DO_ICE} == "YES" ]]; then
-     MEMDIR="${memchar}" YMD=${PDY} HH=${cyc} generate_com -x COM_ICE_HISTORY
+     MEMDIR="${memchar}" YMD=${PDY} HH=${cyc} generate_com -x COM_ICE_HISTORY COM_ICE_INPUT COM_ICE_RESTART
      RUN=${rCDUMP} MEMDIR="${memchar}" YMD="${gPDY}" HH="${gcyc}" generate_com -x COM_ICE_RESTART_PREV:COM_ICE_RESTART_TMPL
    fi
 
@@ -178,7 +178,7 @@ for imem in $(seq $ENSBEG $ENSEND); do
      MEMDIR="${memchar}" YMD=${PDY} HH=${cyc} generate_com -x COM_CHEM_HISTORY
    fi
 
-   
+
    if [ $skip_mem = "NO" ]; then
 
       ra=0


### PR DESCRIPTION
**Description**
This PR:
- is a first in a number of PRs that will extend the capability mentioned in the title.
- allows a user to run an ensemble of coupled model forecasts with `APP=S2S`

The user will have to:
- set `DO_OCN` and `DO_ICE`  as `YES` in `config.efcs`.  They are currently wired to `NO`.  These toggle switches will be revisited 
- manufacture ensemble initial conditions for the coupled model.  In the test, the deterministic member was used to replicate as `mem001`, `mem002` ...

This work was trivial following the work done in PR #1421.  Thank you @WalterKolczynski-NOAA 

**Type of change**

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

**How Has This Been Tested?**

A forecast from the first half cycle was successfully executed on Hera.
The setup is exactly same as the case used by @guillaumevernieres at C48 with a 5 degree ocean.
In a future PR, self-cycling of the ocean and ice states will be tested.

A sample output from `mem001` is available on Hera at:
```
/scratch1/NCEPDEV/stmp2/Rahul.Mahajan/ROTDIR/s2scyc_h3d/enkfgdas.20210323/12/mem001
```
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [X] Any dependent changes have been merged and published
