### PR TITLE
Change metp dependency

### DIFF
--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -887,7 +887,7 @@ class GFSTasks(Tasks):
 
     def metp(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}post'}
+        dep_dict = {'type': 'task', 'name': f'{self.cdump}arch'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
@@ -916,9 +916,6 @@ class GFSTasks(Tasks):
             deps.append(rocoto.add_dependency(dep_dict))
         if self.cdump in ['gdas'] and self.app_config.do_fit2obs:
             dep_dict = {'type': 'task', 'name': f'{self.cdump}fit2obs'}
-            deps.append(rocoto.add_dependency(dep_dict))
-        if self.app_config.do_metp and self.cdump in ['gfs']:
-            dep_dict = {'type': 'metatask', 'name': f'{self.cdump}metp'}
             deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_wave:
             dep_dict = {'type': 'task', 'name': f'{self.cdump}wavepostsbs'}


### PR DESCRIPTION
# Description
MET+ jobs rely on files already having been placed in the local archive directory, but the job only depended on post, resulting in the job prematurely firing. The dependency is now updated to be on the archive job instead.

Refs #1756

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Cycled test on Orion

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
