### PR TITLE
Update ufs-weather-model version 

### DIFF
--- a/parm/ufs/ufs.configure.atm.IN
+++ b/parm/ufs/ufs.configure.atm.IN
@@ -3,10 +3,20 @@ logKindFlag:            @[esmf_logkind]
 globalResourceControl:  true
 
 EARTH_component_list: ATM
+EARTH_attributes::
+  Verbosity = 0
+::
+
+# ATM #
 ATM_model:                      @[atm_model]
 ATM_petlist_bounds:             @[atm_petlist_bounds]
 ATM_omp_num_threads:            @[atm_omp_num_threads]
+ATM_attributes::
+  Verbosity = 0
+  Diagnostic = 0
+::
 
+# Run Sequence #
 runSeq::
   ATM
 ::

--- a/parm/ufs/ufs.configure.atm_aero.IN
+++ b/parm/ufs/ufs.configure.atm_aero.IN
@@ -9,7 +9,7 @@ globalResourceControl:  true
 # EARTH #
 EARTH_component_list: ATM CHM
 EARTH_attributes::
-  Verbosity = max
+  Verbosity = 0
 ::
 
 # ATM #
@@ -17,7 +17,7 @@ ATM_model:                      @[atm_model]
 ATM_petlist_bounds:             @[atm_petlist_bounds]
 ATM_omp_num_threads:            @[atm_omp_num_threads]
 ATM_attributes::
-  Verbosity = max
+  Verbosity = 0
 ::
 
 # CHM #
@@ -25,7 +25,7 @@ CHM_model:                      @[chm_model]
 CHM_petlist_bounds:             @[chm_petlist_bounds]
 CHM_omp_num_threads:            @[chm_omp_num_threads]
 CHM_attributes::
-  Verbosity = max
+  Verbosity = 0
 ::
 
 # Run Sequence #
@@ -37,14 +37,4 @@ runSeq::
     CHM -> ATM
     ATM phase2
   @
-::
-
-# CMEPS variables
-
-DRIVER_attributes::
-  mediator_read_restart = .false.
-::
-
-ALLCOMP_attributes::
-  start_type = startup
 ::

--- a/parm/ufs/ufs.configure.cpld.IN
+++ b/parm/ufs/ufs.configure.cpld.IN
@@ -39,6 +39,8 @@ OCN_attributes::
   ProfileMemory = false
   OverwriteSlice = true
   mesh_ocn = @[MESH_OCN_ICE]
+  use_coldstart = @[use_coldstart]
+  use_mommesh = @[use_mommesh]
 ::
 
 # ICE #
@@ -51,6 +53,7 @@ ICE_attributes::
   ProfileMemory = false
   OverwriteSlice = true
   mesh_ice = @[MESH_OCN_ICE]
+  eps_imesh = @[eps_imesh]
   stop_n = @[RESTART_N]
   stop_option = nhours
   stop_ymd = -999
@@ -107,9 +110,6 @@ ALLCOMP_attributes::
       restart_option = nhours
       restart_ymd = -999
       dbug_flag = @[cap_dbug_flag]
-      use_coldstart = @[use_coldstart]
-      use_mommesh = @[use_mommesh]
-      eps_imesh = @[eps_imesh]
       stop_n = @[FHMAX]
       stop_option = nhours
       stop_ymd = -999

--- a/parm/ufs/ufs.configure.cpld_aero.IN
+++ b/parm/ufs/ufs.configure.cpld_aero.IN
@@ -47,6 +47,8 @@ OCN_attributes::
   ProfileMemory = false
   OverwriteSlice = true
   mesh_ocn = @[MESH_OCN_ICE]
+  use_coldstart = @[use_coldstart]
+  use_mommesh = @[use_mommesh]
 ::
 
 # ICE #
@@ -59,6 +61,7 @@ ICE_attributes::
   ProfileMemory = false
   OverwriteSlice = true
   mesh_ice = @[MESH_OCN_ICE]
+  eps_imesh = @[eps_imesh]
   stop_n = @[RESTART_N]
   stop_option = nhours
   stop_ymd = -999
@@ -119,9 +122,6 @@ ALLCOMP_attributes::
       restart_option = nhours
       restart_ymd = -999
       dbug_flag = @[cap_dbug_flag]
-      use_coldstart = @[use_coldstart]
-      use_mommesh = @[use_mommesh]
-      eps_imesh = @[eps_imesh]
       stop_n = @[FHMAX]
       stop_option = nhours
       stop_ymd = -999

--- a/parm/ufs/ufs.configure.cpld_aero_outerwave.IN
+++ b/parm/ufs/ufs.configure.cpld_aero_outerwave.IN
@@ -47,6 +47,8 @@ OCN_attributes::
   ProfileMemory = false
   OverwriteSlice = true
   mesh_ocn = @[MESH_OCN_ICE]
+  use_coldstart = @[use_coldstart]
+  use_mommesh = @[use_mommesh]
 ::
 
 # ICE #
@@ -59,6 +61,7 @@ ICE_attributes::
   ProfileMemory = false
   OverwriteSlice = true
   mesh_ice = @[MESH_OCN_ICE]
+  eps_imesh = @[eps_imesh]
   stop_n = @[RESTART_N]
   stop_option = nhours
   stop_ymd = -999
@@ -71,10 +74,7 @@ WAV_omp_num_threads:            @[wav_omp_num_threads]
 WAV_attributes::
   Verbosity = 0
   OverwriteSlice = false
-  diro = "."
-  logfile = wav.log
   mesh_wav = @[MESH_WAV]
-  multigrid = @[MULTIGRID]
 ::
 
 # CMEPS warm run sequence
@@ -139,9 +139,6 @@ ALLCOMP_attributes::
       restart_option = nhours
       restart_ymd = -999
       dbug_flag = @[cap_dbug_flag]
-      use_coldstart = @[use_coldstart]
-      use_mommesh = @[use_mommesh]
-      eps_imesh = @[eps_imesh]
       stop_n = @[FHMAX]
       stop_option = nhours
       stop_ymd = -999

--- a/parm/ufs/ufs.configure.cpld_aero_wave.IN
+++ b/parm/ufs/ufs.configure.cpld_aero_wave.IN
@@ -47,6 +47,8 @@ OCN_attributes::
   ProfileMemory = false
   OverwriteSlice = true
   mesh_ocn = @[MESH_OCN_ICE]
+  use_coldstart = @[use_coldstart]
+  use_mommesh = @[use_mommesh]
 ::
 
 # ICE #
@@ -59,6 +61,7 @@ ICE_attributes::
   ProfileMemory = false
   OverwriteSlice = true
   mesh_ice = @[MESH_OCN_ICE]
+  eps_imesh = @[eps_imesh]
   stop_n = @[RESTART_N]
   stop_option = nhours
   stop_ymd = -999
@@ -71,10 +74,7 @@ WAV_omp_num_threads:            @[wav_omp_num_threads]
 WAV_attributes::
   Verbosity = 0
   OverwriteSlice = false
-  diro = "."
-  logfile = wav.log
   mesh_wav = @[MESH_WAV]
-  multigrid = @[MULTIGRID]
 ::
 
 # CMEPS warm run sequence
@@ -139,9 +139,6 @@ ALLCOMP_attributes::
       restart_option = nhours
       restart_ymd = -999
       dbug_flag = @[cap_dbug_flag]
-      use_coldstart = @[use_coldstart]
-      use_mommesh = @[use_mommesh]
-      eps_imesh = @[eps_imesh]
       stop_n = @[FHMAX]
       stop_option = nhours
       stop_ymd = -999

--- a/parm/ufs/ufs.configure.cpld_outerwave.IN
+++ b/parm/ufs/ufs.configure.cpld_outerwave.IN
@@ -39,6 +39,8 @@ OCN_attributes::
   ProfileMemory = false
   OverwriteSlice = true
   mesh_ocn = @[MESH_OCN_ICE]
+  use_coldstart = @[use_coldstart]
+  use_mommesh = @[use_mommesh]
 ::
 
 # ICE #
@@ -51,6 +53,7 @@ ICE_attributes::
   ProfileMemory = false
   OverwriteSlice = true
   mesh_ice = @[MESH_OCN_ICE]
+  eps_imesh = @[eps_imesh]
   stop_n = @[RESTART_N]
   stop_option = nhours
   stop_ymd = -999
@@ -63,10 +66,7 @@ WAV_omp_num_threads:            @[wav_omp_num_threads]
 WAV_attributes::
   Verbosity = 0
   OverwriteSlice = false
-  diro = "."
-  logfile = wav.log
   mesh_wav = @[MESH_WAV]
-  multigrid = @[MULTIGRID]
 ::
 
 # CMEPS warm run sequence
@@ -127,9 +127,6 @@ ALLCOMP_attributes::
       restart_option = nhours
       restart_ymd = -999
       dbug_flag = @[cap_dbug_flag]
-      use_coldstart = @[use_coldstart]
-      use_mommesh = @[use_mommesh]
-      eps_imesh = @[eps_imesh]
       stop_n = @[FHMAX]
       stop_option = nhours
       stop_ymd = -999

--- a/parm/ufs/ufs.configure.cpld_wave.IN
+++ b/parm/ufs/ufs.configure.cpld_wave.IN
@@ -39,6 +39,8 @@ OCN_attributes::
   ProfileMemory = false
   OverwriteSlice = true
   mesh_ocn = @[MESH_OCN_ICE]
+  use_coldstart = @[use_coldstart]
+  use_mommesh = @[use_mommesh]
 ::
 
 # ICE #
@@ -51,6 +53,7 @@ ICE_attributes::
   ProfileMemory = false
   OverwriteSlice = true
   mesh_ice = @[MESH_OCN_ICE]
+  eps_imesh = @[eps_imesh]
   stop_n = @[RESTART_N]
   stop_option = nhours
   stop_ymd = -999
@@ -63,10 +66,7 @@ WAV_omp_num_threads:            @[wav_omp_num_threads]
 WAV_attributes::
   Verbosity = 0
   OverwriteSlice = false
-  diro = "."
-  logfile = wav.log
   mesh_wav = @[MESH_WAV]
-  multigrid = @[MULTIGRID]
 ::
 
 # CMEPS warm run sequence
@@ -127,9 +127,6 @@ ALLCOMP_attributes::
       restart_option = nhours
       restart_ymd = -999
       dbug_flag = @[cap_dbug_flag]
-      use_coldstart = @[use_coldstart]
-      use_mommesh = @[use_mommesh]
-      eps_imesh = @[eps_imesh]
       stop_n = @[FHMAX]
       stop_option = nhours
       stop_ymd = -999

--- a/ush/parsing_model_configure_FV3.sh
+++ b/ush/parsing_model_configure_FV3.sh
@@ -41,6 +41,7 @@ write_groups:            ${WRITE_GROUP:-1}
 write_tasks_per_group:   ${WRTTASK_PER_GROUP:-24}
 itasks:                  1
 output_history:          ${OUTPUT_HISTORY:-".true."}
+history_file_on_native_grid: .false.
 write_dopost:            ${WRITE_DOPOST:-".false."}
 write_nsflip:            ${WRITE_NSFLIP:-".false."}
 num_files:               ${NUM_FILES:-2}
@@ -54,7 +55,8 @@ ichunk3d:                ${ichunk3d:-0}
 jchunk3d:                ${jchunk3d:-0}
 kchunk3d:                ${kchunk3d:-0}
 ideflate:                ${ideflate:-1}
-nbits:                   ${nbits:-14}
+quantize_mode:           'quantize_bitround'
+quantize_nsd:            ${QUANTIZE_NSD:-0}
 imo:                     ${LONB_IMO}
 jmo:                     ${LATB_JMO}
 output_fh:               ${FV3_OUTPUT_FH}


### PR DESCRIPTION
# Description
Update ufs-weather-model version 


This includes the latest updates to ufs-weather-model.  This includes a bug-fix for an issue several have run into.  It updates the contents of the ufs.configure files and model_configure, but this does not update variable names and or the names of the ufs.configure files.   These will be addressed in a follow-up PR from @aerorahul  The reason for delaying the full scale set of updates is to allow faster access to the bug-fixed version of the model. 

Changes in the ufs-waether-model can be found here: https://github.com/ufs-community/ufs-weather-model/compare/3ba8dff29a7395445ce5da8c9b48cfe0ff8a668a...991d6527da22d11016df035998ec1352d0449875 

# Type of change
- Maintenance:  Routine update of ufs-weather-model 

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update?  NO

# How has this been tested?

Ran forecast only C384 S2SW on hera and orion (still running post, but no failures so far). 

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
