### PR TITLE
Fix `SDATE_GFS` issue in cycled and forecast-only modes

### DIFF
--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -890,9 +890,11 @@ class GFSTasks(Tasks):
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         metpenvars = self.envars.copy()
-        metpenvar_dict = {'SDATE_GFS': self._base.get('SDATE_GFS'),
-                          # TODO - in Forecast-only, this is `SDATE` on the RHS
-                          'METPCASE': '#metpcase#'}
+        if self.app_config.mode in ['cycled']:
+            metpenvar_dict = {'SDATE_GFS': self._base.get('SDATE_GFS').strftime("%Y%m%d%H")}
+        elif self.app_config.mode in ['forecast-only']:
+            metpenvar_dict = {'SDATE_GFS': self._base.get('SDATE').strftime("%Y%m%d%H")}
+        metpenvar_dict['METPCASE'] = '#metpcase#'
         for key, value in metpenvar_dict.items():
             metpenvars.append(rocoto.create_envar(name=key, value=str(value)))
 


### PR DESCRIPTION
**Description**

On further examination, `SDATE_GFS` in the context of `metp` task is the first date that METP was run and started generating statistics.  This is different when doing cycled (`gfs_cyc` determines `SDATE_GFS`).  In the case of forecast-only, `SDATE_GFS` is always the date the first free-forecast was launched (`SDATE`)

While the fix by @RussTreadon-NOAA worked for cycling, it broke for forecast-only setups and needed to account for the other mode of operation.

Fixes #1748 

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Created XML for cycled and forecast-only experiments on Hera.
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
