### PR TITLE
Update GDASApp hash

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -57,7 +57,7 @@ protocol = git
 required = False
 
 [GDASApp]
-hash = d347d22
+hash = 3043f9a
 local_path = sorc/gdas.cd
 repo_url = https://github.com/NOAA-EMC/GDASApp.git
 protocol = git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -57,7 +57,7 @@ protocol = git
 required = False
 
 [GDASApp]
-hash = 3043f9a
+hash = 7659c10
 local_path = sorc/gdas.cd
 repo_url = https://github.com/NOAA-EMC/GDASApp.git
 protocol = git

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -164,7 +164,7 @@ if [[ ${checkout_gsi} == "YES" ]]; then
 fi
 
 if [[ ${checkout_gdas} == "YES" ]]; then
-  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "3043f9a" &
+  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "7659c10" &
 fi
 
 if [[ ${checkout_gsi} == "YES" || ${checkout_gdas} == "YES" ]]; then

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -164,7 +164,7 @@ if [[ ${checkout_gsi} == "YES" ]]; then
 fi
 
 if [[ ${checkout_gdas} == "YES" ]]; then
-  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "d347d22" &
+  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git" "3043f9a" &
 fi
 
 if [[ ${checkout_gsi} == "YES" || ${checkout_gdas} == "YES" ]]; then


### PR DESCRIPTION
# Description
Update GDASApp hash to bring recent UFSDA development into g-w.

Resolves #1972

# Type of change
- Maintenance (update GDASApp hash)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? **_NO_**
- Does this change require a documentation update? **_NO_**

# How has this been tested?
The following test was conducted
-  `git clone https://github.com/RussTreadon-NOAA/global-workflow.git .`
- `git checkout feature/GDASApp_hash`
- `cd sorc`
- `./checkout.sh -u`
- `cd gdas.cd`
- `git status`
- confirm the GDASApp hash is [`7659c10`](https://github.com/NOAA-EMC/GDASApp/commit/7659c103416294cfff9995c0044db71098556d2a)

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

