### PR TITLE
ARFC GFSv16.3.8 - add debug flag to resolve wave post runtimes

### DIFF
--- a/docs/Release_Notes.gfs.v16.3.8.md
+++ b/docs/Release_Notes.gfs.v16.3.8.md
@@ -1,0 +1,129 @@
+GFS V16.3.8 RELEASE NOTES
+
+-------
+PRELUDE
+-------
+
+A debug option is added to the wave post scripts to resolve an issue with long runtimes in production.
+
+IMPLEMENTATION INSTRUCTIONS
+---------------------------
+
+The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub .com are used to manage the GFS code.  The SPA(s) handling the GFS implementation need to have permissions to clone VLab Gerrit repositories and private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are publicly readable and do not require access permissions.  Please proceed with the following steps to install the package on WCOSS2:
+
+```bash
+cd $PACKAGEROOT
+mkdir gfs.v16.3.8
+cd gfs.v16.3.8
+git clone -b EMC-v16.3.8 https://github.com/NOAA-EMC/global-workflow.git .
+cd sorc
+./checkout.sh -o
+```
+
+The checkout script extracts the following GFS components:
+
+| Component | Tag         | POC               |
+| --------- | ----------- | ----------------- |
+| MODEL     | GFS.v16.3.0   | Jun.Wang@noaa.gov |
+| GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
+| GSI       | gfsda.v16.3.7 | Andrew.Collard@noaa.gov |
+| UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
+| POST      | upp_v8.2.0 | Wen.Meng@noaa.gov |
+| WAFS      | gfs_wafs.v6.3.1 | Yali.Mao@noaa.gov |
+
+To build all the GFS components, execute:
+```bash
+./build_all.sh
+```
+The `build_all.sh` script compiles all GFS components. Runtime output from the build for each package is written to log files in directory logs. To build an individual program, for instance, gsi, use `build_gsi.sh`.
+
+Next, link the executables, fix files, parm files, etc in their final respective locations by executing:
+```bash
+./link_fv3gfs.sh nco wcoss2
+```
+
+Lastly, link the ecf scripts by moving back up to the ecf folder and executing:
+```bash
+cd ../ecf
+./setup_ecf_links.sh
+```
+
+VERSION FILE CHANGES
+--------------------
+
+* `versions/run.ver` - change `version=v16.3.8` and `gfs_ver=v16.3.8`
+
+SORC CHANGES
+------------
+
+* No changes from GFS v16.3.7
+
+JOBS CHANGES
+------------
+
+* No changes from GFS v16.3.7
+
+PARM/CONFIG CHANGES
+-------------------
+
+* No changes from GFS v16.3.7
+
+SCRIPT CHANGES
+--------------
+
+* Add the `-l ldebug=true` PBS option to the following ecf scripts:
+  * `ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpntbll.ecf`
+  * `ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf`
+  * `ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf`
+
+FIX CHANGES
+-----------
+
+* No changes from GFS v16.3.7
+
+MODULE CHANGES
+--------------
+
+* No changes from GFS v16.3.7
+
+CHANGES TO FILE SIZES
+---------------------
+
+* No changes from GFS v16.3.7
+
+ENVIRONMENT AND RESOURCE CHANGES
+--------------------------------
+
+* No changes from GFS v16.3.7
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+---------------------------------------
+
+* Which production jobs should be tested as part of this implementation?
+  * N/A
+* Does this change require a 30-day evaluation?
+  * No
+
+DISSEMINATION INFORMATION
+-------------------------
+
+* No changes from GFS v16.3.7
+
+HPSS ARCHIVE
+------------
+
+* No changes from GFS v16.3.7
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+---------------------------------
+
+* No changes from GFS v16.3.7
+
+DOCUMENTATION
+-------------
+
+* No changes from GFS v16.3.7
+
+PREPARED BY
+-----------
+Kate.Friedman@noaa.gov

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf
@@ -7,6 +7,7 @@
 #PBS -l select=3:ncpus=80:ompthreads=1
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true
+#PBS -l ldebug=true
 
 model=gfs
 %include <head.h>

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpntbll.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpntbll.ecf
@@ -7,6 +7,7 @@
 #PBS -l select=4:ncpus=112:ompthreads=1
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true
+#PBS -l ldebug=true
 
 model=gfs
 %include <head.h>

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf
@@ -7,6 +7,7 @@
 #PBS -l select=4:ncpus=50:ompthreads=1
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true
+#PBS -l ldebug=true
 
 model=gfs
 %include <head.h>

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.7
-export gfs_ver=v16.3.7
+export version=v16.3.8
+export gfs_ver=v16.3.8
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2


### PR DESCRIPTION
# Description

GFSv16.3.8 in operations via an ARFC. The wave post jobs were running long in production. GDIT added the `ldebug` PBS statements to the wave post ecf scripts to resolve the issue.

Resolves #1843

# Type of change

Operational updates (accelerated)

# Change characteristics

- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? YES - will make one in `develop` branch

# How has this been tested?

Tested by NCO/GDIT in para.

# Checklist

- [ ] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
