### PR TITLE
Replace full-path restart links with relative links

### DIFF
--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -210,7 +210,7 @@ FV3_predet(){
       done
     done
     for file in ${files}; do
-      ${NLN} "${COM_ATMOS_RESTART}/${file}" "${COM_ATMOS_RESTART}/${forecast_end_cycle:0:8}.${forecast_end_cycle:8:2}0000.${file}"
+      ${NLN} "${file}" "${COM_ATMOS_RESTART}/${forecast_end_cycle:0:8}.${forecast_end_cycle:8:2}0000.${file}"
     done
   else
     mkdir -p "${DATA}/RESTART"


### PR DESCRIPTION
**Description**

Symlinks for the final restart time used the full path name, even though the targets are in the same directory. This means the links would break if the directory were moved or (more importantly) put in a tarball. The links have now been replaced with relative links.

Resolves #1446

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] Cycled test on Orion
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
