### PR TITLE
Sync GFSv16.3.12 branch with GFSv16.3.11 branch WAFS update

### DIFF
--- a/ecf/defs/gfs_v16_3.def
+++ b/ecf/defs/gfs_v16_3.def
@@ -1584,6 +1584,9 @@ suite gfs_v16_3
                     trigger ../../post/jgfs_atmos_post_f000 == complete
                   task jgfs_atmos_wafs_grib2_0p25
                     trigger ../../post/jgfs_atmos_post_f036 == complete
+                  task jgfs_atmos_wafs_blending
+                    trigger ./jgfs_atmos_wafs_grib2 == complete
+                    time 04:33
                   task jgfs_atmos_wafs_blending_0p25
                     trigger ./jgfs_atmos_wafs_grib2_0p25 == complete
                     time 04:25
@@ -4209,6 +4212,9 @@ suite gfs_v16_3
                     trigger ../../post/jgfs_atmos_post_f000 == complete
                   task jgfs_atmos_wafs_grib2_0p25
                     trigger ../../post/jgfs_atmos_post_f036 == complete
+                  task jgfs_atmos_wafs_blending
+                    trigger ./jgfs_atmos_wafs_grib2 == complete
+                    time 10:33
                   task jgfs_atmos_wafs_blending_0p25
                     trigger ./jgfs_atmos_wafs_grib2_0p25 == complete
                     time 10:25
@@ -6833,6 +6839,9 @@ suite gfs_v16_3
                     trigger ../../post/jgfs_atmos_post_f000 == complete
                   task jgfs_atmos_wafs_grib2_0p25
                     trigger ../../post/jgfs_atmos_post_f036 == complete
+                  task jgfs_atmos_wafs_blending
+                    trigger ./jgfs_atmos_wafs_grib2 == complete
+                    time 16:33
                   task jgfs_atmos_wafs_blending_0p25
                     trigger ./jgfs_atmos_wafs_grib2_0p25 == complete
                     time 16:25
@@ -9459,6 +9468,9 @@ suite gfs_v16_3
                     trigger ../../post/jgfs_atmos_post_f000 == complete
                   task jgfs_atmos_wafs_grib2_0p25
                     trigger ../../post/jgfs_atmos_post_f036 == complete
+                  task jgfs_atmos_wafs_blending
+                    trigger ./jgfs_atmos_wafs_grib2 == complete
+                    time 22:33
                   task jgfs_atmos_wafs_blending_0p25
                     trigger ./jgfs_atmos_wafs_grib2_0p25 == complete
                     time 22:25


### PR DESCRIPTION
# Description

This PR syncs the `release/gfs.v16.12` branch with a change in the `release/gfs.v16.3.11` branch to add the `wafs_blending` job back into the ecflow def file. From PR #2113.

This change is in the ops `gfs.v16.3.11` package so this syncs things on the EMC side.

# Type of change

Sync merge