### PR TITLE
Add AWS cpu info to resources

### DIFF
--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -27,9 +27,6 @@ fi
 
 step=$1
 
-echo "${machine}"
-stop 9099
-
 echo "BEGIN: config.resources"
 
 if [[ "${machine}" = "WCOSS2" ]]; then

--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -27,6 +27,9 @@ fi
 
 step=$1
 
+echo "${machine}"
+stop 9099
+
 echo "BEGIN: config.resources"
 
 if [[ "${machine}" = "WCOSS2" ]]; then
@@ -47,6 +50,9 @@ elif [[ ${machine} = "S4" ]]; then
    elif [[ ${PARTITION_BATCH} = "ivy" ]]; then
       export npe_node_max=20
    fi
+elif [[ "${machine}" = "AWSPW" ]]; then
+     export PARTITION_BATCH="compute"
+     export npe_node_max=40
 elif [[ ${machine} = "ORION" ]]; then
    export npe_node_max=40
 fi

--- a/workflow/hosts/awspw.yaml
+++ b/workflow/hosts/awspw.yaml
@@ -6,7 +6,7 @@ COMINsyn: '${COMROOT}/gfs/prod/syndat' #TODO: This does not yet exist.
 HOMEDIR: '/contrib/${USER}'
 STMP: '/lustre/${USER}/stmp2/'
 PTMP: '/lustre/${USER}/stmp4/'
-NOSCRUB: $HOMEDIR
+NOSCRUB: ${HOMEDIR}
 ACCOUNT: hwufscpldcld
 SCHEDULER: slurm
 QUEUE: batch


### PR DESCRIPTION
**Description**

Partition name and node size for AWS were missing from `config.resources`. This information has now been added.

Resolves #1727

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

The script `workflow/setup_xml.py` completes successfully. CI has not been implement for NOAA CSPs. Manual testing was successful.

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
