### PR TITLE
Adds GDAS GEMPAK jobs to rocoto task mesh

### DIFF
--- a/jobs/rocoto/gempakmeta.sh
+++ b/jobs/rocoto/gempakmeta.sh
@@ -7,11 +7,11 @@ source "${HOMEgfs}/ush/preamble.sh"
 status=$?
 if (( status != 0 )); then exit "${status}"; fi
 
-export job="gempak"
+export job="gempakmeta"
 export jobid="${job}.$$"
 
 # Execute the JJOB
-"${HOMEgfs}/jobs/J${RUN^^}_ATMOS_GEMPAK"
+"${HOMEgfs}/jobs/JGFS_ATMOS_GEMPAK_META"
 
 status=$?
 exit "${status}"

--- a/jobs/rocoto/gempakmetancdc.sh
+++ b/jobs/rocoto/gempakmetancdc.sh
@@ -7,11 +7,11 @@ source "${HOMEgfs}/ush/preamble.sh"
 status=$?
 if (( status != 0 )); then exit "${status}"; fi
 
-export job="gempak"
+export job="gempakmetancdc"
 export jobid="${job}.$$"
 
 # Execute the JJOB
-"${HOMEgfs}/jobs/J${RUN^^}_ATMOS_GEMPAK"
+"${HOMEgfs}/jobs/JGDAS_ATMOS_GEMPAK_META_NCDC"
 
 status=$?
 exit "${status}"

--- a/jobs/rocoto/gempakncdcupapgif.sh
+++ b/jobs/rocoto/gempakncdcupapgif.sh
@@ -7,11 +7,11 @@ source "${HOMEgfs}/ush/preamble.sh"
 status=$?
 if (( status != 0 )); then exit "${status}"; fi
 
-export job="gempak"
+export job="gempakncdcupapgif"
 export jobid="${job}.$$"
 
 # Execute the JJOB
-"${HOMEgfs}/jobs/J${RUN^^}_ATMOS_GEMPAK"
+"${HOMEgfs}/jobs/JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF"
 
 status=$?
 exit "${status}"

--- a/jobs/rocoto/gempakpgrb2spec.sh
+++ b/jobs/rocoto/gempakpgrb2spec.sh
@@ -7,11 +7,11 @@ source "${HOMEgfs}/ush/preamble.sh"
 status=$?
 if (( status != 0 )); then exit "${status}"; fi
 
-export job="gempak"
+export job="gempakpgrb2spec"
 export jobid="${job}.$$"
 
 # Execute the JJOB
-"${HOMEgfs}/jobs/J${RUN^^}_ATMOS_GEMPAK"
+"${HOMEgfs}/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC"
 
 status=$?
 exit "${status}"

--- a/jobs/rocoto/npoess.sh
+++ b/jobs/rocoto/npoess.sh
@@ -7,7 +7,7 @@ source "${HOMEgfs}/ush/preamble.sh"
 status=$?
 if (( status != 0 )); then exit "${status}"; fi
 
-export job="npoess"
+export job="npoess_pgrb2_0p5deg"
 export jobid="${job}.$$"
 
 # Execute the JJOB

--- a/workflow/applications/applications.py
+++ b/workflow/applications/applications.py
@@ -61,7 +61,6 @@ class AppConfig(ABC, metaclass=AppConfigInit):
         self.do_genesis = _base.get('DO_GENESIS', True)
         self.do_genesis_fsu = _base.get('DO_GENESIS_FSU', False)
         self.do_metp = _base.get('DO_METP', False)
-        self.do_npoess = _base.get('DO_NPOESS', False)
         self.do_upp = not _base.get('WRITE_DOPOST', True)
 
         self.do_hpssarch = _base.get('HPSSARCH', False)

--- a/workflow/applications/gfs_cycled.py
+++ b/workflow/applications/gfs_cycled.py
@@ -185,8 +185,7 @@ class GFSCycledAppConfig(AppConfig):
             gdas_tasks += ['vminmon']
 
         if self.do_gempak:
-            gdas_tasks += ['gempak']
-            gdas_tasks += ['gempakmetancdc']
+            gdas_tasks += ['gempak', 'gempakmetancdc']
 
         gdas_tasks += gdas_gfs_common_cleanup_tasks
 

--- a/workflow/applications/gfs_cycled.py
+++ b/workflow/applications/gfs_cycled.py
@@ -89,9 +89,6 @@ class GFSCycledAppConfig(AppConfig):
         if self.do_awips:
             configs += ['awips']
 
-        if self.do_npoess:
-            configs += ['npoess']
-
         if self.do_wave:
             configs += ['waveinit', 'waveprep', 'wavepostsbs', 'wavepostpnt']
             if self.do_wave_bnd:
@@ -187,6 +184,10 @@ class GFSCycledAppConfig(AppConfig):
         if self.do_vminmon:
             gdas_tasks += ['vminmon']
 
+        if self.do_gempak:
+            gdas_tasks += ['gempak']
+            gdas_tasks += ['gempakmetancdc']
+
         gdas_tasks += gdas_gfs_common_cleanup_tasks
 
         # Collect "gfs" cycle tasks
@@ -230,12 +231,13 @@ class GFSCycledAppConfig(AppConfig):
 
         if self.do_gempak:
             gfs_tasks += ['gempak']
+            gfs_tasks += ['gempakmeta']
+            gfs_tasks += ['gempakncdcupapgif']
+            gfs_tasks += ['gempakpgrb2spec']
+            gfs_tasks += ['npoess_pgrb2_0p5deg']
 
         if self.do_awips:
             gfs_tasks += ['awips_20km_1p0deg', 'awips_g2', 'fbwinds']
-
-        if self.do_npoess:
-            gfs_tasks += ['npoess']
 
         gfs_tasks += gdas_gfs_common_cleanup_tasks
 

--- a/workflow/applications/gfs_cycled.py
+++ b/workflow/applications/gfs_cycled.py
@@ -233,8 +233,8 @@ class GFSCycledAppConfig(AppConfig):
             gfs_tasks += ['gempak']
             gfs_tasks += ['gempakmeta']
             gfs_tasks += ['gempakncdcupapgif']
-            gfs_tasks += ['gempakpgrb2spec']
             gfs_tasks += ['npoess_pgrb2_0p5deg']
+            gfs_tasks += ['gempakpgrb2spec']
 
         if self.do_awips:
             gfs_tasks += ['awips_20km_1p0deg', 'awips_g2', 'fbwinds']

--- a/workflow/applications/gfs_cycled.py
+++ b/workflow/applications/gfs_cycled.py
@@ -81,8 +81,7 @@ class GFSCycledAppConfig(AppConfig):
             configs += ['metp']
 
         if self.do_gempak:
-            configs += ['gempak']
-            configs += ['npoess']
+            configs += ['gempak', 'npoess']
 
         if self.do_bufrsnd:
             configs += ['postsnd']

--- a/workflow/applications/gfs_cycled.py
+++ b/workflow/applications/gfs_cycled.py
@@ -82,6 +82,7 @@ class GFSCycledAppConfig(AppConfig):
 
         if self.do_gempak:
             configs += ['gempak']
+            configs += ['npoess']
 
         if self.do_bufrsnd:
             configs += ['postsnd']

--- a/workflow/applications/gfs_forecast_only.py
+++ b/workflow/applications/gfs_forecast_only.py
@@ -113,6 +113,9 @@ class GFSForecastOnlyAppConfig(AppConfig):
 
             if self.do_gempak:
                 tasks += ['gempak']
+                tasks += ['gempakmeta']
+                tasks += ['gempakncdcupapgif']
+                tasks += ['gempakpgrb2spec']
 
             if self.do_awips:
                 tasks += ['awips_20km_1p0deg', 'awips_g2', 'fbwinds']

--- a/workflow/applications/gfs_forecast_only.py
+++ b/workflow/applications/gfs_forecast_only.py
@@ -112,10 +112,7 @@ class GFSForecastOnlyAppConfig(AppConfig):
                 tasks += ['postsnd']
 
             if self.do_gempak:
-                tasks += ['gempak']
-                tasks += ['gempakmeta']
-                tasks += ['gempakncdcupapgif']
-                tasks += ['gempakpgrb2spec']
+                tasks += ['gempak', 'gempakmeta', 'gempakncdcupagif', 'gempakpgrb2spec']
 
             if self.do_awips:
                 tasks += ['awips_20km_1p0deg', 'awips_g2', 'fbwinds']

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -970,7 +970,7 @@ class GFSTasks(Tasks):
 
     def gempakpgrb2spec(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}npoess_pgrb2_0p5deg'}
+        dep_dict = {'type': 'task', 'name': f'{self.cdump}npoess_pgrb2_0p5deg'}
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('gempak')

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -935,7 +935,50 @@ class GFSTasks(Tasks):
 
         return task
 
-    def npoess(self):
+    def gempakmeta(self):
+        deps = []
+        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}post'}
+        deps.append(rocoto.add_dependency(dep_dict))
+        dependencies = rocoto.create_dependency(dep=deps)
+
+        resources = self.get_resource('gempak')
+        task = create_wf_task('gempakmeta', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies)
+
+        return task
+
+    def gempakmetancdc(self):
+        deps = []
+        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}post'}
+        deps.append(rocoto.add_dependency(dep_dict))
+        dependencies = rocoto.create_dependency(dep=deps)
+
+        resources = self.get_resource('gempak')
+        task = create_wf_task('gempakmetancdc', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies)
+
+        return task
+
+    def gempakncdcupapgif(self):
+        deps = []
+        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}post'}
+        deps.append(rocoto.add_dependency(dep_dict))
+        dependencies = rocoto.create_dependency(dep=deps)
+
+        resources = self.get_resource('gempak')
+        task = create_wf_task('gempakncdcupapgif', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies)
+
+        return task
+
+    def gempakpgrb2spec(self):
+        deps = []
+        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}npoess_pgrb2_0p5deg'}
+        dependencies = rocoto.create_dependency(dep=deps)
+
+        resources = self.get_resource('gempak')
+        task = create_wf_task('gempakpgrb2spec', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies)
+
+        return task
+
+    def npoess_pgrb2_0p5deg(self):
 
         deps = []
         dep_dict = {'type': 'task', 'name': f'{self.cdump}atmanlprod'}
@@ -943,7 +986,7 @@ class GFSTasks(Tasks):
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('npoess')
-        task = create_wf_task('npoess', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies)
+        task = create_wf_task('npoess_pgrb2_0p5deg', resources, cdump=self.cdump, envar=self.envars, dependency=dependencies)
 
         return task
 

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -937,7 +937,7 @@ class GFSTasks(Tasks):
 
     def gempakmeta(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}post'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}atmprod'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
@@ -948,7 +948,7 @@ class GFSTasks(Tasks):
 
     def gempakmetancdc(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}post'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}atmprod'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
@@ -959,7 +959,7 @@ class GFSTasks(Tasks):
 
     def gempakncdcupapgif(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}post'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.cdump}atmprod'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 

--- a/workflow/rocoto/tasks.py
+++ b/workflow/rocoto/tasks.py
@@ -25,7 +25,8 @@ class Tasks:
                    'verfozn', 'verfrad', 'vminmon',
                    'metp',
                    'tracker', 'genesis', 'genesis_fsu',
-                   'postsnd', 'awips_g2', 'awips_20km_1p0deg', 'fbwinds', 'gempak',
+                   'postsnd', 'awips_g2', 'awips_20km_1p0deg', 'fbwinds',
+                   'gempak', 'gempakmeta', 'gempakmetancdc', 'gempakncdcupapgif', 'gempakpgrb2spec', 'npoess_pgrb2_0p5deg'
                    'waveawipsbulls', 'waveawipsgridded', 'wavegempak', 'waveinit',
                    'wavepostbndpnt', 'wavepostbndpntbll', 'wavepostpnt', 'wavepostsbs', 'waveprep',
                    'npoess']


### PR DESCRIPTION
# Description

This PR addresses issue #1219. The following was accomplished:

- Rocoto task `jobs/rocoto/gempak.sh` was updated to support `JGDAS_ATMOS_GEMPAK` and `JGFS_ATMOS_GEMPAK`;
- Rocoto task `jobs/rocoto/gempakmeta.sh` was added to support `JGFS_ATMOS_GEMPAK_META`;
- Rocoto task `jobs/rocoto/gempakmetancdc.sh` was added to support `JGDAS_ATMOS_GEMPAK_META_NCDC`;
- Rocoto task `jobs/rocoto/gempakncdcupapgif.sh` was added to support `JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF`;
- Rocoto task `jobs/rocoto/gempakpgrb2spec.sh` was added to support `JGFS_ATMOS_GEMPAK_PGRB2_SPEC`;
- The `npoess` switch is removed and the NPOESS task is renamed to `npoess_pgrb2_0p5deg` as per @KateFriedman-NOAA's requests (please see notes below).

  Resolves #1219 
  References #1222 #2073

**NOTE** This is a replicated PR open to resolve developer mishap with Github interface.

**NOTE** @KateFriedman-NOAA The `npoess` switch has been removed and the `npoess_pgrb2_0p5deg` task is now grouped beneath the `gempak` switches. This assumes that the `npoess_pgrb2_0p5deg` and all `gempak`-type tasks will use the same resources. However, the resource requirements (from `parm/config/gfs/config.resources` are different:

```
elif [[ ${step} = "npoess" ]]; then

    export wtime_npoess="03:30:00"
    export npe_npoess=1
    export npe_node_npoess=1
    export nth_npoess=1
    export memory_npoess="3GB"

elif [[ ${step} = "gempak" ]]; then

    export wtime_gempak="03:00:00"
    export npe_gempak=2
    export npe_gempak_gfs=28
    export npe_node_gempak=2
    export npe_node_gempak_gfs=28
    export nth_gempak=1
    export memory_gempak="4GB"
    export memory_gempak_gfs="2GB"
```

I am not sure how this is to be resolved and as a result I have maintained the `NPOESS` switch [here](https://github.com/HenryWinterbottom-NOAA/global-workflow/blob/feature/gfsv17_issue_1219.fix.002/parm/config/gfs/config.base.emc.dyn#L60.) until there is a resolution.

# Type of change

- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

The Rocoto XML configuration has been executed as follows.

```
user@host$: cd /scratch1/NCEPDEV/da/Henry.Winterbottom/trunk/global-workflow.develop.20231117/workflow
user@host$: ./setup_xml.py /scratch1/NCEPDEV/da/Henry.Winterbottom/work/GLOBAL_WORKFLOW/x002_gfsv17_issue_1219/x002_gfsv17_issue_1219.xml
```

The resulting Rocoto workflow is as follows.

```
       CYCLE                    TASK                       JOBID               STATE         EXIT STATUS     TRIES      DURATION
================================================================================================================================
202103231200             gfsstage_ic                    51952235              QUEUED                   -         0           0.0
202103231200                 gfsfcst                           -                   -                   -         -             -
202103231200            gfspost_f000                    51952236              QUEUED                   -         0           0.0
202103231200            gfspost_f006                    51952237              QUEUED                   -         0           0.0
202103231200            gfspost_f012                    51952238              QUEUED                   -         0           0.0
202103231200                 gfsvrfy                           -                   -                   -         -             -
202103231200             gfsmetpg2g1                           -                   -                   -         -             -
202103231200             gfsmetpg2o1                           -                   -                   -         -             -
202103231200             gfsmetppcp1                           -                   -                   -         -             -
202103231200               gfsgempak                           -                   -                   -         -             -
202103231200           gfsgempakmeta                           -                   -                   -         -             -
202103231200       gfsgempakmetancdc                           -                   -                   -         -             -
202103231200    gfsgempakncdcupapgif                           -                   -                   -         -             -
202103231200      gfsgempakpgrb2spec                           -                   -                   -         -             -
202103231200                 gfsarch                           -                   -                   -         -             -
202103231200              gfscleanup                           -                   -                   -         -             -

```

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary