### PR TITLE
Updated cron bash ci script to remove weekly CI test PR on success

### DIFF
--- a/ci/scripts/check_ci.sh
+++ b/ci/scripts/check_ci.sh
@@ -89,7 +89,7 @@ for pr in ${pr_list}; do
     # Check to see if this PR that was opened by the weekly tests and if so close it if it passed on all platforms
     weekly_labels=$(${GH} pr view "${pr}" --repo "${REPO_URL}"  --json headRefName,labels,author --jq 'select(.author.login | contains("emcbot")) | select(.headRefName | contains("weekly_ci")) | .labels[].name ') || true
     if [[ -n "${weekly_labels}" ]]; then
-      num_platforms=$(ls -1 ../platforms/config.* | wc -l)
+      num_platforms=$(find ../platforms -type f -name "config.*")
       passed=0
       for platforms in ../platforms/config.*; do
         machine=$(basename "${platforms}" | cut -d. -f2)

--- a/ci/scripts/check_ci.sh
+++ b/ci/scripts/check_ci.sh
@@ -14,7 +14,8 @@ echo "Begin ${scriptname} at $(date -u)" || true
 export PS4='+ $(basename ${BASH_SOURCE})[${LINENO}]'
 
 GH=${HOME}/bin/gh
-REPO_URL=${REPO_URL:-"https://github.com/NOAA-EMC/global-workflow.git"}
+#REPO_URL=${REPO_URL:-"https://github.com/NOAA-EMC/global-workflow.git"}
+REPO_URL="https://github.com/NOAA-EMC/global-workflow.git"
 
 #########################################################################
 #  Set up runtime environment varibles for accounts on supproted machines
@@ -87,13 +88,14 @@ for pr in ${pr_list}; do
     "${GH}" pr comment "${pr}" --repo "${REPO_URL}" --body-file "${GFS_CI_ROOT}/PR/${pr}/output_${id}"
     "${HOMEgfs}/ci/scripts/pr_list_database.py" --remove_pr "${pr}" --dbfile "${pr_list_dbfile}"
     # Check to see if this PR that was opened by the weekly tests and if so close it if it passed on all platforms
-    weekly_labels = $(${GH} pr view ${pr} --repo ${REPO_URL}  --json headRefName,labels,author --jq 'select(.author.login | contains("emcbot")) | select(.headRefName | contains("weekly_ci") ) | .labels[].name ') || true
+    weekly_labels=$(${GH} pr view ${pr} --repo ${REPO_URL}  --json headRefName,labels,author --jq 'select(.author.login | contains("emcbot")) | select(.headRefName | contains("weekly_ci")) | .labels[].name ') || true
+    echo "weekly_labels: ${weekly_labels}"
     if [[ -n "${weekly_labels}" ]]; then
       num_platforms=$(ls -1 ../platforms/config.* | wc -l)
       passed=0
-      for platforms in ../platforms/config.* ; do
+      for platforms in ../platforms/config.*; do
         machine=$(basename $platforms | cut -d. -f2)
-        if [[ "${weekly_labels}" == *"CI-${machine^}-Passed"* ]]  && ; then
+        if [[ "${weekly_labels}" == *"CI-${machine^}-Passed"* ]]; then
           ((passed=passed+1))
         fi
       done

--- a/ci/scripts/check_ci.sh
+++ b/ci/scripts/check_ci.sh
@@ -92,7 +92,7 @@ for pr in ${pr_list}; do
       num_platforms=$(ls -1 ../platforms/config.* | wc -l)
       passed=0
       for platforms in ../platforms/config.*; do
-        machine=$(basename $platforms | cut -d. -f2)
+        machine=$(basename "${platforms}" | cut -d. -f2)
         if [[ "${weekly_labels}" == *"CI-${machine^}-Passed"* ]]; then
           ((passed=passed+1))
         fi

--- a/ci/scripts/check_ci.sh
+++ b/ci/scripts/check_ci.sh
@@ -14,7 +14,6 @@ echo "Begin ${scriptname} at $(date -u)" || true
 export PS4='+ $(basename ${BASH_SOURCE})[${LINENO}]'
 
 GH=${HOME}/bin/gh
-#REPO_URL=${REPO_URL:-"https://github.com/NOAA-EMC/global-workflow.git"}
 REPO_URL="https://github.com/NOAA-EMC/global-workflow.git"
 
 #########################################################################
@@ -89,7 +88,6 @@ for pr in ${pr_list}; do
     "${HOMEgfs}/ci/scripts/pr_list_database.py" --remove_pr "${pr}" --dbfile "${pr_list_dbfile}"
     # Check to see if this PR that was opened by the weekly tests and if so close it if it passed on all platforms
     weekly_labels=$(${GH} pr view ${pr} --repo ${REPO_URL}  --json headRefName,labels,author --jq 'select(.author.login | contains("emcbot")) | select(.headRefName | contains("weekly_ci")) | .labels[].name ') || true
-    echo "weekly_labels: ${weekly_labels}"
     if [[ -n "${weekly_labels}" ]]; then
       num_platforms=$(ls -1 ../platforms/config.* | wc -l)
       passed=0

--- a/ci/scripts/check_ci.sh
+++ b/ci/scripts/check_ci.sh
@@ -87,7 +87,7 @@ for pr in ${pr_list}; do
     "${GH}" pr comment "${pr}" --repo "${REPO_URL}" --body-file "${GFS_CI_ROOT}/PR/${pr}/output_${id}"
     "${HOMEgfs}/ci/scripts/pr_list_database.py" --remove_pr "${pr}" --dbfile "${pr_list_dbfile}"
     # Check to see if this PR that was opened by the weekly tests and if so close it if it passed on all platforms
-    weekly_labels=$(${GH} pr view ${pr} --repo ${REPO_URL}  --json headRefName,labels,author --jq 'select(.author.login | contains("emcbot")) | select(.headRefName | contains("weekly_ci")) | .labels[].name ') || true
+    weekly_labels=$(${GH} pr view "${pr}" --repo "${REPO_URL}"  --json headRefName,labels,author --jq 'select(.author.login | contains("emcbot")) | select(.headRefName | contains("weekly_ci")) | .labels[].name ') || true
     if [[ -n "${weekly_labels}" ]]; then
       num_platforms=$(ls -1 ../platforms/config.* | wc -l)
       passed=0

--- a/ci/scripts/check_ci.sh
+++ b/ci/scripts/check_ci.sh
@@ -86,7 +86,23 @@ for pr in ${pr_list}; do
     sed -i "s/\`\`\`//2g" "${GFS_CI_ROOT}/PR/${pr}/output_${id}"
     "${GH}" pr comment "${pr}" --repo "${REPO_URL}" --body-file "${GFS_CI_ROOT}/PR/${pr}/output_${id}"
     "${HOMEgfs}/ci/scripts/pr_list_database.py" --remove_pr "${pr}" --dbfile "${pr_list_dbfile}"
-    # Completely remove the PR and its cloned repo on sucess of all cases
+    # Check to see if this PR that was opened by the weekly tests and if so close it if it passed on all platforms
+    weekly_labels = $(${GH} pr view ${pr} --repo ${REPO_URL}  --json headRefName,labels,author --jq 'select(.author.login | contains("emcbot")) | select(.headRefName | contains("weekly_ci") ) | .labels[].name ') || true
+    if [[ -n "${weekly_labels}" ]]; then
+      num_platforms=$(ls -1 ../platforms/config.* | wc -l)
+      passed=0
+      for platforms in ../platforms/config.* ; do
+        machine=$(basename $platforms | cut -d. -f2)
+        if [[ "${weekly_labels}" == *"CI-${machine^}-Passed"* ]]  && ; then
+          ((passed=passed+1))
+        fi
+      done
+      if [[ "${passed}" == "${num_platforms}" ]]; then
+        "${GH}" pr close --repo "${REPO_URL}" "${pr}"
+      fi
+    fi
+    # Completely remove the PR and its cloned repo on sucess
+    # of all cases on this platform
     rm -Rf "${pr_dir}" 
     continue 
   fi


### PR DESCRIPTION
# Description

This PR updates the check CI bash script in cron to remove the PR that is created by the weekly CI test driver when all the tests has passed on all the platforms.

This is done by the script checking if all other labels for all the platforms for the PR that has currently been flagged to have run to a successfull completion by the check ci bash script.

# Type of change
<!-- Delete all except one -->

- New feature (adds functionality) to the existing Weekly CI Tests


# Change characteristics
- Does this change does NOT require a documentation update? YES/NO

# How has this been tested?
The script was ran from cron (as it also has) but with the updates it successfully closed a PR that also had both **CI-${MACHINE}-Pass** flags set.


# Checklist
- [ ] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
