### PR TITLE
Fix missing pipe in check_ci

### DIFF
--- a/ci/scripts/check_ci.sh
+++ b/ci/scripts/check_ci.sh
@@ -89,7 +89,7 @@ for pr in ${pr_list}; do
     # Check to see if this PR that was opened by the weekly tests and if so close it if it passed on all platforms
     weekly_labels=$(${GH} pr view "${pr}" --repo "${REPO_URL}"  --json headRefName,labels,author --jq 'select(.author.login | contains("emcbot")) | select(.headRefName | contains("weekly_ci")) | .labels[].name ') || true
     if [[ -n "${weekly_labels}" ]]; then
-      num_platforms=$(find ../platforms -type f -name "config.*")
+      num_platforms=$(find ../platforms -type f -name "config.*" | wc -l)
       passed=0
       for platforms in ../platforms/config.*; do
         machine=$(basename "${platforms}" | cut -d. -f2)


### PR DESCRIPTION
# Description

Bugfix:  left out pipe to word count` | wc -l` after updating:

`num_platforms=$(ls ../platforms/config.* | wc -l)` to
`num_platforms=$(find ../platforms -type f -name "config.*")`

when it was flagged by the BASH linter.

# Type of change
<!-- Delete all except one -->
- Bug fix (fixes something broken)


# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO