### PR TITLE
Fix post octal bugs

### DIFF
--- a/scripts/exgfs_atmos_post.sh
+++ b/scripts/exgfs_atmos_post.sh
@@ -399,8 +399,6 @@ else   ## not_anl if_stime
       fi
 
       if [[ "${SENDCOM}" = "YES" ]]; then
-        #       echo "$PDY$cyc$pad$fhr" > $COMOUT/${RUN}.t${cyc}z.master.control
-
         mv goesfile "${COM_ATMOS_GOES}/${SPECIALFL}f${fhr3}"
         mv goesifile "${COM_ATMOS_GOES}/${SPECIALFLIDX}f${fhr3}"
 

--- a/scripts/exgfs_atmos_post.sh
+++ b/scripts/exgfs_atmos_post.sh
@@ -175,8 +175,9 @@ else   ## not_anl if_stime
   # Loop Through the Post Forecast Files 
   ############################################################
 
-  for fhr in ${post_times}; do
-    echo "Start processing fhr=${post_times}"
+  for fhr3 in ${post_times}; do
+    echo "Start processing fhr=${fhr3}"
+    fhr=$(( 10#${fhr3} ))
     ###############################
     # Start Looping for the 
     # existence of the restart files
@@ -184,7 +185,7 @@ else   ## not_anl if_stime
     export pgm="postcheck"
     ic=1
     while (( ic <= SLEEP_LOOP_MAX )); do
-      if [[ -f "${restart_file}${fhr}.txt" ]]; then
+      if [[ -f "${restart_file}${fhr3}.txt" ]]; then
         break
       else
         ic=$(( ic + 1 ))
@@ -196,7 +197,7 @@ else   ## not_anl if_stime
       # period and error exit
       ###############################
       if (( ic == SLEEP_LOOP_MAX )); then
-        echo " *** FATAL ERROR: No model output for f${fhr} "
+        echo " *** FATAL ERROR: No model output for f${fhr3} "
         export err=9
         err_chk
       fi
@@ -207,9 +208,9 @@ else   ## not_anl if_stime
     # for backup to start Model Fcst
     ###############################
     [[ -f flxfile ]] && rm flxfile ; [[ -f nemsfile ]] && rm nemsfile
-    ln -fs "${COM_ATMOS_HISTORY}/${PREFIX}atmf${fhr}.nc" nemsfile
+    ln -fs "${COM_ATMOS_HISTORY}/${PREFIX}atmf${fhr3}.nc" nemsfile
     export NEMSINP=nemsfile
-    ln -fs "${COM_ATMOS_HISTORY}/${PREFIX}sfcf${fhr}.nc" flxfile
+    ln -fs "${COM_ATMOS_HISTORY}/${PREFIX}sfcf${fhr3}.nc" flxfile
     export FLXINP=flxfile
 
     if (( fhr > 0 )); then
@@ -224,7 +225,7 @@ else   ## not_anl if_stime
     # shellcheck disable=
     export VDATE
     export OUTTYP=${OUTTYP:-4}
-    export GFSOUT="${PREFIX}gfsio${fhr}"
+    export GFSOUT="${PREFIX}gfsio${fhr3}"
 
     if [[ "${GRIBVERSION}" = 'grib2' ]]; then
       export POSTGRB2TBL="${POSTGRB2TBL:-${g2tmpl_ROOT}/share/params_grib2_tbl_new}"
@@ -261,8 +262,8 @@ else   ## not_anl if_stime
     export PGIOUT2=pgifile.grib2.idx
     export FILTER=0 
     if [[ "${GRIBVERSION}" = 'grib2' ]]; then
-      MASTERFL=${PREFIX}master.grb2f${fhr}
-      MASTERFLIDX=${PREFIX}master.grb2if${fhr}
+      MASTERFL=${PREFIX}master.grb2f${fhr3}
+      MASTERFLIDX=${PREFIX}master.grb2if${fhr3}
     fi
 
     if [[ "${INLINE_POST}" = ".false." ]]; then
@@ -278,7 +279,7 @@ else   ## not_anl if_stime
 
     #  Process pgb files
     if [[ "${PGBF}" = 'YES' ]]; then
-      export FH=$(( 10#${fhr} + 0 ))
+      export FH=$(( fhr ))
       export downset=${downset:-2}
       ${GFSDOWNSH}
       export err=$?; err_chk
@@ -295,23 +296,23 @@ else   ## not_anl if_stime
       if [[ "${SENDDBN}" = 'YES' ]]; then
         if [[ "${GRIBVERSION}" = 'grib2' ]]; then
           if [[ "${PGBF}" = 'YES' ]]; then
-            "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_0P25 "${job}" "${COM_ATMOS_GRIB_0p25}/${PREFIX}pgrb2.0p25.f${fhr}"
-            "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_0P25_WIDX "${job}" "${COM_ATMOS_GRIB_0p25}/${PREFIX}pgrb2.0p25.f${fhr}.idx"
-            "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_0P25 "${job}" "${COM_ATMOS_GRIB_0p25}/${PREFIX}pgrb2b.0p25.f${fhr}"
-            "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_0P25_WIDX "${job}" "${COM_ATMOS_GRIB_0p25}/${PREFIX}pgrb2b.0p25.f${fhr}.idx"
+            "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_0P25 "${job}" "${COM_ATMOS_GRIB_0p25}/${PREFIX}pgrb2.0p25.f${fhr3}"
+            "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_0P25_WIDX "${job}" "${COM_ATMOS_GRIB_0p25}/${PREFIX}pgrb2.0p25.f${fhr3}.idx"
+            "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_0P25 "${job}" "${COM_ATMOS_GRIB_0p25}/${PREFIX}pgrb2b.0p25.f${fhr3}"
+            "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_0P25_WIDX "${job}" "${COM_ATMOS_GRIB_0p25}/${PREFIX}pgrb2b.0p25.f${fhr3}.idx"
 
-            if [[ -s "${COM_ATMOS_GRIB_0p50}/${PREFIX}pgrb2.0p50.f${fhr}" ]]; then
-              "${DBNROOT}/bin/dbn_alert"  MODEL GFS_PGB2_0P5 "${job}" "${COM_ATMOS_GRIB_0p50}/${PREFIX}pgrb2.0p50.f${fhr}"
-              "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_0P5_WIDX "${job}" "${COM_ATMOS_GRIB_0p50}/${PREFIX}pgrb2.0p50.f${fhr}.idx"
-              "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_0P5 "${job}" "${COM_ATMOS_GRIB_0p50}/${PREFIX}pgrb2b.0p50.f${fhr}"
-              "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_0P5_WIDX "${job}" "${COM_ATMOS_GRIB_0p50}/${PREFIX}pgrb2b.0p50.f${fhr}.idx"
+            if [[ -s "${COM_ATMOS_GRIB_0p50}/${PREFIX}pgrb2.0p50.f${fhr3}" ]]; then
+              "${DBNROOT}/bin/dbn_alert"  MODEL GFS_PGB2_0P5 "${job}" "${COM_ATMOS_GRIB_0p50}/${PREFIX}pgrb2.0p50.f${fhr3}"
+              "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_0P5_WIDX "${job}" "${COM_ATMOS_GRIB_0p50}/${PREFIX}pgrb2.0p50.f${fhr3}.idx"
+              "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_0P5 "${job}" "${COM_ATMOS_GRIB_0p50}/${PREFIX}pgrb2b.0p50.f${fhr3}"
+              "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_0P5_WIDX "${job}" "${COM_ATMOS_GRIB_0p50}/${PREFIX}pgrb2b.0p50.f${fhr3}.idx"
             fi
 
-            if [[ -s "${COM_ATMOS_GRIB_1p00}/${PREFIX}pgrb2.1p00.f${fhr}" ]]; then
-              "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_1P0 "${job}" "${COM_ATMOS_GRIB_1p00}/${PREFIX}pgrb2.1p00.f${fhr}"
-              "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_1P0_WIDX "${job}" "${COM_ATMOS_GRIB_1p00}/${PREFIX}pgrb2.1p00.f${fhr}.idx"
-              "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_1P0 "${job}" "${COM_ATMOS_GRIB_1p00}/${PREFIX}pgrb2b.1p00.f${fhr}"
-              "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_1P0_WIDX "${job}" "${COM_ATMOS_GRIB_1p00}/${PREFIX}pgrb2b.1p00.f${fhr}.idx"
+            if [[ -s "${COM_ATMOS_GRIB_1p00}/${PREFIX}pgrb2.1p00.f${fhr3}" ]]; then
+              "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_1P0 "${job}" "${COM_ATMOS_GRIB_1p00}/${PREFIX}pgrb2.1p00.f${fhr3}"
+              "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2_1P0_WIDX "${job}" "${COM_ATMOS_GRIB_1p00}/${PREFIX}pgrb2.1p00.f${fhr3}.idx"
+              "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_1P0 "${job}" "${COM_ATMOS_GRIB_1p00}/${PREFIX}pgrb2b.1p00.f${fhr3}"
+              "${DBNROOT}/bin/dbn_alert" MODEL GFS_PGB2B_1P0_WIDX "${job}" "${COM_ATMOS_GRIB_1p00}/${PREFIX}pgrb2b.1p00.f${fhr3}.idx"
             fi
           fi
         fi 
@@ -335,8 +336,8 @@ else   ## not_anl if_stime
       fi
       export PGBOUT=fluxfile
       export FILTER=0
-      export FLUXFL=${PREFIX}sfluxgrbf${fhr}.grib2
-      FLUXFLIDX=${PREFIX}sfluxgrbf${fhr}.grib2.idx
+      export FLUXFL=${PREFIX}sfluxgrbf${fhr3}.grib2
+      FLUXFLIDX=${PREFIX}sfluxgrbf${fhr3}.grib2.idx
 
       if [[ "${INLINE_POST}" = ".false." ]]; then
         ${POSTGPSH}
@@ -347,7 +348,7 @@ else   ## not_anl if_stime
 
       #Add extra flux.1p00 file for coupled
       if [[ "${FLXGF}" = 'YES' ]]; then
-        export FH=$(( 10#${fhr} + 0 ))
+        export FH=$(( fhr ))
         ${GFSDOWNSHF}
         export err=$?; err_chk
       fi
@@ -367,7 +368,7 @@ else   ## not_anl if_stime
       # if model already runs gfs io, make sure GFSOUT is linked to the gfsio file
       # new imported variable for global_post.sh
 
-      export GFSOUT=${PREFIX}gfsio${fhr}
+      export GFSOUT=${PREFIX}gfsio${fhr3}
 
       # link satellite coefficients files, use hwrf version as ops crtm 2.0.5
       # does not new coefficient files used by post
@@ -396,16 +397,15 @@ else   ## not_anl if_stime
         SPECIALFL="${PREFIX}special.grb2"
         SPECIALFLIDX="${PREFIX}special.grb2i"
       fi
-      fhr3=${fhr}
 
       if [[ "${SENDCOM}" = "YES" ]]; then
         #       echo "$PDY$cyc$pad$fhr" > $COMOUT/${RUN}.t${cyc}z.master.control
 
-        mv goesfile "${COM_ATMOS_GOES}/${SPECIALFL}f${fhr}"
-        mv goesifile "${COM_ATMOS_GOES}/${SPECIALFLIDX}f${fhr}"
+        mv goesfile "${COM_ATMOS_GOES}/${SPECIALFL}f${fhr3}"
+        mv goesifile "${COM_ATMOS_GOES}/${SPECIALFLIDX}f${fhr3}"
 
         if [[ "${SENDDBN}" = "YES" ]]; then
-          "${DBNROOT}/bin/dbn_alert" MODEL GFS_SPECIAL_GB2 "${job}" "${COM_ATMOS_GOES}/${SPECIALFL}f${fhr}"
+          "${DBNROOT}/bin/dbn_alert" MODEL GFS_SPECIAL_GB2 "${job}" "${COM_ATMOS_GOES}/${SPECIALFL}f${fhr3}"
         fi
       fi
     fi

--- a/ush/gfs_transfer.sh
+++ b/ush/gfs_transfer.sh
@@ -15,7 +15,7 @@
 # echo "-----------------------------------------------------"
 #####################################################################
 
-source "$HOMEgfs/ush/preamble.sh"
+source "${HOMEgfs}/ush/preamble.sh"
 
 # export CNVGRIB=/nwprod/util/exec/cnvgrib
 # export GRB2INDX=/nwprod/util/exec/grb2index
@@ -59,7 +59,7 @@ source "$HOMEgfs/ush/preamble.sh"
 # DBNet Alerts for gfs suite
 #
 
-if [ "$SENDDBN" = 'YES' -a "$RUN" = 'gfs' ]; then
+if [[ "${SENDDBN}" = 'YES' && "${RUN}" = 'gfs' ]]; then
   #if [ $(expr $fhr % 3) -eq 0 ]; then
   #echo $DBNROOT/bin/dbn_alert MODEL GFS_SGB $job $COMOUT/${RUN}.${cycle}.sfluxgrbf$fhr
   #echo $DBNROOT/bin/dbn_alert MODEL GFS_SGBI $job $COMOUT/${RUN}.${cycle}.sfluxgrbif$fhr
@@ -67,14 +67,14 @@ if [ "$SENDDBN" = 'YES' -a "$RUN" = 'gfs' ]; then
   #echo $DBNROOT/bin/dbn_alert MODEL GFS_SGB_GB2_WIDX $job $COMOUT/${RUN}.${cycle}.sfluxgrbf${fhr}.grib2.idx
   #fi
 
-  fhr=$(printf "%03d" $fhr)
-  $DBNROOT/bin/dbn_alert MODEL GFS_SF $job $COMOUT/${RUN}.t${cyc}z.atmf$fhr.nc
+  fhr3=$(printf "%03d" "${fhr}")
+  "${DBNROOT}/bin/dbn_alert" MODEL GFS_SF "${job}" "${COMOUT}/${RUN}.t${cyc}z.atmf${fhr3}.nc"
  
-  if [[ $fhr -gt 0  && $fhr -le 84  ]]; then
-     $DBNROOT/bin/dbn_alert MODEL GFS_BF $job $COMOUT/${RUN}.t${cyc}z.sfcf$fhr.nc
+  if (( fhr > 0  && fhr <= 84 )); then
+     "${DBNROOT}/bin/dbn_alert" MODEL GFS_BF "${job}" "${COMOUT}/${RUN}.t${cyc}z.sfcf${fhr3}.nc"
   fi
-  if [[ $fhr -eq 120  ]]; then
-     $DBNROOT/bin/dbn_alert MODEL GFS_BF $job $COMOUT/${RUN}.t${cyc}z.sfcf$fhr.nc
+  if (( fhr == 120 )); then
+     "${DBNROOT}/bin/dbn_alert" MODEL GFS_BF "${job}" "${COMOUT}/${RUN}.t${cyc}z.sfcf${fhr3}.nc"
   fi
 fi
 

--- a/ush/gfs_transfer.sh
+++ b/ush/gfs_transfer.sh
@@ -17,56 +17,7 @@
 
 source "${HOMEgfs}/ush/preamble.sh"
 
-# export CNVGRIB=/nwprod/util/exec/cnvgrib
-# export GRB2INDX=/nwprod/util/exec/grb2index
-# export WGRIB2=/nwprod/util/exec/wgrib2
-
- 
-#if test "$SENDCOM" = "YES"
-#then
-   #
-   # Save Pressure and SFLUX GRIB/GRIB Index files
-   #
-#  cp flxifile $COMOUT/${RUN}.${cycle}.sfluxgrbif$fhr
-   
-# Chuang: keeping gfs surface files around because post and dng
-# use them now   
-   #if [[ $fhr -gt 84 ]]
-   #then
-   #  if [[ $fhr -ne 120 && $fhr -ne 168 ]]
-   #    then
-   #      rm $COMOUT/${RUN}.${cycle}.bf$fhr
-   #  fi
-   #fi
-#fi
-
-############################################
-# Convert the sflux file to grib2 format:
-############################################
-#cp $COMIN/${RUN}.${cycle}.sfluxgrbf$fhr sfluxgrbf$fhr
-#if [ $(expr $fhr % 3) -eq 0 ]; then
-#$CNVGRIB -g12 -p40 $COMIN/${RUN}.${cycle}.sfluxgrbf$fhr sfluxgrbf${fhr}.grib2
-#$WGRIB2 sfluxgrbf${fhr}.grib2 -s> sfluxgrbf${fhr}.grib2.idx
-
-#if [ $SENDCOM = YES ]
-#then
-#  cp sfluxgrbf${fhr}.grib2 $COMOUT/${RUN}.${cycle}.sfluxgrbf${fhr}.grib2
-#  cp sfluxgrbf${fhr}.grib2.idx $COMOUT/${RUN}.${cycle}.sfluxgrbf${fhr}.grib2.idx
-#fi
-
-#fi
-#
-# DBNet Alerts for gfs suite
-#
-
 if [[ "${SENDDBN}" = 'YES' && "${RUN}" = 'gfs' ]]; then
-  #if [ $(expr $fhr % 3) -eq 0 ]; then
-  #echo $DBNROOT/bin/dbn_alert MODEL GFS_SGB $job $COMOUT/${RUN}.${cycle}.sfluxgrbf$fhr
-  #echo $DBNROOT/bin/dbn_alert MODEL GFS_SGBI $job $COMOUT/${RUN}.${cycle}.sfluxgrbif$fhr
-  #echo $DBNROOT/bin/dbn_alert MODEL GFS_SGB_GB2 $job $COMOUT/${RUN}.${cycle}.sfluxgrbf${fhr}.grib2
-  #echo $DBNROOT/bin/dbn_alert MODEL GFS_SGB_GB2_WIDX $job $COMOUT/${RUN}.${cycle}.sfluxgrbf${fhr}.grib2.idx
-  #fi
-
   fhr3=$(printf "%03d" "${fhr}")
   "${DBNROOT}/bin/dbn_alert" MODEL GFS_SF "${job}" "${COMOUT}/${RUN}.t${cyc}z.atmf${fhr3}.nc"
  
@@ -78,5 +29,5 @@ if [[ "${SENDDBN}" = 'YES' && "${RUN}" = 'gfs' ]]; then
   fi
 fi
 
-exit 0 
+exit 0
 


### PR DESCRIPTION
# Description
Yet more base bugs were found in post. To eliminate these once and for all, `fhr` is changed to have no leading zeros, and places where the zero-padded string is needed now use `fhr3`.

Resolves #1195

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Cycled test on Orion

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
