### PR TITLE
Update GDAS hash to most recent stable versions

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -57,7 +57,7 @@ protocol = git
 required = False
 
 [GDASApp]
-hash = 7659c10
+hash = f44a6d5
 local_path = sorc/gdas.cd
 repo_url = https://github.com/NOAA-EMC/GDASApp.git
 protocol = git

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -164,7 +164,7 @@ if [[ ${checkout_gsi} == "YES" ]]; then
 fi
 
 if [[ ${checkout_gdas} == "YES" ]]; then
-  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git"                  "7659c10" &
+  checkout "gdas.cd" "https://github.com/NOAA-EMC/GDASApp.git"                  "f44a6d5" &
 fi
 
 if [[ ${checkout_gsi} == "YES" || ${checkout_gdas} == "YES" ]]; then


### PR DESCRIPTION
# Description
This PR updates the GDAS hash from a version in late October to the most recent stable-nightly commit from overnight last night/this morning. This will be a prerequisite before JEDI-based DA tests can be added to the workflow test suite.

# Type of change
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Cycled test on Hera

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
