### PR TITLE
Save the required CICE history for the sea-ice DA

### DIFF
--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -883,7 +883,7 @@ CICE_postdet() {
   dumpfreq=${dumpfreq:-"y"} #  "h","d","m" or "y" for restarts at intervals of "hours", "days", "months" or "years"
 
   if [[ "${RUN}" =~ "gdas" ]]; then
-    cice_hist_avg=".false."   # DA needs instantaneous
+    cice_hist_avg=".false., .false., .false., .false., .false."   # DA needs instantaneous
   else
     cice_hist_avg=".true."    # P8 wants averaged over histfreq_n
   fi

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -885,7 +885,7 @@ CICE_postdet() {
   if [[ "${RUN}" =~ "gdas" ]]; then
     cice_hist_avg=".false., .false., .false., .false., .false."   # DA needs instantaneous
   else
-    cice_hist_avg=".true."    # P8 wants averaged over histfreq_n
+    cice_hist_avg=".true., .true., .true., .true., .true."    # P8 wants averaged over histfreq_n
   fi
 
   FRAZIL_FWSALT=${FRAZIL_FWSALT:-".true."}


### PR DESCRIPTION
The `hist_avg` setting of CICE was changed to be an array.

Fixes #2059

# Type of change
<!-- Delete all except one -->
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? **NO**
- Does this change require a documentation update? **NO**

# How has this been tested?
Cycled marine DA test on Hera

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
