### PR TITLE
Fix enkfgfs cleanup dependency

### DIFF
--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -948,7 +948,7 @@ class GFSTasks(Tasks):
     def cleanup(self):
         deps = []
         if 'enkf' in self.cdump:
-            dep_dict = {'type': 'metatask', 'name': 'enkfgdaseamn'}
+            dep_dict = {'type': 'metatask', 'name': f'{self.cdump}eamn'}
             deps.append(rocoto.add_dependency(dep_dict))
         else:
             dep_dict = {'type': 'task', 'name': f'{self.cdump}arch'}


### PR DESCRIPTION
# Description
When #1906 was merged, the dependency for enkf cycles was hard-coded to use the enkfgdas archive instead of depending on the `RUN`.

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?


# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
