### PR TITLE
Remove gdas bump fix files

### DIFF
--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -172,7 +172,7 @@ if [[ -d "${script_dir}/gdas.cd" ]]; then
   cd "${top_dir}/fix" || exit 1
     [[ ! -d gdas ]] && mkdir -p gdas
     cd gdas || exit 1
-    for gdas_sub in bump crtm fv3jedi gsibec; do
+    for gdas_sub in crtm fv3jedi gsibec; do
       if [[ -d "${gdas_sub}" ]]; then
          rm -rf "${gdas_sub}"
       fi

--- a/versions/fix.ver
+++ b/versions/fix.ver
@@ -7,7 +7,6 @@ export chem_ver=20220805
 export cice_ver=20220805
 export cpl_ver=20220805
 export datm_ver=20220805
-export gdas_bump_ver=20220805
 export gdas_crtm_ver=20220805
 export gdas_fv3jedi_ver=20220805
 export gdas_gsibec_ver=20221031


### PR DESCRIPTION
**Description**

This PR removes the `gdas/bump` fix file variable and symlink setup from global-workflow. See issue #1552 for more info.

Resolves #1552 

**Type of change**

Fix file retirement/cleanup.

**Testing**

Ran `./checkout.sh -u` and `./link_workflow.sh` in branch clone to confirm no errors introduced by removal of bump fix references.