### PR TITLE
Fix analysis post processing's handling of 0-padded negative integers

### DIFF
--- a/jobs/rocoto/atmos_products.sh
+++ b/jobs/rocoto/atmos_products.sh
@@ -22,7 +22,11 @@ IFS='_' read -ra fhrs <<< "${FHRLST//f}" # strip off the 'f's and convert to arr
 #---------------------------------------------------------------
 # Execute the JJOB
 for fhr in "${fhrs[@]}"; do
-    export FORECAST_HOUR=$(( 10#${fhr} ))
+    # The analysis fhr is -001.  Performing math on negative, leading 0 integers is tricky.
+    # The negative needs to be in front of "10#", so do some regex magic to make it happen.
+    fhr="10#${fhr}"
+    fhr=$( echo ${fhr} | sed "s/10#-/-10#/" )
+    export FORECAST_HOUR=$(( ${fhr} ))
     "${HOMEgfs}/jobs/JGLOBAL_ATMOS_PRODUCTS"
     status=$?
     if (( status != 0 )); then exit "${status}"; fi

--- a/jobs/rocoto/atmos_products.sh
+++ b/jobs/rocoto/atmos_products.sh
@@ -25,8 +25,8 @@ for fhr in "${fhrs[@]}"; do
     # The analysis fhr is -001.  Performing math on negative, leading 0 integers is tricky.
     # The negative needs to be in front of "10#", so do some regex magic to make it happen.
     fhr="10#${fhr}"
-    fhr=$( echo ${fhr} | sed "s/10#-/-10#/" )
-    export FORECAST_HOUR=$(( ${fhr} ))
+    fhr=$( echo "${fhr}" | sed "s/10#-/-10#/" )
+    export FORECAST_HOUR=$(( fhr ))
     "${HOMEgfs}/jobs/JGLOBAL_ATMOS_PRODUCTS"
     status=$?
     if (( status != 0 )); then exit "${status}"; fi

--- a/jobs/rocoto/atmos_products.sh
+++ b/jobs/rocoto/atmos_products.sh
@@ -25,7 +25,7 @@ for fhr in "${fhrs[@]}"; do
     # The analysis fhr is -001.  Performing math on negative, leading 0 integers is tricky.
     # The negative needs to be in front of "10#", so do some regex magic to make it happen.
     fhr="10#${fhr}"
-    fhr=$( echo "${fhr}" | sed "s/10#-/-10#/" )
+    fhr=${fhr//10#-/-10#}
     export FORECAST_HOUR=$(( fhr ))
     "${HOMEgfs}/jobs/JGLOBAL_ATMOS_PRODUCTS"
     status=$?

--- a/jobs/rocoto/atmos_products.sh
+++ b/jobs/rocoto/atmos_products.sh
@@ -25,7 +25,7 @@ for fhr in "${fhrs[@]}"; do
     # The analysis fhr is -001.  Performing math on negative, leading 0 integers is tricky.
     # The negative needs to be in front of "10#", so do some regex magic to make it happen.
     fhr="10#${fhr}"
-    fhr=${fhr//10#-/-10#}
+    fhr=${fhr//10\#-/-10\#}
     export FORECAST_HOUR=$(( fhr ))
     "${HOMEgfs}/jobs/JGLOBAL_ATMOS_PRODUCTS"
     status=$?


### PR DESCRIPTION
# Description
This screens for the analysis 'forecast' hour (-001) and handles the '-' and circumvents octal issues.

Resolves #2185

# Type of change
<!-- Delete all except one -->
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Ran an analysis post and a forecast group post for both the gfs and gdas cycles on Hercules.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
       It does generate a new warning, but I am dismissing it for the sake of preserving vim syntax highlighting.
- [ ] New and existing tests pass with my changes