### PR TITLE
Update GFS version in index.rst to v16.3.10

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Status
 ======
 
 * State of develop (HEAD) branch: GFSv17+ development
-* State of operations (dev/gfs.v16 branch): GFS v16.3.9 `tag: [gfs.v16.3.9] <https://github.com/NOAA-EMC/global-workflow/releases/tag/gfs.v16.3.9>`_
+* State of operations (dev/gfs.v16 branch): GFS v16.3.10 `tag: [gfs.v16.3.10] <https://github.com/NOAA-EMC/global-workflow/releases/tag/gfs.v16.3.10>`_
 
 =============
 Code managers


### PR DESCRIPTION
# Description

This PR updates the "State of operations" GFS version number to the new `v16.3.10` (Annual CO2 fix file update in operations) in the main page of the RTD documentation.

Refs #1924

# Type of change

- Maintenance (documentation update)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? YES

# How has this been tested?

N/A
