### PR TITLE
Copy land increments and land DA confs to COM

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -57,7 +57,7 @@ protocol = git
 required = False
 
 [GDASApp]
-hash = 09757ce
+hash = 2774a10
 local_path = sorc/gdas.cd
 repo_url = https://github.com/NOAA-EMC/GDASApp.git
 protocol = git

--- a/jobs/JGLOBAL_LAND_ANALYSIS
+++ b/jobs/JGLOBAL_LAND_ANALYSIS
@@ -17,12 +17,12 @@ GDUMP="gdas"
 # Begin JOB SPECIFIC work
 ##############################################
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS COM_LAND_ANALYSIS
+YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS COM_LAND_ANALYSIS COM_CONF
 
 RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
     COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
 
-mkdir -m 775 -p "${COM_LAND_ANALYSIS}"
+mkdir -m 775 -p "${COM_LAND_ANALYSIS}" "${COM_CONF}"
 
 ###############################################################
 # Run relevant script

--- a/parm/config/gfs/config.com
+++ b/parm/config/gfs/config.com
@@ -48,6 +48,7 @@ COM_BASE='${ROTDIR}/${RUN}.${YMD}/${HH}/${MEMDIR}'
 
 declare -rx COM_TOP_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}'
 
+declare -rx COM_CONF_TMPL=${COM_BASE}'/conf'
 declare -rx COM_ATMOS_INPUT_TMPL=${COM_BASE}'/model_data/atmos/input'
 declare -rx COM_ATMOS_RESTART_TMPL=${COM_BASE}'/model_data/atmos/restart'
 declare -rx COM_ATMOS_ANALYSIS_TMPL=${COM_BASE}'/analysis/atmos'

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -160,7 +160,7 @@ if [[ ${checkout_gsi} == "YES" ]]; then
 fi
 
 if [[ ${checkout_gdas} == "YES" ]]; then
-  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "09757ce"; errs=$((errs + $?))
+  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "2774a10"; errs=$((errs + $?))
 fi
 
 if [[ ${checkout_gsi} == "YES" || ${checkout_gdas} == "YES" ]]; then

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -34,7 +34,7 @@ class LandAnalysis(Analysis):
 
         _res = int(self.config['CASE'][1:])
         _window_begin = add_to_datetime(self.runtime_config.current_cycle, -to_timedelta(f"{self.config['assim_freq']}H") / 2)
-        _window_begin = add_to_datetime(_window_begin, -to_timedelta(f"2S"))
+        _window_begin = add_to_datetime(_window_begin, -to_timedelta(f"1S"))
         _letkfoi_yaml = os.path.join(self.runtime_config.DATA, f"{self.runtime_config.RUN}.t{self.runtime_config['cyc']:02d}z.letkfoi.yaml")
 
         # Create a local dictionary that is repeatedly used across this class
@@ -45,7 +45,7 @@ class LandAnalysis(Analysis):
                 'npz_ges': self.config.LEVS - 1,
                 'npz': self.config.LEVS - 1,
                 'LAND_WINDOW_BEGIN': _window_begin,
-                'LAND_WINDOW_LENGTH': f"PT{self.config['assim_freq']}H1S",
+                'LAND_WINDOW_LENGTH': f"PT{self.config['assim_freq']}H2S",
                 'OPREFIX': f"{self.runtime_config.RUN}.t{self.runtime_config.cyc:02d}z.",
                 'APREFIX': f"{self.runtime_config.RUN}.t{self.runtime_config.cyc:02d}z.",
                 'jedi_yaml': _letkfoi_yaml

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -45,7 +45,7 @@ class LandAnalysis(Analysis):
                 'npz_ges': self.config.LEVS - 1,
                 'npz': self.config.LEVS - 1,
                 'LAND_WINDOW_BEGIN': _window_begin,
-                'LAND_WINDOW_LENGTH': f"PT{self.config['assim_freq']}H2S",
+                'LAND_WINDOW_LENGTH': f"PT{self.config['assim_freq']}H1S",
                 'OPREFIX': f"{self.runtime_config.RUN}.t{self.runtime_config.cyc:02d}z.",
                 'APREFIX': f"{self.runtime_config.RUN}.t{self.runtime_config.cyc:02d}z.",
                 'jedi_yaml': _letkfoi_yaml

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -34,7 +34,7 @@ class LandAnalysis(Analysis):
 
         _res = int(self.config['CASE'][1:])
         _window_begin = add_to_datetime(self.runtime_config.current_cycle, -to_timedelta(f"{self.config['assim_freq']}H") / 2)
-        _window_begin = add_to_datetime(_window_begin, -to_timedelta(f"1S") )
+        _window_begin = add_to_datetime(_window_begin, -to_timedelta(f"1S"))
         _letkfoi_yaml = os.path.join(self.runtime_config.DATA, f"{self.runtime_config.RUN}.t{self.runtime_config['cyc']:02d}z.letkfoi.yaml")
 
         # Create a local dictionary that is repeatedly used across this class

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -340,8 +340,8 @@ class LandAnalysis(Analysis):
         self.tgz_diags(statfile, self.task_config.DATA)
 
         logger.info("Copy full YAML to COM")
-        src = os.path.join(self.task_config['DATA'], f"{self.task_config['CDUMP']}.t{self.runtime_config['cyc']:02d}z.letkfoi.yaml")
-        dest = os.path.join(self.task_config.COM_CONF, f"{self.task_config['CDUMP']}.t{self.runtime_config['cyc']:02d}z.letkfoi.yaml")
+        src = os.path.join(self.task_config['DATA'], f"{self.task_config.APREFIX}letkfoi.yaml")
+        dest = os.path.join(self.task_config.COM_CONF, f"{self.task_config.APREFIX}letkfoi.yaml")
         yaml_copy = {
             'mkdir': [self.task_config.COM_CONF],
             'copy': [[src, dest]]

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -34,7 +34,7 @@ class LandAnalysis(Analysis):
 
         _res = int(self.config['CASE'][1:])
         _window_begin = add_to_datetime(self.runtime_config.current_cycle, -to_timedelta(f"{self.config['assim_freq']}H") / 2)
-        _window_begin = add_to_datetime(_window_begin, -to_timedelta(f"1S"))
+        _window_begin = add_to_datetime(_window_begin, -to_timedelta(f"2S"))
         _letkfoi_yaml = os.path.join(self.runtime_config.DATA, f"{self.runtime_config.RUN}.t{self.runtime_config['cyc']:02d}z.letkfoi.yaml")
 
         # Create a local dictionary that is repeatedly used across this class

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -34,7 +34,6 @@ class LandAnalysis(Analysis):
 
         _res = int(self.config['CASE'][1:])
         _window_begin = add_to_datetime(self.runtime_config.current_cycle, -to_timedelta(f"{self.config['assim_freq']}H") / 2)
-        _window_begin = add_to_datetime(_window_begin, -to_timedelta(f"1S"))
         _letkfoi_yaml = os.path.join(self.runtime_config.DATA, f"{self.runtime_config.RUN}.t{self.runtime_config['cyc']:02d}z.letkfoi.yaml")
 
         # Create a local dictionary that is repeatedly used across this class
@@ -45,7 +44,7 @@ class LandAnalysis(Analysis):
                 'npz_ges': self.config.LEVS - 1,
                 'npz': self.config.LEVS - 1,
                 'LAND_WINDOW_BEGIN': _window_begin,
-                'LAND_WINDOW_LENGTH': f"PT{self.config['assim_freq']}H1S",
+                'LAND_WINDOW_LENGTH': f"PT{self.config['assim_freq']}H",
                 'OPREFIX': f"{self.runtime_config.RUN}.t{self.runtime_config.cyc:02d}z.",
                 'APREFIX': f"{self.runtime_config.RUN}.t{self.runtime_config.cyc:02d}z.",
                 'jedi_yaml': _letkfoi_yaml

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -45,7 +45,7 @@ class LandAnalysis(Analysis):
                 'npz_ges': self.config.LEVS - 1,
                 'npz': self.config.LEVS - 1,
                 'LAND_WINDOW_BEGIN': _window_begin,
-                'LAND_WINDOW_LENGTH': f"PT{self.config['assim_freq']}H",
+                'LAND_WINDOW_LENGTH': f"PT{self.config['assim_freq']}H1S",
                 'OPREFIX': f"{self.runtime_config.RUN}.t{self.runtime_config.cyc:02d}z.",
                 'APREFIX': f"{self.runtime_config.RUN}.t{self.runtime_config.cyc:02d}z.",
                 'jedi_yaml': _letkfoi_yaml
@@ -324,10 +324,10 @@ class LandAnalysis(Analysis):
     def finalize(self) -> None:
         """Performs closing actions of the Land analysis task
         This method:
-        - tarring up output diag files and place in COM/
-        - copying the generated YAML file from initialize to the COM/
-        - copying the analysis files to the COM/
-        - copying the increment files to the COM/
+        - tar and gzip the output diag files and place in COM/
+        - copy the generated YAML file from initialize to the COM/
+        - copy the analysis files to the COM/
+        - copy the increment files to the COM/
 
         Parameters
         ----------
@@ -339,7 +339,7 @@ class LandAnalysis(Analysis):
         statfile = os.path.join(self.task_config.COM_LAND_ANALYSIS, f"{self.task_config.APREFIX}landstat.tgz")
         self.tgz_diags(statfile, self.task_config.DATA)
 
-        logger.info("Copy full YAML  to COM")
+        logger.info("Copy full YAML to COM")
         src = os.path.join(self.task_config['DATA'], f"{self.task_config['CDUMP']}.t{self.runtime_config['cyc']:02d}z.letkfoi.yaml")
         dest = os.path.join(self.task_config.COM_LAND_ANALYSIS, f"{self.task_config['CDUMP']}.t{self.runtime_config['cyc']:02d}z.letkfoi.yaml")
         yaml_copy = {

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -341,9 +341,9 @@ class LandAnalysis(Analysis):
 
         logger.info("Copy full YAML to COM")
         src = os.path.join(self.task_config['DATA'], f"{self.task_config['CDUMP']}.t{self.runtime_config['cyc']:02d}z.letkfoi.yaml")
-        dest = os.path.join(self.task_config.COM_LAND_ANALYSIS, f"{self.task_config['CDUMP']}.t{self.runtime_config['cyc']:02d}z.letkfoi.yaml")
+        dest = os.path.join(self.task_config.COM_CONF, f"{self.task_config['CDUMP']}.t{self.runtime_config['cyc']:02d}z.letkfoi.yaml")
         yaml_copy = {
-            'mkdir': [self.task_config.COM_LAND_ANALYSIS],
+            'mkdir': [self.task_config.COM_CONF],
             'copy': [[src, dest]]
         }
         FileHandler(yaml_copy).sync()


### PR DESCRIPTION
`The NCEP 'dump' convention is the opposite of the JEDI IODA convention. For example, NCEP is [t03z-t09z), whereas IODA is (t03z-t09z], so the observations right at 03:00 and 09:00 will be missing (https://github.com/JCSDA-internal/ufo/issues/2233). This PR solved this issue by shifting the DA window_begin 1 second backward. `
**The above DA window manipulation is being handled somewhere else.**

This PR created `COM_CONF_TMPL`, copied the generated YAML file from initialize to the COM and copied the increment files to the COM. 

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
