### PR TITLE
Enable radar reflectivity output

### DIFF
--- a/parm/config/gefs/config.fcst
+++ b/parm/config/gefs/config.fcst
@@ -173,7 +173,7 @@ case ${imp_physics} in
         export random_clds=".false."
         export effr_in=".true."
         export ltaerosol=".false."
-        export lradar=".false."
+        export lradar=".true."
         export ttendlim="-999"
         export dt_inner=$((DELTIM/2))
         export sedi_semi=.true.

--- a/parm/config/gfs/config.fcst
+++ b/parm/config/gfs/config.fcst
@@ -173,7 +173,7 @@ case ${imp_physics} in
         export random_clds=".false."
         export effr_in=".true."
         export ltaerosol=".false."
-        export lradar=".false."
+        export lradar=".true."
         export ttendlim="-999"
         export dt_inner=$((DELTIM/2))
         export sedi_semi=.true.

--- a/parm/ufs/fv3/diag_table
+++ b/parm/ufs/fv3/diag_table
@@ -99,6 +99,7 @@
 "gfs_dyn",     "w",           "dzdt",         "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "ps",          "pressfc",      "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "hs",          "hgtsfc",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_phys",    "refl_10cm",   "refl_10cm",    "fv3_history",    "all",  .false.,  "none",  2
 
 "gfs_phys",    "cldfra",        "cldfra",        "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_phys",    "frzr",          "frzr",          "fv3_history2d",  "all",  .false.,  "none",  2
@@ -265,7 +266,6 @@
 "gfs_sfc",     "xzts",          "xzts",         "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_sfc",     "d_conv",        "dconv",        "fv3_history2d",  "all",  .false.,  "none",  2
 "gfs_sfc",     "qrain",         "qrain",        "fv3_history2d",  "all",  .false.,  "none",  2
-
 
 #=============================================================================================
 #

--- a/sorc/build_ufs.sh
+++ b/sorc/build_ufs.sh
@@ -34,8 +34,6 @@ CLEAN_BEFORE=YES
 CLEAN_AFTER=NO
 
 if [[ "${MACHINE_ID}" != "noaacloud" ]]; then
-  # Hack to work around error in UFS because python3 is not defined (see ufs-community/ufs-weather-model #1587)
-  module load intelpython3/2022.1.2
   ./tests/compile.sh "${MACHINE_ID}" "${MAKE_OPT}" "${COMPILE_NR}" "intel" "${CLEAN_BEFORE}" "${CLEAN_AFTER}"
   mv "./tests/fv3_${COMPILE_NR}.exe" ./tests/ufs_model.x
   mv "./tests/modules.fv3_${COMPILE_NR}.lua" ./tests/modules.ufs_model.lua

--- a/sorc/build_ufs.sh
+++ b/sorc/build_ufs.sh
@@ -34,6 +34,8 @@ CLEAN_BEFORE=YES
 CLEAN_AFTER=NO
 
 if [[ "${MACHINE_ID}" != "noaacloud" ]]; then
+  # Hack to work around error in UFS because python3 is not defined (see ufs-community/ufs-weather-model #1587)
+  module load intelpython3/2022.1.2
   ./tests/compile.sh "${MACHINE_ID}" "${MAKE_OPT}" "${COMPILE_NR}" "intel" "${CLEAN_BEFORE}" "${CLEAN_AFTER}"
   mv "./tests/fv3_${COMPILE_NR}.exe" ./tests/ufs_model.x
   mv "./tests/modules.fv3_${COMPILE_NR}.lua" ./tests/modules.ufs_model.lua

--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -251,7 +251,7 @@ EOF
   cat >> input.nml << EOF
   iovr         = ${iovr:-"3"}
   ltaerosol    = ${ltaerosol:-".false."}
-  lradar       = ${lradar:-".false."}
+  lradar       = ${lradar:-".true."}
   ttendlim     = ${ttendlim:-"-999"}
   dt_inner     = ${dt_inner:-"${default_dt_inner}"}
   sedi_semi    = ${sedi_semi:-".true."}


### PR DESCRIPTION
# Description
Turns on radar reflectivity output from FV3. This eliminates missing values appearing in the grib2 files.

Resolves #1513

# Type of change
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Forecast-only on Orion

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
