### PR TITLE
Fix previous restart paths for ensemble

### DIFF
--- a/jobs/JGDAS_ENKF_FCST
+++ b/jobs/JGDAS_ENKF_FCST
@@ -8,7 +8,6 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "efcs" -c "base fcst efcs"
 # Set variables used in the script
 ##############################################
 export CDUMP=${RUN/enkf}
-export rCDUMP="enkfgdas"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/scripts/exgdas_enkf_fcst.sh
+++ b/scripts/exgdas_enkf_fcst.sh
@@ -131,22 +131,22 @@ for imem in $(seq "${ENSBEG}" "${ENSEND}"); do
    MEMDIR="${memchar}" YMD=${PDY} HH=${cyc} generate_com -x COM_ATMOS_RESTART COM_ATMOS_INPUT COM_ATMOS_ANALYSIS \
      COM_ATMOS_HISTORY COM_ATMOS_MASTER
 
-   RUN=${rCDUMP} MEMDIR="${memchar}" YMD="${gPDY}" HH="${gcyc}" generate_com -x COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
+   MEMDIR="${memchar}" YMD="${gPDY}" HH="${gcyc}" generate_com -x COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
 
    if [[ ${DO_WAVE} == "YES" ]]; then
      MEMDIR="${memchar}" YMD=${PDY} HH=${cyc} generate_com -x COM_WAVE_RESTART COM_WAVE_PREP COM_WAVE_HISTORY
-     RUN=${rCDUMP} MEMDIR="${memchar}" YMD="${gPDY}" HH="${gcyc}" generate_com -x COM_WAVE_RESTART_PREV:COM_WAVE_RESTART_TMPL
+     MEMDIR="${memchar}" YMD="${gPDY}" HH="${gcyc}" generate_com -x COM_WAVE_RESTART_PREV:COM_WAVE_RESTART_TMPL
    fi
 
    if [[ ${DO_OCN} == "YES" ]]; then
      MEMDIR="${memchar}" YMD=${PDY} HH=${cyc} generate_com -x COM_MED_RESTART COM_OCEAN_RESTART \
        COM_OCEAN_INPUT COM_OCEAN_HISTORY COM_OCEAN_ANALYSIS
-     RUN=${rCDUMP} MEMDIR="${memchar}" YMD="${gPDY}" HH="${gcyc}" generate_com -x COM_OCEAN_RESTART_PREV:COM_OCEAN_RESTART_TMPL
+     MEMDIR="${memchar}" YMD="${gPDY}" HH="${gcyc}" generate_com -x COM_OCEAN_RESTART_PREV:COM_OCEAN_RESTART_TMPL
    fi
 
    if [[ ${DO_ICE} == "YES" ]]; then
      MEMDIR="${memchar}" YMD=${PDY} HH=${cyc} generate_com -x COM_ICE_HISTORY COM_ICE_INPUT COM_ICE_RESTART
-     RUN=${rCDUMP} MEMDIR="${memchar}" YMD="${gPDY}" HH="${gcyc}" generate_com -x COM_ICE_RESTART_PREV:COM_ICE_RESTART_TMPL
+     MEMDIR="${memchar}" YMD="${gPDY}" HH="${gcyc}" generate_com -x COM_ICE_RESTART_PREV:COM_ICE_RESTART_TMPL
    fi
 
    if [[ ${DO_AERO} == "YES" ]]; then


### PR DESCRIPTION
**Description**

GEFS was failing because the `rCDUMP` in the forecast job was hard-coded to `enkfgdas`. This resulted in always looking in that directory for previous cycle restart files. This was not caught previously because the manual staging method was copying the gdas directories as well, masking the problem.

Resolves #1771

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] Forecast-only GEFS test on Hera
- [x] Forecast-only GEFS test on Orion
 
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
