### PR TITLE
Adjust modules in post.sh hack for WCOSS2

### DIFF
--- a/jobs/rocoto/post.sh
+++ b/jobs/rocoto/post.sh
@@ -20,11 +20,13 @@ module load prod_util
 if [[ "${MACHINE_ID}" = "wcoss2" ]]; then
     module load cray-pals
     module load cfp
+    module load libjpeg
+    module load grib_util
 else
     # shellcheck disable=SC2154
     export UTILROOT="${prod_util_ROOT}"
+    module load grib-util
 fi
-module load grib-util
 module load wgrib2
 export WGRIB2=wgrib2
 # End hack


### PR DESCRIPTION
# Description

This PR is a hotfix to resolve failing post jobs on WCOSS2 after PR #2046. It adjusts the modules loaded in the hack in `post.sh` to handle the `grib_util` module on WCOSS2.

# Type of change

- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Cycled low-res atmos-only test on WCOSS2-Cactus.
