### PR TITLE
Add settings for containers to config.resources

### DIFF
--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -60,6 +60,9 @@ case ${machine} in
     export PARTITION_BATCH="compute"
     npe_node_max=40
     ;;
+  "CONTAINER")
+    npe_node_max=1
+    ;;
   *)
     echo "FATAL ERROR: Unknown machine encountered by ${BASH_SOURCE[0]}"
     exit 2


### PR DESCRIPTION
I'm not sure when this happened, but the container case in `config.resources` is missing.
- fixes #2257  