### PR TITLE
Use correct number of tasks in CICE when using threads

### DIFF
--- a/ush/parsing_namelists_CICE.sh
+++ b/ush/parsing_namelists_CICE.sh
@@ -25,8 +25,8 @@ fi
 # Get correct MPI options for NPROC and grid
 local processor_shape=${cice6_processor_shape:-'slenderX2'}
 local shape=${processor_shape#${processor_shape%?}}
-local NPX=$(( ICEPETS / shape )) #number of processors in x direction
-local NPY=$(( ICEPETS / NPX ))   #number of processors in y direction
+local NPX=$(( ntasks_cice6 / shape )) #number of processors in x direction
+local NPY=$(( ntasks_cice6 / NPX ))   #number of processors in y direction
 if (( $(( NX_GLB % NPX )) == 0 )); then
   local block_size_x=$(( NX_GLB / NPX ))
 else
@@ -201,7 +201,7 @@ cat > ice_in <<eof
 /
 
 &domain_nml
-   nprocs = ${ICEPETS}
+   nprocs            = ${ntasks_cice6}
    nx_global         = ${NX_GLB}
    ny_global         = ${NY_GLB}
    block_size_x      = ${block_size_x}


### PR DESCRIPTION
**Description**
When the workflow was updated to use ESMF threading, the CICE namelist was not updated to use the new `ntasks_cic6` variable instead of `ICEPETS`. This caused the incorrect number to be used when using multiple threads.

Fixes #1549

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] P8 test using two threads for marine components on Orion
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
