### PR TITLE
Make proper j-job for METplus

### DIFF
--- a/jobs/JGFS_ATMOS_VERIFICATION
+++ b/jobs/JGFS_ATMOS_VERIFICATION
@@ -1,0 +1,43 @@
+#! /usr/bin/env bash
+
+source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "metp" -c "base metp"
+
+###############################################################
+## Abstract:
+## Inline METplus verification and diagnostics driver script
+## HOMEgfs   : /full/path/to/workflow
+## EXPDIR : /full/path/to/config/files
+## CDATE  : current analysis date (YYYYMMDDHH)
+## CDUMP  : cycle name (gdas / gfs)
+## PDY    : current date (YYYYMMDD)
+## cyc    : current cycle (HH)
+## SDATE_GFS  : first date of GFS cycle (YYYYMMDDHHMM)
+## METPCASE : METplus verification use case (g2g1 | g2o1 | pcp1)
+###############################################################
+
+# TODO: This should not be permitted as DATAROOT is set at the job-card level.
+# TODO: DATAROOT is being used as DATA in metp jobs.  This should be rectified in metp.
+# TODO: The temporary directory is DATA and is created at the top of the J-Job.
+# TODO: remove this line
+export DATAROOT=${DATA}
+
+VDATE=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} - ${VRFYBACK_HRS} hours")
+export VDATE
+
+# Since this is currently a one-element list, shellcheck things we would rather run this as a command
+# shellcheck disable=SC2041
+for grid in '1p00'; do
+  prod_dir="COM_ATMOS_GRIB_${grid}"
+  GRID=${grid} YMD=${PDY} HH=${cyc} generate_com -rx "${prod_dir}:COM_ATMOS_GRIB_GRID_TMPL"
+done
+
+# TODO: If none of these are on, why are we running this job?
+if [[ "${RUN_GRID2GRID_STEP1}" == "YES" || "${RUN_GRID2OBS_STEP1}" == "YES" || "${RUN_PRECIP_STEP1}" == "YES" ]]; then
+    ${VERIF_GLOBALSH}
+    status=$?
+	if (( status != 0 )); then exit "${status}"; fi
+fi
+
+if [[ ${KEEPDATA:-"NO"} = "NO" ]] ; then rm -rf "${DATAROOT}" ; fi  # TODO: This should be $DATA
+

--- a/jobs/rocoto/metp.sh
+++ b/jobs/rocoto/metp.sh
@@ -3,93 +3,13 @@
 source "${HOMEgfs}/ush/preamble.sh"
 
 ###############################################################
-## Abstract:
-## Inline METplus verification and diagnostics driver script
-## HOMEgfs   : /full/path/to/workflow
-## EXPDIR : /full/path/to/config/files
-## CDATE  : current analysis date (YYYYMMDDHH)
-## CDUMP  : cycle name (gdas / gfs)
-## PDY    : current date (YYYYMMDD)
-## cyc    : current cycle (HH)
-## SDATE_GFS  : first date of GFS cycle (YYYYMMDDHHMM)
-## METPCASE : METplus verification use case (g2g1 | g2o1 | pcp1)
-###############################################################
-
-###############################################################
-echo
-echo "=============== START TO SOURCE FV3GFS WORKFLOW MODULES ==============="
-. ${HOMEgfs}/ush/load_fv3gfs_modules.sh
+source "${HOMEgfs}/ush/load_fv3gfs_modules.sh"
 status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+if (( status != 0 )); then exit "${status}"; fi
 
 export job="metp${METPCASE}"
 export jobid="${job}.$$"
 
-##############################################
-# make temp directory
-##############################################
-export DATA=${DATA:-${DATAROOT}/${jobid}}
-mkdir -p ${DATA}
-cd ${DATA}
+"${HOMEgfs}/jobs/JGFS_ATMOS_VERIFICATION"
 
-
-##############################################
-# Run setpdy and initialize PDY variables
-##############################################
-export cycle="t${cyc}z"
-setpdy.sh
-. ./PDY
-
-###############################################################
-echo
-echo "=============== START TO SOURCE RELEVANT CONFIGS ==============="
-configs="base metp"
-for config in ${configs}; do
-    . ${EXPDIR}/config.${config}
-    status=$?
-    [[ ${status} -ne 0 ]] && exit ${status}
-done
-
-
-###############################################################
-echo
-echo "=============== START TO SOURCE MACHINE RUNTIME ENVIRONMENT ==============="
-. ${BASE_ENV}/${machine}.env metp
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
-
-###############################################################
-export COMPONENT="atmos"
-export VDATE="$(echo $(${NDATE} -${VRFYBACK_HRS} ${CDATE}) | cut -c1-8)"
-export COMIN="${ROTDIR}/${CDUMP}.${PDY}/${cyc}/${COMPONENT}"
-
-# TODO: This should not be permitted as DATAROOT is set at the job-card level.
-# TODO: DATAROOT is being used as DATA in metp jobs.  This should be rectified in metp.
-# TODO: The temporary directory is DATA and is created at the top of the J-Job.
-# TODO: remove this line
-export DATAROOT=${DATA}
-
-###############################################################
-echo
-echo "=============== START TO RUN METPLUS VERIFICATION ==============="
-if [ ${CDUMP} = "gfs" ]; then
-
-    if [ ${RUN_GRID2GRID_STEP1} = "YES" -o ${RUN_GRID2OBS_STEP1} = "YES" -o ${RUN_PRECIP_STEP1} = "YES" ]; then
-
-        ${VERIF_GLOBALSH}
-        status=$?
-        [[ ${status} -ne 0 ]] && exit ${status}
-        [[ ${status} -eq 0 ]] && echo "Succesfully ran ${VERIF_GLOBALSH}"
-    fi
-fi
-
-
-if [ ${CDUMP} = "gdas" ]; then
-    echo "METplus verification currently not supported for CDUMP=${CDUMP}"
-fi
-###############################################################
-# Force Exit out cleanly
-if [ ${KEEPDATA:-"NO"} = "NO" ] ; then rm -rf ${DATAROOT} ; fi  # TODO: This should be $DATA
-
-
-exit 0
+exit $?


### PR DESCRIPTION
# Description
Creates a proper j-job for the metp job, moving much of the material from the `jobs/rocoto` script there (some of it within `jjob_header`).

Also updates the old `COMIN` variable for the COM refactor (although it does not appear used in the verify scripts currently).

This is a partial step towards restoring/improving metp functionality and remains untested.

Refs #1575

# Type of change
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Not

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
