### PR TITLE
Add atm-only test for CI

### DIFF
--- a/ci/cases/C48_ATM.yaml
+++ b/ci/cases/C48_ATM.yaml
@@ -1,0 +1,13 @@
+experiment:
+  type: gfs
+  mode: forecast-only
+
+arguments:
+  pslot: ${pslot}
+  app: ATM
+  resdet: 48
+  comrot: ${RUNTESTS}/COMROT
+  expdir: ${RUNTESTS}/EXPDIR
+  idate: 2021032312
+  edate: 2021032312
+  yaml: ${HOMEgfs_PR}/ci/platforms/gfs_defaults_ci-updates.yaml


### PR DESCRIPTION
**Description**
Adds a single atmosphere forecast-only test at C48.

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
The CI will automagically pick this test and run.
  
**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
