### PR TITLE
Fix wavepostbndpntbll data dependency

### DIFF
--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -658,8 +658,8 @@ class GFSTasks(Tasks):
 
     def wavepostbndpntbll(self):
         deps = []
-        wave_hist_path = self._template_to_rocoto_cycstring(self._base["COM_WAVE_HISTORY_TMPL"])
-        data = f'{wave_hist_path}/{self.cdump}.t@Hz.atm.logf180.txt'
+        atmos_hist_path = self._template_to_rocoto_cycstring(self._base["COM_ATMOS_HISTORY_TMPL"])
+        data = f'{atmos_hist_path}/{self.cdump}.t@Hz.atm.logf180.txt'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)


### PR DESCRIPTION
# Description

This PR fixes the data dependency path for the wavepostbndpntbll job to use the ATMOS/atmos subfolder instead of WAVE/wave for the atm.logf file it needs to fire off.

Resolves #1887

# Type of change

- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Remade xml in coupled forecast-only S2SW test on WCOSS2 and the data dependency was corrected and the wavepostbndpntbll job fired off.
