### PR TITLE
Orion CI Test on develop branch Monday May 15 6:30 PM

### DIFF
--- a/ci/scripts/driver.sh
+++ b/ci/scripts/driver.sh
@@ -16,7 +16,7 @@ set -eux
 #######################################################################################
 
 #################################################################
-# TODO using static build for GitHub CLI until fixed in HPC-Stack
+# TODO  using static build for GitHub CLI until fixed in HPC-Stack
 #################################################################
 export GH=${HOME}/bin/gh
 export REPO_URL=${REPO_URL:-"https://github.com/NOAA-EMC/global-workflow.git"}


### PR DESCRIPTION
This is CI Test on develop because I had a run fail on Hera today (Monday May 15)
If this fails it will automatically report the log errors for failed jobs.

- [x] Cycled test  **C96_atm3DVar** on Orion
