### PR TITLE
Change JEDI jobs to grab fieldmetadata from GDASApp rather than glopara fix

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -57,7 +57,7 @@ protocol = git
 required = False
 
 [GDASApp]
-hash = 1da2e63
+hash = 7e3d694
 local_path = sorc/gdas.cd
 repo_url = https://github.com/NOAA-EMC/GDASApp.git
 protocol = git

--- a/parm/parm_gdas/aero_jedi_fix.yaml
+++ b/parm/parm_gdas/aero_jedi_fix.yaml
@@ -7,5 +7,5 @@ copy:
   - !ENV ${DATA}/fv3jedi/fmsmpp.nml
 - - !ENV ${FV3JEDI_FIX}/fv3jedi/fv3files/field_table_gfdl
   - !ENV ${DATA}/fv3jedi/field_table
-- - !ENV ${FV3JEDI_FIX}/fv3jedi/fieldmetadata/gfs-aerosol.yaml
-  - !ENV ${DATA}/fv3jedi/gfs-restart.yaml
+- - !ENV $(HOMEgfs)/sorc/gdas.cd/parm/io/fv3jedi_fieldmetadata_restart.yaml
+  - !ENV ${DATA}/fv3jedi/fv3jedi_fieldmetadata_restart.yaml

--- a/parm/parm_gdas/atm_jedi_fix.yaml
+++ b/parm/parm_gdas/atm_jedi_fix.yaml
@@ -4,4 +4,4 @@ copy:
 - [$(HOMEgfs)/fix/gdas/fv3jedi/fv3files/akbk$(npz).nc4, $(DATA)/fv3jedi/akbk.nc4]
 - [$(HOMEgfs)/fix/gdas/fv3jedi/fv3files/fmsmpp.nml, $(DATA)/fv3jedi/fmsmpp.nml]
 - [$(HOMEgfs)/fix/gdas/fv3jedi/fv3files/field_table_gfdl, $(DATA)/fv3jedi/field_table]
-- [$(HOMEgfs)/fix/gdas/fv3jedi/fieldmetadata/gfs-restart.yaml, $(DATA)/fv3jedi/gfs-restart.yaml]
+- [$(HOMEgfs)/sorc/gdas.cd/parm/io/fv3jedi_fieldmetadata_restart.yaml, $(DATA)/fv3jedi/fv3jedi_fieldmetadata_restart.yaml]

--- a/parm/parm_gdas/land_jedi_fix.yaml
+++ b/parm/parm_gdas/land_jedi_fix.yaml
@@ -4,4 +4,4 @@ copy:
 - [$(HOMEgfs)/fix/gdas/fv3jedi/fv3files/akbk$(npz).nc4, $(DATA)/fv3jedi/akbk.nc4]
 - [$(HOMEgfs)/fix/gdas/fv3jedi/fv3files/fmsmpp.nml, $(DATA)/fv3jedi/fmsmpp.nml]
 - [$(HOMEgfs)/fix/gdas/fv3jedi/fv3files/field_table_gfdl, $(DATA)/fv3jedi/field_table]
-- [$(HOMEgfs)/fix/gdas/fv3jedi/fieldmetadata/gfs-land.yaml, $(DATA)/fv3jedi/gfs-land.yaml]
+- [$(HOMEgfs)/sorc/gdas.cd/parm/io/fv3jedi_fieldmetadata_restart.yaml, $(DATA)/fv3jedi/fv3jedi_fieldmetadata_restart.yaml]

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -160,7 +160,7 @@ if [[ ${checkout_gsi} == "YES" ]]; then
 fi
 
 if [[ ${checkout_gdas} == "YES" ]]; then
-  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "1da2e63"; errs=$((errs + $?))
+  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "7e3d694"; errs=$((errs + $?))
 fi
 
 if [[ ${checkout_gsi} == "YES" || ${checkout_gdas} == "YES" ]]; then


### PR DESCRIPTION
**Description**

I think out of convenience before, the glopara/fix/gdas directories contain several text files that do not need to be maintained by the glopara group, and can instead store them in GDASApp or global-workflow.

This PR is the first step towards that, by moving the FV3-JEDI IO fieldmetadata files into GDASApp. Subsequent work will need to determine if things like FV3 diag tables can be shared between FV3-JEDI and the UFS.

This is a complimentary PR to https://github.com/NOAA-EMC/GDASApp/pull/537

Before this can be merged, the above PR must be merged and this PR will need an updated GDASApp hash added in a commit.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] GDASApp workflow-based ctests
- [ ] Cycled test on Hera
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
