### PR TITLE
Update fit2obs for COM refactor

### DIFF
--- a/jobs/JGDAS_FIT2OBS
+++ b/jobs/JGDAS_FIT2OBS
@@ -40,8 +40,8 @@ export HORZ_DIR=${ARCDIR}/horiz
 export COMLOX=${DATA}/fitx
 [[ ! -d "${COMLOX}" ]] && mkdir -p "${COMLOX}"
 
-echo "echo err_chk">"${DATA}"/err_chk; chmod 755 "${DATA}"/err_chk
-echo "echo postmsg">"${DATA}"/postmsg; chmod 755 "${DATA}"/postmsg
+echo "echo err_chk">"${DATA}/err_chk"; chmod 755 "${DATA}/err_chk"
+echo "echo postmsg">"${DATA}/postmsg"; chmod 755 "${DATA}/postmsg"
 
 ##############################################
 # Check spinup and available inputs

--- a/jobs/JGDAS_FIT2OBS
+++ b/jobs/JGDAS_FIT2OBS
@@ -18,6 +18,7 @@ vday=${CDATE:0:8}
 vcyc=${CDATE:8:2}
 
 # These are used by fit2obs, so we can't change them to the standard COM variable names
+# shellcheck disable=SC2153
 YMD=${vday} HH=${vcyc} generate_com -rx COM_INA:COM_ATMOS_ANALYSIS_TMPL
 RUN=${CDUMP} YMD=${vday} HH=${vcyc} generate_com -rx COM_PRP:COM_OBS_TMPL
 

--- a/jobs/JGDAS_FIT2OBS
+++ b/jobs/JGDAS_FIT2OBS
@@ -17,15 +17,13 @@ export CDATE
 vday=${CDATE:0:8}
 vcyc=${CDATE:8:2}
 
-YMD=${vday} HH=${vcyc} generate_com -rx COM_ATMOS_ANALYSIS_VERIF:COM_ATMOS_ANALYSIS_TMPL
-RUN=${CDUMP} YMD=${vday} HH=${vcyc} generate_com -rx COM_OBS_VERIF:COM_OBS_TMPL
-
 # These are used by fit2obs, so we can't change them to the standard COM variable names
-export COM_INA=${COM_ATMOS_ANALYSIS_VERIF}
+YMD=${vday} HH=${vcyc} generate_com -rx COM_INA:COM_ATMOS_ANALYSIS_TMPL
+RUN=${CDUMP} YMD=${vday} HH=${vcyc} generate_com -rx COM_PRP:COM_OBS_TMPL
+
 # We want to defer variable expansion, so ignore warning about single quotes
 # shellcheck disable=SC2016
 export COM_INF='$ROTDIR/vrfyarch/gfs.$fdy/$fzz'
-export COM_PRP=${COM_OBS_VERIF}
 
 export PRPI=${COM_PRP}/${RUN}.t${vcyc}z.prepbufr
 export sig1=${COM_INA}/${RUN}.t${vcyc}z.atmanl.nc

--- a/jobs/JGDAS_FIT2OBS
+++ b/jobs/JGDAS_FIT2OBS
@@ -27,6 +27,7 @@ RUN=${CDUMP} YMD=${vday} HH=${vcyc} generate_com -rx COM_PRP:COM_OBS_TMPL
 export COM_INF='$ROTDIR/vrfyarch/gfs.$fdy/$fzz'
 
 export PRPI=${COM_PRP}/${RUN}.t${vcyc}z.prepbufr
+# shellcheck disable=SC2153
 export sig1=${COM_INA}/${RUN}.t${vcyc}z.atmanl.nc
 export sfc1=${COM_INA}/${RUN}.t${vcyc}z.atmanl.nc
 export CNVS=${COM_INA}/${RUN}.t${vcyc}z.cnvstat

--- a/jobs/JGDAS_FIT2OBS
+++ b/jobs/JGDAS_FIT2OBS
@@ -17,11 +17,14 @@ export CDATE
 vday=${CDATE:0:8}
 vcyc=${CDATE:8:2}
 
-export COM_INA=${ROTDIR}/gdas.${vday}/${vcyc}/atmos
+YMD=${vday} HH=${vcyc} generate_com -rx COM_ATMOS_ANALYSIS_VERIF:COM_ATMOS_ANALYSIS_TMPL
+RUN=${CDUMP} YMD=${vday} HH=${vcyc} generate_com -rx COM_OBS_VERIF:COM_OBS_TMPL
+
+export COM_INA=${COM_ATMOS_ANALYSIS_VERIF}
 # We want to defer variable expansion, so ignore warning about single quotes
 # shellcheck disable=SC2016
 export COM_INF='$ROTDIR/vrfyarch/gfs.$fdy/$fzz'
-export COM_PRP=${ROTDIR}/gdas.${vday}/${vcyc}/obs
+export COM_PRP=${COM_OBS_VERIF}
 
 export PRPI=${COM_PRP}/${RUN}.t${vcyc}z.prepbufr
 export sig1=${COM_INA}/${RUN}.t${vcyc}z.atmanl.nc

--- a/jobs/JGDAS_FIT2OBS
+++ b/jobs/JGDAS_FIT2OBS
@@ -20,6 +20,7 @@ vcyc=${CDATE:8:2}
 YMD=${vday} HH=${vcyc} generate_com -rx COM_ATMOS_ANALYSIS_VERIF:COM_ATMOS_ANALYSIS_TMPL
 RUN=${CDUMP} YMD=${vday} HH=${vcyc} generate_com -rx COM_OBS_VERIF:COM_OBS_TMPL
 
+# These are used by fit2obs, so we can't change them to the standard COM variable names
 export COM_INA=${COM_ATMOS_ANALYSIS_VERIF}
 # We want to defer variable expansion, so ignore warning about single quotes
 # shellcheck disable=SC2016

--- a/parm/config/gfs/config.base.emc.dyn
+++ b/parm/config/gfs/config.base.emc.dyn
@@ -384,7 +384,7 @@ export binary_diag=".false."
 
 # Verification options
 export DO_METP="YES"         # Run METPLUS jobs - set METPLUS settings in config.metp
-export DO_FIT2OBS="NO"      # Run fit to observations package
+export DO_FIT2OBS="YES"      # Run fit to observations package
 
 # Archiving options
 export HPSSARCH="@HPSSARCH@"        # save data to HPSS archive

--- a/scripts/exglobal_archive.sh
+++ b/scripts/exglobal_archive.sh
@@ -103,8 +103,8 @@ if [[ "${RUN}" == "gfs" ]] && [[ "${FITSARC}" = "YES" ]]; then
     fhr=0
     while [[ ${fhr} -le ${fhmax} ]]; do
         fhr3=$(printf %03i "${fhr}")
-        sfcfile="${COM_ATMOS_MASTER}/${prefix}.sfcf${fhr3}.nc"
-        sigfile="${COM_ATMOS_MASTER}/${prefix}.atmf${fhr3}.nc"
+        sfcfile="${COM_ATMOS_HISTORY}/${prefix}.sfcf${fhr3}.nc"
+        sigfile="${COM_ATMOS_HISTORY}/${prefix}.atmf${fhr3}.nc"
         nb_copy "${sfcfile}" "${VFYARC}/${RUN}.${PDY}/${cyc}/"
         nb_copy "${sigfile}" "${VFYARC}/${RUN}.${PDY}/${cyc}/"
         (( fhr = 10#${fhr} + 6 ))


### PR DESCRIPTION
**Description**

Updates the fit2obs j-job for COM refactor. Also corrects a related error in the archive job where the wrong source was being used for history files to be copied to the verification archive.

Fixes #1486

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] Cycled test on Orion
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
