### PR TITLE
Fix octal bug in ocean post

### DIFF
--- a/jobs/rocoto/ocnpost.sh
+++ b/jobs/rocoto/ocnpost.sh
@@ -56,7 +56,7 @@ for fhr in ${fhrlst}; do
   # shellcheck disable=
   declare -x VDATE
   cd "${DATA}" || exit 2
-  if (( fhr > 0 )); then
+  if (( 10#${fhr} > 0 )); then
     # TODO: This portion calls NCL scripts that are deprecated (see Issue #923)
     if [[ "${MAKE_OCN_GRIB:-YES}" == "YES" ]]; then
       export MOM6REGRID=${MOM6REGRID:-${HOMEgfs}}


### PR DESCRIPTION
**Description**

Ocean post was incorrectly treating zero-padded forecast hours as octals. This is now fixed.

Fixes #1710
Refs #1195

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] P8 on Orion
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
