### PR TITLE
Stop attempting to comment link to RTD for non-PRs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,17 +9,14 @@ on:
       - release/*
     paths:
       - docs/**
-  pull_request_target:
-    types: [issues, opened, reopened, synchronize]
+  pull_request:
+    types: [opened, reopened, synchronize]
     paths:
       - docs/**
 
 jobs:
 
   documentation:
-    
-    permissions:
-      pull-requests: 'write'
 
     runs-on: ubuntu-latest
     name: Build and deploy documentation
@@ -55,18 +52,3 @@ jobs:
         name: documentation_warnings.log
         path: artifact/doc_warnings.log
         if-no-files-found: ignore
-
-    - name: Comment ReadDocs
-      uses: actions/github-script@v6
-      with:
-        script: |
-          const message = `
-          Link to ReadTheDocs sample build for this PR can be found at:
-          https://global-workflow--${{ github.event.pull_request.number }}.org.readthedocs.build/en/${{ github.event.pull_request.number }}
-          `
-          github.rest.issues.createComment({
-           issue_number: context.issue.number,
-           owner: context.repo.owner,
-           repo: context.repo.repo,
-           body: message 
-          })     

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,14 +9,17 @@ on:
       - release/*
     paths:
       - docs/**
-  pull_request:
-    types: [opened, reopened, synchronize]
+  pull_request_target:
+    types: [issues, opened, reopened, synchronize]
     paths:
       - docs/**
 
 jobs:
 
   documentation:
+
+    permissions:
+      pull-requests: 'write'
 
     runs-on: ubuntu-latest
     name: Build and deploy documentation
@@ -52,3 +55,19 @@ jobs:
         name: documentation_warnings.log
         path: artifact/doc_warnings.log
         if-no-files-found: ignore
+
+    - name: Comment ReadDocs Link in PR
+      if: github.event_name == "pull_request"
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const message = `
+          Link to ReadTheDocs sample build for this PR can be found at:
+          https://global-workflow--${{ github.event.pull_request.number }}.org.readthedocs.build/en/${{ github.event.pull_request.number }}
+          `
+          github.rest.issues.createComment({
+           issue_number: context.issue.number,
+           owner: context.repo.owner,
+           repo: context.repo.repo,
+           body: message
+          })


### PR DESCRIPTION
# Description
Each time a branch is created, updated and pushed to GH on a developers fork, the documentation action tries to comment on the PR a link to the RTD page for that PR.
This is fine if a PR exists, but this fails when there is no PR the push is a simple merge of `develop` into the feature branch.

This "feature" was introduced in #1786 

# Type of change
<!-- Delete all except one -->
- Bug fix (fixes something broken). Fixes error emails from GH that it was unsuccessful in building documentation (it wasn't).  The failure was the commenting part.

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
No tests are necessary to eliminate this.


# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
