### PR TITLE
Stop calling ufs-utils link script

### DIFF
--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -122,12 +122,6 @@ do
 done
 
 
-if [[ -d "${HOMEgfs}/sorc/ufs_utils.fd" ]]; then
-  cd "${HOMEgfs}/sorc/ufs_utils.fd/fix" || exit 1
-  ./link_fixdirs.sh "${RUN_ENVIR}" "${machine}" 2> /dev/null
-fi
-
-
 #---------------------------------------
 #--add files from external repositories
 #---------------------------------------


### PR DESCRIPTION
# Description
The `link_workflow.sh` script was calling the ufs_utils version of the same. That step is only necessary if a user is going to run one of the stand-alone ufs-utils, which is rare.

This change will also sidestep the issue of the script not yet having been updated for Hercules.

# Type of change
- Bug fix (fixes something broken)
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
