### PR TITLE
Remove RUN_ENVIR from as many places as possible.

### DIFF
--- a/jobs/JGFS_ATMOS_CYCLONE_GENESIS
+++ b/jobs/JGFS_ATMOS_CYCLONE_GENESIS
@@ -4,9 +4,6 @@ source "${HOMEgfs}/ush/preamble.sh"
 source "${HOMEgfs}/ush/jjob_header.sh" -e "vrfy" -c "base vrfy"
 
 
-# TODO (#1220) Determine if this is still needed
-export RUN_ENVIR=${RUN_ENVIR:-"nco"}
-
 ##############################################
 # Set variables used in the exglobal script
 ##############################################

--- a/jobs/JGFS_ATMOS_CYCLONE_TRACKER
+++ b/jobs/JGFS_ATMOS_CYCLONE_TRACKER
@@ -4,9 +4,6 @@ source "${HOMEgfs}/ush/preamble.sh"
 source "${HOMEgfs}/ush/jjob_header.sh" -e "vrfy" -c "base vrfy"
 
 
-# TODO (#1220) Determine if this is still needed
-export RUN_ENVIR=${RUN_ENVIR:-"nco"}
-
 export COMPONENT="atmos"
 
 

--- a/jobs/JGFS_ATMOS_FSU_GENESIS
+++ b/jobs/JGFS_ATMOS_FSU_GENESIS
@@ -3,8 +3,6 @@
 source "${HOMEgfs}/ush/preamble.sh"
 source "${HOMEgfs}/ush/jjob_header.sh" -e "vrfy" -c "base vrfy"
 
-export RUN_ENVIR=${RUN_ENVIR:-"nco"}
-
 export COMPONENT="atmos"
 
 

--- a/jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP
+++ b/jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP
@@ -3,8 +3,6 @@
 source "${HOMEgfs}/ush/preamble.sh"
 source "${HOMEgfs}/ush/jjob_header.sh" -e "sfc_prep" -c "base"
 
-export RUN_ENVIR=${RUN_ENVIR:-"nco"}
-
 export SENDDBN=${SENDDBN:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 

--- a/jobs/JGLOBAL_ATMOS_SFCANL
+++ b/jobs/JGLOBAL_ATMOS_SFCANL
@@ -8,9 +8,6 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "sfcanl" -c "base sfcanl"
 # Set variables used in the script
 ##############################################
 export CDUMP="${RUN/enkf}"
-if [[ ${RUN_ENVIR} = "nco" ]]; then
-    export ROTDIR=${COMROOT:?}/${NET}/${envir}
-fi
 
 
 ##############################################

--- a/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
+++ b/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
@@ -3,9 +3,6 @@
 source "${HOMEgfs}/ush/preamble.sh"
 source "${HOMEgfs}/ush/jjob_header.sh" -e "prep" -c "base prep"
 
-# TODO (#1220) Evaluate if this is still needed
-export RUN_ENVIR=${RUN_ENVIR:-"nco"}
-
 
 ##############################################
 # Set variables used in the exglobal script

--- a/jobs/rocoto/awips.sh
+++ b/jobs/rocoto/awips.sh
@@ -5,7 +5,6 @@ source "${HOMEgfs}/ush/preamble.sh"
 ###############################################################
 ## Abstract:
 ## Inline awips driver script
-## RUN_ENVIR : runtime environment (emc | nco)
 ## HOMEgfs   : /full/path/to/workflow
 ## EXPDIR : /full/path/to/config/files
 ## CDATE  : current analysis date (YYYYMMDDHH)
@@ -49,7 +48,7 @@ for fhr in ${fhrlst}; do
             export fcsthrs=${fhr3}
             ${AWIPS20SH}
         fi
-    
+
         if ((fhr % 6 == 0)); then
             ${AWIPSG2SH}
         fi
@@ -57,9 +56,9 @@ for fhr in ${fhrlst}; do
 
     fhmin=90
     fhmax=240
-    if (( fhr >= fhmin && fhr <= fhmax )); then    
+    if (( fhr >= fhmin && fhr <= fhmax )); then
         if ((fhr % 6 == 0)); then
-            fhr3=$(printf %03i $((10#${fhr})))            
+            fhr3=$(printf %03i $((10#${fhr})))
             export fcsthrs=${fhr3}
             ${AWIPS20SH}
             ${AWIPSG2SH}

--- a/jobs/rocoto/metp.sh
+++ b/jobs/rocoto/metp.sh
@@ -5,7 +5,6 @@ source "${HOMEgfs}/ush/preamble.sh"
 ###############################################################
 ## Abstract:
 ## Inline METplus verification and diagnostics driver script
-## RUN_ENVIR : runtime environment (emc | nco)
 ## HOMEgfs   : /full/path/to/workflow
 ## EXPDIR : /full/path/to/config/files
 ## CDATE  : current analysis date (YYYYMMDDHH)

--- a/jobs/rocoto/ocnpost.sh
+++ b/jobs/rocoto/ocnpost.sh
@@ -21,9 +21,6 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "ocnpost" -c "base ocnpost"
 # Set variables used in the exglobal script
 ##############################################
 export CDUMP=${RUN/enkf}
-if [[ ${RUN_ENVIR} = "nco" ]]; then
-    export ROTDIR=${COMROOT:?}/${NET}/${envir}
-fi
 
 ##############################################
 # Begin JOB SPECIFIC work
@@ -49,7 +46,7 @@ export ENSMEM=${ENSMEM:-000}
 export IDATE=${PDY}${cyc}
 
 for fhr in ${fhrlst}; do
-  export fhr=${fhr}  
+  export fhr=${fhr}
   # Ignore possible spelling error (nothing is misspelled)
   # shellcheck disable=SC2153
   VDATE=$(${NDATE} "${fhr}" "${IDATE}")
@@ -110,7 +107,7 @@ for fhr in ${fhrlst}; do
       status=$?
       [[ ${status} -ne 0 ]] && exit "${status}"
     fi
-  fi 
+  fi
 done
 
 # clean up working folder

--- a/jobs/rocoto/prep.sh
+++ b/jobs/rocoto/prep.sh
@@ -65,14 +65,12 @@ fi
 if [[ ${PROCESS_TROPCY} = "YES" ]]; then
 
     export COMINsyn=${COMINsyn:-$(compath.py gfs/prod/syndat)}
-    if [[ ${RUN_ENVIR} != "nco" ]]; then
-        export ARCHSYND=${ROTDIR}/syndat
-        if [[ ! -d ${ARCHSYND} ]]; then mkdir -p ${ARCHSYND}; fi
-        if [[ ! -s ${ARCHSYND}/syndat_akavit ]]; then
-            for file in syndat_akavit syndat_dateck syndat_stmcat.scr syndat_stmcat syndat_sthisto syndat_sthista ; do
-                cp ${COMINsyn}/${file} ${ARCHSYND}/.
-            done
-        fi
+    export ARCHSYND=${ROTDIR}/syndat
+    if [[ ! -d ${ARCHSYND} ]]; then mkdir -p ${ARCHSYND}; fi
+    if [[ ! -s ${ARCHSYND}/syndat_akavit ]]; then
+        for file in syndat_akavit syndat_dateck syndat_stmcat.scr syndat_stmcat syndat_sthisto syndat_sthista ; do
+            cp ${COMINsyn}/${file} ${ARCHSYND}/.
+        done
     fi
 
     if [[ ${ROTDIR_DUMP} = "YES" ]]; then rm "${COM_OBS}/${CDUMP}.t${cyc}z.syndata.tcvitals.tm00"; fi

--- a/parm/config/gfs/config.prep
+++ b/parm/config/gfs/config.prep
@@ -13,8 +13,6 @@ export cdate10=${PDY}${cyc}
 
 # Relocation and syndata QC
 export PROCESS_TROPCY=${PROCESS_TROPCY:-NO}
-[[ $RUN_ENVIR == "nco" && $envir == "prod" ]] && export PROCESS_TROPCY="YES"
-export DO_RELOCATE="NO"
 export TROPCYQCRELOSH="$HOMEgfs/scripts/exglobal_atmos_tropcy_qc_reloc.sh"
 export SENDCOM=YES
 

--- a/scripts/exgdas_atmos_verfozn.sh
+++ b/scripts/exgdas_atmos_verfozn.sh
@@ -6,7 +6,7 @@ source "$HOMEgfs/ush/preamble.sh"
 # exgdas_vrfyozn.sh
 #
 # This script runs the data extract/validation portion of the Ozone Monitor
-# (OznMon) DA package.  
+# (OznMon) DA package.
 #
 ################################################################################
 err=0
@@ -14,7 +14,6 @@ err=0
 #-------------------------------------------------------------------------------
 #  Set environment
 #
-export RUN_ENVIR=${RUN_ENVIR:-nco}
 export NET=${NET:-gfs}
 export RUN=${RUN:-gdas}
 export envir=${envir:-prod}
@@ -49,11 +48,11 @@ fi
 data_available=0
 
 if [[ -s ${oznstat} ]]; then
-   data_available=1                                         
+   data_available=1
 
    #------------------------------------------------------------------
-   #  Copy data files file to local data directory.  
-   #  Untar oznstat file.  
+   #  Copy data files file to local data directory.
+   #  Untar oznstat file.
    #------------------------------------------------------------------
 
    $NCP $oznstat ./oznstat.$PDATE
@@ -70,7 +69,7 @@ if [[ -s ${oznstat} ]]; then
          mv $filenc4 $file
       done
    fi
-   
+
    export OZNMON_NETCDF=${netcdf}
 
    ${HOMEoznmon}/ush/ozn_xtrct.sh

--- a/scripts/exgdas_atmos_verfrad.sh
+++ b/scripts/exgdas_atmos_verfrad.sh
@@ -10,8 +10,8 @@ source "$HOMEgfs/ush/preamble.sh"
 #
 # Author:        Ed Safford       Org: NP23         Date: 2012-01-18
 #
-# Abstract: This script runs the data extract/validation portion of the 
-#           RadMon package.  
+# Abstract: This script runs the data extract/validation portion of the
+#           RadMon package.
 #
 # Condition codes
 #       0 - no problem encountered
@@ -21,7 +21,6 @@ source "$HOMEgfs/ush/preamble.sh"
 
 export VERBOSE=${VERBOSE:-YES}
 
-export RUN_ENVIR=${RUN_ENVIR:-nco}
 export NET=${NET:-gfs}
 export RUN=${RUN:-gdas}
 export envir=${envir:-prod}
@@ -60,11 +59,11 @@ fi
 
 data_available=0
 if [[ -s ${radstat} && -s ${biascr} ]]; then
-   data_available=1                                         
+   data_available=1
 
    #------------------------------------------------------------------
-   #  Copy data files file to local data directory.  
-   #  Untar radstat file.  
+   #  Copy data files file to local data directory.
+   #  Untar radstat file.
    #------------------------------------------------------------------
 
    $NCP $biascr  ./biascr.$PDATE
@@ -75,8 +74,8 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
 
    #------------------------------------------------------------------
    #  SATYPE is the list of expected satellite/instrument sources
-   #  in the radstat file.  It should be stored in the $TANKverf 
-   #  directory.  If it isn't there then use the $FIXgdas copy.  In all 
+   #  in the radstat file.  It should be stored in the $TANKverf
+   #  directory.  If it isn't there then use the $FIXgdas copy.  In all
    #  cases write it back out to the radmon.$PDY directory.  Add any
    #  new sources to the list before writing back out.
    #------------------------------------------------------------------
@@ -87,10 +86,10 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
    fi
 
    echo satype_file = $satype_file
-  
+
    #------------------------------------------------------------------
-   #  Get previous cycle's date, and look for the satype_file.  Using 
-   #  the previous cycle will get us the previous day's directory if 
+   #  Get previous cycle's date, and look for the satype_file.  Using
+   #  the previous cycle will get us the previous day's directory if
    #  the cycle being processed is 00z.
    #------------------------------------------------------------------
    if [[ $cyc = "00" ]]; then
@@ -101,11 +100,11 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
 
    echo satype_file = $satype_file
    export SATYPE=$(cat ${satype_file})
-   
+
 
    #-------------------------------------------------------------
-   #  Update the SATYPE if any new sat/instrument was 
-   #  found in $radstat_satype.  Write the SATYPE contents back 
+   #  Update the SATYPE if any new sat/instrument was
+   #  found in $radstat_satype.  Write the SATYPE contents back
    #  to $TANKverf/radmon.$PDY.
    #-------------------------------------------------------------
    satype_changes=0
@@ -122,7 +121,7 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
       fi
    done
 
- 
+
    #------------------------------------------------------------------
    # Rename the diag files and uncompress
    #------------------------------------------------------------------
@@ -133,14 +132,14 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
       if [[ netcdf -eq 0 && -e diag_${type}_ges.${PDATE}.nc4.${Z} ]]; then
          netcdf=1
       fi
-     
+
       if [[ $(find . -maxdepth 1 -type f -name "diag_${type}_ges.${PDATE}*.${Z}" | wc -l) -gt 0 ]]; then
         mv diag_${type}_ges.${PDATE}*.${Z} ${type}.${Z}
         ${UNCOMPRESS} ./${type}.${Z}
       else
         echo "WARNING: diag_${type}_ges.${PDATE}*.${Z} not available, skipping"
       fi
-     
+
       if [[ $USE_ANL -eq 1 ]]; then
         if [[ $(find . -maxdepth 1 -type f -name "diag_${type}_anl.${PDATE}*.${Z}" | wc -l) -gt 0 ]]; then
           mv diag_${type}_anl.${PDATE}*.${Z} ${type}_anl.${Z}

--- a/scripts/exgdas_atmos_vminmon.sh
+++ b/scripts/exgdas_atmos_vminmon.sh
@@ -10,8 +10,8 @@ source "$HOMEgfs/ush/preamble.sh"
 #
 # Author:        Ed Safford       Org: NP23         Date: 2015-04-10
 #
-# Abstract: This script runs the data extract/validation portion of the 
-#           MinMon package.  
+# Abstract: This script runs the data extract/validation portion of the
+#           MinMon package.
 #
 # Condition codes
 #       0 - no problem encountered
@@ -23,7 +23,6 @@ source "$HOMEgfs/ush/preamble.sh"
 ########################################
 #  Set environment
 ########################################
-export RUN_ENVIR=${RUN_ENVIR:-nco}
 export NET=${NET:-gfs}
 export RUN=${RUN:-gdas}
 export envir=${envir:-prod}
@@ -60,7 +59,7 @@ data_available=0
 
 if [[ -s ${gsistat} ]]; then
 
-   data_available=1                                         
+   data_available=1
 
    #-----------------------------------------------------------------------
    #  Copy the $MINMON_SUFFIX.gnorm_data.txt file to the working directory

--- a/scripts/exgfs_atmos_vminmon.sh
+++ b/scripts/exgfs_atmos_vminmon.sh
@@ -10,8 +10,8 @@ source "$HOMEgfs/ush/preamble.sh"
 #
 # Author:        Ed Safford       Org: NP23         Date: 2015-04-10
 #
-# Abstract: This script runs the data extract/validation portion of the 
-#           MinMon package.  
+# Abstract: This script runs the data extract/validation portion of the
+#           MinMon package.
 #
 #    Condition codes
 #       0 - no problem encountered
@@ -23,7 +23,6 @@ source "$HOMEgfs/ush/preamble.sh"
 ########################################
 #  Set environment
 ########################################
-export RUN_ENVIR=${RUN_ENVIR:-nco}
 export NET=${NET:-gfs}
 export RUN=${RUN:-gfs}
 export envir=${envir:-prod}
@@ -31,7 +30,7 @@ export envir=${envir:-prod}
 ########################################
 #  Command line arguments
 ########################################
-export PDY=${1:-${PDY:?}} 
+export PDY=${1:-${PDY:?}}
 export cyc=${2:-${cyc:?}}
 
 ########################################
@@ -68,7 +67,7 @@ data_available=0
 
 if [[ -s ${gsistat} ]]; then
 
-   data_available=1                                         
+   data_available=1
 
    #------------------------------------------------------------------
    #  Copy the $MINMON_SUFFIX.gnorm_data.txt file to the working directory


### PR DESCRIPTION
**Description**

This PR:
- eliminates superfluous `RUN_ENVIR` definitions from jobs and scripts as `config.base` contains that definition and all jobs must source `config.base`.
- retains `RUN_ENVIR` conditionals in `configs` where it is necessary to distinguish between datasets as well as in genesis and tracker jobs where external directories to GFS are created to place products.
 
Fixes #1220 

**Type of change**
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
CI should be able to test this changeset.
  
**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
