### PR TITLE
Fix incorrect usage of CFP on WCOSS2

### DIFF
--- a/ush/run_mpmd.sh
+++ b/ush/run_mpmd.sh
@@ -45,7 +45,7 @@ elif [[ "${launcher:-}" =~ ^mpiexec.* ]]; then  # mpiexec
 
   chmod 755 "${mpmd_cmdfile}"
   # shellcheck disable=SC2086
-  ${launcher:-} -np ${nprocs} ${mpmd_out:-} "${mpmd_cmdfile}"
+  ${launcher:-} -np ${nprocs} ${mpmd_opt:-} "${mpmd_cmdfile}"
   rc=$?
   if (( rc == 0 )); then
     out_files=$(find . -name 'mpmd.*.out')

--- a/ush/run_mpmd.sh
+++ b/ush/run_mpmd.sh
@@ -4,6 +4,9 @@ source "${HOMEgfs}/ush/preamble.sh"
 
 cmdfile=${1:?"run_mpmd requires an input file containing commands to execute in MPMD mode"}
 
+# Determine the number of MPMD processes from incoming ${cmdfile}
+nprocs=$(wc -l < "${cmdfile}")
+
 # Local MPMD file containing instructions to run in CFP
 mpmd_cmdfile="${DATA:-}/mpmd_cmdfile"
 if [[ -s "${mpmd_cmdfile}" ]]; then rm -f "${mpmd_cmdfile}"; fi
@@ -19,7 +22,6 @@ if [[ "${launcher:-}" =~ ^srun.* ]]; then  #  srun-based system e.g. Hera, Orion
     ((nm=nm+1))
   done < "${cmdfile}"
 
-  nprocs=$(wc -l < "${mpmd_cmdfile}")
   set +e
   # shellcheck disable=SC2086
   ${launcher:-} ${mpmd_opt:-} -n ${nprocs} "${mpmd_cmdfile}"
@@ -42,7 +44,8 @@ elif [[ "${launcher:-}" =~ ^mpiexec.* ]]; then  # mpiexec
   done < "${cmdfile}"
 
   chmod 755 "${mpmd_cmdfile}"
-  ${launcher:-} "${mpmd_cmdfile}"
+  # shellcheck disable=SC2086
+  ${launcher:-} -np ${nprocs} ${mpmd_out:-} "${mpmd_cmdfile}"
   rc=$?
   if (( rc == 0 )); then
     out_files=$(find . -name 'mpmd.*.out')


### PR DESCRIPTION
# Description
This PR:
- fixes the use of CFP on WCOSS2.  This was seen by @WenMeng-NOAA and documented in #1948 

Fixes #1948 

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Hera and Orion are not impacted by this change.
This change is not tested on WCOSS2 in the CI, so a test of the gfs/gdas post job on WCOSS2 should suffice for this PR to be accepted.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
