### PR TITLE
Reduce GDASApp default build jobs to 8

### DIFF
--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -141,7 +141,7 @@ fi
 
 # Optional DA builds
 if [[ -d gdas.cd ]]; then
-   build_jobs["gdas"]=16
+   build_jobs["gdas"]=8
    big_jobs=$((big_jobs+1))
    build_opts["gdas"]="${_verbose_opt}"
 fi


### PR DESCRIPTION
# Description
Reduce the default number of build jobs for the GDASApp to 8 from 16.

This is needed for Orion as the build crashes during a linking step.  Though not verified, it appears this may be caused by using too much memory with 16 builds.  The issue disappears when using 8 build jobs.

Resolves #2029

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Build test on Orion

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes