### PR TITLE
Fix bufr sounding job

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -15,7 +15,7 @@ protocol = git
 required = True
 
 [gfs-utils]
-hash = 8965258
+hash = a283262
 local_path = sorc/gfs_utils.fd
 repo_url = https://github.com/NOAA-EMC/gfs-utils
 protocol = git

--- a/parm/config/gfs/config.base.emc.dyn
+++ b/parm/config/gfs/config.base.emc.dyn
@@ -53,7 +53,7 @@ export NOSCRUB="@NOSCRUB@"
 export BASE_GIT="@BASE_GIT@"
 
 # Toggle to turn on/off GFS downstream processing.
-export DO_BUFRSND="YES"     # BUFR sounding products
+export DO_BUFRSND="NO"     # BUFR sounding products
 export DO_GEMPAK="NO"      # GEMPAK products
 export DO_AWIPS="NO"       # AWIPS products
 export DO_VRFY="YES"       # VRFY step

--- a/parm/config/gfs/config.base.emc.dyn
+++ b/parm/config/gfs/config.base.emc.dyn
@@ -53,7 +53,7 @@ export NOSCRUB="@NOSCRUB@"
 export BASE_GIT="@BASE_GIT@"
 
 # Toggle to turn on/off GFS downstream processing.
-export DO_BUFRSND="NO"     # BUFR sounding products
+export DO_BUFRSND="YES"     # BUFR sounding products
 export DO_GEMPAK="NO"      # GEMPAK products
 export DO_AWIPS="NO"       # AWIPS products
 export DO_VRFY="YES"       # VRFY step

--- a/scripts/exgfs_atmos_postsnd.sh
+++ b/scripts/exgfs_atmos_postsnd.sh
@@ -71,7 +71,7 @@ export FINT=$NINT1
 
    ic=0
    while [ $ic -lt 1000 ]; do
-      if [[ ! -f "${COM_ATMOS_HISTORY}/${RUN}.${cycle}.logf${FEND}.${logfm}" ]]; then
+      if [[ ! -f "${COM_ATMOS_HISTORY}/${RUN}.${cycle}.atm.logf${FEND}.${logfm}" ]]; then
           sleep 10
           ic=$(expr $ic + 1)
       else

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -150,7 +150,7 @@ source "${topdir}/../workflow/gw_setup.sh"
 # The checkout version should always be a speciifc commit (hash or tag), not a branch
 errs=0
 checkout "wxflow"          "https://github.com/NOAA-EMC/wxflow"                 "528f5ab"                    ; errs=$((errs + $?))
-checkout "gfs_utils.fd"    "https://github.com/NOAA-EMC/gfs-utils"              "8965258"                    ; errs=$((errs + $?))
+checkout "gfs_utils.fd"    "https://github.com/NOAA-EMC/gfs-utils"              "a283262"                    ; errs=$((errs + $?))
 checkout "ufs_utils.fd"    "https://github.com/ufs-community/UFS_UTILS.git"     "72a0471"                    ; errs=$((errs + $?))
 checkout "ufs_model.fd"    "https://github.com/ufs-community/ufs-weather-model" "${ufs_model_hash:-4d05445}" ; errs=$((errs + $?))
 checkout "verif-global.fd" "https://github.com/NOAA-EMC/EMC_verif-global.git"   "c267780"                    ; errs=$((errs + $?))

--- a/ush/gfs_bufr.sh
+++ b/ush/gfs_bufr.sh
@@ -58,7 +58,7 @@ for (( hr = 10#${FSTART}; hr <= 10#${FEND}; hr = hr + 10#${FINT} )); do
    # Make sure all files are available:
    ic=0
    while (( ic < 1000 )); do
-      if [[ ! -f "${COM_ATMOS_HISTORY}/${RUN}.${cycle}.logf${hh3}.${logfm}" ]]; then
+      if [[ ! -f "${COM_ATMOS_HISTORY}/${RUN}.${cycle}.atm.logf${hh3}.${logfm}" ]]; then
           sleep 10
           ic=$((ic + 1))
       else


### PR DESCRIPTION
# Description

This PR gets the bufr sounding job working again by making two changes:

1. updating the logf filename within the relevant scripts to match the new naming convention that includes ".atm"
2. updating to a newer gfs-utils repo hash that includes a change to file length in the gfs_bufr code (resolves failure in testing), see https://github.com/NOAA-EMC/gfs-utils/issues/21 & https://github.com/NOAA-EMC/gfs-utils/pull/22

Resolves #1832
Refs https://github.com/NOAA-EMC/gfs-utils/issues/21

# Type of change

- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

- Low res cycled test on WCOSS2 with `DO_BUFRSND="YES"` set and the gfspostsnd job included in the cycle.
- CI tests on Hera and Orion.

# Checklist
- [ ] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
