### PR TITLE
Set SENDCOM=YES for tracker/genesis tasks

### DIFF
--- a/parm/config/gfs/config.vrfy
+++ b/parm/config/gfs/config.vrfy
@@ -66,6 +66,8 @@ fi
 # Cyclone genesis and cyclone track verification
 #-------------------------------------------------
 
+export SENDCOM="YES" # Needed by tracker/genesis scripts still
+
 export HOMEens_tracker=$BASE_GIT/TC_tracker/${tracker_ver}
 
 if [[ "${VRFYTRAK}" = "YES" ]]; then


### PR DESCRIPTION
# Description

This PR sets `SENDCOM="YES"` in `config.vrfy` in order to get outputs copied back to COM in the tracker and genesis tasks.

Will reevaluate the need for `SENDCOM` when moving the tracker/genesis jobs out of the `vrfy` job with issue #235 work.

Thanks for reporting this issue @JessicaMeixner-NOAA !

Resolves #1947

# Type of change

- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Forecast-only S2SWA test on WCOSS2-Dogwood that mimicked the test done by the user who reported the failure.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
