### PR TITLE
Remove remnant WAVE_RUN from archive

### DIFF
--- a/scripts/exglobal_archive.sh
+++ b/scripts/exglobal_archive.sh
@@ -179,7 +179,7 @@ if [[ ${HPSSARCH} = "YES" || ${LOCALARCH} = "YES" ]]; then
             fi
         fi
 
-        if [ "${DO_WAVE}" = "YES" ] && [ "${WAVE_RUN}" != "gdas" ]; then
+        if [ "${DO_WAVE}" = "YES" ]; then
             targrp_list="${targrp_list} gfswave"
         fi
 


### PR DESCRIPTION
**Description**
`$WAVE_RUN` is no longer used in workflow, but one reference remained in the archive job, which would cause failures. The conditional did not need to be replaced by `$RUN` since `$RUN` has already been checked at that point.

Fixes #1548

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
Tested during testing of #1509
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes