### PR TITLE
Fix missing `_PREV` in ocean restart file location

### DIFF
--- a/scripts/exglobal_stage_ic.sh
+++ b/scripts/exglobal_stage_ic.sh
@@ -90,7 +90,7 @@ for MEMDIR in "${MEMDIR_ARRAY[@]}"; do
       "025" )
         for nn in $(seq 1 3); do
           src="${BASE_CPLIC}/${CPL_OCNIC:-}/${PDY}${cyc}/${MEMDIR}/ocean/${PDY}.${cyc}0000.MOM.res_${nn}.nc"
-          tgt="${COM_OCEAN_RESTART}/${PDY}.${cyc}0000.MOM.res_${nn}.nc"
+          tgt="${COM_OCEAN_RESTART_PREV}/${PDY}.${cyc}0000.MOM.res_${nn}.nc"
           ${NCP} "${src}" "${tgt}"
           rc=$?
           ((rc != 0)) && error_message "${src}" "${tgt}" "${rc}"


### PR DESCRIPTION
# Description
This PR:
- fixes a bug in PR #2031 found by @JessicaMeixner-NOAA.  See https://github.com/NOAA-EMC/global-workflow/pull/2031#discussion_r1394797159

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
