### PR TITLE
Add coupled forecast-only tests for S2S and S2SW

### DIFF
--- a/ci/cases/pr/C48_S2SW.yaml
+++ b/ci/cases/pr/C48_S2SW.yaml
@@ -4,7 +4,7 @@ experiment:
 
 arguments:
   pslot: ${pslot}
-  app: S2S
+  app: S2SW
   resdet: 48
   comrot: ${RUNTESTS}/COMROT
   expdir: ${RUNTESTS}/EXPDIR

--- a/ci/cases/weekly/C384_S2SWA.yaml
+++ b/ci/cases/weekly/C384_S2SWA.yaml
@@ -1,0 +1,13 @@
+experiment:
+  type: gfs
+  mode: forecast-only
+
+arguments:
+  pslot: ${pslot}
+  app: S2SWA
+  resdet: 384
+  comrot: ${RUNTESTS}/COMROT
+  expdir: ${RUNTESTS}/EXPDIR
+  idate: 2016070100
+  edate: 2016070100
+  yaml: ${HOMEgfs_PR}/ci/platforms/gfs_defaults_ci-updates.yaml


### PR DESCRIPTION
# Description
This PR:
- replaces the PR C48 S2S forecast-only test with a S2SW configuration
- adds a weekly C384 S2SWA forecast-only test.

The C384 S2SWA is a weekly test and will not be triggered/tested in this PR, but will be tested on Friday.  See notes on Orion below in the testing section.

@JessicaMeixner-NOAA kindly provided the details in [here](https://github.com/NOAA-EMC/global-workflow/issues/1794#issuecomment-1740768751)

# Type of change
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
These are intended to be run through CI.
See this [comment](https://github.com/NOAA-EMC/global-workflow/issues/1794#issuecomment-1740768751) for previous testing on Hera.

@WalterKolczynski-NOAA 
For orion we will have to move the wave IC created for the C384 case to the staged location. 
The file on Hera is at:
`/scratch1/NCEPDEV/climate/role.ufscpara/IC/GEFSwave20210528v2/2016070100/wav/glo_025/20160701.000000.restart.glo_025`


# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
