### PR TITLE
Set place=shared for shared jobs on WCOSS2 (develop)

### DIFF
--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_diag.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_diag.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:06:00
 #PBS -l select=1:mpiprocs=48:ompthreads=1:ncpus=48:mem=24GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
+++ b/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:06:00
 #PBS -l select=1:mpiprocs=80:ompthreads=1:ncpus=80:mem=80GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_diag.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_diag.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=96:ompthreads=1:ncpus=96:mem=48GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 export model=gfs

--- a/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak.ecf
+++ b/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
 #PBS -l select=1:ncpus=2:mpiprocs=2:mem=4GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak_meta_ncdc.ecf
+++ b/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak_meta_ncdc.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/obsproc/dump/jgdas_atmos_tropcy_qc_reloc.ecf
+++ b/ecf/scripts/gdas/atmos/obsproc/dump/jgdas_atmos_tropcy_qc_reloc.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_emcsfc_sfc_prep.ecf
+++ b/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_emcsfc_sfc_prep.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:08:00
 #PBS -l select=1:ncpus=1:mem=2GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_manager.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_manager.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:15:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/post_processing/jgdas_atmos_chgres_forenkf.ecf
+++ b/ecf/scripts/gdas/atmos/post_processing/jgdas_atmos_chgres_forenkf.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:ncpus=3:mpiprocs=3:ompthreads=1:mem=200GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfozn.ecf
+++ b/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfozn.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfrad.ecf
+++ b/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfrad.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
 #PBS -l select=1:ncpus=1:mem=5GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/verf/jgdas_atmos_vminmon.ecf
+++ b/ecf/scripts/gdas/atmos/verf/jgdas_atmos_vminmon.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/wave/init/jgdas_wave_init.ecf
+++ b/ecf/scripts/gdas/wave/init/jgdas_wave_init.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=11:ompthreads=1:ncpus=11:mem=2GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/wave/post/jgdas_wave_postpnt.ecf
+++ b/ecf/scripts/gdas/wave/post/jgdas_wave_postpnt.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:12:00
 #PBS -l select=4:mpiprocs=50:ompthreads=1:ncpus=50:mem=10GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/wave/post/jgdas_wave_postsbs.ecf
+++ b/ecf/scripts/gdas/wave/post/jgdas_wave_postsbs.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
 #PBS -l select=1:mpiprocs=8:ompthreads=1:ncpus=8:mem=10GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
+++ b/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=5:ompthreads=1:ncpus=5:mem=100GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
 #PBS -l select=1:ncpus=28:mpiprocs=28:mem=2GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_meta.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_meta.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
 #PBS -l select=1:ncpus=23:mpiprocs=23:mem=2GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_ncdc_upapgif.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_ncdc_upapgif.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_npoess_pgrb2_0p5deg.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_npoess_pgrb2_0p5deg.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_pgrb2_spec_gempak.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_pgrb2_spec_gempak.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_tropcy_qc_reloc.ecf
+++ b/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_tropcy_qc_reloc.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_emcsfc_sfc_prep.ecf
+++ b/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_emcsfc_sfc_prep.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:07:00
 #PBS -l select=1:ncpus=1:mem=2GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_manager.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_manager.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=04:00:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:ncpus=1:mem=3GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:ncpus=1:mem=3GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:ncpus=1:mem=4GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/verf/jgfs_atmos_vminmon.ecf
+++ b/ecf/scripts/gfs/atmos/verf/jgfs_atmos_vminmon.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/gempak/jgfs_wave_gempak.ecf
+++ b/ecf/scripts/gfs/wave/gempak/jgfs_wave_gempak.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/init/jgfs_wave_init.ecf
+++ b/ecf/scripts/gfs/wave/init/jgfs_wave_init.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=11:ompthreads=1:ncpus=11:mem=2GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_postsbs.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_postsbs.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
 #PBS -l select=1:mpiprocs=8:ompthreads=1:ncpus=8:mem=10GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_bulls.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_bulls.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_gridded.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_gridded.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
+++ b/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=65:ompthreads=1:ncpus=65:mem=150GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/workflow/rocoto/tasks.py
+++ b/workflow/rocoto/tasks.py
@@ -153,8 +153,11 @@ class Tasks:
         native = None
         if scheduler in ['pbspro']:
             native = '-l debug=true,place=vscatter'
+            # Set either exclusive or shared - default on WCOSS2 is exclusive when not set
             if task_config.get('is_exclusive', False):
                 native += ':exclhost'
+            else:
+                native += ':shared'
         elif scheduler in ['slurm']:
             native = '--export=NONE'
 


### PR DESCRIPTION
# Description

This PR updates the rocoto xml setup to set `place=shared` (add `:shared` to place setting) via the `<native>` tag when a job is shared (not exclusive). Previously only the `:exclhost` setting was added to PBS `place` when a job was to be run exclusively and all other jobs were assumed to run shared. PBS on WCOSS2 no longer assumes shared when exclusive is not set, it actually assumes the opposite now, that a job is exclusive if not specified. We now need to set either exclusive (`exclhost`) or shared (`shared`) for all jobs run on WCOSS2.

Have also updated all ecf scripts in `develop` to include `:shared` when not already set to `:exclhost`. The ecf scripts need updates for GFSv17 but for now they will be correct in term of exclusive vs shared until a developer sweeps through for the GFSv17 updates.

This change came from knowledge obtained during recent updated WCOSS2 training.

Addresses #2135

# Type of change

- Bug fix (fixes something broken)
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

1.5 cycle atmos-only test on WCOSS2-Dogwood.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
