### PR TITLE
Update documentation for PR standards

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -96,7 +96,7 @@ All new code after 2022 Sep 1 will be required to meet these standards. We will 
 Pull request standards
 ======================
 
-Pull reqeusts should follow the pre-filled template provided when you open the PR. PR titles and descriptions become the commit message when the PR is squashed and merged, so we ask that they follow best practices for commit messages:
+Pull requests should follow the pre-filled template provided when you open the PR. PR titles and descriptions become the commit message when the PR is squashed and merged, so we ask that they follow best practices for commit messages:
 
  * Limit the subject line (PR title) to 50 characters
  * Capitalize the subject line
@@ -105,7 +105,7 @@ Pull reqeusts should follow the pre-filled template provided when you open the P
  * Use the body to explain what and why vs. how
  * The final line of the commit message should include tags to relevant issues (e.g. ``Refs: #217, #300``)
 
-This list is a modified version of the one provided at https://chris.beams.io/posts/git-commit/ with a couple removed that are not relevant to GitHub PRs.
+This list is a modified version of the one provided at https://chris.beams.io/posts/git-commit/ with a couple removed that are not relevant to GitHub PRs. That source also provides the motivation for making sure we have good commit messages.
 
 Here is the example commit message from the article linked above; it includes descriptions of what would be in each part of the commit message for guidance:
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -92,20 +92,20 @@ All new code after 2022 Sep 1 will be required to meet these standards. We will 
 
 .. _commit-standards:
 
-========================
-Commit message standards
-========================
+======================
+Pull request standards
+======================
 
-**ALL** commits must follow best practices for commit messages: https://chris.beams.io/posts/git-commit/
+Pull reqeusts should follow the pre-filled template provided when you open the PR. PR titles and descriptions become the commit message when the PR is squashed and merged, so we ask that they follow best practices for commit messages:
 
- * Separate subject from body with a blank line
- * Limit the subject line to 50 characters
+ * Limit the subject line (PR title) to 50 characters
  * Capitalize the subject line
  * Do not end the subject line with a period
  * Use the `imperative mood <https://en.wikipedia.org/wiki/Imperative_mood>`_ in the subject line
- * Wrap the body at 72 characters
  * Use the body to explain what and why vs. how
  * The final line of the commit message should include tags to relevant issues (e.g. ``Refs: #217, #300``)
+
+This list is a modified version of the one provided at https://chris.beams.io/posts/git-commit/ with a couple removed that are not relevant to GitHub PRs.
 
 Here is the example commit message from the article linked above; it includes descriptions of what would be in each part of the commit message for guidance:
 


### PR DESCRIPTION
**Description**
The section on commit message standards is updated to be for pull requests instead as we do not enforce standards on branch commits that are fed into a PR. Additional messaging about using the provided template is added, and bullets not relevant to PRs (line-wrapping and leaving a space between subject and body) are removed.

**Type of change**
- [x] This change requires a documentation update

**How Has This Been Tested?**
N/A Documentation only

**Checklist**
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
