### PR TITLE
Update DMPDIR for WCOSS2

### DIFF
--- a/workflow/hosts/wcoss2.yaml
+++ b/workflow/hosts/wcoss2.yaml
@@ -1,5 +1,5 @@
 BASE_GIT: '/lfs/h2/emc/global/save/emc.global/git'
-DMPDIR: '/lfs/h2/emc/global/noscrub/emc.global/dump'
+DMPDIR: '/lfs/h2/emc/dump/noscrub/dump'
 PACKAGEROOT: '${PACKAGEROOT:-"/lfs/h1/ops/prod/packages"}'
 COMROOT: '${COMROOT:-"/lfs/h1/ops/prod/com"}'
 COMINsyn: '${COMROOT}/gfs/${gfs_ver:-"v16.2"}/syndat'


### PR DESCRIPTION
**Description**

This PR updates `DMPDIR` (global dump archive path) on WCOSS2 to the new dedicated path: `/lfs/h2/emc/dump/noscrub/dump`

Closes #1655

**Type of change**

Path changes

**How Has This Been Tested?**

- [x] Clone and Build tests on WCOSS2
- [x] Cycled test on WCOSS2 (gdasprep job worked with new path)