### PR TITLE
Corrects GEMPAK Rocoto workflow mesh task.

### DIFF
--- a/workflow/applications/gfs_forecast_only.py
+++ b/workflow/applications/gfs_forecast_only.py
@@ -112,7 +112,7 @@ class GFSForecastOnlyAppConfig(AppConfig):
                 tasks += ['postsnd']
 
             if self.do_gempak:
-                tasks += ['gempak', 'gempakmeta', 'gempakncdcupagif', 'gempakpgrb2spec']
+                tasks += ['gempak', 'gempakmeta', 'gempakncdcupapgif', 'gempakpgrb2spec']
 
             if self.do_awips:
                 tasks += ['awips_20km_1p0deg', 'awips_g2', 'fbwinds']


### PR DESCRIPTION
# Description

This PR addresses issue #2136. The following was accomplished:

- A typo for the GEMPAK task  `gempakncdcupapgif` was correct; the misspelling as `gempakncdcupagif` raised an exception when attempting to build the Rocoto workflow mesh.

  Resolves #2136 

# Type of change
<!-- Delete all except one -->
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
 
```
(base) bash-4.2$ ./setup_xml.py /scratch1/NCEPDEV/da/Henry.Winterbottom/work/GLOBAL_WORKFLOW/EXPDIR/x001_gfsv17_issue_2136
Finalizing initialize
sourcing config.stage_ic
sourcing config.fcst
sourcing config.arch
sourcing config.cleanup
sourcing config.atmos_products
sourcing config.gempak
```

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
