### PR TITLE
Update ufs-weather-model tag and add prelude to release notes for GFSv16.3.10

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,7 @@
 # External sub-modules of global-workflow
 
 [FV3GFS]
-tag = GFS.v16.3.0
+tag = GFS.v16.3.1
 local_path = sorc/fv3gfs.fd
 repo_url = https://github.com/ufs-community/ufs-weather-model.git
 protocol = git

--- a/docs/Release_Notes.gfs.v16.3.10.md
+++ b/docs/Release_Notes.gfs.v16.3.10.md
@@ -23,7 +23,7 @@ The checkout script extracts the following GFS components:
 
 | Component | Tag         | POC               |
 | --------- | ----------- | ----------------- |
-| MODEL     | GFS.v16.3.0   | Jun.Wang@noaa.gov |
+| MODEL     | GFS.v16.3.1   | Jun.Wang@noaa.gov |
 | GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
 | GSI       | gfsda.v16.3.10 | Andrew.Collard@noaa.gov |
 | UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
@@ -130,3 +130,5 @@ PREPARED BY
 Kate.Friedman@noaa.gov
 Andrew.Collard@noaa.gov
 Iliana.Genkova@noaa.gov
+Wen.Meng@noaa.gov
+Jun.Wang@noaa.gov

--- a/docs/Release_Notes.gfs.v16.3.10.md
+++ b/docs/Release_Notes.gfs.v16.3.10.md
@@ -48,6 +48,8 @@ cd ../ecf
 ./setup_ecf_links.sh
 ```
 
+Additional release notes for upp/8.3.0 installation on WCOSS2: https://docs.google.com/document/d/18bUYWmsN7FuweyA2CQTBW1rk3FNRMHKPlYHZlbS8ODs/edit?pli=1
+
 VERSION FILE CHANGES
 --------------------
 

--- a/docs/Release_Notes.gfs.v16.3.10.md
+++ b/docs/Release_Notes.gfs.v16.3.10.md
@@ -4,6 +4,7 @@ GFS V16.3.10 RELEASE NOTES
 PRELUDE
 -------
 
+Enable the monitoring of NOAA-21 and GOES-18 radiances in the GFS. A new version of CRTM with new coefficient files is required and included in this change.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -26,7 +26,7 @@ echo $topdir
 echo fv3gfs checkout ...
 if [[ ! -d fv3gfs.fd ]] ; then
     rm -f ${topdir}/checkout-fv3gfs.log
-    git clone --recursive --branch GFS.v16.3.0 https://github.com/ufs-community/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
+    git clone --recursive --branch GFS.v16.3.1 https://github.com/ufs-community/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory fv3gfs.fd already exists.'


### PR DESCRIPTION
# Description

This PR includes two updates for the GFSv16.3.10 release branch:

1. Updated ufs-weather-model tag for new CRTM version and UPP library
2. Add a prelude to the release notes (@ADCollard please provide feedback on prelude)

Refs #1356
