### PR TITLE
Update index.rst for new GFSv16.3.11 version

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Status
 ======
 
 * State of develop (HEAD) branch: GFSv17+ development
-* State of operations (dev/gfs.v16 branch): GFS v16.3.10 `tag: [gfs.v16.3.10] <https://github.com/NOAA-EMC/global-workflow/releases/tag/gfs.v16.3.10>`_
+* State of operations (dev/gfs.v16 branch): GFS v16.3.11 `tag: [gfs.v16.3.11] <https://github.com/NOAA-EMC/global-workflow/releases/tag/gfs.v16.3.11>`_
 
 =============
 Code managers


### PR DESCRIPTION
# Description

This PR updates the operational GFS version in the Read-The-Docs to the new `v16.3.11`.

Refs #1356

# Type of change

Production update

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? YES

# How has this been tested?

N/A
