### PR TITLE
CI driver_weekly bugfix deleting new branch if is already on repo

### DIFF
--- a/ci/scripts/driver_weekly.sh
+++ b/ci/scripts/driver_weekly.sh
@@ -75,13 +75,14 @@ git checkout -b "${branch}"
 # and push new branch for PR weekly CI tests to GitHub
 REPO_OWNER="emcbot"
 REPO_NAME="global-workflow"
+REMOTE_NAME="${REPO_OWNER}"
 
 rm -Rf ci/cases/pr
 mv ci/cases/weekly ci/cases/pr
 git add ci/cases
 git commit -m "Moved weekly cases files into pr for high resolution testing"
 
-git remote add upstream "git@github.com:${REPO_OWNER}/${REPO_NAME}.git"
+git remote add "${REMOTE_NAME}" "git@github.com:${REPO_OWNER}/${REPO_NAME}.git"
 
 set +e
 # Delete the branch if it exists

--- a/ci/scripts/driver_weekly.sh
+++ b/ci/scripts/driver_weekly.sh
@@ -86,7 +86,7 @@ git remote add "${REMOTE_NAME}" "git@github.com:${REPO_OWNER}/${REPO_NAME}.git"
 
 set +e
 # Delete the branch if it exists
-git ls-remote --exit-code upstream "${branch}"
+git ls-remote --exit-code "${REMOTE_NAME}" "${branch}"
 ci_status=$?
 if [[ "${ci_status}" == '0' ]]; then
     git push "${REMOTE_NAME}" --delete "${branch}"

--- a/ci/scripts/driver_weekly.sh
+++ b/ci/scripts/driver_weekly.sh
@@ -90,7 +90,7 @@ git push --set-upstream origin "${branch}"
 # Create Pull Request using GitHub CLI and add labels for CI testing
 ####################################################################
 
-REPO_OWNER="NOAA-EMC"
+REPO_OWNER="TerrenceMcGuinness-NOAA"
 REPO_NAME="global-workflow"
 BASE_BRANCH="develop"
 HEAD_BRANCH="${branch}"

--- a/ci/scripts/driver_weekly.sh
+++ b/ci/scripts/driver_weekly.sh
@@ -89,7 +89,7 @@ set +e
 git ls-remote --exit-code upstream "${branch}"
 ci_status=$?
 if [[ "${ci_status}" == '0' ]]; then
-    git push "${REMMOT_NAME}" --delete "${branch}"
+    git push "${REMOTE_NAME}" --delete "${branch}"
 fi
 set -e
 

--- a/ci/scripts/driver_weekly.sh
+++ b/ci/scripts/driver_weekly.sh
@@ -89,11 +89,11 @@ set +e
 git ls-remote --exit-code upstream "${branch}"
 ci_status=$?
 if [[ "${ci_status}" == '0' ]]; then
-    git push upstream --delete "${branch}"
+    git push "${REMMOT_NAME}" --delete "${branch}"
 fi
 set -e
 
-git push --set-upstream upstream "${branch}"
+git push --set-upstream "${REMOTE_NAME}" "${branch}"
 
 ####################################################################
 # Create Pull Request using GitHub CLI and add labels for CI testing

--- a/ci/scripts/driver_weekly.sh
+++ b/ci/scripts/driver_weekly.sh
@@ -22,7 +22,7 @@ set -eux
 # TODO using static build for GitHub CLI until fixed in HPC-Stack
 #################################################################
 export GH=${HOME}/bin/gh
-export REPO_URL=${REPO_URL:-"https://github.com/NOAA-EMC/global-workflow.git"}
+export REPO_URL="ssh://git@ssh.github.com:443/NOAA-EMC/global-workflow.git"
 
 ################################################################
 # Setup the relative paths to scripts and PS4 for better logging
@@ -68,6 +68,11 @@ mkdir -p "${develop_dir}"
 cd "${develop_dir}" || exit 1
 git clone "${REPO_URL}"
 cd global-workflow || exit 1
+git ls-remote --exit-code origin "${branch}"
+if [[ $? == '0' ]]; then
+    # Delete the branch if it exists
+    git push origin --delete "${branch}"
+fi
 git checkout -b "${branch}"
 
 ######################################################

--- a/ci/scripts/driver_weekly.sh
+++ b/ci/scripts/driver_weekly.sh
@@ -69,7 +69,8 @@ cd "${develop_dir}" || exit 1
 git clone "${REPO_URL}"
 cd global-workflow || exit 1
 git ls-remote --exit-code origin "${branch}"
-if [[ $? == '0' ]]; then
+ci_status=$?
+if [[ "${ci_status}" == '0' ]]; then
     # Delete the branch if it exists
     git push origin --delete "${branch}"
 fi

--- a/ci/scripts/driver_weekly.sh
+++ b/ci/scripts/driver_weekly.sh
@@ -101,7 +101,7 @@ git push --set-upstream "${REMOTE_NAME}" "${branch}"
 
 HEAD_BRANCH="${REPO_OWNER}:${branch}"
 BASE_BRANCH="develop"
-PULL_REQUEST_TITLE="[DO NOT MERGE] Weekly High Resolution CI Tests $(date +'%A %b %d, %Y')"
+PULL_REQUEST_TITLE="[DO NOT MERGE] Weekly CI Tests $(date +'%A %b %d, %Y')"
 PULL_REQUEST_BODY="${PULL_REQUEST_TITLE}"
 PULL_REQUEST_LABELS=("CI/CD" "CI-Orion-Ready" "CI-Hera-Ready")
 

--- a/ci/scripts/run_ci.sh
+++ b/ci/scripts/run_ci.sh
@@ -22,7 +22,7 @@ source "${HOMEgfs}/ush/detect_machine.sh"
 case ${MACHINE_ID} in
   hera | orion)
    echo "Running Automated Testing on ${MACHINE_ID}"
-   source "${HOMEgfs}/ci/platforms/${MACHINE_ID}.sh"
+   source "${HOMEgfs}/ci/platforms/config.${MACHINE_ID}"
    ;;
  *)
    echo "Unsupported platform. Exiting with error."


### PR DESCRIPTION
# Description
Bugfix and updates to weekly CI test that deletes the new modfied branch  if it is already on the repo but now also makes sure that the intermediary branch that creates the PR is coming from **emcbot**.

# Type of chang
- Bugfix (CI weekly test can fail if ran twice)
- Does not push branch to NOAA-EMC global-workflow branch but comes from emcbot instead

# How has this been tested?
- Ran the script in cron on Orion (didn't work on Hera because gh is to old there)

