### PR TITLE
Feature/pygw schema

### DIFF
--- a/ush/python/pygw/src/pygw/schema.py
+++ b/ush/python/pygw/src/pygw/schema.py
@@ -1,0 +1,780 @@
+"""schema is a library for validating Python data structures, such as those
+obtained from config-files, forms, external services or command-line
+parsing, converted from JSON/YAML (or something else) to Python data-types."""
+
+import inspect
+import re
+
+try:
+    from contextlib import ExitStack
+except ImportError:
+    from contextlib2 import ExitStack
+
+
+__version__ = "0.7.5"
+__all__ = [
+    "Schema",
+    "And",
+    "Or",
+    "Regex",
+    "Optional",
+    "Use",
+    "Forbidden",
+    "Const",
+    "Literal",
+    "SchemaError",
+    "SchemaWrongKeyError",
+    "SchemaMissingKeyError",
+    "SchemaForbiddenKeyError",
+    "SchemaUnexpectedTypeError",
+    "SchemaOnlyOneAllowedError",
+]
+
+
+class SchemaError(Exception):
+    """Error during Schema validation."""
+
+    def __init__(self, autos, errors=None):
+        self.autos = autos if type(autos) is list else [autos]
+        self.errors = errors if type(errors) is list else [errors]
+        Exception.__init__(self, self.code)
+
+    @property
+    def code(self):
+        """
+        Removes duplicates values in auto and error list.
+        parameters.
+        """
+
+        def uniq(seq):
+            """
+            Utility function that removes duplicate.
+            """
+            seen = set()
+            seen_add = seen.add
+            # This way removes duplicates while preserving the order.
+            return [x for x in seq if x not in seen and not seen_add(x)]
+
+        data_set = uniq(i for i in self.autos if i is not None)
+        error_list = uniq(i for i in self.errors if i is not None)
+        if error_list:
+            return "\n".join(error_list)
+        return "\n".join(data_set)
+
+
+class SchemaWrongKeyError(SchemaError):
+    """Error Should be raised when an unexpected key is detected within the
+    data set being."""
+
+    pass
+
+
+class SchemaMissingKeyError(SchemaError):
+    """Error should be raised when a mandatory key is not found within the
+    data set being validated"""
+
+    pass
+
+
+class SchemaOnlyOneAllowedError(SchemaError):
+    """Error should be raised when an only_one Or key has multiple matching candidates"""
+
+    pass
+
+
+class SchemaForbiddenKeyError(SchemaError):
+    """Error should be raised when a forbidden key is found within the
+    data set being validated, and its value matches the value that was specified"""
+
+    pass
+
+
+class SchemaUnexpectedTypeError(SchemaError):
+    """Error should be raised when a type mismatch is detected within the
+    data set being validated."""
+
+    pass
+
+
+class And(object):
+    """
+    Utility function to combine validation directives in AND Boolean fashion.
+    """
+
+    def __init__(self, *args, **kw):
+        self._args = args
+        if not set(kw).issubset({"error", "schema", "ignore_extra_keys"}):
+            diff = {"error", "schema", "ignore_extra_keys"}.difference(kw)
+            raise TypeError("Unknown keyword arguments %r" % list(diff))
+        self._error = kw.get("error")
+        self._ignore_extra_keys = kw.get("ignore_extra_keys", False)
+        # You can pass your inherited Schema class.
+        self._schema = kw.get("schema", Schema)
+
+    def __repr__(self):
+        return "%s(%s)" % (self.__class__.__name__, ", ".join(repr(a) for a in self._args))
+
+    @property
+    def args(self):
+        """The provided parameters"""
+        return self._args
+
+    def validate(self, data, **kwargs):
+        """
+        Validate data using defined sub schema/expressions ensuring all
+        values are valid.
+        :param data: to be validated with sub defined schemas.
+        :return: returns validated data
+        """
+        for s in [self._schema(s, error=self._error, ignore_extra_keys=self._ignore_extra_keys) for s in self._args]:
+            data = s.validate(data, **kwargs)
+        return data
+
+
+class Or(And):
+    """Utility function to combine validation directives in a OR Boolean
+    fashion."""
+
+    def __init__(self, *args, **kwargs):
+        self.only_one = kwargs.pop("only_one", False)
+        self.match_count = 0
+        super(Or, self).__init__(*args, **kwargs)
+
+    def reset(self):
+        failed = self.match_count > 1 and self.only_one
+        self.match_count = 0
+        if failed:
+            raise SchemaOnlyOneAllowedError(["There are multiple keys present " + "from the %r condition" % self])
+
+    def validate(self, data, **kwargs):
+        """
+        Validate data using sub defined schema/expressions ensuring at least
+        one value is valid.
+        :param data: data to be validated by provided schema.
+        :return: return validated data if not validation
+        """
+        autos, errors = [], []
+        for s in [self._schema(s, error=self._error, ignore_extra_keys=self._ignore_extra_keys) for s in self._args]:
+            try:
+                validation = s.validate(data, **kwargs)
+                self.match_count += 1
+                if self.match_count > 1 and self.only_one:
+                    break
+                return validation
+            except SchemaError as _x:
+                autos += _x.autos
+                errors += _x.errors
+        raise SchemaError(
+            ["%r did not validate %r" % (self, data)] + autos,
+            [self._error.format(data) if self._error else None] + errors,
+        )
+
+
+class Regex(object):
+    """
+    Enables schema.py to validate string using regular expressions.
+    """
+
+    # Map all flags bits to a more readable description
+    NAMES = [
+        "re.ASCII",
+        "re.DEBUG",
+        "re.VERBOSE",
+        "re.UNICODE",
+        "re.DOTALL",
+        "re.MULTILINE",
+        "re.LOCALE",
+        "re.IGNORECASE",
+        "re.TEMPLATE",
+    ]
+
+    def __init__(self, pattern_str, flags=0, error=None):
+        self._pattern_str = pattern_str
+        flags_list = [
+            Regex.NAMES[i] for i, f in enumerate("{0:09b}".format(int(flags))) if f != "0"
+        ]  # Name for each bit
+
+        if flags_list:
+            self._flags_names = ", flags=" + "|".join(flags_list)
+        else:
+            self._flags_names = ""
+
+        self._pattern = re.compile(pattern_str, flags=flags)
+        self._error = error
+
+    def __repr__(self):
+        return "%s(%r%s)" % (self.__class__.__name__, self._pattern_str, self._flags_names)
+
+    @property
+    def pattern_str(self):
+        """The pattern for the represented regular expression"""
+        return self._pattern_str
+
+    def validate(self, data, **kwargs):
+        """
+        Validated data using defined regex.
+        :param data: data to be validated
+        :return: return validated data.
+        """
+        e = self._error
+
+        try:
+            if self._pattern.search(data):
+                return data
+            else:
+                raise SchemaError("%r does not match %r" % (self, data), e.format(data) if e else None)
+        except TypeError:
+            raise SchemaError("%r is not string nor buffer" % data, e)
+
+
+class Use(object):
+    """
+    For more general use cases, you can use the Use class to transform
+    the data while it is being validate.
+    """
+
+    def __init__(self, callable_, error=None):
+        if not callable(callable_):
+            raise TypeError("Expected a callable, not %r" % callable_)
+        self._callable = callable_
+        self._error = error
+
+    def __repr__(self):
+        return "%s(%r)" % (self.__class__.__name__, self._callable)
+
+    def validate(self, data, **kwargs):
+        try:
+            return self._callable(data)
+        except SchemaError as x:
+            raise SchemaError([None] + x.autos, [self._error.format(data) if self._error else None] + x.errors)
+        except BaseException as x:
+            f = _callable_str(self._callable)
+            raise SchemaError("%s(%r) raised %r" % (f, data, x), self._error.format(data) if self._error else None)
+
+
+COMPARABLE, CALLABLE, VALIDATOR, TYPE, DICT, ITERABLE = range(6)
+
+
+def _priority(s):
+    """Return priority for a given object."""
+    if type(s) in (list, tuple, set, frozenset):
+        return ITERABLE
+    if type(s) is dict:
+        return DICT
+    if issubclass(type(s), type):
+        return TYPE
+    if isinstance(s, Literal):
+        return COMPARABLE
+    if hasattr(s, "validate"):
+        return VALIDATOR
+    if callable(s):
+        return CALLABLE
+    else:
+        return COMPARABLE
+
+
+def _invoke_with_optional_kwargs(f, **kwargs):
+    s = inspect.signature(f)
+    if len(s.parameters) == 0:
+        return f()
+    return f(**kwargs)
+
+
+class Schema(object):
+    """
+    Entry point of the library, use this class to instantiate validation
+    schema for the data that will be validated.
+    """
+
+    def __init__(self, schema, error=None, ignore_extra_keys=False, name=None, description=None, as_reference=False):
+        self._schema = schema
+        self._error = error
+        self._ignore_extra_keys = ignore_extra_keys
+        self._name = name
+        self._description = description
+        # Ask json_schema to create a definition for this schema and use it as part of another
+        self.as_reference = as_reference
+        if as_reference and name is None:
+            raise ValueError("Schema used as reference should have a name")
+
+    def __repr__(self):
+        return "%s(%r)" % (self.__class__.__name__, self._schema)
+
+    @property
+    def schema(self):
+        return self._schema
+
+    @property
+    def description(self):
+        return self._description
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def ignore_extra_keys(self):
+        return self._ignore_extra_keys
+
+    @staticmethod
+    def _dict_key_priority(s):
+        """Return priority for a given key object."""
+        if isinstance(s, Hook):
+            return _priority(s._schema) - 0.5
+        if isinstance(s, Optional):
+            return _priority(s._schema) + 0.5
+        return _priority(s)
+
+    @staticmethod
+    def _is_optional_type(s):
+        """Return True if the given key is optional (does not have to be found)"""
+        return any(isinstance(s, optional_type) for optional_type in [Optional, Hook])
+
+    def is_valid(self, data, **kwargs):
+        """Return whether the given data has passed all the validations
+        that were specified in the given schema.
+        """
+        try:
+            self.validate(data, **kwargs)
+        except SchemaError:
+            return False
+        else:
+            return True
+
+    def _prepend_schema_name(self, message):
+        """
+        If a custom schema name has been defined, prepends it to the error
+        message that gets raised when a schema error occurs.
+        """
+        if self._name:
+            message = "{0!r} {1!s}".format(self._name, message)
+        return message
+
+    def validate(self, data, **kwargs):
+        Schema = self.__class__
+        s = self._schema
+        e = self._error
+        i = self._ignore_extra_keys
+
+        if isinstance(s, Literal):
+            s = s.schema
+
+        flavor = _priority(s)
+        if flavor == ITERABLE:
+            data = Schema(type(s), error=e).validate(data, **kwargs)
+            o = Or(*s, error=e, schema=Schema, ignore_extra_keys=i)
+            return type(data)(o.validate(d, **kwargs) for d in data)
+        if flavor == DICT:
+            exitstack = ExitStack()
+            data = Schema(dict, error=e).validate(data, **kwargs)
+            new = type(data)()  # new - is a dict of the validated values
+            coverage = set()  # matched schema keys
+            # for each key and value find a schema entry matching them, if any
+            sorted_skeys = sorted(s, key=self._dict_key_priority)
+            for skey in sorted_skeys:
+                if hasattr(skey, "reset"):
+                    exitstack.callback(skey.reset)
+
+            with exitstack:
+                # Evaluate dictionaries last
+                data_items = sorted(data.items(), key=lambda value: isinstance(value[1], dict))
+                for key, value in data_items:
+                    for skey in sorted_skeys:
+                        svalue = s[skey]
+                        try:
+                            nkey = Schema(skey, error=e).validate(key, **kwargs)
+                        except SchemaError:
+                            pass
+                        else:
+                            if isinstance(skey, Hook):
+                                # As the content of the value makes little sense for
+                                # keys with a hook, we reverse its meaning:
+                                # we will only call the handler if the value does match
+                                # In the case of the forbidden key hook,
+                                # we will raise the SchemaErrorForbiddenKey exception
+                                # on match, allowing for excluding a key only if its
+                                # value has a certain type, and allowing Forbidden to
+                                # work well in combination with Optional.
+                                try:
+                                    nvalue = Schema(svalue, error=e).validate(value, **kwargs)
+                                except SchemaError:
+                                    continue
+                                skey.handler(nkey, data, e)
+                            else:
+                                try:
+                                    nvalue = Schema(svalue, error=e, ignore_extra_keys=i).validate(value, **kwargs)
+                                except SchemaError as x:
+                                    k = "Key '%s' error:" % nkey
+                                    message = self._prepend_schema_name(k)
+                                    raise SchemaError([message] + x.autos, [e.format(data) if e else None] + x.errors)
+                                else:
+                                    new[nkey] = nvalue
+                                    coverage.add(skey)
+                                    break
+            required = set(k for k in s if not self._is_optional_type(k))
+            if not required.issubset(coverage):
+                missing_keys = required - coverage
+                s_missing_keys = ", ".join(repr(k) for k in sorted(missing_keys, key=repr))
+                message = "Missing key%s: %s" % (_plural_s(missing_keys), s_missing_keys)
+                message = self._prepend_schema_name(message)
+                raise SchemaMissingKeyError(message, e.format(data) if e else None)
+            if not self._ignore_extra_keys and (len(new) != len(data)):
+                wrong_keys = set(data.keys()) - set(new.keys())
+                s_wrong_keys = ", ".join(repr(k) for k in sorted(wrong_keys, key=repr))
+                message = "Wrong key%s %s in %r" % (_plural_s(wrong_keys), s_wrong_keys, data)
+                message = self._prepend_schema_name(message)
+                raise SchemaWrongKeyError(message, e.format(data) if e else None)
+
+            # Apply default-having optionals that haven't been used:
+            defaults = set(k for k in s if isinstance(k, Optional) and hasattr(k, "default")) - coverage
+            for default in defaults:
+                new[default.key] = _invoke_with_optional_kwargs(default.default, **kwargs) if callable(default.default) else default.default
+
+            return new
+        if flavor == TYPE:
+            if isinstance(data, s) and not (isinstance(data, bool) and s == int):
+                return data
+            else:
+                message = "%r should be instance of %r" % (data, s.__name__)
+                message = self._prepend_schema_name(message)
+                raise SchemaUnexpectedTypeError(message, e.format(data) if e else None)
+        if flavor == VALIDATOR:
+            try:
+                return s.validate(data, **kwargs)
+            except SchemaError as x:
+                raise SchemaError([None] + x.autos, [e.format(data) if e else None] + x.errors)
+            except BaseException as x:
+                message = "%r.validate(%r) raised %r" % (s, data, x)
+                message = self._prepend_schema_name(message)
+                raise SchemaError(message, e.format(data) if e else None)
+        if flavor == CALLABLE:
+            f = _callable_str(s)
+            try:
+                if s(data):
+                    return data
+            except SchemaError as x:
+                raise SchemaError([None] + x.autos, [e.format(data) if e else None] + x.errors)
+            except BaseException as x:
+                message = "%s(%r) raised %r" % (f, data, x)
+                message = self._prepend_schema_name(message)
+                raise SchemaError(message, e.format(data) if e else None)
+            message = "%s(%r) should evaluate to True" % (f, data)
+            message = self._prepend_schema_name(message)
+            raise SchemaError(message, e.format(data) if e else None)
+        if s == data:
+            return data
+        else:
+            message = "%r does not match %r" % (s, data)
+            message = self._prepend_schema_name(message)
+            raise SchemaError(message, e.format(data) if e else None)
+
+    def json_schema(self, schema_id, use_refs=False, **kwargs):
+        """Generate a draft-07 JSON schema dict representing the Schema.
+        This method must be called with a schema_id.
+
+        :param schema_id: The value of the $id on the main schema
+        :param use_refs: Enable reusing object references in the resulting JSON schema.
+                         Schemas with references are harder to read by humans, but are a lot smaller when there
+                         is a lot of reuse
+        """
+
+        seen = dict()  # For use_refs
+        definitions_by_name = {}
+
+        def _json_schema(schema, is_main_schema=True, description=None, allow_reference=True):
+            Schema = self.__class__
+
+            def _create_or_use_ref(return_dict):
+                """If not already seen, return the provided part of the schema unchanged.
+                If already seen, give an id to the already seen dict and return a reference to the previous part
+                of the schema instead.
+                """
+                if not use_refs or is_main_schema:
+                    return return_schema
+
+                hashed = hash(repr(sorted(return_dict.items())))
+
+                if hashed not in seen:
+                    seen[hashed] = return_dict
+                    return return_dict
+                else:
+                    id_str = "#" + str(hashed)
+                    seen[hashed]["$id"] = id_str
+                    return {"$ref": id_str}
+
+            def _get_type_name(python_type):
+                """Return the JSON schema name for a Python type"""
+                if python_type == str:
+                    return "string"
+                elif python_type == int:
+                    return "integer"
+                elif python_type == float:
+                    return "number"
+                elif python_type == bool:
+                    return "boolean"
+                elif python_type == list:
+                    return "array"
+                elif python_type == dict:
+                    return "object"
+                return "string"
+
+            def _to_json_type(value):
+                """Attempt to convert a constant value (for "const" and "default") to a JSON serializable value"""
+                if value is None or type(value) in (str, int, float, bool, list, dict):
+                    return value
+
+                if type(value) in (tuple, set, frozenset):
+                    return list(value)
+
+                if isinstance(value, Literal):
+                    return value.schema
+
+                return str(value)
+
+            def _to_schema(s, ignore_extra_keys):
+                if not isinstance(s, Schema):
+                    return Schema(s, ignore_extra_keys=ignore_extra_keys)
+
+                return s
+
+            s = schema.schema
+            i = schema.ignore_extra_keys
+            flavor = _priority(s)
+
+            return_schema = {}
+
+            return_description = description or schema.description
+            if return_description:
+                return_schema["description"] = return_description
+
+            # Check if we have to create a common definition and use as reference
+            if allow_reference and schema.as_reference:
+                # Generate sub schema if not already done
+                if schema.name not in definitions_by_name:
+                    definitions_by_name[schema.name] = {}  # Avoid infinite loop
+                    definitions_by_name[schema.name] = _json_schema(schema, is_main_schema=False, allow_reference=False)
+
+                return_schema["$ref"] = "#/definitions/" + schema.name
+            else:
+                if flavor == TYPE:
+                    # Handle type
+                    return_schema["type"] = _get_type_name(s)
+                elif flavor == ITERABLE:
+                    # Handle arrays or dict schema
+
+                    return_schema["type"] = "array"
+                    if len(s) == 1:
+                        return_schema["items"] = _json_schema(_to_schema(s[0], i), is_main_schema=False)
+                    elif len(s) > 1:
+                        return_schema["items"] = _json_schema(Schema(Or(*s)), is_main_schema=False)
+                elif isinstance(s, Or):
+                    # Handle Or values
+
+                    # Check if we can use an enum
+                    if all(priority == COMPARABLE for priority in [_priority(value) for value in s.args]):
+                        or_values = [str(s) if isinstance(s, Literal) else s for s in s.args]
+                        # All values are simple, can use enum or const
+                        if len(or_values) == 1:
+                            return_schema["const"] = _to_json_type(or_values[0])
+                            return return_schema
+                        return_schema["enum"] = or_values
+                    else:
+                        # No enum, let's go with recursive calls
+                        any_of_values = []
+                        for or_key in s.args:
+                            new_value = _json_schema(_to_schema(or_key, i), is_main_schema=False)
+                            if new_value != {} and new_value not in any_of_values:
+                                any_of_values.append(new_value)
+                        if len(any_of_values) == 1:
+                            # Only one representable condition remains, do not put under anyOf
+                            return_schema.update(any_of_values[0])
+                        else:
+                            return_schema["anyOf"] = any_of_values
+                elif isinstance(s, And):
+                    # Handle And values
+                    all_of_values = []
+                    for and_key in s.args:
+                        new_value = _json_schema(_to_schema(and_key, i), is_main_schema=False)
+                        if new_value != {} and new_value not in all_of_values:
+                            all_of_values.append(new_value)
+                    if len(all_of_values) == 1:
+                        # Only one representable condition remains, do not put under allOf
+                        return_schema.update(all_of_values[0])
+                    else:
+                        return_schema["allOf"] = all_of_values
+                elif flavor == COMPARABLE:
+                    return_schema["const"] = _to_json_type(s)
+                elif flavor == VALIDATOR and type(s) == Regex:
+                    return_schema["type"] = "string"
+                    return_schema["pattern"] = s.pattern_str
+                else:
+                    if flavor != DICT:
+                        # If not handled, do not check
+                        return return_schema
+
+                    # Schema is a dict
+
+                    required_keys = []
+                    expanded_schema = {}
+                    additional_properties = i
+                    for key in s:
+                        if isinstance(key, Hook):
+                            continue
+
+                        def _key_allows_additional_properties(key):
+                            """Check if a key is broad enough to allow additional properties"""
+                            if isinstance(key, Optional):
+                                return _key_allows_additional_properties(key.schema)
+
+                            return key == str or key == object
+
+                        def _get_key_description(key):
+                            """Get the description associated to a key (as specified in a Literal object). Return None if not a Literal"""
+                            if isinstance(key, Optional):
+                                return _get_key_description(key.schema)
+
+                            if isinstance(key, Literal):
+                                return key.description
+
+                            return None
+
+                        def _get_key_name(key):
+                            """Get the name of a key (as specified in a Literal object). Return the key unchanged if not a Literal"""
+                            if isinstance(key, Optional):
+                                return _get_key_name(key.schema)
+
+                            if isinstance(key, Literal):
+                                return key.schema
+
+                            return key
+
+                        additional_properties = additional_properties or _key_allows_additional_properties(key)
+                        sub_schema = _to_schema(s[key], ignore_extra_keys=i)
+                        key_name = _get_key_name(key)
+
+                        if isinstance(key_name, str):
+                            if not isinstance(key, Optional):
+                                required_keys.append(key_name)
+                            expanded_schema[key_name] = _json_schema(
+                                sub_schema, is_main_schema=False, description=_get_key_description(key)
+                            )
+                            if isinstance(key, Optional) and hasattr(key, "default"):
+                                expanded_schema[key_name]["default"] = _to_json_type(_invoke_with_optional_kwargs(key.default, **kwargs) if callable(key.default) else key.default)
+                        elif isinstance(key_name, Or):
+                            # JSON schema does not support having a key named one name or another, so we just add both options
+                            # This is less strict because we cannot enforce that one or the other is required
+
+                            for or_key in key_name.args:
+                                expanded_schema[_get_key_name(or_key)] = _json_schema(
+                                    sub_schema, is_main_schema=False, description=_get_key_description(or_key)
+                                )
+
+                    return_schema.update(
+                        {
+                            "type": "object",
+                            "properties": expanded_schema,
+                            "required": required_keys,
+                            "additionalProperties": additional_properties,
+                        }
+                    )
+
+            if is_main_schema:
+                return_schema.update({"$id": schema_id, "$schema": "http://json-schema.org/draft-07/schema#"})
+                if self._name:
+                    return_schema["title"] = self._name
+
+                if definitions_by_name:
+                    return_schema["definitions"] = {}
+                    for definition_name, definition in definitions_by_name.items():
+                        return_schema["definitions"][definition_name] = definition
+
+            return _create_or_use_ref(return_schema)
+
+        return _json_schema(self, True)
+
+
+class Optional(Schema):
+    """Marker for an optional part of the validation Schema."""
+
+    _MARKER = object()
+
+    def __init__(self, *args, **kwargs):
+        default = kwargs.pop("default", self._MARKER)
+        super(Optional, self).__init__(*args, **kwargs)
+        if default is not self._MARKER:
+            # See if I can come up with a static key to use for myself:
+            if _priority(self._schema) != COMPARABLE:
+                raise TypeError(
+                    "Optional keys with defaults must have simple, "
+                    "predictable values, like literal strings or ints. "
+                    '"%r" is too complex.' % (self._schema,)
+                )
+            self.default = default
+            self.key = str(self._schema)
+
+    def __hash__(self):
+        return hash(self._schema)
+
+    def __eq__(self, other):
+        return (
+            self.__class__ is other.__class__
+            and getattr(self, "default", self._MARKER) == getattr(other, "default", self._MARKER)
+            and self._schema == other._schema
+        )
+
+    def reset(self):
+        if hasattr(self._schema, "reset"):
+            self._schema.reset()
+
+
+class Hook(Schema):
+    def __init__(self, *args, **kwargs):
+        self.handler = kwargs.pop("handler", lambda *args: None)
+        super(Hook, self).__init__(*args, **kwargs)
+        self.key = self._schema
+
+
+class Forbidden(Hook):
+    def __init__(self, *args, **kwargs):
+        kwargs["handler"] = self._default_function
+        super(Forbidden, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    def _default_function(nkey, data, error):
+        raise SchemaForbiddenKeyError("Forbidden key encountered: %r in %r" % (nkey, data), error)
+
+
+class Literal(object):
+    def __init__(self, value, description=None):
+        self._schema = value
+        self._description = description
+
+    def __str__(self):
+        return self._schema
+
+    def __repr__(self):
+        return 'Literal("' + self.schema + '", description="' + (self.description or "") + '")'
+
+    @property
+    def description(self):
+        return self._description
+
+    @property
+    def schema(self):
+        return self._schema
+
+
+class Const(Schema):
+    def validate(self, data, **kwargs):
+        super(Const, self).validate(data, **kwargs)
+        return data
+
+
+def _callable_str(callable_):
+    if hasattr(callable_, "__name__"):
+        return callable_.__name__
+    return str(callable_)
+
+
+def _plural_s(sized):
+    return "s" if len(sized) > 1 else ""

--- a/ush/python/pygw/src/schema_pkg/build_schema.py
+++ b/ush/python/pygw/src/schema_pkg/build_schema.py
@@ -1,0 +1,142 @@
+import logging
+from pydoc import locate
+from typing import Dict
+
+import pygw.yaml_file
+from pygw.attrdict import AttrDict
+from pygw.logger import logit
+from pygw.schema import Optional, Schema
+
+# ----
+
+logger = logging.getLogger(__name__.split(".")[-1])
+
+# ----
+
+__all__ = ["BuildSchema"]
+
+# ----
+
+
+class BuildSchema:
+    """
+    Description
+    -----------
+
+    This is the base-class object for setting up and defining the
+    schema for a give application; it is based on
+    https://tinyurl.com/pyutils-schema-build.
+
+    Parameters
+    ----------
+
+    yaml_file: str
+
+        A Python string containg the YAML-formatted file path
+        containing the schema; the YAML-formatted file containing the
+        schema attributes should be formatted similar to the example
+        below.
+
+        required:
+            variable1: bool
+            variable2: float
+            variable3: int
+
+        optional:
+            variable4:
+                type: bool
+                default: False
+            variable5:
+                type: bool
+                default: True
+            variable6:
+                type: float
+                default: 1.0
+
+    """
+
+    @logit(logger, name="BuildSchema")
+    def __init__(self: object, yaml_file: str):
+        """
+        Description
+        -----------
+
+        Creates a new BuildSchema object.
+
+        """
+
+        # Define the base-class attributes.
+        self.schema = {}
+        self.data = pygw.yaml_file.parse_yaml(path=yaml_file)
+
+    @logit(logger)
+    def reqschema(self: object) -> None:
+        """
+        Description
+        -----------
+
+        Collect any required schema attributes from the schema YAML
+        file.
+
+        """
+
+        try:
+            reqdict = self.data["required"]
+            if len(reqdict) > 0:
+                for (key, value) in reqdict.items():
+                    self.schema[key] = locate(value)
+        except KeyError:
+            # TODO: A logger warning informing the user that no
+            # required attributes were determined from the YAML
+            # file; this would be useful for debugging.
+            pass
+
+    @logit(logger)
+    def optschema(self: object) -> None:
+        """
+        Description
+        -----------
+
+        Collect any optional schema attributes and the default values
+        from the schema YAML file.
+
+        """
+
+        try:
+            optdict = self.data["optional"]
+            if len(optdict) > 0:
+                for (key, value) in optdict.items():
+                    vardef = value["default"]
+                    vartyp = value["type"]
+                    self.schema[Optional(key, default=vardef)] = locate(vartyp)
+        except KeyError:
+            # TODO: A logger warning informing the user that no
+            # optional attributes were determined from the YAML file;
+            # this would be useful for debugging.
+            pass
+
+    @logit(logger)
+    def build(self) -> None:
+        """
+        Description
+        -----------
+
+        This method performs the following tasks.
+
+        - Builds the required (if any) schema attributes.
+
+        - Build the optional (if any) schema attributes.
+
+        Returns
+        -------
+
+        self.schema: Dict
+
+            A Python dictionary containing the schema attributes.
+
+        """
+
+        self.reqschema()
+        self.optschema()
+
+        return self.schema

--- a/ush/python/pygw/src/schema_pkg/check_schema.py
+++ b/ush/python/pygw/src/schema_pkg/check_schema.py
@@ -1,0 +1,93 @@
+import logging
+from typing import Dict
+
+from pygw.logger import logit
+import pygw.schema
+from pygw.schema import Schema
+
+# ----
+
+logger = logging.getLogger(__name__.split(".")[-1])
+
+# ----
+
+__all__ = ["CheckSchema"]
+
+# ----
+
+
+class CheckSchema:
+    """
+    Description
+    -----------
+
+    This is the base-class object for schema validation.
+
+    Parameters
+    ----------
+
+    cls_schema: Dict
+
+        A Python dictionary containing the schema; these are the
+        attributes against which a given set of options (see
+        `cls_opts`) would be compared.
+
+    cls_opts: Dict
+
+        A Python dictionary containing the provide application
+        attributes; if the respective attribute datatypes in this
+        dictionary do not match that of the schema (see `cls_schema`)
+        an exception will be raised.
+
+    """
+
+    @logit(logger, name="CheckSchema")
+    def __init__(self: object, cls_schema: Dict, cls_opts: Dict):
+        """
+        Description
+        -----------
+
+        Creates a new CheckSchema object.
+
+        """
+
+        # Define the base-class attributes.
+        self.cls_schema = cls_schema
+        self.cls_opts = cls_opts
+
+    @logit(logger)
+    def defaults(self: object) -> None:
+        """
+        Description
+        -----------
+
+        This method parses the calling class options (`cls_opts`),
+        determines the optional values from the call class schema
+        (`cls_schema`) and update `cls_opts` accordingly.
+
+        """
+        for (key, value) in self.cls_schema.items():
+
+            # TODO: This may need to be updated.
+            if isinstance(key, pygw.schema.Optional):
+                if key not in self.cls_opts:
+                    self.cls_opts[key] = key.default
+
+    @logit(logger)
+    def validate(self: object) -> None:
+        """
+        Description
+        -----------
+
+        Validates the schema.
+
+        """
+
+        # Update any not-specified optional schema values with the
+        # default values if not specified explicitly.
+        self.defaults()
+        schema = Schema([self.cls_schema], ignore_extra_keys=True)
+        schema.validate([self.cls_opts])
+
+        # TODO: A logger message and exception if the validation fails
+        # would be useful here.

--- a/ush/python/pygw/src/schema_pkg/check_schema.py
+++ b/ush/python/pygw/src/schema_pkg/check_schema.py
@@ -66,12 +66,16 @@ class CheckSchema:
         (`cls_schema`) and update `cls_opts` accordingly.
 
         """
+
         for (key, value) in self.cls_schema.items():
 
             # TODO: This may need to be updated.
             if isinstance(key, pygw.schema.Optional):
+
+                # TODO: This will need to be cleanup up; it will be
+                # confusing otherwise.
                 if key not in self.cls_opts:
-                    self.cls_opts[key] = key.default
+                    self.cls_opts[key.key] = key.default
 
     @logit(logger)
     def validate(self: object) -> None:
@@ -91,3 +95,4 @@ class CheckSchema:
 
         # TODO: A logger message and exception if the validation fails
         # would be useful here.
+        return self.cls_opts

--- a/ush/python/pygw/src/schema_pkg/model_configure.out
+++ b/ush/python/pygw/src/schema_pkg/model_configure.out
@@ -1,0 +1,21 @@
+start_year:              2000
+start_month:             1
+start_day:               1
+start_hour:              0
+start_minute:            0
+start_second:            0
+nhours_fcst:             120
+
+dt_atmos:                1200
+output_1st_tstep_rst:    .false.
+
+write_groups:            1
+write_tasks_per_group:   4
+output_history:          @[OUTPUT_HISTORY]
+write_dopost:            @[WRITE_DOPOST]
+write_nsflip:            @[WRITE_NSFLIP]
+num_files:               @[NUM_FILES]
+filename_base:           @[FILENAME_BASE]
+imo:                     384
+jmo:                     192
+

--- a/ush/python/pygw/src/schema_pkg/model_configure.out
+++ b/ush/python/pygw/src/schema_pkg/model_configure.out
@@ -10,12 +10,12 @@ dt_atmos:                1200
 output_1st_tstep_rst:    .false.
 
 write_groups:            1
-write_tasks_per_group:   4
-output_history:          @[OUTPUT_HISTORY]
-write_dopost:            @[WRITE_DOPOST]
-write_nsflip:            @[WRITE_NSFLIP]
-num_files:               @[NUM_FILES]
-filename_base:           @[FILENAME_BASE]
+write_tasks_per_group:   1
+output_history:          True
+write_dopost:            True
+write_nsflip:            True
+num_files:               2
+filename_base:           'atm' 'sfc'
 imo:                     384
 jmo:                     192
 

--- a/ush/python/pygw/src/schema_pkg/test_files/model_configure.schema.yaml
+++ b/ush/python/pygw/src/schema_pkg/test_files/model_configure.schema.yaml
@@ -1,0 +1,70 @@
+required:
+
+    DT_ATMOS: int
+    FHMAX: int
+    IMO: int
+    JMO: int
+    SDAY: int
+    SHOUR: int
+    SMONTH: int
+    SYEAR: int
+
+optional:
+
+    CALENDAR:
+         type: str
+         default: julian
+    FHROT:
+         type: int
+         default: 0
+    FILENAME_BASE:
+         type: str
+         default: "'atm' 'sfc'"
+    IAU_OFFSET:
+         type: int
+         default: 0
+    IDEFLATE:
+         type: int
+         default: 1
+    ITASKS:
+         type: int
+         default: 1
+    NBITS:
+         type: int
+         default: 1
+    NUM_FILES:
+         type: int
+         default: 2
+    OUTPUT_FILE:
+         type: str
+         default: "'netcdf' 'netcdf'"
+    OUTPUT_GRID:
+         type: str
+         default: gaussian_grid
+    OUTPUT_HISTORY:
+         type: bool
+         default: True
+    QUILTING:
+         type: bool
+         default: True
+    RESTART_INTERVAL:
+         type: int
+         default: 0
+    SMINUTE:
+         type: int
+         default: 0
+    SSECOND:
+         type: int
+         default: 0
+    WRITE_DOPOST:
+         type: bool
+         default: True
+    WRITE_GROUP:
+         type: int
+         default: 1
+    WRITE_NSFLIP:
+         type: bool
+         default: True
+    WRTTASK_PER_GROUP:
+         type: int
+         default: 1

--- a/ush/python/pygw/src/schema_pkg/test_files/model_configure.template
+++ b/ush/python/pygw/src/schema_pkg/test_files/model_configure.template
@@ -1,0 +1,21 @@
+start_year:              @[SYEAR]
+start_month:             @[SMONTH]
+start_day:               @[SDAY]
+start_hour:              @[SHOUR]
+start_minute:            0
+start_second:            0
+nhours_fcst:             @[FHMAX]
+
+dt_atmos:                @[DT_ATMOS]
+output_1st_tstep_rst:    .false.
+
+write_groups:            @[WRITE_GROUP]
+write_tasks_per_group:   @[WRTTASK_PER_GROUP]
+output_history:          @[OUTPUT_HISTORY]
+write_dopost:            @[WRITE_DOPOST]
+write_nsflip:            @[WRITE_NSFLIP]
+num_files:               @[NUM_FILES]
+filename_base:           @[FILENAME_BASE]
+imo:                     @[IMO]
+jmo:                     @[JMO]
+

--- a/ush/python/pygw/src/schema_pkg/test_schema.py
+++ b/ush/python/pygw/src/schema_pkg/test_schema.py
@@ -40,7 +40,7 @@ TEST_SCHEMA = {"DT_ATMOS": 1200,
                "WRTTASK_PER_GROUP": 4,
 
                # TODO: This needs to be transformed via `f90_bool`.
-               "WRITE_DO_POST": True,
+               "WRITE_DOPOST": True,
                }
 
 # ----
@@ -60,11 +60,11 @@ def main() -> None:
     cls_schema = BuildSchema(yaml_file=schema_yaml).build()
 
     # Attempt to validate the schemas.
-    CheckSchema(cls_schema=cls_schema,
-                cls_opts=TEST_SCHEMA).validate()
+    cfg = CheckSchema(cls_schema=cls_schema,
+                      cls_opts=TEST_SCHEMA).validate()
 
     # Create the file based on the specified template.
-    WriteFromTemplate(cfg=TEST_SCHEMA, tmpl=tmpl_path,
+    WriteFromTemplate(cfg=cfg, tmpl=tmpl_path,
                       output=out_path).write()
 
 

--- a/ush/python/pygw/src/schema_pkg/test_schema.py
+++ b/ush/python/pygw/src/schema_pkg/test_schema.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# ----
+
+import os
+import os
+
+# TODO: Do we want to add the `global-workflow`/`pygw` specific class
+# (e.g., `BuildSchema`, `CheckSchema`, etc.,) to `pygw.schema.py`?
+import pygw.schema
+
+# TODO: This is a package containing all schema attribute tools; see
+# the above comment for clarification/questions.
+from build_schema import BuildSchema
+from check_schema import CheckSchema
+from write_schema import WriteFromTemplate
+
+# ----
+
+schema_yaml = os.path.join(
+    "", "test_files", "model_configure.schema.yaml")
+tmpl_path = os.path.join("", "test_files", "model_configure.template")
+out_path = os.path.join("", "model_configure.out")
+
+# ----
+
+# The following is a schema to be validated against the schema defined
+# within `schema_yaml`; the validated schema with then be used to
+# populate the template specified within `tmpl_path` and write it to
+# `out_path`.
+TEST_SCHEMA = {"DT_ATMOS": 1200,
+               "FHMAX": 120,
+               "IMO": 384,
+               "JMO": 192,
+               "SYEAR": 2000,
+               "SMONTH": 1,
+               "SDAY": 1,
+               "SHOUR": 0,
+               "WRITE_GROUP": 1,
+               "WRTTASK_PER_GROUP": 4,
+
+               # TODO: This needs to be transformed via `f90_bool`.
+               "WRITE_DO_POST": True,
+               }
+
+# ----
+
+
+def main() -> None:
+    """
+    Description
+    -----------
+
+    This is the driver-level function to invoke the tasks within this
+    script.
+
+    """
+
+    # Build the schema.
+    cls_schema = BuildSchema(yaml_file=schema_yaml).build()
+
+    # Attempt to validate the schemas.
+    CheckSchema(cls_schema=cls_schema,
+                cls_opts=TEST_SCHEMA).validate()
+
+    # Create the file based on the specified template.
+    WriteFromTemplate(cfg=TEST_SCHEMA, tmpl=tmpl_path,
+                      output=out_path).write()
+
+
+# ----
+if __name__ == '__main__':
+    main()

--- a/ush/python/pygw/src/schema_pkg/write_schema.py
+++ b/ush/python/pygw/src/schema_pkg/write_schema.py
@@ -1,0 +1,78 @@
+import logging
+
+from pygw.attrdict import AttrDict
+from pygw.logger import logit
+from pygw.template import Template, TemplateConstants
+
+# ----
+
+logger = logging.getLogger(__name__.split(".")[-1])
+
+# ----
+
+__all__ = ["WriteFromTemplate"]
+
+# ----
+
+
+class WriteFromTemplate:
+    """
+    Description
+    -----------
+
+    This is the base-class for writing an output file provided
+    configuration values and template.
+
+    Parameters
+    ----------
+
+    cfg: AttrDict
+
+        A Python dictionary containing configuration values.
+
+    tmpl: str
+
+        A Python string specifying the path to the template.
+
+    output: str
+
+        A Python string specifying the path to the output file
+        generated from the template and configuration values.
+
+    """
+
+    @logit(logger, name="WriteFromTemplate")
+    def __init__(self: object, cfg: AttrDict, tmpl: str, output: str):
+        """
+        Description
+        -----------
+
+        Creates a new WriteFromTemplate object.
+
+        """
+
+        # Define the base-class attributes.
+        self.cfg = cfg
+        self.output = output
+        self.tmpl = tmpl
+
+    @logit(logger)
+    def write(self: object):
+        """
+        Description
+        -----------
+
+        This method writes an output file using the specified template
+        and configuration values.
+
+        """
+
+        # TODO: Logger messages regarding the template and output file
+        # paths would be useful for debugging.
+        with open(self.tmpl, "r", encoding="utf-8") as file_in:
+            tmpl = file_in.read()
+            tmpl_out = Template.substitute_structure(
+                tmpl, TemplateConstants.AT_SQUARE_BRACES, self.cfg.get)
+
+        with open(self.output, "w", encoding="utf-8") as file_out:
+            file_out.write(tmpl_out)


### PR DESCRIPTION
This draft PR provides an implementation example for a schema validator to be considered for `pygw`. It is intended to initiate a discussion for a possible path forward for such an implementation.

The example application, for an abbreviate UFS `model_configure` file configuration, can be executed as follows from within the `schema_pkg` path.

```
export PYTHONPATH=/path/to/pygw/src
python test_schema.py
```

The above application attempts to validate the attributes defined within `TEST_SCHEMA` below against those defined within the YAML-formatted file path `test_files/model_configure.schema.yaml`. The latter defines the valid configuration for the `model_configure` example schema.

```
TEST_SCHEMA = {"DT_ATMOS": 1200,
               "FHMAX": 120,
               "IMO": 384,
               "JMO": 192,
               "SYEAR": 2000,
               "SMONTH": 1,
               "SDAY": 1,
               "SHOUR": 0,
               "WRITE_GROUP": 1,
               "WRTTASK_PER_GROUP": 4,

               # TODO: This needs to be transformed via `f90_bool`.
               "WRITE_DOPOST": True,
               }
```

Next, this application seeks any optional variables for the established schema. If they not are defined within `TEST_SCHEMA` the validator class `check_schema/CheckSchema` updates the dictionary using the default values (defined in `test_files/model_configure.schema.yaml) prior validation. The resulting dictionary (i.e., configuration) is used to build an abbreviated `model_configure.out` using the `test_files/model_configure.template` file. The template file and the resulting rendered `model_configure.out` file respecctively appear as follows.

```
start_year:              @[SYEAR]
start_month:             @[SMONTH]
start_day:               @[SDAY]
start_hour:              @[SHOUR]
start_minute:            0
start_second:            0
nhours_fcst:             @[FHMAX]

dt_atmos:                @[DT_ATMOS]
output_1st_tstep_rst:    .false.

write_groups:            @[WRITE_GROUP]
write_tasks_per_group:   @[WRTTASK_PER_GROUP]
output_history:          @[OUTPUT_HISTORY]
write_dopost:            @[WRITE_DOPOST]
write_nsflip:            @[WRITE_NSFLIP]
num_files:               @[NUM_FILES]
filename_base:           @[FILENAME_BASE]
imo:                     @[IMO]
jmo:                     @[JMO]
```

```
start_year:              2000
start_month:             1
start_day:               1
start_hour:              0
start_minute:            0
start_second:            0
nhours_fcst:             120

dt_atmos:                1200
output_1st_tstep_rst:    .false.

write_groups:            1
write_tasks_per_group:   1
output_history:          True
write_dopost:            True
write_nsflip:            True
num_files:               2
filename_base:           'atm' 'sfc'
imo:                     384
jmo:                     192
```

Note that the optional variables `OUTPUT_HISTORY`, `WRITE_DOPOST`, `WRITE_NSFLIP`, `NUM_FILES`, and `FILENAME_BASE`, that are not defined within the `TEST_SCHEMA` dictionary. These values are populated using the default values for the respective variable (defined within `test_files/model_configure.schema.yaml`).

Additional `Schema` validators such as `Or` maybe considered and as demonstrated [here](https://github.com/HenryWinterbottom-NOAA/ufs_pyutils/blob/develop/utils/schema_interface.py#L270). However, no use case has yet been demonstrated within the context of the global-workflow applications for such a feature.