### PR TITLE
Update GFS version to v16.3.12 in RTD index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Status
 ======
 
 * State of develop (HEAD) branch: GFSv17+ development
-* State of operations (dev/gfs.v16 branch): GFS v16.3.11 `tag: [gfs.v16.3.11] <https://github.com/NOAA-EMC/global-workflow/releases/tag/gfs.v16.3.11>`_
+* State of operations (dev/gfs.v16 branch): GFS v16.3.12 `tag: [gfs.v16.3.12] <https://github.com/NOAA-EMC/global-workflow/releases/tag/gfs.v16.3.12>`_
 
 =============
 Code managers


### PR DESCRIPTION
# Description

This PR updates the GFS version documented on the first page of the global-workflow Read-The-Docs to be the newly implemented GFSv16.3.12 version.

Resolves #2096

# Type of change

Documentation update

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? YES

# How has this been tested?

N/A
