### PR TITLE
Cast dict as an AttDict to handle nested dicts properly in update_configs

### DIFF
--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -229,14 +229,15 @@ def fill_EXPDIR(inputs):
 def update_configs(host, inputs):
 
     def _update_defaults(dict_in: dict) -> dict:
-        defaults = dict_in.pop('defaults', dict())
-        return AttrDict(defaults, **dict_in)
+        defaults = dict_in.pop('defaults', AttrDict())
+        defaults.update(dict_in)
+        return defaults
 
     # Read in the YAML file to fill out templates and override host defaults
     data = AttrDict(host.info, **inputs.__dict__)
     data.HOMEgfs = _top
     yaml_path = inputs.yaml
-    yaml_dict = _update_defaults(parse_j2yaml(yaml_path, data))
+    yaml_dict = _update_defaults(AttrDict(parse_j2yaml(yaml_path, data)))
 
     # First update config.base
     edit_baseconfig(host, inputs, yaml_dict)


### PR DESCRIPTION
**Description**
@TerrenceMcGuinness-NOAA noticed that some of the keys in the `defaults` were not being updated.
It was discovered that using `**dict` would only update keys at the top-level.  These dictionaries are nested and deep.

This PR:
- fixes the bug by replacing `**dict` with the `update` method from `AttrDict`.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
A test was performed using the `test_ci.yaml` case from @TerrenceMcGuinness-NOAA 
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [X] Any dependent changes have been merged and published
