### PR TITLE
Correct dependencies for Ocean restarts at 0.25 degree and other resolutions

### DIFF
--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -43,10 +43,15 @@ class GFSTasks(Tasks):
         if self.app_config.do_ocean:
             ocn_res = f"{self._base.get('OCNRES', '025'):03d}"
             prefix = f"{cpl_ic['BASE_CPLIC']}/{cpl_ic['CPL_OCNIC']}/@Y@m@d@H/ocn"
-            for res in ['res'] + [f'res_{res_index}' for res_index in range(1, 4)]:
-                data = f"{prefix}/{ocn_res}/MOM.{res}.nc"
-                dep_dict = {'type': 'data', 'data': data}
-                deps.append(rocoto.add_dependency(dep_dict))
+            data = f"{prefix}/{ocn_res}/MOM.res.nc"
+            dep_dict = {'type': 'data', 'data': data}
+            deps.append(rocoto.add_dependency(dep_dict))
+            if ocn_res in ['025']:
+                # 0.25 degree ocean model also has these additional restarts
+                for res in [f'res_{res_index}' for res_index in range(1, 4)]:
+                    data = f"{prefix}/{ocn_res}/MOM.{res}.nc"
+                    dep_dict = {'type': 'data', 'data': data}
+                    deps.append(rocoto.add_dependency(dep_dict))
 
         # Ice ICs
         if self.app_config.do_ice:


### PR DESCRIPTION
**Description**
This PR corrects the dependencies for the coupled_ic job when running a coupled model at lower (than 0.25 degree) resolutions.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
@TerrenceMcGuinness-NOAA will test in the CI
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
