### PR TITLE
Update vrfy.sh to only run MINMON in cycled mode

### DIFF
--- a/jobs/rocoto/vrfy.sh
+++ b/jobs/rocoto/vrfy.sh
@@ -91,7 +91,7 @@ fi
 ###############################################################
 echo
 echo "=============== START TO RUN MINMON ==============="
-if [[ "${VRFYMINMON}" == "YES" && "${PDY}${cyc}" != "${SDATE}" ]]; then
+if [[ "${VRFYMINMON}" == "YES" && "${PDY}${cyc}" != "${SDATE}" && "${MODE}" = "cycled" ]]; then
 
     export M_TANKverfM0="${M_TANKverf}/stats/${PSLOT}/${RUN}.${PDY}/${cyc}"
     export M_TANKverfM1="${M_TANKverf}/stats/${PSLOT}/${RUN}.${PDYm1c}/${pcyc}"


### PR DESCRIPTION
# Description

This PR updates the MINMON if-block in the `jobs/rocoto/vrfy.sh` script to only invoke this section when `MODE=cycled`.

Resolves #1076

# Type of change

- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Forecast-only coupled test on WCOSS2.