### PR TITLE
Update main CI driver to remove previous RUNDIR

### DIFF
--- a/ci/platforms/hera.sh
+++ b/ci/platforms/hera.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/bash
+
 export GFS_CI_ROOT=/scratch1/NCEPDEV/global/Terry.McGuinness/GFS_CI_ROOT
+export ICSDIR_ROOT=/scratch1/NCEPDEV/global/glopara/data/ICSDIR
+export STMP="/scratch1/NCEPDEV/stmp2/${USER}"
 export SLURM_ACCOUNT=nems
-export ICSDIR_ROOT="/scratch1/NCEPDEV/global/glopara/data/ICSDIR"
 export max_concurrent_cases=2
 export max_concurrent_pr=2

--- a/ci/platforms/orion.sh
+++ b/ci/platforms/orion.sh
@@ -2,6 +2,7 @@
 
 export GFS_CI_ROOT=/work2/noaa/stmp/GFS_CI_ROOT
 export ICSDIR_ROOT=/work/noaa/global/glopara/data/ICSDIR
+export STMP="/work/noaa/stmp/${USER}"
 export SLURM_ACCOUNT=nems
 export max_concurrent_cases=2
 export max_concurrent_pr=2

--- a/ci/scripts/driver.sh
+++ b/ci/scripts/driver.sh
@@ -153,6 +153,7 @@ for pr in ${pr_list}; do
     for yaml_config in "${HOMEgfs_PR}/ci/cases/pr/"*.yaml; do
       case=$(basename "${yaml_config}" .yaml) || true
       pslot="${case}_${pr_sha}"
+      rm -Rf "${STMP}/RUNDIRS/${pslot}"
       export pslot
       set +e
       "${HOMEgfs_PR}/ci/scripts/create_experiment.py" --yaml "${HOMEgfs_PR}/ci/cases/pr/${case}.yaml" --dir "${HOMEgfs_PR}"


### PR DESCRIPTION
# Description
Removes `${STMP}/RUNDIR/${pslot}_sha` before creating an experiment to avoid name cashing on restarts
Resolves #1881 

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? **NO**
- Does this change require a documentation update? **NO**
