### PR TITLE
Add skeleton release notes and tentative version for WAFS update

### DIFF
--- a/docs/Release_Notes.gfs.v16.3.11.md
+++ b/docs/Release_Notes.gfs.v16.3.11.md
@@ -1,0 +1,127 @@
+GFS V16.3.11 RELEASE NOTES
+
+-------
+PRELUDE
+-------
+
+Update to the WAFS package.
+
+IMPLEMENTATION INSTRUCTIONS
+---------------------------
+
+The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub .com are used to manage the GFS code.  The SPA(s) handling the GFS implementation need to have permissions to clone VLab Gerrit repositories and private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are publicly readable and do not require access permissions.  Please proceed with the following steps to install the package on WCOSS2:
+
+```bash
+cd $PACKAGEROOT
+mkdir gfs.v16.3.11
+cd gfs.v16.3.11
+git clone -b EMC-v16.3.11 https://github.com/NOAA-EMC/global-workflow.git .
+cd sorc
+./checkout.sh -o
+```
+
+The checkout script extracts the following GFS components:
+
+| Component | Tag         | POC               |
+| --------- | ----------- | ----------------- |
+| MODEL     | GFS.v16.3.0   | Jun.Wang@noaa.gov |
+| GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
+| GSI       | gfsda.v16.3.8 | Andrew.Collard@noaa.gov |
+| UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
+| POST      | upp_v8.2.0 | Wen.Meng@noaa.gov |
+| WAFS      | gfs_wafs.v6.3.1 | Yali.Mao@noaa.gov |
+
+To build all the GFS components, execute:
+```bash
+./build_all.sh
+```
+The `build_all.sh` script compiles all GFS components. Runtime output from the build for each package is written to log files in directory logs. To build an individual program, for instance, gsi, use `build_gsi.sh`.
+
+Next, link the executables, fix files, parm files, etc in their final respective locations by executing:
+```bash
+./link_fv3gfs.sh nco wcoss2
+```
+
+Lastly, link the ecf scripts by moving back up to the ecf folder and executing:
+```bash
+cd ../ecf
+./setup_ecf_links.sh
+```
+
+VERSION FILE CHANGES
+--------------------
+
+* `versions/run.ver` - change `version=v16.3.11`, and  `gfs_ver=v16.3.11`
+
+SORC CHANGES
+------------
+
+* No changes from GFS v16.3.10
+
+JOBS CHANGES
+------------
+
+* No changes from GFS v16.3.10
+
+PARM/CONFIG CHANGES
+-------------------
+
+* No changes from GFS v16.3.10
+
+SCRIPT CHANGES
+--------------
+
+* No changes from GFS v16.3.10
+
+FIX CHANGES
+-----------
+
+* No changes from GFS v16.3.10
+
+MODULE CHANGES
+--------------
+
+* No changes from GFS v16.3.10
+
+CHANGES TO FILE SIZES
+---------------------
+
+* No changes from GFS v16.3.10
+
+ENVIRONMENT AND RESOURCE CHANGES
+--------------------------------
+
+* No changes from GFS v16.3.10
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+---------------------------------------
+
+* Which production jobs should be tested as part of this implementation?
+  * WAFS 
+* Does this change require a 30-day evaluation?
+  * No
+
+DISSEMINATION INFORMATION
+-------------------------
+
+* No changes from GFS v16.3.10
+
+HPSS ARCHIVE
+------------
+
+* No changes from GFS v16.3.10
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+---------------------------------
+
+* No changes from GFS v16.3.10
+
+DOCUMENTATION
+-------------
+
+* No changes from GFS v16.3.10
+
+PREPARED BY
+-----------
+Kate.Friedman@noaa.gov
+Yali.Mao@noaa.gov

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.10
-export gfs_ver=v16.3.10
+export version=v16.3.11
+export gfs_ver=v16.3.11
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2


### PR DESCRIPTION
# Description

This PR add skeleton release notes and tentative version update (v16.3.11) for WAFS package update in operations. Will further update release notes and version when determined.

@YaliMao-NOAA @HuiyaChuang-NOAA Please provide a follow-up PR with further updates:

1. Release notes: Prelude text
2. WAFS tag name (if changing)
3. GFS version number if you hear from NCO before me
4. What additional updates are needed for this in the workflow.

Refs #2013

# Type of change

Production update