### PR TITLE
Updates for deprecated numpy versions.

### DIFF
--- a/workflow/rocoto/tasks.py
+++ b/workflow/rocoto/tasks.py
@@ -134,7 +134,7 @@ class Tasks:
         if self.cdump in ['gfs'] and f'npe_node_{task_name}_gfs' in task_config.keys():
             ppn = task_config[f'npe_node_{task_name}_gfs']
 
-        nodes = np.int(np.ceil(np.float(cores) / np.float(ppn)))
+        nodes = int(np.ceil(float(cores) / float(ppn)))
 
         threads = task_config[f'nth_{task_name}']
         if self.cdump in ['gfs'] and f'nth_{task_name}_gfs' in task_config.keys():


### PR DESCRIPTION
**Description**

Using numpy to cast type has been deprecated in favor of using the native python functions (i.e. `int()`, `float()`, etc.).

Resolves #1725. 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Rocoto workflow is successfully configured. CI will be the ultimate test.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
