### PR TITLE
Fix check for existence of preamble functions

### DIFF
--- a/ush/load_fv3gfs_modules.sh
+++ b/ush/load_fv3gfs_modules.sh
@@ -50,7 +50,7 @@ ulimit -S -s "${ulimit_s}"
 unset ulimit_s
 
 # If this function exists in the environment, run it; else do not
-ftype=$(type -t set_trace)
+ftype=$(type -t set_trace || echo "")
 if [[ "${ftype}" == "function" ]]; then
   set_trace
 fi

--- a/ush/load_ufswm_modules.sh
+++ b/ush/load_ufswm_modules.sh
@@ -67,7 +67,7 @@ ulimit -S -s "${ulimit_s}"
 unset ulimit_s
 
 # If this function exists in the environment, run it; else do not
-ftype=$(type -t set_trace)
+ftype=$(type -t set_trace || echo "")
 if [[ "${ftype}" == "function" ]]; then
   set_trace
 fi

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -119,7 +119,7 @@ else
 fi
 
 # If this function exists in the environment, run it; else do not
-ftype=$(type -t set_strict)
+ftype=$(type -t set_strict || echo "")
 if [[ "${ftype}" == "function" ]]; then
   set_strict
 else


### PR DESCRIPTION
# Description
A few of the setup scripts were checking for the existence of functions set by the preamble before calling them so they could also be used stand-alone. However, the `type` command returns `1` if the function name does not exist, which will cause the script to die is `set -e` is on. Now the `type` command fails over to an empty string.


# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
