### PR TITLE
Update GSL-prep-chem to gefs_v12.3.8

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -87,7 +87,7 @@ if [[ ! -d gsd_prep_chem.fd ]] ; then
     rc=$?
     ((err+=$rc))
     cd gsd_prep_chem.fd
-    git checkout gefs_v12.3.6
+    git checkout gefs_v12.3.8
     cd ${topdir}
 else
     echo 'Skip.  Directory gsd_prep_chem.fd already exists.'


### PR DESCRIPTION
<!-- PLEASE READ -->
<!-- Any PRs not following this template will be closed -->
<!--
    Please use a short (<60 char), descriptive title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

    PRs should meet these guidelines:
    - Each PR should address ONE topic and have an associated issue.
    - No hard-coded paths or personal directories.
    - No temporary or backup files should be committed (including logs).
    - Any code that you disabled by being commented out should be removed or reenabled.

    Please delete all these comments before submitting the PR.
-->
# Description
<!-- This description will become the commit message for the PR-->
<!-- Please use this format for your description:

  Describe your changes. Focus on the *what* and *why*. The *how* will be evident from the changes. In particular, be sure to note any interface changes, such as command line syntax, that will need to be communicated to users.

  At the end of your description, please be sure to add the issue this PR solves using the word "Resolves". If there are any issues that are related but not yet resolved (including in other repos), you may use "Refs".

  Resolves #1234
  Refs #4321
  Refs NOAA-EMC/repo#5678
-->

This PR serves to update the GSL-prep-chem tag in checkout.sh from gefs_v12.3.6 to gefs_v12.3.8. This new tag in GSL-prep-chem fixes a bug in `exglobal_prep_chem.sh`. This bugfix has been [merged](https://github.com/NOAA-GSL/GSL-prep-chem/pull/10) into release/gefs_v12 in the GSL-prep-chem repository and a new [tag](https://github.com/NOAA-GSL/GSL-prep-chem/releases/tag/gefs_v12.3.8) has been created.

Refs [#9](https://github.com/NOAA-GSL/GSL-prep-chem/issues/9)

# Type of change
<!-- Delete all except one -->
- [ ] Bug fix 
- [x] New feature
- [ ] Maintenance

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->
The global-workflow package has been cloned to WCOSS2, and the release/gefs_v12 branch was checked out . Then, `sorc/checkout.sh` was modified accordingly and executed to ensure the updated tag from GSL-prep-chem is cloned and checked out properly. 

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
