### PR TITLE
Update prepobs install copy for atm log filename fix

### DIFF
--- a/modulefiles/module_base.hera.lua
+++ b/modulefiles/module_base.hera.lua
@@ -28,7 +28,7 @@ load(pathJoin("crtm", "2.4.0"))
 load(pathJoin("wgrib2", "2.0.8"))
 setenv("WGRIB2","wgrib2")
 
-prepend_path("MODULEPATH", pathJoin("/scratch1/NCEPDEV/global/glopara/git/prepobs/feature-GFSv17_com_reorg/modulefiles"))
+prepend_path("MODULEPATH", pathJoin("/scratch1/NCEPDEV/global/glopara/git/prepobs/feature-GFSv17_com_reorg_log_update/modulefiles"))
 load(pathJoin("prepobs", "1.0.1"))
 
 prepend_path("MODULEPATH", pathJoin("/scratch1/NCEPDEV/global/glopara/git/Fit2Obs/v1.0.0/modulefiles"))

--- a/modulefiles/module_base.jet.lua
+++ b/modulefiles/module_base.jet.lua
@@ -35,7 +35,7 @@ load(pathJoin("prepobs", "1.0.1"))
 prepend_path("MODULEPATH", "/contrib/anaconda/modulefiles")
 load(pathJoin("anaconda", "5.3.1"))
 
-prepend_path("MODULEPATH", pathJoin("/lfs4/HFIP/hfv3gfs/glopara/git/prepobs/feature-GFSv17_com_reorg/modulefiles"))
+prepend_path("MODULEPATH", pathJoin("/lfs4/HFIP/hfv3gfs/glopara/git/prepobs/feature-GFSv17_com_reorg_log_update/modulefiles"))
 load(pathJoin("prepobs", "1.0.1"))
 prepend_path("MODULEPATH", pathJoin("/lfs4/HFIP/hfv3gfs/glopara/git/Fit2Obs/v1.0.0/modulefiles"))
 load(pathJoin("fit2obs", "1.0.0"))

--- a/modulefiles/module_base.orion.lua
+++ b/modulefiles/module_base.orion.lua
@@ -27,7 +27,7 @@ load(pathJoin("crtm", "2.4.0"))
 load(pathJoin("wgrib2", "2.0.8"))
 setenv("WGRIB2","wgrib2")
 
-prepend_path("MODULEPATH", pathJoin("/work/noaa/global/glopara/git/prepobs/feature-GFSv17_com_reorg/modulefiles"))
+prepend_path("MODULEPATH", pathJoin("/work/noaa/global/glopara/git/prepobs/feature-GFSv17_com_reorg_log_update/modulefiles"))
 load(pathJoin("prepobs", "1.0.1"))
 
 prepend_path("MODULEPATH", pathJoin("/work/noaa/global/glopara/git/Fit2Obs/v1.0.0/modulefiles"))

--- a/modulefiles/module_base.wcoss2.lua
+++ b/modulefiles/module_base.wcoss2.lua
@@ -31,7 +31,7 @@ load(pathJoin("ncdiag", "1.0.0"))
 load(pathJoin("crtm", "2.4.0"))
 load(pathJoin("wgrib2", "2.0.7"))
 
-prepend_path("MODULEPATH", pathJoin("/lfs/h2/emc/global/save/emc.global/git/prepobs/feature-GFSv17_com_reorg/modulefiles"))
+prepend_path("MODULEPATH", pathJoin("/lfs/h2/emc/global/save/emc.global/git/prepobs/feature-GFSv17_com_reorg_log_update/modulefiles"))
 load(pathJoin("prepobs", "1.0.1"))
 
 prepend_path("MODULEPATH", pathJoin("/lfs/h2/emc/global/save/emc.global/git/Fit2Obs/v1.0.0/modulefiles"))


### PR DESCRIPTION
**Description**

This PR updates the prepobs install copy to the new `feature-GFSv17_com_reorg_log_update` copy. This install includes a small update to use the new atm log filename introduced with the recent ufs-weather-model hash update. The prior prepobs feature branch install is left as-is so as not to break older snapshots.

Fixes #1570

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] Clone and build tests on Hera, Orion, Jet, and WCOSS2s
- [x] Prep job tests on Hera, Orion, and WCOSS2-Cactus
