### PR TITLE
Add `waveinit` and `waveprep` to GDAS half-cycle

### DIFF
--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -129,6 +129,8 @@ class GFSTasks(Tasks):
         deps = []
         dep_dict = {'type': 'task', 'name': f'{self.cdump}waveinit'}
         deps.append(rocoto.add_dependency(dep_dict))
+        dep_dict = {'type': 'cycleexist', 'condition': 'not', 'offset': '-06:00:00'}
+        deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         cycledef = 'gdas_half,gdas' if self.cdump in ['gdas'] else self.cdump
         resources = self.get_resource('waveprep')

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -130,9 +130,9 @@ class GFSTasks(Tasks):
         dep_dict = {'type': 'task', 'name': f'{self.cdump}waveinit'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
-
+        cycledef = 'gdas_half,gdas' if self.cdump in ['gdas'] else self.cdump
         resources = self.get_resource('waveprep')
-        task = create_wf_task('waveprep', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies)
+        task = create_wf_task('waveprep', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies, cycledef=cycledef)
 
         return task
 

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -110,6 +110,7 @@ class GFSTasks(Tasks):
 
         resources = self.get_resource('waveinit')
         dependencies = None
+        cycledef = None
         if self.app_config.mode in ['cycled']:
             deps = []
             dep_dict = {'type': 'task', 'name': f'{self.cdump}prep'}
@@ -117,8 +118,9 @@ class GFSTasks(Tasks):
             dep_dict = {'type': 'cycleexist', 'condition': 'not', 'offset': '-06:00:00'}
             deps.append(rocoto.add_dependency(dep_dict))
             dependencies = rocoto.create_dependency(dep_condition='or', dep=deps)
-
-        task = create_wf_task('waveinit', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies)
+            cycledef = 'gdas_half,gdas' if self.cdump in ['gdas'] else self.cdump
+            
+        task = create_wf_task('waveinit', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies, cycledef=cycledef)
 
         return task
 


### PR DESCRIPTION
# Description

This PR addresses issue #1444. Logic has been added to `workflow/rocoto/gfs_tasks.py` to add the `gdas_half` attribute to the Rocoto cycledef directive.

  Resolves #1444

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

The following experiment was configured.

`/setup_expt.py gfs cycled --app S2SW --resdet 96 --resens 48 --comrot /scratch1/NCEPDEV/da/Henry.Winterbottom/work/GLOBAL_WORKFLOW/ --expdir /scratch1/NCEPDEV/da/Henry.Winterbottom/work/GLOBAL_WORKFLOW/ --idate 2021122018 --edate 2021122100 --nens 2 --gfs_cyc 1 --start cold --pslot x001_issue_1444`

The corresponding XML was initialized and the Rocoto cycledef attribute is the following for the `waveinit` and `waveprep` tasks respectively.

`<task name="gdaswaveinit" cycledefs="gdas_half,gdas" maxtries="&MAXTRIES;">`
`<task name="gdaswaveprep" cycledefs="gdas_half,gdas" maxtries="&MAXTRIES;">`

The CI will test the actual implementation.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
