### PR TITLE
Update wave IC source for C384

### DIFF
--- a/parm/config/gfs/config.stage_ic
+++ b/parm/config/gfs/config.stage_ic
@@ -18,7 +18,7 @@ case "${CASE}" in
     export CPL_ATMIC=GEFS-NoahMP-aerosols-p8c_refactored
     export CPL_ICEIC=CPC_refactored
     export CPL_OCNIC=CPC3Dvar_refactored
-    export CPL_WAVIC=GEFSwave20210528v2_refactored
+    export CPL_WAVIC=workflow_C384_refactored
     ;;
   "C768")
     export CPL_ATMIC=HR2_refactored


### PR DESCRIPTION
# Description
The default wave grid for C384 has changed since P8, so a single wave IC on the new grid is available under a different IC name.

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
