### PR TITLE
Small changes to get (aerosol) cycling going at C384

### DIFF
--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -884,10 +884,7 @@ elif [[ ${step} = "epos" ]]; then
 
     export wtime_epos="00:15:00"
     export npe_epos=80
-    export nth_epos=4
-    if [[ "${machine}" == "HERA" ]]; then
-      export nth_epos=1
-    fi
+    export nth_epos=1
     npe_node_epos=$(echo "${npe_node_max} / ${nth_epos}" | bc)
     export npe_node_epos
     export is_exclusive=True

--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -250,12 +250,12 @@ elif [[ "${step}" = "aeroanlinit" ]]; then
    # below lines are for creating JEDI YAML
    case ${CASE} in
      C768)
-        layout_x=6
-        layout_y=6
+        layout_x=8
+        layout_y=8
         ;;
       C384)
-        layout_x=5
-        layout_y=5
+        layout_x=8
+        layout_y=8
         ;;
      C192 | C96 | C48)
         layout_x=8
@@ -280,12 +280,12 @@ elif [[ "${step}" = "aeroanlrun" ]]; then
 
    case ${CASE} in
      C768)
-        layout_x=6
-        layout_y=6
+        layout_x=8
+        layout_y=8
         ;;
       C384)
-        layout_x=5
-        layout_y=5
+        layout_x=8
+        layout_y=8
         ;;
      C192 | C96 | C48)
         layout_x=8
@@ -470,6 +470,7 @@ elif [[ ${step} = "analcalc" ]]; then
     npe_node_analcalc=$(echo "${npe_node_max} / ${nth_analcalc}" | bc)
     export npe_node_analcalc
     export is_exclusive=True
+    export memory_analcalc="48GB"
 
 elif [[ ${step} = "analdiag" ]]; then
 
@@ -885,7 +886,7 @@ elif [[ ${step} = "epos" ]]; then
     export npe_epos=80
     export nth_epos=4
     if [[ "${machine}" == "HERA" ]]; then
-      export nth_epos=6
+      export nth_epos=1
     fi
     npe_node_epos=$(echo "${npe_node_max} / ${nth_epos}" | bc)
     export npe_node_epos

--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -870,7 +870,7 @@ elif [[ ${step} = "ecen" ]]; then
 
 elif [[ ${step} = "esfc" ]]; then
 
-    export wtime_esfc="00:06:00"
+    export wtime_esfc="00:08:00"
     export npe_esfc=80
     export nth_esfc=1
     npe_node_esfc=$(echo "${npe_node_max} / ${nth_esfc}" | bc)

--- a/parm/config/gfs/config.ufs
+++ b/parm/config/gfs/config.ufs
@@ -151,7 +151,7 @@ case "${fv3_res}" in
         export layout_y=8
         export layout_x_gfs=8
         export layout_y_gfs=8
-        export nthreads_fv3=1
+        export nthreads_fv3=2
         export nthreads_fv3_gfs=2
         export cdmbgwd="1.1,0.72,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
         export WRITE_GROUP=2

--- a/ush/python/pygfs/task/aero_analysis.py
+++ b/ush/python/pygfs/task/aero_analysis.py
@@ -30,7 +30,7 @@ class AerosolAnalysis(Analysis):
         super().__init__(config)
 
         _res = int(self.config['CASE'][1:])
-        _res_enkf = int(self.config['CASE_ENS'][1:])
+        _res_anl = int(self.config['CASE_ANL'][1:])
         _window_begin = add_to_datetime(self.runtime_config.current_cycle, -to_timedelta(f"{self.config['assim_freq']}H") / 2)
         _fv3jedi_yaml = os.path.join(self.runtime_config.DATA, f"{self.runtime_config.CDUMP}.t{self.runtime_config['cyc']:02d}z.aerovar.yaml")
 
@@ -41,8 +41,8 @@ class AerosolAnalysis(Analysis):
                 'npy_ges': _res + 1,
                 'npz_ges': self.config.LEVS - 1,
                 'npz': self.config.LEVS - 1,
-                'npx_anl': _res_enkf + 1,
-                'npy_anl': _res_enkf + 1,
+                'npx_anl': _res_anl + 1,
+                'npy_anl': _res_anl + 1,
                 'npz_anl': self.config['LEVS'] - 1,
                 'AERO_WINDOW_BEGIN': _window_begin,
                 'AERO_WINDOW_LENGTH': f"PT{self.config['assim_freq']}H",
@@ -284,7 +284,7 @@ class AerosolAnalysis(Analysis):
             berror_list.append([
                 os.path.join(b_dir, coupler), os.path.join(config.DATA, 'berror', coupler)
             ])
-            template = '{b_datestr}.{ftype}.fv_tracer.res.tile{{tilenum}}.nc'
+            template = f'{b_datestr}.{ftype}.fv_tracer.res.tile{{tilenum}}.nc'
             for itile in range(1, config.ntiles + 1):
                 tracer = template.format(tilenum=itile)
                 berror_list.append([


### PR DESCRIPTION
**Description**

Trying both ATM C384/C192 cycling with GSI hybrid-4DEnVar (half res of ops) and ATMA C384 3DVar on Hera, I ran into several problems. This PR solves them (for now!)

Change summary:
1. The aeroanl layouts are now all 8x8, this is just so that we can use the C96 BUMP files that are 8x8 layout for higher resolutions (this is not expected to be a permanent change, and we will have 'optimized' values later)
2. analcalc would fail (Closes #1738 ), this specifies the amount of memory and allows it to complete
3. The first half cycle C384 forecast would fail, changing `nthreads_fv3` to 2 fixes this
4. The epos jobs do not need 14 nodes allocated, this changes it to 2 nodes, and it runs at this resolution in only 3 mins on Hera
5. A bugfix (missing `f` before a f-string) and changed `_res_enkf` to `_res_anl` because `CASE_ANL` is set in `config.aeroanl` but `CASE_ENKF` will not be set by the setup_expt script if you specify `nmem` to be 0  



**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] Cycled test on Hera ATM
- [x] Cycled test on Hera ATMA

  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
