### PR TITLE
Update List in tasks.py for python error on WCOSS2

### DIFF
--- a/workflow/rocoto/tasks.py
+++ b/workflow/rocoto/tasks.py
@@ -4,6 +4,7 @@ import numpy as np
 from applications.applications import AppConfig
 import rocoto.rocoto as rocoto
 from wxflow import Template, TemplateConstants, to_timedelta
+from typing import List
 
 __all__ = ['Tasks']
 
@@ -124,7 +125,7 @@ class Tasks:
                                              rocoto_conversion_dict.get)
 
     @staticmethod
-    def _get_forecast_hours(cdump, config) -> list[str]:
+    def _get_forecast_hours(cdump, config) -> List[str]:
         fhmin = config['FHMIN']
         fhmax = config['FHMAX']
         fhout = config['FHOUT']


### PR DESCRIPTION
# Description

The typing hint `typing.List` was deprecated with python 3.9 in favor of using the primitive `list[str]`, but the functional version of python on WCOSS2 is <3.9, causing `setup_xml.py` to fail there. This replaces `list[str]` as a typing hint with the deprecated form until the supported version on WCOSS2 is >=3.9.

# Type of change

- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Setup script test on Cactus and Hera with change.
