### PR TITLE
Prepare GTS snow depth observations for JEDI-based Land DA

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -57,7 +57,7 @@ protocol = git
 required = False
 
 [GDASApp]
-hash = fd8aa2f
+hash = 7966501
 local_path = sorc/gdas.cd
 repo_url = https://github.com/NOAA-EMC/GDASApp.git
 protocol = git

--- a/parm/config/gfs/config.preplandobs
+++ b/parm/config/gfs/config.preplandobs
@@ -8,6 +8,9 @@ echo "BEGIN: config.preplandobs"
 # Get task specific resources
 . "${EXPDIR}/config.resources" preplandobs
 
+export GTS_OBS_LIST="${HOMEgfs}/sorc/gdas.cd/parm/land/prep/prep_gts.yaml"
+export BUFR2IODAX="${HOMEgfs}/exec/bufr2ioda.x"
+export BUFR2IODAYAML="${HOMEgfs}/sorc/gdas.cd/test/testinput/bufr_adpsfc_snow.yaml"
 export FIMS_NML_TMPL="${HOMEgfs}/sorc/gdas.cd/parm/land/prep/fims.nml.j2"
 export IMS_OBS_LIST="${HOMEgfs}/sorc/gdas.cd/parm/land/prep/prep_ims.yaml"
 export CALCFIMSEXE="${HOMEgfs}/exec/calcfIMS.exe"

--- a/scripts/exglobal_prep_land_obs.py
+++ b/scripts/exglobal_prep_land_obs.py
@@ -17,8 +17,10 @@ if __name__ == '__main__':
 
     # Take configuration from environment and cast it as python dictionary
     config = cast_strdict_as_dtypedict(os.environ)
+    HH = os.environ.get("CDATE")[8:]
 
     # Instantiate the land prepare task
     LandAnl = LandAnalysis(config)
     LandAnl.prepare_GTS()
-    LandAnl.prepare_IMS()
+    if HH == '18':
+        LandAnl.prepare_IMS()

--- a/scripts/exglobal_prep_land_obs.py
+++ b/scripts/exglobal_prep_land_obs.py
@@ -17,10 +17,9 @@ if __name__ == '__main__':
 
     # Take configuration from environment and cast it as python dictionary
     config = cast_strdict_as_dtypedict(os.environ)
-    HH = os.environ.get("CDATE")[8:]
 
     # Instantiate the land prepare task
     LandAnl = LandAnalysis(config)
     LandAnl.prepare_GTS()
-    if HH == '18':
+    if f"{ LandAnl.runtime_config.cyc }" == '18':
         LandAnl.prepare_IMS()

--- a/scripts/exglobal_prep_land_obs.py
+++ b/scripts/exglobal_prep_land_obs.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 # exglobal_land_analysis_prepare.py
 # This script creates a LandAnalysis object
-# and runs the prepare_IMS method
-# which perform the pre-processing for IMS data
+# and runs the prepare_GTS and prepare_IMS method
+# which perform the pre-processing for GTS and IMS data
 import os
 
 from wxflow import Logger, cast_strdict_as_dtypedict
@@ -20,4 +20,5 @@ if __name__ == '__main__':
 
     # Instantiate the land prepare task
     LandAnl = LandAnalysis(config)
+    LandAnl.prepare_GTS()
     LandAnl.prepare_IMS()

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -160,7 +160,7 @@ if [[ ${checkout_gsi} == "YES" ]]; then
 fi
 
 if [[ ${checkout_gdas} == "YES" ]]; then
-  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "fd8aa2f"; errs=$((errs + $?))
+  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "7966501"; errs=$((errs + $?))
 fi
 
 if [[ ${checkout_gsi} == "YES" || ${checkout_gdas} == "YES" ]]; then

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -308,6 +308,7 @@ if [[ -d "${HOMEgfs}/sorc/gdas.cd" ]]; then
                        "soca_setcorscales.x" \
                        "soca_gridgen.x" \
                        "soca_var.x" \
+                       "bufr2ioda.x" \
                        "calcfIMS.exe" \
                        "apply_incr.exe" )
   for gdasexe in "${JEDI_EXE[@]}"; do

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -123,12 +123,11 @@ class LandAnalysis(Analysis):
 
         # Ensure the IODA snow depth GTS file is produced by the IODA converter
         # If so, copy to COM_OBS/
-        if not os.path.isfile(f"{os.path.join(localconf.DATA, output_file)}"):
-            logger.exception(f"{self.task_config.BUFR2IODAX} failed to produce {output_file}")
-            raise FileNotFoundError(f"{os.path.join(localconf.DATA, output_file)}")
-        else:
-            logger.info(f"Copy {output_file} to {self.task_config.COM_OBS}")
+        try:
             FileHandler(prep_gts_config.gtsioda).sync()
+        except OSError:
+            logger.exception(f"{self.task_config.BUFR2IODAX} failed to produce {output_file}")
+            raise Exception(err)
 
     @logit(logger)
     def prepare_IMS(self) -> None:

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -7,15 +7,15 @@ from pprint import pformat
 import numpy as np
 from netCDF4 import Dataset
 
-from pygw.attrdict import AttrDict
-from pygw.file_utils import FileHandler
-from pygw.timetools import to_fv3time, to_YMD, to_YMDH, to_timedelta, add_to_datetime, to_julian
-from pygw.fsutils import rm_p
-from pygw.yaml_file import parse_j2yaml, parse_yamltmpl, save_as_yaml
-from pygw.jinja import Jinja
-from pygw.logger import logit
-from pygw.executable import Executable
-from pygw.exceptions import WorkflowException
+from wxflow import (AttrDict,
+                    FileHandler,
+                    to_fv3time, to_YMD, to_YMDH, to_timedelta, add_to_datetime,
+                    rm_p,
+                    parse_j2yaml, parse_yamltmpl, save_as_yaml,
+                    Jinja,
+                    logit,
+                    Executable,
+                    WorkflowException)
 from pygfs.task.analysis import Analysis
 
 logger = getLogger(__name__.split('.')[-1])
@@ -249,7 +249,7 @@ class LandAnalysis(Analysis):
         # create a temporary dict of all keys needed in this method
         localconf = AttrDict()
         keys = ['DATA', 'current_cycle', 'COM_OBS', 'COM_ATMOS_RESTART_PREV',
-                'OPREFIX', 'CASE', 'ntiles', 'SNOWDEPTHVAR', 'FRAC_GRID']
+                'OPREFIX', 'CASE', 'ntiles']
         for key in keys:
             localconf[key] = self.task_config[key]
 
@@ -301,8 +301,7 @@ class LandAnalysis(Analysis):
         localconf = AttrDict()
         keys = ['HOMEgfs', 'DATA', 'current_cycle',
                 'COM_ATMOS_RESTART_PREV', 'COM_LAND_ANALYSIS', 'APREFIX',
-                'SNOWDEPTHVAR', 'BESTDDEV',
-                'FRAC_GRID', 'CASE', 'ntiles',
+                'SNOWDEPTHVAR', 'BESTDDEV', 'CASE', 'ntiles',
                 'APRUN_LANDANL', 'JEDIEXE', 'jedi_yaml',
                 'APPLY_INCR_NML_TMPL', 'APPLY_INCR_EXE', 'APRUN_APPLY_INCR']
         for key in keys:
@@ -460,7 +459,7 @@ class LandAnalysis(Analysis):
         Parameters
         ----------
         vname : str
-            snow depth variable to perturb. "snowdl" or "snwdph" depending on FRAC_GRID (.true.|.false.)
+            snow depth variable to perturb: "snodl"
         bestddev : float
             Background Error Standard Deviation to perturb around to create ensemble
         config: Dict
@@ -509,7 +508,6 @@ class LandAnalysis(Analysis):
              COM_ATMOS_RESTART_PREV
              DATA
              current_cycle
-             FRAC_GRID
              CASE
              ntiles
              APPLY_INCR_NML_TMPL

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -35,7 +35,6 @@ class LandAnalysis(Analysis):
         _res = int(self.config['CASE'][1:])
         _window_begin = add_to_datetime(self.runtime_config.current_cycle, -to_timedelta(f"{self.config['assim_freq']}H") / 2)
         _letkfoi_yaml = os.path.join(self.runtime_config.DATA, f"{self.runtime_config.RUN}.t{self.runtime_config['cyc']:02d}z.letkfoi.yaml")
-#        _bufr2ioda_yaml = os.path.join(self.runtime_config.DATA, f"bufr_adpsfc_snow.yaml")
 
         # Create a local dictionary that is repeatedly used across this class
         local_dict = AttrDict(
@@ -49,7 +48,6 @@ class LandAnalysis(Analysis):
                 'OPREFIX': f"{self.runtime_config.RUN}.t{self.runtime_config.cyc:02d}z.",
                 'APREFIX': f"{self.runtime_config.RUN}.t{self.runtime_config.cyc:02d}z.",
                 'jedi_yaml': _letkfoi_yaml
-#                'bufr2ioda_yaml': _bufr2ioda_yaml
             }
         )
 

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -35,7 +35,7 @@ class LandAnalysis(Analysis):
         _res = int(self.config['CASE'][1:])
         _window_begin = add_to_datetime(self.runtime_config.current_cycle, -to_timedelta(f"{self.config['assim_freq']}H") / 2)
         _letkfoi_yaml = os.path.join(self.runtime_config.DATA, f"{self.runtime_config.RUN}.t{self.runtime_config['cyc']:02d}z.letkfoi.yaml")
-        _bufr2ioda_yaml = os.path.join(self.runtime_config.DATA, f"bufr_adpsfc_snow.yaml")
+#        _bufr2ioda_yaml = os.path.join(self.runtime_config.DATA, f"bufr_adpsfc_snow.yaml")
 
         # Create a local dictionary that is repeatedly used across this class
         local_dict = AttrDict(
@@ -48,8 +48,8 @@ class LandAnalysis(Analysis):
                 'LAND_WINDOW_LENGTH': f"PT{self.config['assim_freq']}H",
                 'OPREFIX': f"{self.runtime_config.RUN}.t{self.runtime_config.cyc:02d}z.",
                 'APREFIX': f"{self.runtime_config.RUN}.t{self.runtime_config.cyc:02d}z.",
-                'jedi_yaml': _letkfoi_yaml,
-                'bufr2ioda_yaml': _bufr2ioda_yaml
+                'jedi_yaml': _letkfoi_yaml
+#                'bufr2ioda_yaml': _bufr2ioda_yaml
             }
         )
 
@@ -90,10 +90,11 @@ class LandAnalysis(Analysis):
         FileHandler(prep_gts_config.gtsbufr).sync()
 
         # generate bufr2ioda YAML file
-        logger.info(f"Generate BUFR2IODA YAML file: {self.task_config.bufr2ioda_yaml}")
-        bufr2ioda_yaml = parse_j2yaml(self.task_config.BUFR2IODAYAML, self.task_config)
-        save_as_yaml(bufr2ioda_yaml, self.task_config.bufr2ioda_yaml)
-        logger.info(f"Wrote bufr2ioda YAML to: {self.task_config.bufr2ioda_yaml}")
+        bufr2ioda_yaml = os.path.join(self.runtime_config.DATA, "bufr_adpsfc_snow.yaml")
+        logger.info(f"Generate BUFR2IODA YAML file: {bufr2ioda_yaml}")
+        temp_yaml = parse_j2yaml(self.task_config.BUFR2IODAYAML, self.task_config)
+        save_as_yaml(temp_yaml, bufr2ioda_yaml)
+        logger.info(f"Wrote bufr2ioda YAML to: {bufr2ioda_yaml}")
 
         logger.info("Link BUFR2IODAX into DATA/")
         exe_src = self.task_config.BUFR2IODAX

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -86,7 +86,7 @@ class LandAnalysis(Analysis):
         logger.debug(f"{self.task_config.GTS_OBS_LIST}:\n{pformat(prep_gts_config)}")
 
         # copy the GTS obs files from COM_OBS to DATA/obs
-        logger.info("Copying GTS obs for BUFR2IODAX")
+        logger.info("Copying GTS obs for bufr2ioda.x")
         FileHandler(prep_gts_config.gtsbufr).sync()
 
         # generate bufr2ioda YAML file

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -125,9 +125,9 @@ class LandAnalysis(Analysis):
         # If so, copy to COM_OBS/
         try:
             FileHandler(prep_gts_config.gtsioda).sync()
-        except OSError:
+        except OSError as err:
             logger.exception(f"{self.task_config.BUFR2IODAX} failed to produce {output_file}")
-            raise Exception(err)
+            raise OSError(err)
 
     @logit(logger)
     def prepare_IMS(self) -> None:

--- a/workflow/rocoto/gfs_cycled_xml.py
+++ b/workflow/rocoto/gfs_cycled_xml.py
@@ -20,12 +20,6 @@ class GFSCycledRocotoXML(RocotoXML):
         sdate = sdate + to_timedelta(interval)
         strings.append(f'\t<cycledef group="gdas">{sdate.strftime("%Y%m%d%H%M")} {edate.strftime("%Y%m%d%H%M")} {interval}</cycledef>')
 
-        if self._app_config.do_jedilandda:
-            sdate_land_str = sdate.replace(hour=18, minute=0, second=0).strftime("%Y%m%d%H%M")
-            edate_land_str = edate.strftime("%Y%m%d%H%M")
-            if edate >= sdate:
-                strings.append(f'\t<cycledef group="gdas_land_prep">{sdate_land_str} {edate_land_str} 24:00:00</cycledef>')
-
         if self._app_config.gfs_cyc != 0:
             sdate_gfs = self._base['SDATE_GFS']
             edate_gfs = self._base['EDATE_GFS']

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -337,26 +337,16 @@ class GFSTasks(Tasks):
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('preplandobs')
-        task = create_wf_task('preplandobs', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies,
-                              cycledef=f'{self.cdump}_land_prep')
+        task = create_wf_task('preplandobs', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies)
 
         return task
 
     def landanl(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.cdump}prep'}
-        deps.append(rocoto.add_dependency(dep_dict))
-
-        # Either gdaspreplandobs (runs in 18z cycle) or not 18z cycle
-        sub_deps = []
         dep_dict = {'type': 'task', 'name': f'{self.cdump}preplandobs'}
-        sub_deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'strneq', 'left': '@H', 'right': 18}
-        sub_deps.append(rocoto.add_dependency(dep_dict))
-        deps.append(rocoto.create_dependency(dep_condition='xor', dep=sub_deps))
-
-        dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
+        deps.append(rocoto.add_dependency(dep_dict))
+        dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('landanl')
         task = create_wf_task('landanl', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies)


### PR DESCRIPTION
This PR:

- adds a job to prepare GTS snow depth observations as a task in the workflow. This task depends on the `prep.sh` job to bring GTS adpsfc bufr data. To test this type of data DMPDIR in `config.base` needed to be pointed to "/scratch1/NCEPDEV/global/Jiarui.Dong/JEDI/GlobalWorkflow/para_gfs/glopara_dump". 
- land_analysis.py introduces a method `prepare_GTS` for this type of data.
- Updates are necessary in the GDASApp repo. See companion PR https://github.com/NOAA-EMC/GDASApp/pull/541

The `preplandobs` job runs at the all four cycles in the workflow. The `prepare_IMS` job runs only at 18z cycle, and this is controlled in the script. 

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
