### PR TITLE
Convert land DA scripts from shell to python

### DIFF
--- a/env/HERA.env
+++ b/env/HERA.env
@@ -4,7 +4,7 @@ if [[ $# -ne 1 ]]; then
 
     echo "Must specify an input argument to set runtime environment variables!"
     echo "argument can be any one of the following:"
-    echo "atmanlrun atmensanlrun aeroanlrun landanlrun"
+    echo "atmanlrun atmensanlrun aeroanlrun landanlrun landanlfinal"
     echo "anal sfcanl fcst post vrfy metp"
     echo "eobs eupd ecen efcs epos"
     echo "postsnd awips gempak"
@@ -85,6 +85,14 @@ elif [[ "${step}" = "landanlrun" ]]; then
     export NTHREADS_LANDANL=${nth_landanlrun:-${nth_max}}
     [[ ${NTHREADS_LANDANL} -gt ${nth_max} ]] && export NTHREADS_LANDANL=${nth_max}
     export APRUN_LANDANL="${launcher} -n ${npe_landanlrun}"
+
+elif [[ "${step}" = "landanlfinal" ]]; then
+
+    nth_max=$((npe_node_max / npe_node_landanlfinal))
+
+    export NTHREADS_LANDANL=${nth_landanlfinal:-${nth_max}}
+    [[ ${NTHREADS_LANDANL} -gt ${nth_max} ]] && export NTHREADS_LANDANL=${nth_max}
+    export APRUN_LANDANL="${launcher} -n ${npe_landanlfinal}"
 
 elif [[ "${step}" = "ocnanalbmat" ]]; then
 

--- a/jobs/JGLOBAL_LAND_ANALYSIS_RUN
+++ b/jobs/JGLOBAL_LAND_ANALYSIS_RUN
@@ -20,7 +20,7 @@ YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS
 ###############################################################
 # Run relevant script
 
-EXSCRIPT=${GDASLANDRUNSH:-${HOMEgfs}/scripts/exglobal_land_analysis_run.sh}
+EXSCRIPT=${GDASLANDRUNSH:-${HOMEgfs}/scripts/exglobal_land_analysis_run.py}
 ${EXSCRIPT}
 status=$?
 [[ ${status} -ne 0 ]] && exit "${status}"

--- a/parm/config/gfs/config.landanl
+++ b/parm/config/gfs/config.landanl
@@ -10,14 +10,22 @@ if [[ "${cyc}" == "18" ]]; then
     obs_list_name=gdas_land_prototype.yaml
 fi
 
+export INCR_NML_TMPL="${HOMEgfs}/sorc/gdas.cd/parm/land/prep/incr.nml.j2"
+export PREP_RUN_LIST="${HOMEgfs}/sorc/gdas.cd/parm/land/prep/prep_run.yaml"
 export OBS_YAML_DIR=${HOMEgfs}/sorc/gdas.cd/parm/land/obs/config/
 export OBS_LIST=${HOMEgfs}/sorc/gdas.cd/parm/land/obs/lists/${obs_list_name}
 export LANDVARYAML=${HOMEgfs}/sorc/gdas.cd/parm/land/letkfoi/letkfoi.yaml
 export FV3JEDI_FIX=${HOMEgfs}/fix/gdas
 
+export OROGPATH="${HOMEgfs}/fix/orog/${CASE}"
+export OROGTYPE="${CASE}_oro_data"
+export FRACGRID="NO"
+
 export io_layout_x=@IO_LAYOUT_X@
 export io_layout_y=@IO_LAYOUT_Y@
 
-export JEDIEXE=${HOMEgfs}/exec/fv3jedi_letkf.x
+export JEDIEXE="${HOMEgfs}/exec/fv3jedi_letkf.x"
+export JEDIINCEXE="${HOMEgfs}/exec/apply_incr.exe"
+export ENSPY="${HOMEgfs}/ush/letkf_create_ens.py"
 
 echo "END: config.landanl"

--- a/parm/parm_gdas/land_jedi_fix.yaml
+++ b/parm/parm_gdas/land_jedi_fix.yaml
@@ -1,0 +1,7 @@
+mkdir:
+- $(DATA)/fv3jedi
+copy:
+- [$(FV3JEDI_FIX)/fv3jedi/fv3files/akbk$(npz).nc4, $(DATA)/fv3jedi/akbk.nc4]
+- [$(FV3JEDI_FIX)/fv3jedi/fv3files/fmsmpp.nml, $(DATA)/fv3jedi/fmsmpp.nml]
+- [$(FV3JEDI_FIX)/fv3jedi/fv3files/field_table_gfdl, $(DATA)/fv3jedi/field_table]
+- [$(FV3JEDI_FIX)/fv3jedi/fieldmetadata/gfs-land.yaml, $(DATA)/fv3jedi/gfs-land.yaml]

--- a/parm/parm_gdas/landanl_inc_vars.yaml
+++ b/parm/parm_gdas/landanl_inc_vars.yaml
@@ -1,0 +1,1 @@
+incvars: ['snwdph']

--- a/scripts/exglobal_land_analysis_finalize.py
+++ b/scripts/exglobal_land_analysis_finalize.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# exglobal_land_analysis_finalize.py
+# This script creates an LandAnalysis class
+# and runs the finalize method
+# which perform post-processing and clean up activities
+# for a global land letkfoi analysis
+import os
+
+from pygw.logger import Logger
+from pygw.configuration import cast_strdict_as_dtypedict
+from pygfs.task.land_analysis import LandAnalysis
+
+
+# Initialize root logger
+logger = Logger(level='DEBUG', colored_log=True)
+
+
+if __name__ == '__main__':
+
+    # Take configuration from environment and cast it as python dictionary
+    config = cast_strdict_as_dtypedict(os.environ)
+
+    # Instantiate the aerosol analysis task
+    LandAnl = LandAnalysis(config)
+    LandAnl.finalize()

--- a/scripts/exglobal_land_analysis_initialize.py
+++ b/scripts/exglobal_land_analysis_initialize.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# exglobal_land_analysis_initialize.py
+# This script creates an LandAnalysis class
+# and runs the initialize method
+# which create and stage the runtime directory
+# and create the YAML configuration
+# for a global land letkfoi analysis
+import os
+
+from pygw.logger import Logger
+from pygw.configuration import cast_strdict_as_dtypedict
+from pygfs.task.land_analysis import LandAnalysis
+
+# Initialize root logger
+logger = Logger(level='DEBUG', colored_log=True)
+
+
+if __name__ == '__main__':
+
+    # Take configuration from environment and cast it as python dictionary
+    config = cast_strdict_as_dtypedict(os.environ)
+
+    # Instantiate the land analysis task
+    LandAnl = LandAnalysis(config)
+    LandAnl.initialize()

--- a/scripts/exglobal_land_analysis_run.py
+++ b/scripts/exglobal_land_analysis_run.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# exglobal_land_analysis_run.py
+# This script creates an LandAnalysis object
+# and runs the execute method
+# which executes the global land letkfoi analysis
+import os
+
+from pygw.logger import Logger
+from pygw.configuration import cast_strdict_as_dtypedict
+from pygfs.task.land_analysis import LandAnalysis
+
+# Initialize root logger
+logger = Logger(level='DEBUG', colored_log=True)
+
+
+if __name__ == '__main__':
+
+    # Take configuration from environment and cast it as python dictionary
+    config = cast_strdict_as_dtypedict(os.environ)
+
+    # Instantiate the land analysis task
+    LandAnl = LandAnalysis(config)
+    LandAnl.execute()

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -165,7 +165,7 @@ if [[ ${checkout_gsi} == "YES" ]]; then
 fi
 
 if [[ ${checkout_gdas} == "YES" ]]; then
-  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "81675c9"; errs=$((errs + $?))
+  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "fa8a260"; errs=$((errs + $?))
 fi
 
 if [[ ${checkout_gsi} == "YES" || ${checkout_gdas} == "YES" ]]; then

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -249,7 +249,6 @@ class LandAnalysis(Analysis):
         except Exception:
             raise WorkflowException(f"An error occured during execution of {exe}")
 
-
         # run jedi executable
         exec_cmd = Executable(self.task_config.APRUN_LANDANL)
         exec_name = os.path.join(self.task_config.DATA, 'fv3jedi_letkf.x')
@@ -269,7 +268,6 @@ class LandAnalysis(Analysis):
         # change names of the increments
         logger.info("Changing the names of the increments")
         FileHandler(prep_run_config.increment).sync()
-
 
     @logit(logger)
     def finalize(self: Analysis) -> None:


### PR DESCRIPTION
To support global land initialization for future GFS implementations, we need to add to global-workflow experiment setup and rocoto XML generation scripts support for including land DA related tasks. 

This PR is a final major part from PR #1541. There are two other PRs pulled from the PR #1541 were merged. One is #1564 (Update LandDA related job post COM refactor plus other minor fixes), and the other is #1609 (Prepare snow depth observations for JEDI-based Land DA).  

This PR converted several land DA related scripts from shell scripts to python codes. 

Specifically, this PR:

Converted the following land DA related jobs into python codes:
- scripts/exglobal_land_analysis_initialize.py
- scripts/exglobal_land_analysis_run.py
- scripts/exglobal_land_analysis_finalize.py

`land_analysis.py` introduces the methods `initialize`, `execute`, `finalize`, and `_add_fms_cube_sphere_increments` for above land analysis jobs. The following tasks are included: 
- create ensembles for using letkfoi
- run the JEDI executable
- apply jedi increments

Updates are necessary in the GDASApp repo. See companion PR: https://github.com/NOAA-EMC/GDASApp/pull/483 Add yaml files and namelist template for land DA in G-W.

Checklist

 My code follows the style guidelines of this project

- [X]  I have performed a self-review of my own code
- [X]  I have commented my code, particularly in hard-to-understand areas
- [X]  My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X]  My changes generate no new warnings
- [X]  New and existing tests pass with my changes
- [X]  Any dependent changes have been merged and published