### PR TITLE
Set shared for non-exclusive jobs on WCOSS2 (GFSv16)

### DIFF
--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_diag.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_diag.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:06:00
 #PBS -l select=1:mpiprocs=48:ompthreads=1:ncpus=48:mem=48GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
+++ b/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:06:00
 #PBS -l select=1:mpiprocs=80:ompthreads=1:ncpus=80:mem=60GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_diag.ecf
+++ b/ecf/scripts/gdas/atmos/analysis/jgdas_atmos_analysis_diag.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=96:ompthreads=1:ncpus=96:mem=48GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 export model=gfs

--- a/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak.ecf
+++ b/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
 #PBS -l select=1:ncpus=2:mpiprocs=2:mem=4GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak_meta_ncdc.ecf
+++ b/ecf/scripts/gdas/atmos/gempak/jgdas_atmos_gempak_meta_ncdc.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/obsproc/dump/jgdas_atmos_tropcy_qc_reloc.ecf
+++ b/ecf/scripts/gdas/atmos/obsproc/dump/jgdas_atmos_tropcy_qc_reloc.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_emcsfc_sfc_prep.ecf
+++ b/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_emcsfc_sfc_prep.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:08:00
 #PBS -l select=1:ncpus=1:mem=2GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_manager.ecf
+++ b/ecf/scripts/gdas/atmos/post/jgdas_atmos_post_manager.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:15:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/post_processing/jgdas_atmos_chgres_forenkf.ecf
+++ b/ecf/scripts/gdas/atmos/post_processing/jgdas_atmos_chgres_forenkf.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:ncpus=3:mpiprocs=3:ompthreads=1:mem=200GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfozn.ecf
+++ b/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfozn.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfrad.ecf
+++ b/ecf/scripts/gdas/atmos/verf/jgdas_atmos_verfrad.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
 #PBS -l select=1:ncpus=1:mem=5GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/atmos/verf/jgdas_atmos_vminmon.ecf
+++ b/ecf/scripts/gdas/atmos/verf/jgdas_atmos_vminmon.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/wave/init/jgdas_wave_init.ecf
+++ b/ecf/scripts/gdas/wave/init/jgdas_wave_init.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=11:ompthreads=1:ncpus=11:mem=2GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/wave/post/jgdas_wave_postpnt.ecf
+++ b/ecf/scripts/gdas/wave/post/jgdas_wave_postpnt.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:12:00
 #PBS -l select=4:mpiprocs=50:ompthreads=1:ncpus=50:mem=10GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/wave/post/jgdas_wave_postsbs.ecf
+++ b/ecf/scripts/gdas/wave/post/jgdas_wave_postsbs.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
 #PBS -l select=1:mpiprocs=8:ompthreads=1:ncpus=8:mem=10GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
+++ b/ecf/scripts/gdas/wave/prep/jgdas_wave_prep.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=5:ompthreads=1:ncpus=5:mem=100GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
 #PBS -l select=1:ncpus=28:mpiprocs=28:mem=2GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_meta.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_meta.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
 #PBS -l select=1:ncpus=23:mpiprocs=23:mem=2GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_ncdc_upapgif.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_ncdc_upapgif.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_npoess_pgrb2_0p5deg.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_npoess_pgrb2_0p5deg.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_pgrb2_spec_gempak.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_pgrb2_spec_gempak.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_tropcy_qc_reloc.ecf
+++ b/ecf/scripts/gfs/atmos/obsproc/dump/jgfs_atmos_tropcy_qc_reloc.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_emcsfc_sfc_prep.ecf
+++ b/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_emcsfc_sfc_prep.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:07:00
 #PBS -l select=1:ncpus=1:mem=2GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_manager.ecf
+++ b/ecf/scripts/gfs/atmos/post/jgfs_atmos_post_manager.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=04:00:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:ncpus=1:mem=3GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:ncpus=1:mem=3GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:ncpus=1:mem=4GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
 #PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
 #PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=15GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
 #PBS -l select=1:mpiprocs=18:ompthreads=1:ncpus=18:mem=80GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2_0p25.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2_0p25.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
 #PBS -l select=1:mpiprocs=11:ompthreads=1:ncpus=11:mem=80GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_master.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/post_processing/jgfs_atmos_wafs_gcip.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/jgfs_atmos_wafs_gcip.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
 #PBS -l select=1:mpiprocs=2:ompthreads=1:ncpus=2:mem=50GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/atmos/verf/jgfs_atmos_vminmon.ecf
+++ b/ecf/scripts/gfs/atmos/verf/jgfs_atmos_vminmon.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/gempak/jgfs_wave_gempak.ecf
+++ b/ecf/scripts/gfs/wave/gempak/jgfs_wave_gempak.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/init/jgfs_wave_init.ecf
+++ b/ecf/scripts/gfs/wave/init/jgfs_wave_init.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=11:ompthreads=1:ncpus=11:mem=2GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_postsbs.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_postsbs.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
 #PBS -l select=1:mpiprocs=8:ompthreads=1:ncpus=8:mem=10GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_bulls.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_bulls.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:20:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_gridded.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_gridded.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
 #PBS -l select=1:ncpus=1:mem=1GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
+++ b/ecf/scripts/gfs/wave/prep/jgfs_wave_prep.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
 #PBS -l select=1:mpiprocs=65:ompthreads=1:ncpus=65:mem=150GB
-#PBS -l place=vscatter
+#PBS -l place=vscatter:shared
 #PBS -l debug=true
 
 model=gfs

--- a/ush/rocoto/setup_expt.py
+++ b/ush/rocoto/setup_expt.py
@@ -186,7 +186,7 @@ link initial condition files from $ICSDIR to $COMROT'''
     if machine == 'WCOSS2':
       base_git = '/lfs/h2/emc/global/save/emc.global/git'
       base_svn = '/lfs/h2/emc/global/save/emc.global/git'
-      dmpdir = '/lfs/h2/emc/global/noscrub/emc.global/dump'
+      dmpdir = '/lfs/h2/emc/dump/noscrub/dump'
       packageroot = '${PACKAGEROOT:-"/lfs/h1/ops/prod/packages"}'
       comroot = '${COMROOT:-"/lfs/h1/ops/prod/com"}'
       cominsyn = '${COMROOT}/gfs/${gfs_ver:-"v16.3"}/syndat'

--- a/ush/rocoto/setup_expt_fcstonly.py
+++ b/ush/rocoto/setup_expt_fcstonly.py
@@ -157,7 +157,7 @@ Create COMROT experiment directory structure'''
     if machine == 'WCOSS2':
       base_git = '/lfs/h2/emc/global/save/emc.global/git'
       base_svn = '/lfs/h2/emc/global/save/emc.global/git'
-      dmpdir = '/lfs/h2/emc/global/noscrub/emc.global/dump'
+      dmpdir = '/lfs/h2/emc/dump/noscrub/dump'
       packageroot = '${PACKAGEROOT:-"/lfs/h1/ops/prod/packages"}'
       comroot = '${COMROOT:-"/lfs/h1/ops/prod/com"}'
       cominsyn = '${COMROOT}/gfs/${gfs_ver:-"v16.3"}/syndat'

--- a/ush/rocoto/workflow_utils.py
+++ b/ush/rocoto/workflow_utils.py
@@ -336,10 +336,16 @@ def get_resources(machine, cfg, task, reservation, cdump='gdas'):
         if machine in ['WCOSS2']:
             natstr = "-l debug=true"
 
-            if task not in ['arch', 'earc', 'getic']:
+            # Add place settings
+            if task in ['arch', 'earc', 'getic']: # dev_transfer shared only
+               natstr += ",place=shared"
+            else:
                natstr += ",place=vscatter"
+               # Set either exclusive or shared - default on WCOSS2 is exclusive when not set
                if memory is None:
                   natstr += ":exclhost"
+               else:
+                  natstr += ":shared"
 
     elif machine in ['WCOSS']:
         resstr = f'<cores>{tasks}</cores>'


### PR DESCRIPTION
# Description

This PR updates the GFSv16 system to set `place=shared` for non-exclusive jobs. Previously, only `place=exclhost` was set and the default was `shared` if not set. The default is now exclusive, therefore `place=shared` needs to be set for shared jobs on WCOSS2. This change was already made for the GFSv17 `develop` branch and is now being done for the operational GFSv16 system ahead of the next planned implementation. The ecf scripts are updated to add `:shared` to the place setting for jobs that aren't already set as exclusive with `:exclhost`.

Additionally, the global dump archive `DMPDIR` path on WCOSS2 is updated to the new dump project location.

Resolves #2135

# Type of change

Update for new requirement on WCOSS2.

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Cycled test on WCOSS2.