### PR TITLE
Changes required for NOAA-21 monitoring

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.3.8
+tag = gfsda.v16.3.10
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git
@@ -22,7 +22,7 @@ protocol = git
 required = True
 
 [UPP]
-tag = upp_v8.2.0
+tag = upp_v8.3.0
 local_path = sorc/gfs_post.fd
 repo_url = https://github.com/NOAA-EMC/UPP.git
 protocol = git

--- a/docs/Release_Notes.gfs.v16.3.10.md
+++ b/docs/Release_Notes.gfs.v16.3.10.md
@@ -50,7 +50,8 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* `versions/run.ver` - change `version=v16.3.10`, `gfs_ver=v16.3.10`, and `obsproc_ver=v1.2`
+* `versions/base.ver` - change `crtm_ver=2.4.0.1`
+* `versions/run.ver` - change `version=v16.3.10`, `gfs_ver=v16.3.10`, `obsproc_ver=v1.2` and `crtm_ver=2.4.0.1`
 * `versions/hera.ver` - change `obsproc_run_ver=1.2.0`
 * `versions/orion.ver` - change `obsproc_run_ver=1.2.0`
 * `versions/wcoss2.ver` - change `obsproc_run_ver=1.2.0`
@@ -73,12 +74,13 @@ PARM/CONFIG CHANGES
 SCRIPT CHANGES
 --------------
 
-* No changes from GFS v16.3.9
+* Changes to sorc/gsi.fd/scripts/exglobal_atmos_analysis.sh
 
 FIX CHANGES
 -----------
 
-* No changes from GFS v16.3.9
+* Changes to fix/fix_gsi/global_anavinfo.l127.txt, fix/fix_gsi/global_satinfo.txt
+  and add fix/fix_gsi/Rcov_crisn21 
 
 MODULE CHANGES
 --------------

--- a/docs/Release_Notes.gfs.v16.3.10.md
+++ b/docs/Release_Notes.gfs.v16.3.10.md
@@ -25,9 +25,9 @@ The checkout script extracts the following GFS components:
 | --------- | ----------- | ----------------- |
 | MODEL     | GFS.v16.3.0   | Jun.Wang@noaa.gov |
 | GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
-| GSI       | gfsda.v16.3.8 | Andrew.Collard@noaa.gov |
+| GSI       | gfsda.v16.3.10 | Andrew.Collard@noaa.gov |
 | UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
-| POST      | upp_v8.2.0 | Wen.Meng@noaa.gov |
+| POST      | upp_v8.3.0 | Wen.Meng@noaa.gov |
 | WAFS      | gfs_wafs.v6.3.1 | Yali.Mao@noaa.gov |
 
 To build all the GFS components, execute:
@@ -50,7 +50,7 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* `versions/base.ver` - change `crtm_ver=2.4.0.1`
+* `versions/build.ver` - change `crtm_ver=2.4.0.1`
 * `versions/run.ver` - change `version=v16.3.10`, `gfs_ver=v16.3.10`, `obsproc_ver=v1.2` and `crtm_ver=2.4.0.1`
 * `versions/hera.ver` - change `obsproc_run_ver=1.2.0`
 * `versions/orion.ver` - change `obsproc_run_ver=1.2.0`

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -35,7 +35,7 @@ fi
 echo gsi checkout ...
 if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
-    git clone --recursive --branch gfsda.v16.3.8 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
+    git clone --recursive --branch gfsda.v16.3.10 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
     git submodule update --init
     cd ${topdir}

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -64,7 +64,7 @@ fi
 echo EMC_post checkout ...
 if [[ ! -d gfs_post.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_post.log
-    git clone ${gtg_git_args:-} --branch upp_v8.2.0 https://github.com/NOAA-EMC/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
+    git clone ${gtg_git_args:-} --branch upp_v8.3.0 https://github.com/NOAA-EMC/UPP.git gfs_post.fd >> ${topdir}/checkout-gfs_post.log 2>&1
     ################################################################################
     # checkout_gtg
     ## yes: The gtg code at NCAR private repository is available for ops. GFS only.

--- a/versions/build.ver
+++ b/versions/build.ver
@@ -15,7 +15,7 @@ export netcdf_ver=4.7.4
 export esmf_ver=8.0.1
 export wgrib2_ver=2.0.7
 
-export crtm_ver=2.4.0
+export crtm_ver=2.4.0.1
 
 export g2tmpl_ver=1.9.1
 export bacio_ver=2.4.1

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -35,7 +35,7 @@ export util_shared_ver=1.4.0
 export grib_util_ver=1.2.3
 export wgrib2_ver=2.0.7
 
-export crtm_ver=2.4.0
+export crtm_ver=2.4.0.1
 
 export g2tmpl_ver=1.9.1
 export bacio_ver=2.4.1


### PR DESCRIPTION
If merged, this PR will Change the version of crtm to 2.4.0.1 to allow assimilation of NOAA-21 and GOES-18 radiances

# Description
<!--Allow monitoring of NOAA-21 and GOES-18 radiances-->

This PR will turn on the monitoring of NOAA-21 and GOES-18 radiances.  A new version of CRTM with new coefficient files is required for this change.

Refs #1356

# Type of change
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Cycled test on WCOSS2 


# Checklist
- [] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
