### PR TITLE
Update issue template assignees to remove KateFriedman-NOAA

### DIFF
--- a/.github/ISSUE_TEMPLATE/NCO_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/NCO_bug_report.md
@@ -3,7 +3,7 @@ name: NCO Bug report
 about: Create a report from NCO
 title:
 labels: nco-bug
-assignees: aerorahul, KateFriedman-NOAA
+assignees: aerorahul
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/fix_file.md
+++ b/.github/ISSUE_TEMPLATE/fix_file.md
@@ -4,7 +4,6 @@ about: Use this template for adding, updating, or removing fix files from global
 title:
 labels: Fix Files
 assignees:
-  - KateFriedman-NOAA
   - WalterKolczynski-NOAA
 
 ---

--- a/.github/ISSUE_TEMPLATE/production_update.md
+++ b/.github/ISSUE_TEMPLATE/production_update.md
@@ -4,7 +4,7 @@ about: Use this template for operational production updates
 title:
 labels: production update
 assignees:
-  - KateFriedman-NOAA
+  - WalterKolczynski-NOAA
 
 ---
 


### PR DESCRIPTION
**Description**

This PR removes `KateFriedman-NOAA` from the auto assignee list in the issue templates. User will be on leave for a while. Add them back in upon return to work.

**Type of change**

Temporary personnel change. 
