### PR TITLE
Update nth_eupd to 8 for Orion

### DIFF
--- a/parm/config/gefs/config.resources
+++ b/parm/config/gefs/config.resources
@@ -806,7 +806,7 @@ elif [[ ${step} = "eupd" ]]; then
       fi
     elif [[ ${CASE} = "C384" ]]; then
       export npe_eupd=270
-      export nth_eupd=2
+      export nth_eupd=8
       if [[ "${machine}" = "WCOSS2" ]]; then
         export npe_eupd=315
         export nth_eupd=14


### PR DESCRIPTION
# Description

Small update for `config.resources eupd` when running on Orion.
We updated `ntheupd=8` as is on Hera in anticipation of tomorrow's Weekly CI Tests
as they had previously failed for _enkfgdaseupd_ (`enkf.x`) in **C384C192_hybatmda**

# Type of change
- Bug fix (fixes something broken)


# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Clone, build, and cycle tested on Orion
