### PR TITLE
Fix module load typo in jobs/rocoto/upp.sh

### DIFF
--- a/jobs/rocoto/upp.sh
+++ b/jobs/rocoto/upp.sh
@@ -27,7 +27,7 @@ if [[ "${MACHINE_ID}" = "wcoss2" ]]; then
   module load wgrib2/2.0.8
   export WGRIB2=wgrib2
   module load python/3.8.6
-  module laod crtm/2.4.0  # TODO: This is only needed when UPP_RUN=goes.  Is there a better way to handle this?
+  module load crtm/2.4.0  # TODO: This is only needed when UPP_RUN=goes.  Is there a better way to handle this?
   set_trace
 else
   . "${HOMEgfs}/ush/load_fv3gfs_modules.sh"


### PR DESCRIPTION
# Description

This PR fixes a typo when loading the `crtm` module in the UPP hack for WCOSS2 in `jobs/rocoto/upp.sh`.

Resolves #2144

# Type of change

- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Made fix and reran failed atmanlupp jobs in control test on WCOSS2.
