### PR TITLE
Allow CI case to exclude running on certain platforms

### DIFF
--- a/workflow/create_experiment.py
+++ b/workflow/create_experiment.py
@@ -30,7 +30,6 @@ import setup_xml
 
 from hosts import Host
 
-
 _here = os.path.dirname(__file__)
 _top = os.path.abspath(os.path.join(os.path.abspath(_here), '..'))
 

--- a/workflow/create_experiment.py
+++ b/workflow/create_experiment.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
 
     if 'exclude' in testconf:
         host = Host()
-        if host.machine.lower() in testconf.exclude:
+        if host.machine.lower() in [ excluded_host.lower() for excluded_host in testconf.exclude ]:
             logger.info(f'Skipping creation of case: {testconf.arguments.pslot} on {host.machine.capitalize()}')
             sys.exit(0)
 

--- a/workflow/create_experiment.py
+++ b/workflow/create_experiment.py
@@ -72,7 +72,7 @@ def input_args():
 if __name__ == '__main__':
 
     user_inputs = input_args()
-    
+
     # Create a dictionary to pass to parse_j2yaml for parsing the yaml file
     data = AttrDict(HOMEgfs=_top)
     data.update(os.environ)

--- a/workflow/create_experiment.py
+++ b/workflow/create_experiment.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
 
     if 'exclude' in testconf:
         host = Host()
-        if host.machine.lower() in [ excluded_host.lower() for excluded_host in testconf.exclude ]:
+        if host.machine.lower() in [excluded_host.lower() for excluded_host in testconf.exclude]:
             logger.info(f'Skipping creation of case: {testconf.arguments.pslot} on {host.machine.capitalize()}')
             sys.exit(0)
 

--- a/workflow/create_experiment.py
+++ b/workflow/create_experiment.py
@@ -18,6 +18,7 @@ with an error code of 0 upon success.
 """
 
 import os
+import sys
 
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from pathlib import Path
@@ -26,6 +27,8 @@ from wxflow import AttrDict, parse_j2yaml, Logger, logit
 
 import setup_expt
 import setup_xml
+
+from hosts import Host
 
 
 _here = os.path.dirname(__file__)
@@ -69,11 +72,17 @@ def input_args():
 if __name__ == '__main__':
 
     user_inputs = input_args()
-
+    
     # Create a dictionary to pass to parse_j2yaml for parsing the yaml file
     data = AttrDict(HOMEgfs=_top)
     data.update(os.environ)
     testconf = parse_j2yaml(path=user_inputs.yaml, data=data)
+
+    if 'exclude' in testconf:
+        host = Host()
+        if host.machine.lower() in testconf.exclude:
+            logger.info(f'Skipping creation of case: {testconf.arguments.pslot} on {host.machine.capitalize()}')
+            sys.exit(0)
 
     # Create a list of arguments to setup_expt.py
     setup_expt_args = [testconf.experiment.system, testconf.experiment.mode]


### PR DESCRIPTION
# Description


Added a feature so we can skip specific platforms within a case file in the CI framework

Resolves #1968 


# Type of change
- New feature (adds functionality)


# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Added the line

```
exclude:
 orion
 hera
```

to case file and passed it to the `create_experiment.py` Python script with the `--yaml` switch to demonstrate that the script simply prints in the log that the case **pslot** name is skipped on Orion and quits.