### PR TITLE
Add COMOUT_OBS to marine obs prep task

### DIFF
--- a/jobs/JGLOBAL_PREP_OCEAN_OBS
+++ b/jobs/JGLOBAL_PREP_OCEAN_OBS
@@ -8,6 +8,7 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "prepoceanobs" -c "base prepoceanobs"
 ##############################################
 
 export COMIN_OBS="${DATA}"
+YMD=${PDY} HH=${cyc} generate_com -rx COMOUT_OBS:COM_OBS_TMPL
 
 ##############################################
 # Begin JOB SPECIFIC work


### PR DESCRIPTION
# Description

Adds `COMOUT_OBS` (defined from `COM_OBS_TMPL`) to marine obs prep task to properly handle marine obs prep files. Used to keep obs after IODA conversion, QC, and other prep.

Towards resolving https://github.com/NOAA-EMC/GDASApp/issues/815

# Type of change

- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

GDASApp SOCA ctests on Hera

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
