### PR TITLE
bugzilla 1208, fix compilation error with "-check all"  for gfs_bufrsnd

### DIFF
--- a/sorc/gfs_bufr.fd/meteorg.f
+++ b/sorc/gfs_bufr.fd/meteorg.f
@@ -35,6 +35,7 @@
 !                              RELATED CALLS AND CLEAN UP THE CODE.
 !   2020-04-24  GUANG PING LOU Clean up code and remove station height
 !                              adjustment
+!   2023-03-28  Bo Cui  Fix compilation error with "-check all" for gfs_bufrsnd
 !
 ! USAGE:    CALL PROGRAM meteorg
 !   INPUT:
@@ -1105,7 +1106,7 @@ CC due to rounding and interpolation errors, correct it here -G.P. Lou:
        endif
        print*,'finish computing MSLP'
        print*,'finish computing zp ', (zp(11,k),k=1,levs)
-       print*,'finish computing zp2(11-12) ', zp2(11),zp2(12)
+       print*,'finish computing zp2(1-2) ', zp2(1),zp2(2)         
 !
 !  prepare buffer data
 !


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--
- [ ] Clone and Build tests on WCOSS Dell P3
- [ ] Cycled test on Orion
- [ ] Forecast-only test on Hera
-->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

fix global-workflow issue https://github.com/NOAA-EMC/global-workflow/issues/1245
