### PR TITLE
BASH wrapper to create_experiment.py and removed its redundant 2nd argument

### DIFF
--- a/.github/workflows/globalworkflow-ci.yaml
+++ b/.github/workflows/globalworkflow-ci.yaml
@@ -60,7 +60,7 @@ jobs:
           cd ${{ env.TEST_DIR }}/HOMEgfs
           source workflow/gw_setup.sh
           source ci/platforms/orion.sh
-          ./ci/scripts/create_experiment.py --yaml ci/cases/${{ matrix.case }}.yaml --dir ${{ env.HOMEgfs_PR }}
+          ./ci/scripts/create_experiment.py --yaml ci/cases/${{ matrix.case }}.yaml
 
   run-experiments:
     needs: create-experiments

--- a/ci/scripts/create_experiment.py
+++ b/ci/scripts/create_experiment.py
@@ -62,7 +62,6 @@ def input_args():
                             formatter_class=ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('--yaml', help='full path to yaml file describing the experiment configuration', type=str, required=True)
-    parser.add_argument('--dir', help='full path to global-workflow build', type=str, required=True)
 
     return parser.parse_args()
 
@@ -70,7 +69,6 @@ def input_args():
 if __name__ == '__main__':
 
     user_inputs = input_args()
-    HOMEgfs = Path.absolute(Path(user_inputs.dir))
     testconf = YAMLFile(path=user_inputs.yaml)
     experiment_dir = Path.absolute(Path.joinpath(Path(testconf.arguments.expdir), Path(testconf.arguments.pslot)))
 

--- a/ci/scripts/create_experiment.sh
+++ b/ci/scripts/create_experiment.sh
@@ -65,4 +65,4 @@ export RUNTESTS=${RUNTESTS:-"${PWD}"}
 export HOMEgfs_PR="${HOMEgfs}"
 unset HOMEgfs;
 
-${HOMEgfs_PR}/ci/scripts/create_experiment.py --yaml "${YAML_CASE}"
+"${HOMEgfs_PR}/ci/scripts/create_experiment.py" --yaml "${YAML_CASE}"

--- a/ci/scripts/create_experiment.sh
+++ b/ci/scripts/create_experiment.sh
@@ -58,8 +58,6 @@ case ${MACHINE_ID} in
    ;;
 esac
 
-source "${HOMEgfs}/ci/platforms/${MACHINE_ID}.sh"
-
 filename=$(basename -- ${YAML_CASE})
 export pslot="${filename%.*}"
 export RUNTESTS=${RUNTESTS:-"${PWD}"}

--- a/ci/scripts/create_experiment.sh
+++ b/ci/scripts/create_experiment.sh
@@ -57,7 +57,7 @@ case ${MACHINE_ID} in
    ;;
 esac
 
-filename=$(basename -- ${YAML_CASE})
+filename=$(basename -- "${YAML_CASE}")
 export pslot="${filename%.*}"
 export RUNTESTS=${RUNTESTS:-"${PWD}"}
 # TODO env HOMEgfs being set will cause runtime error
@@ -65,4 +65,4 @@ export RUNTESTS=${RUNTESTS:-"${PWD}"}
 export HOMEgfs_PR="${HOMEgfs}"
 unset HOMEgfs;
 
-${HOMEgfs_PR}/ci/scripts/create_experiment.py --yaml $YAML_CASE
+${HOMEgfs_PR}/ci/scripts/create_experiment.py --yaml "${YAML_CASE}"

--- a/ci/scripts/create_experiment.sh
+++ b/ci/scripts/create_experiment.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -eux
+
+#########################################################################
+#
+# Script description: BASH script for creating an experiment
+#                     by only taking a single YAML file
+########################################################################
+
+usage() {
+  set +x
+  echo
+  echo "Usage: $0 -y case/yaml_conf_file.yaml"
+  echo
+  echo "  -c  global workflow configuration yaml defining an experiment (\$HOMEgfs/ci/cases)"
+  echo "  -d  full path to directory to place COMROT with EXPDIR for createing experiments"
+  echo "  -h  display this message and quit"
+  echo
+  exit 1
+}
+
+while getopts "c:d:h" opt; do
+  case ${opt} in
+    c)
+      YAML_CASE=${OPTARG}
+      ;;
+    d)
+      RUNTESTS=${OPTARG}
+      ;;
+    h|\?|:)
+      usage
+      ;;
+    *)
+      echo "Unrecognized option"
+      usage
+     ;;
+  esac
+done
+
+HOMEgfs="$(cd "$(dirname  "${BASH_SOURCE[0]}")/../.." >/dev/null 2>&1 && pwd )"
+scriptname=$(basename "${BASH_SOURCE[0]}")
+echo "Begin ${scriptname} at $(date -u)" || true
+export PS4='+ $(basename ${BASH_SOURCE})[${LINENO}]'
+
+#########################################################################
+#  Set up runtime environment varibles for accounts on supproted machines
+#########################################################################
+
+source "${HOMEgfs}/ush/detect_machine.sh"
+case ${MACHINE_ID} in
+  hera | orion)
+   echo "Running Automated Testing on ${MACHINE_ID}"
+   source "${HOMEgfs}/ci/platforms/${MACHINE_ID}.sh"
+   ;;
+ *)
+   echo "Unsupported platform. Exiting with error."
+   exit 1
+   ;;
+esac
+
+source "${HOMEgfs}/ci/platforms/${MACHINE_ID}.sh"
+
+filename=$(basename -- ${YAML_CASE})
+export pslot="${filename%.*}"
+export RUNTESTS=${RUNTESTS:-"${PWD}"}
+# TODO env HOMEgfs being set will cause runtime error
+# with HOMEgfs being blank in Rocoto XLM file
+export HOMEgfs_PR="${HOMEgfs}"
+unset HOMEgfs;
+
+${HOMEgfs_PR}/ci/scripts/create_experiment.py --yaml $YAML_CASE

--- a/ci/scripts/create_experiment.sh
+++ b/ci/scripts/create_experiment.sh
@@ -49,7 +49,6 @@ export PS4='+ $(basename ${BASH_SOURCE})[${LINENO}]'
 source "${HOMEgfs}/ush/detect_machine.sh"
 case ${MACHINE_ID} in
   hera | orion)
-   echo "Running Automated Testing on ${MACHINE_ID}"
    source "${HOMEgfs}/ci/platforms/${MACHINE_ID}.sh"
    ;;
  *)

--- a/ci/scripts/driver.sh
+++ b/ci/scripts/driver.sh
@@ -155,7 +155,7 @@ for pr in ${pr_list}; do
       pslot="${case}_${pr_sha}"
       export pslot
       set +e
-      "${HOMEgfs_PR}/ci/scripts/create_experiment.py" --yaml "${HOMEgfs_PR}/ci/cases/${case}.yaml" --dir "${HOMEgfs_PR}"
+      "${HOMEgfs_PR}/ci/scripts/create_experiment.py" --yaml "${HOMEgfs_PR}/ci/cases/${case}.yaml"
       ci_status=$?
       set -e
       if [[ ${ci_status} -eq 0 ]]; then


### PR DESCRIPTION
*Description**

Adding BASH wrapper to `create_experiment.py` so users can use it directly (it previously needed several environments settings  found in `../platforms/${MACHINE}.sh`).  Also removed redundant argument the python script.

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

This was tested by creating experiments with only the needed arguments and checked them with `$HOMEgfs/workflow/test_configuration.py`
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
