### PR TITLE
Add S2SA to the allowed app list in setup expt

### DIFF
--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -97,6 +97,7 @@ where:
      - ATMW: atm-wave
      - ATMA: atm-aerosols
      - S2S: atm-ocean-ice
+     - S2SA: atm-ocean-ice-aerosols
      - S2SW: atm-ocean-ice-wave
      - S2SWA: atm-ocean-ice-wave-aerosols
 

--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -364,7 +364,7 @@ def input_args():
                           required=True, type=lambda dd: to_datetime(dd))
         subp.add_argument('--edate', help='end date experiment', required=True, type=lambda dd: to_datetime(dd))
 
-    ufs_apps = ['ATM', 'ATMA', 'ATMW', 'S2S', 'S2SW']
+    ufs_apps = ['ATM', 'ATMA', 'ATMW', 'S2S', 'S2SA', 'S2SW']
 
     # GFS-only arguments
     for subp in [cycled, forecasts]:


### PR DESCRIPTION
**Description**

Adds S2SA to the list of allowed apps for all experiment types. The workflow config files already supported this option, but it was not on the allowed list.

Refs: #1589

**Type of change**

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**How Has This Been Tested?**

- [x] Experiment setup and workflow generation on Orion
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
