### PR TITLE
Address "OCNRES" to get snow DA global-workflow test working

### DIFF
--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -198,7 +198,7 @@ class LandAnalysis(Analysis):
             raise WorkflowException(f"An error occured during execution of {exe}")
 
         # Ensure the snow depth IMS file is produced by the above executable
-        input_file = f"IMSscf.{to_YMD(localconf.current_cycle)}.{localconf.CASE}.mx{localconf.OCNRES}_oro_data.nc"
+        input_file = f"IMSscf.{to_YMD(localconf.current_cycle)}.{localconf.CASE}_oro_data.nc"
         if not os.path.isfile(f"{os.path.join(localconf.DATA, input_file)}"):
             logger.exception(f"{self.task_config.CALCFIMSEXE} failed to produce {input_file}")
             raise FileNotFoundError(f"{os.path.join(localconf.DATA, input_file)}")
@@ -301,7 +301,7 @@ class LandAnalysis(Analysis):
         localconf = AttrDict()
         keys = ['HOMEgfs', 'DATA', 'current_cycle',
                 'COM_ATMOS_RESTART_PREV', 'COM_LAND_ANALYSIS', 'APREFIX',
-                'SNOWDEPTHVAR', 'BESTDDEV', 'CASE', 'ntiles',
+                'SNOWDEPTHVAR', 'BESTDDEV', 'CASE', 'OCNRES', 'ntiles',
                 'APRUN_LANDANL', 'JEDIEXE', 'jedi_yaml',
                 'APPLY_INCR_NML_TMPL', 'APPLY_INCR_EXE', 'APRUN_APPLY_INCR']
         for key in keys:
@@ -530,6 +530,7 @@ class LandAnalysis(Analysis):
              DATA
              current_cycle
              CASE
+             OCNRES
              ntiles
              APPLY_INCR_NML_TMPL
              APPLY_INCR_EXE


### PR DESCRIPTION
This PR is to address the recent filename changes of the orography data from `$(CASE)_oro_data.nc` to `$(CASE).mx$(OCNRES)_oro_data.nc` in the `add_increments` function of `land_analysis.py`. 

For the orography in the IMS processing code, the orography filename is still `$(CASE)_oro_data.nc`. Therefore we need to remove `OCNRES` in `prepare_IMS`. 

This PR is a prerequisite to support #2199 

@aerorahul Would you please merge these changes into your #2199 for your snow testing. 