### PR TITLE
Update `upp_ver` to `8.3.0` for GFSv16.3.11

### DIFF
--- a/docs/Release_Notes.gfs.v16.3.11.md
+++ b/docs/Release_Notes.gfs.v16.3.11.md
@@ -69,7 +69,7 @@ https://docs.google.com/document/d/18bUYWmsN7FuweyA2CQTBW1rk3FNRMHKPlYHZlbS8ODs/
 VERSION FILE CHANGES
 --------------------
 
-* `versions/build.ver` - change `crtm_ver=2.4.0.1`
+* `versions/build.ver` - change `crtm_ver=2.4.0.1` and `upp_ver=8.3.0`
 * `versions/run.ver` - change `version=v16.3.11`, `gfs_ver=v16.3.11` and `crtm_ver=2.4.0.1`
 
 SORC CHANGES

--- a/versions/build.ver
+++ b/versions/build.ver
@@ -33,4 +33,4 @@ export gfsio_ver=1.4.1
 export sfcio_ver=1.4.1
 export ncio_ver=1.0.0
 
-export upp_ver=8.2.0
+export upp_ver=8.3.0


### PR DESCRIPTION
# Description

This PR updates the `upp_ver` in `versions/build.ver` to the new `8.3.0`. It is now installed in production and being used within the build of `gfs.v16.3.11` in para testing ahead of implementation.

Refs #1356

# Type of change

Library version update
