### PR TITLE
Add filter to doc build action for PRs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,8 @@ on:
       - docs/**
   pull_request_target:
     types: [issues, opened, reopened, synchronize]
+    paths:
+      - docs/**
 
 jobs:
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,16 +3,16 @@ on:
   push:
     branches:
       - develop
-      - feature/*
-      - main/*
-      - bugfix/*
-      - release/*
+      - 'feature/*'
+      - 'main/*'
+      - 'bugfix/*'
+      - 'release/*'
     paths:
-      - docs/**
+      - 'docs/**'
   pull_request_target:
     types: [issues, opened, reopened, synchronize]
     paths:
-      - docs/**
+      - 'docs/**'
 
 jobs:
 


### PR DESCRIPTION
**Description**

A path filter was applied to pushes, but none was applied to PRs, causing the GH action to build documentation to fire every time a PR is opened or updated.

Resolves #1791

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [ ] Check GH doc build action for this PR
  
**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
