### PR TITLE
Update pyenv on Hera and Orion

### DIFF
--- a/modulefiles/module_base.hera.lua
+++ b/modulefiles/module_base.hera.lua
@@ -40,7 +40,7 @@ prepend_path("MODULEPATH", "/scratch2/NCEPDEV/ensemble/save/Walter.Kolczynski/hp
 load(pathJoin("hpc", "1.2.0"))
 load(pathJoin("hpc-intel", "18.0.5.274"))
 load(pathJoin("hpc-miniconda3", "4.6.14"))
-load(pathJoin("ufswm", "1.0.0"))
+load(pathJoin("gfs_workflow", "1.0.0"))
 load(pathJoin("met", "9.1"))
 load(pathJoin("metplus", "3.1"))
 

--- a/modulefiles/module_base.orion.lua
+++ b/modulefiles/module_base.orion.lua
@@ -39,7 +39,7 @@ prepend_path("MODULEPATH", "/work2/noaa/global/wkolczyn/save/hpc-stack/modulefil
 load(pathJoin("hpc", "1.2.0"))
 load(pathJoin("hpc-intel", "2018.4"))
 load(pathJoin("hpc-miniconda3", "4.6.14"))
-load(pathJoin("ufswm", "1.0.0"))
+load(pathJoin("gfs_workflow", "1.0.0"))
 load(pathJoin("met", "9.1"))
 load(pathJoin("metplus", "3.1"))
 


### PR DESCRIPTION
**Description**

Switches the runtime pyenv from ufswm to gfs_workflow on Hera and Orion. gfs_workflow is the new one created just for workflow and is the target going forward. CI modules have already been using it.

**Type of change**

- [x] Routine maintenance

**How Has This Been Tested?**

- [ ] CI Tests
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
