### PR TITLE
Add back 1.25 deg WAFS blending when separating WAFS updates from GFSv16.3.11

### DIFF
--- a/ecf/defs/gfs_v16_3.def
+++ b/ecf/defs/gfs_v16_3.def
@@ -1584,6 +1584,9 @@ suite gfs_v16_3
                     trigger ../../post/jgfs_atmos_post_f000 == complete
                   task jgfs_atmos_wafs_grib2_0p25
                     trigger ../../post/jgfs_atmos_post_f036 == complete
+                  task jgfs_atmos_wafs_blending
+                    trigger ./jgfs_atmos_wafs_grib2 == complete
+                    time 04:33
                   task jgfs_atmos_wafs_blending_0p25
                     trigger ./jgfs_atmos_wafs_grib2_0p25 == complete
                     time 04:25
@@ -4209,6 +4212,9 @@ suite gfs_v16_3
                     trigger ../../post/jgfs_atmos_post_f000 == complete
                   task jgfs_atmos_wafs_grib2_0p25
                     trigger ../../post/jgfs_atmos_post_f036 == complete
+                  task jgfs_atmos_wafs_blending
+                    trigger ./jgfs_atmos_wafs_grib2 == complete
+                    time 10:33
                   task jgfs_atmos_wafs_blending_0p25
                     trigger ./jgfs_atmos_wafs_grib2_0p25 == complete
                     time 10:25
@@ -6833,6 +6839,9 @@ suite gfs_v16_3
                     trigger ../../post/jgfs_atmos_post_f000 == complete
                   task jgfs_atmos_wafs_grib2_0p25
                     trigger ../../post/jgfs_atmos_post_f036 == complete
+                  task jgfs_atmos_wafs_blending
+                    trigger ./jgfs_atmos_wafs_grib2 == complete
+                    time 16:33
                   task jgfs_atmos_wafs_blending_0p25
                     trigger ./jgfs_atmos_wafs_grib2_0p25 == complete
                     time 16:25
@@ -9459,6 +9468,9 @@ suite gfs_v16_3
                     trigger ../../post/jgfs_atmos_post_f000 == complete
                   task jgfs_atmos_wafs_grib2_0p25
                     trigger ../../post/jgfs_atmos_post_f036 == complete
+                  task jgfs_atmos_wafs_blending
+                    trigger ./jgfs_atmos_wafs_grib2 == complete
+                    time 22:33
                   task jgfs_atmos_wafs_blending_0p25
                     trigger ./jgfs_atmos_wafs_grib2_0p25 == complete
                     time 22:25


### PR DESCRIPTION
https://github.com/NOAA-EMC/global-workflow/pull/2100

PR #2100 separates WAFS updates from GFSv16.3.11

<!-- PLEASE READ -->
<!-- Any PRs not following this template will be closed -->
<!--
    Please use a short (<60 char), descriptive title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

    PRs should meet these guidelines:
    - Each PR should address ONE topic and have an associated issue.
    - No hard-coded paths or personal directories.
    - No temporary or backup files should be committed (including logs).
    - Any code that you disabled by being commented out should be removed or reenabled.

    Please delete all these comments before submitting the PR.
-->
# Description
<!-- This description will become the commit message for the PR-->
<!-- Please use this format for your description:

  Describe your changes. Focus on the *what* and *why*. The *how* will be evident from the changes. In particular, be sure to note any interface changes, such as command line syntax, that will need to be communicated to users.

  At the end of your description, please be sure to add the issue this PR solves using the word "Resolves". If there are any issues that are related but not yet resolved (including in other repos), you may use "Refs".

  Resolves #1234
  Refs #4321
  Refs NOAA-EMC/repo#5678
-->

# Type of change
<!-- Delete all except one -->
- Bug fix (fixes something broken)
- New feature (adds functionality)
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? YES/NO
- Does this change require a documentation update? YES/NO

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
