### PR TITLE
Add filter to doc build action for PRs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,8 @@ on:
       - docs/**
   pull_request_target:
     types: [issues, opened, reopened, synchronize]
+    paths:
+      - docs/**
 
 jobs:
 


### PR DESCRIPTION
**Description**

A path filter was applied to pushes, but none was applied to PRs, causing the GH action to build documentation to fire every time a PR is opened or updated.

Resolves #1791

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

This should work, but won't know for sure until it is merged. When using `pull_request_target`, the base branch is used for actions (see https://github.com/orgs/community/discussions/27084)
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
