### PR TITLE
Use GEFS post file for GEFS

### DIFF
--- a/parm/config/gefs/config.base.emc.dyn
+++ b/parm/config/gefs/config.base.emc.dyn
@@ -262,6 +262,12 @@ export OUTPUT_GRID="gaussian_grid"
 export WRITE_DOPOST=".true." # WRITE_DOPOST=true, use inline POST
 export WRITE_NSFLIP=".true."
 
+if [[ ${WRITE_DOPOST} == ".true." ]]; then
+    # Override normal post flat files for GEFS
+    export FLTFILEGFS="${PARMgfs}/post/postxconfig-NT-GEFS.txt"
+    export FLTFILEGFSF00="${PARMgfs}/post/postxconfig-NT-GEFS-F00.txt"
+fi
+
 # Microphysics Options: 99-ZhaoCarr, 8-Thompson; 6-WSM6, 10-MG, 11-GFDL
 export imp_physics=@IMP_PHYSICS@
 

--- a/parm/config/gefs/config.base.emc.dyn
+++ b/parm/config/gefs/config.base.emc.dyn
@@ -262,11 +262,9 @@ export OUTPUT_GRID="gaussian_grid"
 export WRITE_DOPOST=".true." # WRITE_DOPOST=true, use inline POST
 export WRITE_NSFLIP=".true."
 
-if [[ ${WRITE_DOPOST} == ".true." ]]; then
-    # Override normal post flat files for GEFS
-    export FLTFILEGFS="${PARMgfs}/post/postxconfig-NT-GEFS.txt"
-    export FLTFILEGFSF00="${PARMgfs}/post/postxconfig-NT-GEFS-F00.txt"
-fi
+# Override normal post flat files for GEFS
+export FLTFILEGFS="${PARMgfs}/post/postxconfig-NT-GEFS.txt"
+export FLTFILEGFSF00="${PARMgfs}/post/postxconfig-NT-GEFS-F00.txt"
 
 # Microphysics Options: 99-ZhaoCarr, 8-Thompson; 6-WSM6, 10-MG, 11-GFDL
 export imp_physics=@IMP_PHYSICS@


### PR DESCRIPTION
**Description**

The GEFS configuration is updated to override the default (GFS) post flatfiles when running GEFS.

Resolves #1750

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] GEFS forecast on Orion
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
