### PR TITLE
Fix staging of MOM data

### DIFF
--- a/scripts/exglobal_stage_ic.sh
+++ b/scripts/exglobal_stage_ic.sh
@@ -60,6 +60,26 @@ for MEMDIR in "${MEMDIR_ARRAY[@]}"; do
     rc=$?
     ((rc != 0)) && error_message "${src}" "${tgt}" "${rc}"
     err=$((err + rc))
+    case "${OCNRES}" in
+      "500" | "100")
+        # Nothing more to do for these resolutions
+        ;;
+      "025" )
+        for nn in $(seq 1 3); do
+          src="${BASE_CPLIC}/${CPL_OCNIC}/${PDY}${cyc}/${MEMDIR}/ocean/${PDY}.${cyc}0000.MOM.res_${nn}.nc"
+          tgt="${COM_OCEAN_RESTART}/${PDY}.${cyc}0000.MOM.res_${nn}.nc"
+          ${NCP} "${src}" "${tgt}"
+          rc=$?
+          ((rc != 0)) && error_message "${src}" "${tgt}" "${rc}"
+          err=$((err + rc))
+        done
+        ;;
+      *)
+        echo "FATAL ERROR: Unsupported ocean resolution ${OCNRES}"
+        rc=1
+        err=$((err + rc))
+        ;;
+    esac
   fi
   # Stage ice initial conditions to ROTDIR (warm start)
   if [[ "${DO_ICE:-}" = "YES" ]]; then


### PR DESCRIPTION
# Description
During the update to stage_ic, the copying of the additional res_N files for 0p25 was omitted. These are now properly copied.

Resolves #2027

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Tested on WCOSS

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
