### PR TITLE
New UFS_UTILS hash for gdas_init COM reorg updates

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -15,7 +15,7 @@ protocol = git
 required = True
 
 [UFS-Utils]
-hash = 5b67e4d
+hash = 72a0471
 local_path = sorc/ufs_utils.fd
 repo_url = https://github.com/ufs-community/UFS_UTILS.git
 protocol = git

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -156,7 +156,7 @@ mkdir -p "${logdir}"
 # The checkout version should always be a speciifc commit (hash or tag), not a branch
 errs=0
 checkout "gfs_utils.fd"    "https://github.com/NOAA-EMC/gfs-utils"              "0b8ff56"                    ; errs=$((errs + $?))
-checkout "ufs_utils.fd"    "https://github.com/ufs-community/UFS_UTILS.git"     "4e673bf"                    ; errs=$((errs + $?))
+checkout "ufs_utils.fd"    "https://github.com/ufs-community/UFS_UTILS.git"     "72a0471"                    ; errs=$((errs + $?))
 checkout "ufs_model.fd"    "https://github.com/ufs-community/ufs-weather-model" "${ufs_model_hash:-2247060}" ; errs=$((errs + $?))
 checkout "verif-global.fd" "https://github.com/NOAA-EMC/EMC_verif-global.git"   "c267780"                    ; errs=$((errs + $?))
 


### PR DESCRIPTION
**Description**

This PR updates the UFS_UTILS hash to get `gdas_init` updates for the recent COM reorg.

A few additional UFS_UTILS commits are also included but aren't significant changes, as noted by @GeorgeGayno-NOAA: "Updates since that hash have been mostly small things like bug fixes. However, the w3nco library was replaced by the w3emc library at https://github.com/ufs-community/UFS_UTILS/commit/7efbe0fd2dd373ae54d6c2954ebd484e0a3aab48". Updates to improve repo build are also included with this hash (https://github.com/ufs-community/UFS_UTILS/commit/b4900c483bd9cdb274aae6f75c0815a5f86bdaae).

New hash from completion of https://github.com/ufs-community/UFS_UTILS/pull/820

Resolves #1527

**Type of change**

Additional component COM reorg updates.

**How Has This Been Tested?**

- [x] Clone and build tests on Hera
- [x] Cycled test on Hera
- [x] Tested `gdas_init` utility on Hera
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
