### PR TITLE
updating pythonpath in JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP to match changes to ioda

### DIFF
--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
@@ -35,7 +35,8 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
 
 # Add UFSDA to PYTHONPATH
 ufsdaPATH="${HOMEgfs}/sorc/gdas.cd/ush/"
-PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${ufsdaPATH}"
+pyiodaPATH="${HOMEgfs}/sorc/gdas.cd/build/lib/python3.7/"
+PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${ufsdaPATH}:${pyiodaPATH}"
 export PYTHONPATH
 
 ###############################################################


### PR DESCRIPTION


**Description**

Updates `PYTHONPATH` in `jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP` to reflect changes in ioda as described here:
https://github.com/JCSDA-internal/ioda-converters/issues/1238

Also addressed by https://github.com/NOAA-EMC/GDASApp/pull/519 and https://github.com/NOAA-EMC/GDASApp/pull/518


**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Tested with WCDA cycling by @ShastriPaturi 
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
