### PR TITLE
Add GEFS atm-only fcst job support

### DIFF
--- a/jobs/JGLOBAL_FORECAST
+++ b/jobs/JGLOBAL_FORECAST
@@ -17,15 +17,23 @@ rCDUMP=${CDUMP}
 [[ ${CDUMP} = "gfs" ]] && export rCDUMP="gdas"
 
 # Forecast length for GFS forecast
-if [ ${CDUMP} = "gfs" ]; then
+case ${CDUMP} in
+  gfs | gefs)
+    # shellcheck disable=SC2153
     export FHMAX=${FHMAX_GFS}
+    # shellcheck disable=SC2153
     export FHOUT=${FHOUT_GFS}
     export FHMAX_HF=${FHMAX_HF_GFS}
     export FHOUT_HF=${FHOUT_HF_GFS}
-else
+    ;;
+  gdas)
     export FHMAX_HF=0
     export FHOUT_HF=0
-fi
+    ;;
+  *)
+    echo "FATAL ERROR: Unknown CDUMP '${CDUMP}'"
+    exit 1
+esac
 
 
 # Ignore possible spelling error (nothing is misspelled)

--- a/jobs/JGLOBAL_FORECAST
+++ b/jobs/JGLOBAL_FORECAST
@@ -17,8 +17,8 @@ rCDUMP=${CDUMP}
 [[ ${CDUMP} = "gfs" ]] && export rCDUMP="gdas"
 
 # Forecast length for GFS forecast
-case ${CDUMP} in
-  gfs | gefs)
+case ${RUN} in
+  *gfs | *gefs)
     # shellcheck disable=SC2153
     export FHMAX=${FHMAX_GFS}
     # shellcheck disable=SC2153
@@ -26,12 +26,12 @@ case ${CDUMP} in
     export FHMAX_HF=${FHMAX_HF_GFS}
     export FHOUT_HF=${FHOUT_HF_GFS}
     ;;
-  gdas)
+  *gdas)
     export FHMAX_HF=0
     export FHOUT_HF=0
     ;;
   *)
-    echo "FATAL ERROR: Unknown CDUMP '${CDUMP}'"
+    echo "FATAL ERROR: Unsupported RUN '${RUN}'"
     exit 1
 esac
 

--- a/parm/config/gefs/config.base.emc.dyn
+++ b/parm/config/gefs/config.base.emc.dyn
@@ -40,7 +40,6 @@ export FIXreg2grb2=${HOMEgfs}/fix/reg2grb2
 export PACKAGEROOT="@PACKAGEROOT@"    # TODO: set via prod_envir in Ops
 export COMROOT="@COMROOT@"    # TODO: set via prod_envir in Ops
 export COMINsyn="@COMINsyn@"
-export DMPDIR="@DMPDIR@"
 
 # USER specific paths
 export HOMEDIR="@HOMEDIR@"
@@ -55,7 +54,7 @@ export BASE_GIT="@BASE_GIT@"
 export DO_BUFRSND="NO"     # BUFR sounding products
 export DO_GEMPAK="NO"      # GEMPAK products
 export DO_AWIPS="NO"       # AWIPS products
-export DO_VRFY="YES"       # VRFY step
+export DO_VRFY="NO"       # VRFY step
 
 # NO for retrospective parallel; YES for real-time parallel
 #  arch.sh uses REALTIME for MOS.  Need to set REALTIME=YES
@@ -73,9 +72,7 @@ export MODE="@MODE@" # cycled/forecast-only
 # CLEAR
 ####################################################
 # Build paths relative to $HOMEgfs
-export FIXgsi="${HOMEgfs}/fix/gsi"
 export HOMEpost="${HOMEgfs}"
-export HOMEobsproc="${BASE_GIT}/obsproc/v1.1.2"
 
 # CONVENIENT utility scripts and other environment parameters
 export NCP="/bin/cp -p"
@@ -100,11 +97,7 @@ export assim_freq=6
 export PSLOT="@PSLOT@"
 export EXPDIR="@EXPDIR@/${PSLOT}"
 export ROTDIR="@ROTDIR@/${PSLOT}"
-export ROTDIR_DUMP="YES"                #Note: A value of "NO" does not currently work
-export DUMP_SUFFIX=""
-if [[ "${PDY}${cyc}" -ge "2019092100" && "${PDY}${cyc}" -le "2019110700" ]]; then
-    export DUMP_SUFFIX="p"              # Use dumps from NCO GFS v15.3 parallel
-fi
+
 export DATAROOT="${STMP}/RUNDIRS/${PSLOT}"  # TODO: set via prod_envir in Ops
 export RUNDIR="${DATAROOT}"  # TODO: Should be removed; use DATAROOT instead
 export ARCDIR="${NOSCRUB}/archive/${PSLOT}"
@@ -235,14 +228,6 @@ case "${APP}" in
     ;;
 esac
 
-# Output frequency of the forecast model (for cycling)
-export FHMIN=0
-export FHMAX=9
-export FHOUT=3           # Will be changed to 1 in config.base if (DOHYBVAR set to NO and l4densvar set to false)
-
-# Cycle to run EnKF  (set to BOTH for both gfs and gdas)
-export EUPD_CYC="gdas"
-
 # GFS cycle info
 export gfs_cyc=@gfs_cyc@ # 0: no GFS cycle, 1: 00Z only, 2: 00Z and 12Z only, 4: all 4 cycles.
 
@@ -253,7 +238,7 @@ export FHMAX_GFS_00=${FHMAX_GFS_00:-120}
 export FHMAX_GFS_06=${FHMAX_GFS_06:-120}
 export FHMAX_GFS_12=${FHMAX_GFS_12:-120}
 export FHMAX_GFS_18=${FHMAX_GFS_18:-120}
-export FHMAX_GFS=$(eval echo \${FHMAX_GFS_${cyc}})
+current_fhmax_var=FHMAX_GFS_${cyc}; declare -x FHMAX_GFS=${!current_fhmax_var}
 
 export FHOUT_GFS=${FHOUT_GFS:-3}
 export FHMAX_HF_GFS=${FHMAX_HF_GFS:-0}
@@ -265,6 +250,10 @@ else
 fi
 export ILPOST=1           # gempak output frequency up to F120
 
+export FHMIN_ENKF=${FHMIN_GFS}
+export FHMAX_ENKF=${FHMAX_GFS}
+export FHOUT_ENKF=${FHOUT_GFS}
+
 # GFS restart interval in hours
 export restart_interval_gfs=0
 
@@ -272,24 +261,6 @@ export QUILTING=".true."
 export OUTPUT_GRID="gaussian_grid"
 export WRITE_DOPOST=".true." # WRITE_DOPOST=true, use inline POST
 export WRITE_NSFLIP=".true."
-
-# IAU related parameters
-export DOIAU="YES"        # Enable 4DIAU for control with 3 increments
-export IAUFHRS="3,6,9"
-export IAU_FHROT=$(echo ${IAUFHRS} | cut -c1)
-export IAU_DELTHRS=6
-export IAU_OFFSET=6
-export DOIAU_ENKF=${DOIAU:-"YES"}   # Enable 4DIAU for EnKF ensemble
-export IAUFHRS_ENKF="3,6,9"
-export IAU_DELTHRS_ENKF=6
-
-# Use Jacobians in eupd and thereby remove need to run eomg
-export lobsdiag_forenkf=".true."
-
-# if [[ "$SDATE" -lt "2019020100" ]]; then # no rtofs in GDA
-#   export DO_WAVE="NO"
-#   echo "WARNING: Wave suite turned off due to lack of RTOFS in GDA for SDATE"
-# fi
 
 # Microphysics Options: 99-ZhaoCarr, 8-Thompson; 6-WSM6, 10-MG, 11-GFDL
 export imp_physics=@IMP_PHYSICS@
@@ -303,39 +274,13 @@ export DO_JEDILANDDA="NO"
 export DO_MERGENSST="NO"
 
 # Hybrid related
-export DOHYBVAR="@DOHYBVAR@"
 export NMEM_ENS=@NMEM_ENS@
-export NMEM_ENS_GFS=@NMEM_ENS@
-export SMOOTH_ENKF="NO"
-export l4densvar=".true."
-export lwrite4danl=".true."
 
-# EnKF output frequency
-if [[ ${DOHYBVAR} = "YES" ]]; then
-    export FHMIN_ENKF=3
-    export FHMAX_ENKF=9
-    export FHMAX_ENKF_GFS=120
-    export FHOUT_ENKF_GFS=3
-    if [ $l4densvar = ".true." ]; then
-        export FHOUT=1
-        export FHOUT_ENKF=1
-    else
-        export FHOUT_ENKF=3
-    fi
-fi
-
-# if 3DVAR and IAU
-if [[ ${DOHYBVAR} == "NO" && ${DOIAU} == "YES"  ]]; then
-    export IAUFHRS="6"
-    export IAU_FHROT="3"
-    export IAU_FILTER_INCREMENTS=".true."
-    export IAUFHRS_ENKF="6"
-fi
-
-# Check if cycle is cold starting, DOIAU off, or free-forecast mode
-if [[ "${MODE}" = "cycled" && "${SDATE}" = "${PDY}${cyc}" && ${EXP_WARM_START} = ".false." ]] || [[ "${DOIAU}" = "NO" ]] || [[ "${MODE}" = "forecast-only" && ${EXP_WARM_START} = ".false." ]] ; then
-  export IAU_OFFSET=0
-  export IAU_FHROT=0
+# Check if cycle is cold starting
+if [[ "${EXP_WARM_START}" = ".false." ]]; then
+    export IAU_FHROT=0
+else
+    export IAU_FHROT=3
 fi
 
 # turned on nsst in anal and/or fcst steps, and turn off rtgsst
@@ -351,24 +296,8 @@ export MAKE_NSSTBUFR="@MAKE_NSSTBUFR@"
 # Make the aircraft prepbufr file on the fly or use the GDA version
 export MAKE_ACFTBUFR="@MAKE_ACFTBUFR@"
 
-# Analysis increments to zero in CALCINCEXEC
-export INCREMENTS_TO_ZERO="'liq_wat_inc','icmr_inc','rwmr_inc','snmr_inc','grle_inc'"
-
-# Write analysis files for early cycle EnKF
-export DO_CALC_INCREMENT_ENKF_GFS="YES"
-
-# Stratospheric increments to zero
-export INCVARS_ZERO_STRAT="'sphum_inc','liq_wat_inc','icmr_inc','rwmr_inc','snmr_inc','grle_inc'"
-export INCVARS_EFOLD="5"
-
-# Swith to generate netcdf or binary diagnostic files.  If not specified,
-# script default to binary diagnostic files.   Set diagnostic file
-# variables here since used in both DA and vrfy jobs
-export netcdf_diag=".true."
-export binary_diag=".false."
-
 # Verification options
-export DO_METP="YES"         # Run METPLUS jobs - set METPLUS settings in config.metp
+export DO_METP="NO"         # Run METPLUS jobs - set METPLUS settings in config.metp
 export DO_FIT2OBS="NO"      # Run fit to observations package
 
 # Archiving options

--- a/parm/config/gefs/config.efcs
+++ b/parm/config/gefs/config.efcs
@@ -66,12 +66,6 @@ export SPPT_LSCALE=500000.
 export SPPT_LOGIT=".true."
 export SPPT_SFCLIMIT=".true."
 
-if [[ ${QUILTING} = ".true." && ${OUTPUT_GRID} = "gaussian_grid" ]]; then
-    export DIAG_TABLE="${HOMEgfs}/parm/parm_fv3diag/diag_table_da"
-else
-    export DIAG_TABLE="${HOMEgfs}/parm/parm_fv3diag/diag_table_da_orig"
-fi
-
 # FV3 model namelist parameters to over-ride
 export restart_interval=${restart_interval:-6}
 

--- a/parm/config/gefs/config.efcs
+++ b/parm/config/gefs/config.efcs
@@ -22,30 +22,30 @@ if [[ ${DO_OCN} == "YES" ]]; then
     *) export OCNRES=025;;
   esac
 fi
-[[ ${DO_ICE} == "YES" ]] && export ICERES=$OCNRES
-[[ ${DO_WAVE} == "YES" ]] && export waveGRD=${waveGRD_ENKF:-$waveGRD}  # TODO: will we run waves with a different resolution in the ensemble?
+[[ ${DO_ICE} == "YES" ]] && export ICERES=${OCNRES}
+[[ ${DO_WAVE} == "YES" ]] && export waveGRD=${waveGRD_ENKF:-${waveGRD}}  # TODO: will we run waves with a different resolution in the ensemble?
 
 # Source model specific information that is resolution dependent
 string="--fv3 ${CASE_ENS}"
-[[ ${DO_OCN} == "YES" ]] && string="$string --mom6 $OCNRES"
-[[ ${DO_ICE} == "YES" ]] && string="$string --cice6 $ICERES"
-[[ ${DO_WAVE} == "YES" ]] && string="$string --ww3 ${waveGRD// /;}"
-source $EXPDIR/config.ufs ${string}
+[[ ${DO_OCN} == "YES" ]] && string="${string} --mom6 ${OCNRES}"
+[[ ${DO_ICE} == "YES" ]] && string="${string} --cice6 ${ICERES}"
+[[ ${DO_WAVE} == "YES" ]] && string="${string} --ww3 ${waveGRD// /;}"
+# shellcheck disable=SC2086
+source "${EXPDIR}/config.ufs" ${string}
 
 # Get task specific resources
-. $EXPDIR/config.resources efcs
+source "${EXPDIR}/config.resources" efcs
 
 # Use serial I/O for ensemble (lustre?)
 export OUTPUT_FILETYPE_ATM="netcdf"
 export OUTPUT_FILETYPE_SFC="netcdf"
 
 # Number of enkf members per fcst job
-export NMEM_EFCSGRP=2
-export NMEM_EFCSGRP_GFS=1
+export NMEM_EFCSGRP=1
 export RERUN_EFCSGRP="NO"
 
 # Turn off inline UPP for EnKF forecast
-export WRITE_DOPOST=".false."
+export WRITE_DOPOST=".true."
 
 # Stochastic physics parameters (only for ensemble forecasts)
 export DO_SKEB="YES"
@@ -66,32 +66,13 @@ export SPPT_LSCALE=500000.
 export SPPT_LOGIT=".true."
 export SPPT_SFCLIMIT=".true."
 
-if [ $QUILTING = ".true." -a $OUTPUT_GRID = "gaussian_grid" ]; then
-    export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_da"
+if [[ ${QUILTING} = ".true." && ${OUTPUT_GRID} = "gaussian_grid" ]]; then
+    export DIAG_TABLE="${HOMEgfs}/parm/parm_fv3diag/diag_table_da"
 else
-    export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_da_orig"
+    export DIAG_TABLE="${HOMEgfs}/parm/parm_fv3diag/diag_table_da_orig"
 fi
 
 # FV3 model namelist parameters to over-ride
 export restart_interval=${restart_interval:-6}
-
-# For IAU, write restarts at beginning of window also
-if [ $DOIAU_ENKF = "YES" ]; then
-    export restart_interval="3 -1"
-fi
-
-# wave model
-export cplwav=.false.
-
-# ocean model resolution
-case "${CASE_ENS}" in
-    "C48") export OCNRES=500;;
-    "C96") export OCNRES=100;;
-    "C192") export OCNRES=050;;
-    "C384") export OCNRES=025;;
-    "C768") export OCNRES=025;;
-    *) export OCNRES=025;;
-esac
-export ICERES=$OCNRES
 
 echo "END: config.efcs"

--- a/parm/config/gefs/config.fcst
+++ b/parm/config/gefs/config.fcst
@@ -277,75 +277,25 @@ export deflate_level=1
 # Disable the use of coupler.res; get model start time from model_configure
 export USE_COUPLER_RES="NO"
 
-if [[ "${CDUMP}" =~ "gdas" ]] ; then # GDAS cycle specific parameters
+# Write more variables to output
+export DIAG_TABLE="${HOMEgfs}/parm/parm_fv3diag/diag_table"
 
-    # Variables used in DA cycling
-    export DIAG_TABLE="${HOMEgfs}/parm/parm_fv3diag/diag_table_da"
+# Write gfs restart files to rerun fcst from any break point
+export restart_interval=${restart_interval_gfs:-12}
 
-    # Write restart files, where $number is current model start time.
-    # restart_interval:        $number
-    #    number=0, writes out restart files at the end of forecast.
-    #    number>0, writes out restart files at the frequency of $number and at the end of forecast.
-    # restart_interval:        "$number -1"
-    #    writes out restart files only once at $number forecast hour.
-    # restart_interval:        "$number1 $number2 $number3 ..."
-    #    writes out restart file at the specified forecast hours
-    export restart_interval=${restart_interval:-6}
+# Choose coupling with wave
+if [[ "${DO_WAVE}" = "YES" ]]; then
+    export cplwav=".true."
+fi
 
-    # For IAU, write restarts at beginning of window also
-    if [[ "${DOIAU}" == "YES" ]]; then
-       export restart_interval="3 6"
-    fi
+# Turn off dry mass adjustment in GFS
+export adjust_dry_mass=".false."
 
-    # Choose coupling with wave
-    if [[ "${DO_WAVE}" == "YES" ]]; then export cplwav=".true." ; fi
-
-    # Turn on dry mass adjustment in GDAS
-    export adjust_dry_mass=".true."
-
-elif [[ "${CDUMP}" =~ "gfs" ]] ; then # GFS cycle specific parameters
-
-    # Write more variables to output
-    export DIAG_TABLE="${HOMEgfs}/parm/parm_fv3diag/diag_table"
-
-    # Write gfs restart files to rerun fcst from any break point
-    export restart_interval_gfs=${restart_interval_gfs:-0}
-    if (( restart_interval_gfs >= 0 )); then
-        export restart_interval="${FHMAX_GFS}"
-    else
-        rst_list=""
-        IAU_OFFSET=${IAU_OFFSET:-0}
-        [[ ${DOIAU} == "NO" ]] && export IAU_OFFSET=0
-        
-        for ((xfh=restart_interval_gfs+(IAU_OFFSET/2); xfh <= FHMAX_GFS; xfh=xfh+restart_interval_gfs )); do
-          rst_list="${rst_list} ${xfh}"
-          xfh=$((xfh+restart_interval_gfs))
-        done
-        export restart_interval="${rst_list}"
-    fi
-
-    if [[ "${DO_AERO}" == "YES" ]]; then
-        # Make sure a restart file is written at the cadence time
-        if [[ ! "${restart_interval[*]}" =~ ${STEP_GFS}  ]]; then
-            export restart_interval="${STEP_GFS} ${restart_interval}"
-        fi
-    fi
-
-    # Choose coupling with wave
-    if [[ "${DO_WAVE}" = "YES" && "${WAVE_CDUMP}" != "gdas" ]]; then
-        export cplwav=".true."
-    fi
-
-    # Turn off dry mass adjustment in GFS
-    export adjust_dry_mass=".false."
-
-    # Write each restart file in 16 small files to save time
-    if [[ "${CASE}" = C768 ]]; then
-      export io_layout="4,4"
-    else
-      export io_layout="1,1"
-    fi
-
+# Write each restart file in 16 small files to save time
+if [[ "${CASE}" = C768 ]]; then
+  export io_layout="4,4"
+else
+  export io_layout="1,1"
 fi
 
 if [[ "${DO_AERO}" = "YES" ]]; then # temporary settings for aerosol coupling

--- a/parm/config/gefs/config.resources
+++ b/parm/config/gefs/config.resources
@@ -599,11 +599,11 @@ elif [[ "${step}" = "fcst" || "${step}" = "efcs" ]]; then
 
     case "${CASE}" in
       "C48" | "C96" | "C192")
-        declare -x "wtime_${step}"="00:30:00"
+        declare -x "wtime_${step}"="03:00:00"
         declare -x "wtime_${step}_gfs"="03:00:00"
         ;;
       "C384" | "C768" | "C1152")
-        declare -x "wtime_${step}"="01:00:00"
+        declare -x "wtime_${step}"="06:00:00"
         declare -x "wtime_${step}_gfs"="06:00:00"
         ;;
       *)


### PR DESCRIPTION
**Description**

Makes the minor changes necessary to run GEFS atm-only fcst job only from pre-staged ICs. Also many unnecessary DA settings are removed from the GEFS version of `config.base`. A few settings are retained either because they are needed, or are expected to be needed to support running from reanalysis (e.g. `IAU_FHROT`).

Resolves #826

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

- [x] 2+ctrl member GEFS forecast on Orion
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
