### PR TITLE
Fix hi-res resources and CMEPS write time, add WW3 restart

### DIFF
--- a/parm/config/gfs/config.coupled_ic
+++ b/parm/config/gfs/config.coupled_ic
@@ -21,7 +21,7 @@ case "${CASE}" in
     export CPL_WAVIC=GEFSwave20210528v2
     ;;
   "C768")
-    export CPL_ATMIC=HR2
+    export CPL_ATMIC=HR1
     export CPL_ICEIC=HR1
     export CPL_OCNIC=HR1
     export CPL_WAVIC=HR1

--- a/parm/config/gfs/config.coupled_ic
+++ b/parm/config/gfs/config.coupled_ic
@@ -21,7 +21,7 @@ case "${CASE}" in
     export CPL_WAVIC=GEFSwave20210528v2
     ;;
   "C768")
-    export CPL_ATMIC=HR1
+    export CPL_ATMIC=HR2
     export CPL_ICEIC=HR1
     export CPL_OCNIC=HR1
     export CPL_WAVIC=HR1

--- a/parm/config/gfs/config.ufs
+++ b/parm/config/gfs/config.ufs
@@ -171,7 +171,7 @@ case "${fv3_res}" in
         export WRITE_GROUP=2
         export WRTTASK_PER_GROUP_PER_THREAD_PER_TILE=10
         export WRITE_GROUP_GFS=4
-        export WRTTASK_PER_GROUP_PER_THREAD_PER_TILE_GFS=10
+        export WRTTASK_PER_GROUP_PER_THREAD_PER_TILE_GFS=20
         ;;
     "C1152")
         export DELTIM=120

--- a/parm/config/gfs/config.wave
+++ b/parm/config/gfs/config.wave
@@ -135,7 +135,9 @@ if [[ "${CDUMP}" != gfs ]]; then    # Setting is valid for GDAS and GEFS
 else                              # This is a GFS run
   rst_dt_gfs=$(( restart_interval_gfs * 3600 ))  # TODO: This calculation needs to move to parsing_namelists_WW3.sh
   if [[ ${rst_dt_gfs} -gt 0 ]]; then
-    export DT_1_RST_WAV=${rst_dt_gfs:-0}   # time between restart files, set to DTRST=1 for a single restart file
+    export DT_1_RST_WAV=0 #${rst_dt_gfs:-0}   # time between restart files, set to DTRST=1 for a single restart file
+                                          #temporarily set to zero to avoid a clash in requested restart times 
+                                          #which makes the wave model crash a fix for the model issue will be coming
     export DT_2_RST_WAV=${rst_dt_gfs:-0}   # restart stride for checkpointing restart
   else
     rst_dt_fhmax=$(( FHMAX_WAV * 3600 ))

--- a/parm/ufs/nems.configure.cpld.IN
+++ b/parm/ufs/nems.configure.cpld.IN
@@ -94,6 +94,7 @@ MED_attributes::
       history_ymd = -999
       coupling_mode = @[CPLMODE]
       history_tile_atm = @[ATMTILESIZE]
+      pio_rearranger = box
 ::
 ALLCOMP_attributes::
       ScalarFieldCount = 2

--- a/parm/ufs/nems.configure.cpld_aero.IN
+++ b/parm/ufs/nems.configure.cpld_aero.IN
@@ -106,6 +106,7 @@ MED_attributes::
       history_ymd = -999
       coupling_mode = @[CPLMODE]
       history_tile_atm = @[ATMTILESIZE]
+      pio_rearranger = box
 ::
 ALLCOMP_attributes::
       ScalarFieldCount = 2

--- a/parm/ufs/nems.configure.cpld_aero_outerwave.IN
+++ b/parm/ufs/nems.configure.cpld_aero_outerwave.IN
@@ -126,6 +126,7 @@ MED_attributes::
       history_ymd = -999
       coupling_mode = @[CPLMODE]
       history_tile_atm = @[ATMTILESIZE]
+      pio_rearranger = box
 ::
 ALLCOMP_attributes::
       ScalarFieldCount = 2

--- a/parm/ufs/nems.configure.cpld_outerwave.IN
+++ b/parm/ufs/nems.configure.cpld_outerwave.IN
@@ -114,6 +114,7 @@ MED_attributes::
       history_ymd = -999
       coupling_mode = @[CPLMODE]
       history_tile_atm = @[ATMTILESIZE]
+      pio_rearranger = box
 ::
 ALLCOMP_attributes::
       ScalarFieldCount = 2

--- a/parm/ufs/nems.configure.cpld_wave.IN
+++ b/parm/ufs/nems.configure.cpld_wave.IN
@@ -114,6 +114,7 @@ MED_attributes::
       history_ymd = -999
       coupling_mode = @[CPLMODE]
       history_tile_atm = @[ATMTILESIZE]
+      pio_rearranger = box
 ::
 ALLCOMP_attributes::
       ScalarFieldCount = 2


### PR DESCRIPTION
**Description**

We're getting ready to run HR2 and in the process have found a few minor bugs.  While these shouldn't effect others running low resolution cases, I wanted to push these bug fixes for anyone trying to run high resolution.  These bugs address: 
* Issue #1793 Adding extra tasks to write component for hera for C768 (otherwise crashes due to memory)
* Avoiding requesting two wave restarts at the same time (this is a known bug that the workflow usually has work around for.  A fix for the underlying WW3 bug should be coming within the next month, but this will get us through that waiting period) 
* Adding a setting that was missed when updating the ufs-waether-model that ensure that CMEPS restarts are written in a reasonable time (See: https://github.com/ufs-community/ufs-weather-model/issues/1873 for more details) 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] Forecast-only test on Hera: This was tested + using a different atm IC on hera making scout runs for HR2.  The IC update was reverted for this PR, but I wanted to push the bug fixes while we work on other issues. 

  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
