### PR TITLE
Fixes for enkf archival bugs in ush/hpssarch_gen.sh

### DIFF
--- a/jobs/JGDAS_ENKF_ARCHIVE
+++ b/jobs/JGDAS_ENKF_ARCHIVE
@@ -12,6 +12,7 @@ export CDUMP=${RUN/enkf}
 YMD=${PDY} HH=${cyc} generate_com -rx COM_TOP
 MEMDIR="ensstat" YMD=${PDY} HH=${cyc} generate_com -rx \
   COM_ATMOS_ANALYSIS_ENSSTAT:COM_ATMOS_ANALYSIS_TMPL
+  COM_ATMOS_HISTORY_ENSSTAT:COM_ATMOS_HISTORY_TMPL
 
 ###############################################################
 # Run archive script

--- a/jobs/JGDAS_ENKF_ARCHIVE
+++ b/jobs/JGDAS_ENKF_ARCHIVE
@@ -11,7 +11,7 @@ export CDUMP=${RUN/enkf}
 
 YMD=${PDY} HH=${cyc} generate_com -rx COM_TOP
 MEMDIR="ensstat" YMD=${PDY} HH=${cyc} generate_com -rx \
-  COM_ATMOS_ANALYSIS_ENSSTAT:COM_ATMOS_ANALYSIS_TMPL
+  COM_ATMOS_ANALYSIS_ENSSTAT:COM_ATMOS_ANALYSIS_TMPL \
   COM_ATMOS_HISTORY_ENSSTAT:COM_ATMOS_HISTORY_TMPL
 
 ###############################################################

--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -471,7 +471,7 @@ if [[ ${type} == "enkfgdas" || ${type} == "enkfgfs" ]]; then
 
   IAUFHRS_ENKF=${IAUFHRS_ENKF:-6}
   lobsdiag_forenkf=${lobsdiag_forenkf:-".false."}
-  nfhrs="${IAUFHRS_ENKF/,/}"
+  IFS=',' read -ra nfhrs <<< ${IAUFHRS_ENKF}
   NMEM_ENS=${NMEM_ENS:-80}
   NMEM_EARCGRP=${NMEM_EARCGRP:-10}               ##number of ens memebers included in each tarball
   NTARS=$((NMEM_ENS/NMEM_EARCGRP))
@@ -498,7 +498,7 @@ if [[ ${type} == "enkfgdas" || ${type} == "enkfgfs" ]]; then
     if [[ -s "${COM_ATMOS_ANALYSIS_ENSSTAT}/${head}radstat.ensmean" ]]; then
          echo "${COM_ATMOS_ANALYSIS_ENSSTAT/${ROTDIR}\//}/${head}radstat.ensmean"
     fi
-    for FHR in ${nfhrs}; do  # loop over analysis times in window
+    for FHR in ${nfhrs[@]}; do  # loop over analysis times in window
       if [[ ${FHR} -eq 6 ]]; then
         if [[ -s "${COM_ATMOS_ANALYSIS_ENSSTAT}/${head}atmanl.ensmean.nc" ]]; then
           echo "${COM_ATMOS_ANALYSIS_ENSSTAT/${ROTDIR}\//}/${head}atmanl.ensmean.nc"
@@ -560,10 +560,11 @@ if [[ ${type} == "enkfgdas" || ${type} == "enkfgfs" ]]; then
 
       MEMDIR="mem${mem}" YMD=${PDY} HH=${cyc} generate_com \
         COM_ATMOS_ANALYSIS_MEM:COM_ATMOS_ANALYSIS_TMPL \
-        COM_ATMOS_RESTART_MEM:COM_ATMOS_RESTART_TMPL
+        COM_ATMOS_RESTART_MEM:COM_ATMOS_RESTART_TMPL \
+        COM_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL
 
       #---
-      for FHR in $nfhrs; do  # loop over analysis times in window
+      for FHR in ${nfhrs[@]}; do  # loop over analysis times in window
         if [ $FHR -eq 6 ]; then
           {
             if (( n <= NTARS2 )); then
@@ -598,9 +599,9 @@ if [[ ${type} == "enkfgdas" || ${type} == "enkfgfs" ]]; then
           fi
         fi
         {
-          echo "${COM_ATMOS_ANALYSIS_MEM/${ROTDIR}\//}/${head}atmf00${FHR}.nc"
+          echo "${COM_ATMOS_HISTORY/${ROTDIR}\//}/${head}atmf00${FHR}.nc"
           if (( FHR == 6 )); then
-            echo "${COM_ATMOS_ANALYSIS_MEM/${ROTDIR}\//}/${head}sfcf00${FHR}.nc"
+            echo "${COM_ATMOS_HISTORY/${ROTDIR}\//}/${head}sfcf00${FHR}.nc"
           fi
         } >> "${RUN}_grp${n}.txt"
       done # loop over FHR

--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -601,7 +601,7 @@ if [[ ${type} == "enkfgdas" || ${type} == "enkfgfs" ]]; then
         {
           echo "${COM_ATMOS_HISTORY_MEM/${ROTDIR}\//}/${head}atmf00${FHR}.nc"
           if (( FHR == 6 )); then
-            echo "${COM_ATMOS_HISTORY/${ROTDIR}\//}/${head}sfcf00${FHR}.nc"
+            echo "${COM_ATMOS_HISTORY_MEM/${ROTDIR}\//}/${head}sfcf00${FHR}.nc"
           fi
         } >> "${RUN}_grp${n}.txt"
       done # loop over FHR

--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -170,7 +170,7 @@ if [[ ${type} = "gfs" ]]; then
     {
       echo "${COM_ATMOS_GRIB_0p25/${ROTDIR}\//}/${head}pgrb2.0p25.f${fhr}"
       echo "${COM_ATMOS_GRIB_0p25/${ROTDIR}\//}/${head}pgrb2.0p25.f${fhr}.idx"
-      echo "${COM_ATMOS_HISTORY/${ROTDIR}\//}/${head}logf${fhr}.txt"
+      echo "${COM_ATMOS_HISTORY/${ROTDIR}\//}/${head}atm.logf${fhr}.txt"
     } >> gfsa.txt
 
 
@@ -351,7 +351,7 @@ if [[ ${type} == "gdas" ]]; then
       echo "${COM_ATMOS_GRIB_0p25/${ROTDIR}\//}/${head}pgrb2.0p25.f${fhr}.idx"
       echo "${COM_ATMOS_GRIB_1p00/${ROTDIR}\//}/${head}pgrb2.1p00.f${fhr}"
       echo "${COM_ATMOS_GRIB_1p00/${ROTDIR}\//}/${head}pgrb2.1p00.f${fhr}.idx"
-      echo "${COM_ATMOS_HISTORY/${ROTDIR}\//}/${head}logf${fhr}.txt"
+      echo "${COM_ATMOS_HISTORY/${ROTDIR}\//}/${head}atm.logf${fhr}.txt"
       echo "${COM_ATMOS_HISTORY/${ROTDIR}\//}/${head}atmf${fhr}.nc"
       echo "${COM_ATMOS_HISTORY/${ROTDIR}\//}/${head}sfcf${fhr}.nc"
       fh=$((fh+3))

--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -565,7 +565,7 @@ if [[ ${type} == "enkfgdas" || ${type} == "enkfgfs" ]]; then
 
       #---
       for FHR in "${nfhrs[@]}"; do  # loop over analysis times in window
-        if [ $FHR -eq 6 ]; then
+        if [ "${FHR}" -eq 6 ]; then
           {
             if (( n <= NTARS2 )); then
               if [[ -s "${COM_ATMOS_ANALYSIS_MEM}/${head}atmanl.nc" ]] ; then

--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -599,7 +599,7 @@ if [[ ${type} == "enkfgdas" || ${type} == "enkfgfs" ]]; then
           fi
         fi
         {
-          echo "${COM_ATMOS_HISTORY/${ROTDIR}\//}/${head}atmf00${FHR}.nc"
+          echo "${COM_ATMOS_HISTORY_MEM/${ROTDIR}\//}/${head}atmf00${FHR}.nc"
           if (( FHR == 6 )); then
             echo "${COM_ATMOS_HISTORY/${ROTDIR}\//}/${head}sfcf00${FHR}.nc"
           fi

--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -561,7 +561,7 @@ if [[ ${type} == "enkfgdas" || ${type} == "enkfgfs" ]]; then
       MEMDIR="mem${mem}" YMD=${PDY} HH=${cyc} generate_com \
         COM_ATMOS_ANALYSIS_MEM:COM_ATMOS_ANALYSIS_TMPL \
         COM_ATMOS_RESTART_MEM:COM_ATMOS_RESTART_TMPL \
-        COM_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL
+        COM_ATMOS_HISTORY_MEM:COM_ATMOS_HISTORY_TMPL
 
       #---
       for FHR in "${nfhrs[@]}"; do  # loop over analysis times in window

--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -498,7 +498,7 @@ if [[ ${type} == "enkfgdas" || ${type} == "enkfgfs" ]]; then
     if [[ -s "${COM_ATMOS_ANALYSIS_ENSSTAT}/${head}radstat.ensmean" ]]; then
          echo "${COM_ATMOS_ANALYSIS_ENSSTAT/${ROTDIR}\//}/${head}radstat.ensmean"
     fi
-    for FHR in ${nfhrs[@]}; do  # loop over analysis times in window
+    for FHR in "${nfhrs[@]}"; do  # loop over analysis times in window
       if [[ ${FHR} -eq 6 ]]; then
         if [[ -s "${COM_ATMOS_ANALYSIS_ENSSTAT}/${head}atmanl.ensmean.nc" ]]; then
           echo "${COM_ATMOS_ANALYSIS_ENSSTAT/${ROTDIR}\//}/${head}atmanl.ensmean.nc"
@@ -564,7 +564,7 @@ if [[ ${type} == "enkfgdas" || ${type} == "enkfgfs" ]]; then
         COM_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL
 
       #---
-      for FHR in ${nfhrs[@]}; do  # loop over analysis times in window
+      for FHR in "${nfhrs[@]}"; do  # loop over analysis times in window
         if [ $FHR -eq 6 ]; then
           {
             if (( n <= NTARS2 )); then

--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -531,10 +531,10 @@ if [[ ${type} == "enkfgdas" || ${type} == "enkfgfs" ]]; then
     fh=3
     while [ $fh -le 9 ]; do
         fhr=$(printf %03i $fh)
-        echo "${COM_ATMOS_ANALYSIS_ENSSTAT/${ROTDIR}\//}/${head}atmf${fhr}.ensmean.nc"
-        echo "${COM_ATMOS_ANALYSIS_ENSSTAT/${ROTDIR}\//}/${head}sfcf${fhr}.ensmean.nc"
-        if [[ -s "${COM_ATMOS_ANALYSIS_ENSSTAT}/${head}atmf${fhr}.ensspread.nc" ]]; then
-            echo "${COM_ATMOS_ANALYSIS_ENSSTAT/${ROTDIR}\//}/${head}atmf${fhr}.ensspread.nc"
+        echo "${COM_ATMOS_HISTORY_ENSSTAT/${ROTDIR}\//}/${head}atmf${fhr}.ensmean.nc"
+        echo "${COM_ATMOS_HISTORY_ENSSTAT/${ROTDIR}\//}/${head}sfcf${fhr}.ensmean.nc"
+        if [[ -s "${COM_ATMOS_HISTORY_ENSSTAT}/${head}atmf${fhr}.ensspread.nc" ]]; then
+            echo "${COM_ATMOS_HISTORY_ENSSTAT/${ROTDIR}\//}/${head}atmf${fhr}.ensspread.nc"
         fi
         fh=$((fh+3))
     done


### PR DESCRIPTION
**Description**

This PR brings in fixes to `ush/hpssarch_gen.sh` for enkf archival bugs described in issues #1622 and #1623 and beyond:

- Use the correct path for ensemble atm and sfc files (these are located in atm history, not atm analysis
- Fix a syntax error to properly loop over IAU hours
- Update the name of the 'log' files

Fixes #1622
Fixes #1623

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- Reran failing earc jobs in test on Hera (DOIAU=YES and DOIAU=NO) (@KateFriedman-NOAA & @RussTreadon-NOAA)
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
