### PR TITLE
Fix f-o mode not sourcing postsnd when soundings are on

### DIFF
--- a/workflow/applications/gfs_forecast_only.py
+++ b/workflow/applications/gfs_forecast_only.py
@@ -29,6 +29,9 @@ class GFSForecastOnlyAppConfig(AppConfig):
         if self.do_atm and self.do_metp:
             configs += ['metp']
 
+        if self.do_bufrsnd:
+            configs += ['postsnd']
+
         if self.do_gempak:
             configs += ['gempak']
 


### PR DESCRIPTION
**Description**

Soundings are allowed in forecast-only mode, but the config file would not be sourced during experiment creation. Now the config file is sourced if bufr soundings (`DO_BUFRSND`) are on.

Resolves #1431

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] Forecast-only experiment creation with `DO_BUFRSND=YES` on Orion
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
