### PR TITLE
Fix IC linking in setup_expt.py

### DIFF
--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -71,7 +71,15 @@ def fill_COMROT_cycled(host, inputs):
     rdatestr = datetime_to_YMDH(inputs.idate - to_timedelta('T06H'))
     idatestr = datetime_to_YMDH(inputs.idate)
 
-    if os.path.isdir(os.path.join(inputs.icsdir, f'{inputs.cdump}.{rdatestr[:8]}', rdatestr[8:], 'model_data', 'atmos')):
+    # Test if we are using the new COM structure or the old flat one for ICs
+    if(inputs.start in ['warm']):
+      pathstr = os.path.join(inputs.icsdir, f'{inputs.cdump}.{rdatestr[:8]}',
+         rdatestr[8:], 'model_data', 'atmos')
+    else:
+      pathstr = os.path.join(inputs.icsdir, f'{inputs.cdump}.{idatestr[:8]}',
+         idatestr[8:], 'model_data', 'atmos')
+
+    if os.path.isdir(pathstr):
         flat_structure = False
     else:
         flat_structure = True

--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -72,7 +72,7 @@ def fill_COMROT_cycled(host, inputs):
     idatestr = datetime_to_YMDH(inputs.idate)
 
     # Test if we are using the new COM structure or the old flat one for ICs
-    if(inputs.start in ['warm']):
+    if inputs.start in ['warm']:
         pathstr = os.path.join(inputs.icsdir, f'{inputs.cdump}.{rdatestr[:8]}',
                                rdatestr[8:], 'model_data', 'atmos')
     else:

--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -73,11 +73,11 @@ def fill_COMROT_cycled(host, inputs):
 
     # Test if we are using the new COM structure or the old flat one for ICs
     if(inputs.start in ['warm']):
-      pathstr = os.path.join(inputs.icsdir, f'{inputs.cdump}.{rdatestr[:8]}',
-         rdatestr[8:], 'model_data', 'atmos')
+        pathstr = os.path.join(inputs.icsdir, f'{inputs.cdump}.{rdatestr[:8]}',
+                               rdatestr[8:], 'model_data', 'atmos')
     else:
-      pathstr = os.path.join(inputs.icsdir, f'{inputs.cdump}.{idatestr[:8]}',
-         idatestr[8:], 'model_data', 'atmos')
+        pathstr = os.path.join(inputs.icsdir, f'{inputs.cdump}.{idatestr[:8]}',
+                               idatestr[8:], 'model_data', 'atmos')
 
     if os.path.isdir(pathstr):
         flat_structure = False


### PR DESCRIPTION
# Description

This fixes a bug in IC linking within setup_expt.py by correcting the date string based on experiment start type -- warm starts should look at `rdate` (-6 hours) and cold starts should look at `idate` (current cycle).

Fixes #1783

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Tested using the `--icsdir` on both warm and cold ICs on Hera.  The test cases were allowed to run through the first half cycle to verify all files were linked as expected.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
