### PR TITLE
Updated staged INPUT files for C48 on awspw

### DIFF
--- a/workflow/hosts/awspw.yaml
+++ b/workflow/hosts/awspw.yaml
@@ -1,4 +1,5 @@
 BASE_GIT: '/scratch1/NCEPDEV/global/glopara/git' #TODO: This does not yet exist.
+BASE_CPLIC: '/contrib/Terry.McGuinness/home/ICSDIR/prototype_ICs'  
 DMPDIR: '/scratch1/NCEPDEV/global/glopara/dump' # TODO: This does not yet exist.
 PACKAGEROOT: '/scratch1/NCEPDEV/global/glopara/nwpara' #TODO: This does not yet exist.
 COMROOT: '/scratch1/NCEPDEV/global/glopara/com' #TODO: This does not yet exist.


### PR DESCRIPTION
**Description**

Adding configuration for staged INPUT files for free forecast C48 on **awspr** to match test path `workflowtest/2016010100/gfs/C48/INPUT` from `/contrib/Terry.McGuinness/home/ICSDIR/prototype_ICs` set in `$HOMEgfs/workflow/hosts/awspr.yaml` file.

**Type of change**

Simple configuration upadte

**How Has This Been Tested?**

Ran `rocotocheck` and verified valid file dependency on generated XML
