### PR TITLE
Update GFS version to v16.3.13 in RTD index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Status
 ======
 
 * State of develop (HEAD) branch: GFSv17+ development
-* State of operations (dev/gfs.v16 branch): GFS v16.3.12 `tag: [gfs.v16.3.12] <https://github.com/NOAA-EMC/global-workflow/releases/tag/gfs.v16.3.12>`_
+* State of operations (dev/gfs.v16 branch): GFS v16.3.13 `tag: [gfs.v16.3.13] <https://github.com/NOAA-EMC/global-workflow/releases/tag/gfs.v16.3.13>`_
 
 =============
 Code managers


### PR DESCRIPTION
# Description

This PR updates the GFS version and tag link on the main page of the global-workflow Read-The-Docs for the newly implemented GFSv16.3.13.

Refs #2013

# Type of change

- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? YES

# How has this been tested?

N/A