### PR TITLE
Explicitly define IAUFHRS for DOIAU=NO case

### DIFF
--- a/parm/config/gfs/config.base.emc.dyn
+++ b/parm/config/gfs/config.base.emc.dyn
@@ -330,7 +330,7 @@ if [[ "${MODE}" = "cycled" && "${SDATE}" = "${PDY}${cyc}" && ${EXP_WARM_START} =
   export IAUFHRS="6"
 fi
 
-if [[ "$DOIAU_ENKF" = "NO" ]]; then export IAUFHRS_ENKF="6"; fi
+if [[ "${DOIAU_ENKF}" = "NO" ]]; then export IAUFHRS_ENKF="6"; fi
 
 # turned on nsst in anal and/or fcst steps, and turn off rtgsst
 export DONST="YES"

--- a/parm/config/gfs/config.base.emc.dyn
+++ b/parm/config/gfs/config.base.emc.dyn
@@ -327,7 +327,10 @@ fi
 if [[ "${MODE}" = "cycled" && "${SDATE}" = "${PDY}${cyc}" && ${EXP_WARM_START} = ".false." ]] || [[ "${DOIAU}" = "NO" ]] || [[ "${MODE}" = "forecast-only" && ${EXP_WARM_START} = ".false." ]] ; then
   export IAU_OFFSET=0
   export IAU_FHROT=0
+  export IAUFHRS="6"
 fi
+
+if [[ "$DOIAU_ENKF" = "NO" ]]; then export IAUFHRS_ENKF="6"; fi
 
 # turned on nsst in anal and/or fcst steps, and turn off rtgsst
 export DONST="YES"


### PR DESCRIPTION
**Description**

IAUFHRS and IAUFHRS_ENKF are defined in config.base, but they were not reset to the default value if IAU is off. This commit sets IAUFHRS and IAUFHRS_ENKF to "6" in config.base if DOIAU or DOIAU_ENKF are set to NO.

Refs: #1557


**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] C48/C48 hybrid 3DEnVar cycled test on Hera

  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
