### PR TITLE
Simplify and extend load_ufsda_modules to hercules

### DIFF
--- a/ush/load_ufsda_modules.sh
+++ b/ush/load_ufsda_modules.sh
@@ -44,20 +44,15 @@ elif [[ -d /scratch1 ]] ; then
   # set NETCDF variable based on ncdump location
   NETCDF=$( which ncdump )
   export NETCDF
-  # prod_util stuff, find a better solution later...
-  module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/compiler/intel/2022.1.2/
-  module load prod_util
 elif [[ -d /work ]] ; then
-  # We are on MSU Orion
-  # prod_util stuff, find a better solution later...
-  #module use /apps/contrib/NCEP/hpc-stack/libs/hpc-stack/modulefiles/compiler/intel/2022.1.2/
-  #module load prod_util
-  export UTILROOT=/work2/noaa/da/python/opt/intel-2022.1.2/prod_util/1.2.2
-  export MDATE=/work2/noaa/da/python/opt/intel-2022.1.2/prod_util/1.2.2/bin/mdate
-  export NDATE=/work2/noaa/da/python/opt/intel-2022.1.2/prod_util/1.2.2/bin/ndate
-  export NHOUR=/work2/noaa/da/python/opt/intel-2022.1.2/prod_util/1.2.2/bin/nhour
-  export FSYNC=/work2/noaa/da/python/opt/intel-2022.1.2/prod_util/1.2.2/bin/fsync_file
-  module load "${MODS}/orion"
+  # We are on MSU Orion or Hercules
+  if [[ -d /apps/other ]] ; then
+     # Hercules
+     module load "${MODS}/hercules"
+  else
+     # Orion
+     module load "${MODS}/orion"
+  fi
   # set NETCDF variable based on ncdump location
   ncdump=$( which ncdump )
   NETCDF=$( echo "${ncdump}" | cut -d " " -f 3 )


### PR DESCRIPTION
# Description
GDASApp jobs do not run on Hercules because `ush/load_ufsda_modules.sh` does not include logic to load the appropriate GDASApp modules on Hercules.  This PR extends `load_ufsda_modules.sh` functionality to Hercules, thereby enabling GDASApp jobs to run on Hercules.

Resolves #2244

# Type of change
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? **NO**
- Does this change require a documentation update? **NO**

# How has this been tested?
- Clone, build, and cycle GDASApp jobs on Hercules, Hera, and Orion

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
