### PR TITLE
Add missing cut to VDATE setting in JGFS_ATMOS_VERIFICATION

### DIFF
--- a/jobs/JGFS_ATMOS_VERIFICATION
+++ b/jobs/JGFS_ATMOS_VERIFICATION
@@ -22,7 +22,7 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "metp" -c "base metp"
 # TODO: remove this line
 export DATAROOT=${DATA}
 
-VDATE=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} - ${VRFYBACK_HRS} hours")
+VDATE=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} - ${VRFYBACK_HRS} hours" | cut -c1-8)
 export VDATE
 
 # Since this is currently a one-element list, shellcheck things we would rather run this as a command

--- a/jobs/JGFS_ATMOS_VERIFICATION
+++ b/jobs/JGFS_ATMOS_VERIFICATION
@@ -22,8 +22,8 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "metp" -c "base metp"
 # TODO: remove this line
 export DATAROOT=${DATA}
 
-VDATE=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} - ${VRFYBACK_HRS} hours" | cut -c1-8)
-export VDATE
+VDATE=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} - ${VRFYBACK_HRS} hours")
+export VDATE=${VDATE:0:8}
 
 # Since this is currently a one-element list, shellcheck things we would rather run this as a command
 # shellcheck disable=SC2041


### PR DESCRIPTION
# Description

This PR corrects a second bug in the METplus jobs with regards to a missing cut for the `VDATE` variable. See issue #2097 for more details. The gfsmetp jobs finish without error after the missing cut is added back in.

Fix works but am open to doing it differently if reviewers have suggestions.

Resolves #2097

# Type of change

- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Added fix into clone on WCOSS2 (that is synced with `develop` now) and reran `gfsmetp*` jobs to confirm the fix works and there are no other issues. Will also further test in CI tests for PR #2088 once in.