### PR TITLE
Hack UPP version

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -177,6 +177,13 @@ for checkout_pid in $(jobs -p); do
   wait "${checkout_pid}" || errs=$((errs + $?))
 done
 
+# Temporary hack to check out a UPP verison that works on Orion
+# This can be removed once the UFS UPP version advances to or beyond 78f369b
+cd "${topdir}/ufs_model.fd/FV3/upp" || exit 1
+git checkout 78f369b
+cd "${topdir}" || exit 1
+# End hack
+
 if (( errs > 0 )); then
   echo "WARNING: One or more errors encountered during checkout process, please check logs before building"
 fi


### PR DESCRIPTION
# Description
The stack UPP was using on Orion was recently deleted, leaving us unable to build the UFS version of UPP there. UPP has an updated version using spack-stack that works, so the checkout script is modified to check out that version of UPP after UFS has been checked out.

This temporary hack can be removed once we move to a UFS version that advances the UPP version to or beyond 78f369b.

Resolves #2041

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Build on Orion

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
