### PR TITLE
Fix unbound PS1 message from module-setup

### DIFF
--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -15,7 +15,9 @@ elif [[ ${MACHINE_ID} = hera* ]] ; then
         source /apps/lmod/lmod/init/bash
     fi
     export LMOD_SYSTEM_DEFAULT_MODULES=contrib
+    set +u
     module reset
+    set -u
 
 elif [[ ${MACHINE_ID} = orion* ]] ; then
     # We are on Orion
@@ -23,7 +25,9 @@ elif [[ ${MACHINE_ID} = orion* ]] ; then
         source /apps/lmod/init/bash
     fi
     export LMOD_SYSTEM_DEFAULT_MODULES=contrib
+    set +u
     module reset
+    set -u
 
 elif [[ ${MACHINE_ID} = s4* ]] ; then
     # We are on SSEC Wisconsin S4


### PR DESCRIPTION
**Description**

Turns off unbound variable checking when calling `module reset` on Hera and Orion to suppress message about PS1 being unbound since correcting it is outside the control of workflow.

Resolves #1780

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] Run module-setup.sh on Orion
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
