### PR TITLE
Allow use of nested yamls during setup_expt.py

### DIFF
--- a/parm/config/gfs/yaml/test_ci.yaml
+++ b/parm/config/gfs/yaml/test_ci.yaml
@@ -1,0 +1,4 @@
+defaults:
+  !INC {{ HOMEgfs }}/parm/config/gfs/yaml/defaults.yaml
+base:
+  ACCOUNT: "nems"

--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -12,7 +12,8 @@ from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, SUPPRESS
 
 from hosts import Host
 
-from pygw.yaml_file import YAMLFile
+from pygw.yaml_file import parse_j2yaml
+from pygw.attrdict import AttrDict
 from pygw.timetools import to_datetime, to_timedelta, datetime_to_YMDH
 
 
@@ -227,9 +228,15 @@ def fill_EXPDIR(inputs):
 
 def update_configs(host, inputs):
 
+    def _update_defaults(dict_in: dict) -> dict:
+        defaults = dict_in.pop('defaults', dict())
+        return AttrDict(defaults, **dict_in)
+
     # Read in the YAML file to fill out templates and override host defaults
+    data = AttrDict(host.info, **inputs.__dict__)
+    data.HOMEgfs = _top
     yaml_path = inputs.yaml
-    yaml_dict = YAMLFile(path=yaml_path)
+    yaml_dict = _update_defaults(parse_j2yaml(yaml_path, data))
 
     # First update config.base
     edit_baseconfig(host, inputs, yaml_dict)


### PR DESCRIPTION
**Description**
This PR:
- allows a user to define their own configuration via a yaml during `setup_expt.py`, while retaining the `defaults.yaml` which is a must when templates are being set
- updates to `setup_expt.py` to allow the above.
- adds a `test_ci.yaml` as a demonstration for use in CI

This PR will facilitate deprecating `config.defaults.s2s` as well as allowing users to make their own configurations.

**Type of change**

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

**How Has This Been Tested?**
Created experiment with `setup_expt.py` and verified with `develop`.
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [X] Any dependent changes have been merged and published
