### PR TITLE
Fix OpenMP over-allocation of resources in exglobal_atmos_products.sh…

### DIFF
--- a/scripts/exglobal_atmos_products.sh
+++ b/scripts/exglobal_atmos_products.sh
@@ -129,7 +129,7 @@ for (( nset=1 ; nset <= downset ; nset++ )); do
 
   # Run with MPMD or serial
   if [[ "${USE_CFP:-}" = "YES" ]]; then
-    "${HOMEgfs}/ush/run_mpmd.sh" "${DATA}/poescript"
+    OMP_NUM_THREADS=1 "${HOMEgfs}/ush/run_mpmd.sh" "${DATA}/poescript"
     export err=$?
   else
     chmod 755 "${DATA}/poescript"


### PR DESCRIPTION
Fix OpenMP over-allocation of resources running MPMD tasks

<!-- PLEASE READ -->
<!-- Any PRs not following this template will be closed -->
<!--
    Please use a short (<60 char), descriptive title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

    PRs should meet these guidelines:
    - Each PR should address ONE topic and have an associated issue.
    - No hard-coded paths or personal directories.
    - No temporary or backup files should be committed (including logs).
    - Any code that you disabled by being commented out should be removed or reenabled.

    Please delete all these comments before submitting the PR.
-->
# Description
- Prefix the call to "${HOMEgfs}/ush/run_mpmd.sh" by OMP_NUM_THREADS=1.
- This ensures that OMP_NUM_THREADS is set to 1 only when running MPMD, where multiple instances are being kicked off simultaneously. By only prefixing this call, we are sure that no other run is affected.
- It prevent the overthreading in OpenMP when running MPMD tasks
- This fix is transparent to users.
Resolves #2211
<!-- This description will become the commit message for the PR-->
<!-- Please use this format for your description:

  Describe your changes. Focus on the *what* and *why*. The *how* will be evident from the changes. In particular, be sure to note any interface changes, such as command line syntax, that will need to be communicated to users.

  At the end of your description, please be sure to add the issue this PR solves using the word "Resolves". If there are any issues that are related but not yet resolved (including in other repos), you may use "Refs".

  Resolves #1234
  Refs #4321
  Refs NOAA-EMC/repo#5678
-->

# Type of change
<!-- Delete all except one -->
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Cloned and tested on S4
<!-- Please list any test you conducted, including the machine.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
