### PR TITLE
Remove obsproc component from GFSv16.3.11 upgrade

### DIFF
--- a/docs/Release_Notes.gfs.v16.3.11.md
+++ b/docs/Release_Notes.gfs.v16.3.11.md
@@ -54,10 +54,7 @@ VERSION FILE CHANGES
 --------------------
 
 * `versions/build.ver` - change `crtm_ver=2.4.0.1`
-* `versions/run.ver` - change `version=v16.3.11`, `gfs_ver=v16.3.11`, `obsproc_ver=v1.2` and `crtm_ver=2.4.0.1`
-* `versions/hera.ver` - change `obsproc_run_ver=1.2.0`
-* `versions/orion.ver` - change `obsproc_run_ver=1.2.0`
-* `versions/wcoss2.ver` - change `obsproc_run_ver=1.2.0`
+* `versions/run.ver` - change `version=v16.3.11`, `gfs_ver=v16.3.11`, and `crtm_ver=2.4.0.1`
 
 SORC CHANGES
 ------------
@@ -132,6 +129,5 @@ PREPARED BY
 -----------
 Kate.Friedman@noaa.gov
 Andrew.Collard@noaa.gov
-Iliana.Genkova@noaa.gov
 Wen.Meng@noaa.gov
 Jun.Wang@noaa.gov

--- a/versions/hera.ver
+++ b/versions/hera.ver
@@ -2,7 +2,7 @@ export hpc_ver=1.2.0
 export hpc_intel_ver=18.0.5.274
 export hpc_impi_ver=2018.0.4
 
-export obsproc_run_ver=1.2.0
+export obsproc_run_ver=1.1.2
 export prepobs_run_ver=1.0.1
 
 export hpss_ver=hpss

--- a/versions/orion.ver
+++ b/versions/orion.ver
@@ -2,7 +2,7 @@ export hpc_ver=1.2.0
 export hpc_intel_ver=2018.4
 export hpc_impi_ver=2018.4
 
-export obsproc_run_ver=1.2.0
+export obsproc_run_ver=1.1.2
 export prepobs_run_ver=1.0.1
 
 export prod_util_ver=1.2.2

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -5,7 +5,7 @@ export ecmwf_ver=v2.1
 export nam_ver=v4.2
 export rtofs_ver=v2.3
 export radarl2_ver=v1.2
-export obsproc_ver=v1.2
+export obsproc_ver=v1.1
 
 export PrgEnv_intel_ver=8.1.0
 export intel_ver=19.1.3.304

--- a/versions/wcoss2.ver
+++ b/versions/wcoss2.ver
@@ -2,7 +2,7 @@ export envvar_ver=1.0
 export prod_envir_ver=${prod_envir_ver:-2.0.4} # Allow override from ops ecflow
 export prod_util_ver=${prod_util_ver:-2.0.9}   # Allow override from ops ecflow
 
-export obsproc_run_ver=1.2.0
+export obsproc_run_ver=1.1.2
 export prepobs_run_ver=1.0.1
 
 export tracker_ver=v1.1.15.5


### PR DESCRIPTION
# Description

This PR decouples the obsproc upgrade from the GSI upgrade that is occurring in GFSv16.3.11. The obsproc upgrade will occur in a follow-up implementation.

- Remove obsproc version change in the version files
- Remove mention of the obsproc version upgrade from the release notes

FYI @ADCollard @ilianagenkova 

Refs #1356

# Type of change

Production update

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

N/A