### PR TITLE
Use seq to generate the list of times, instead of a bash for-loop

### DIFF
--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -117,10 +117,10 @@ FV3_predet(){
   FV3_OUTPUT_FH=""
   local fhr=${FHMIN}
   if (( FHOUT_HF > 0 && FHMAX_HF > 0 )); then
-    FV3_OUTPUT_FH="${FV3_OUTPUT_FH} $(seq ${FHMIN} ${FHOUT_HF} ${FHMAX_HF})"
+    FV3_OUTPUT_FH="${FV3_OUTPUT_FH} $(seq -s ' ' ${FHMIN} ${FHOUT_HF} ${FHMAX_HF})"
     fhr=${FHMAX_HF}
   fi
-  FV3_OUTPUT_FH="${FV3_OUTPUT_FH} $(seq ${fhr} ${FHOUT} ${FHMAX})"
+  FV3_OUTPUT_FH="${FV3_OUTPUT_FH} $(seq -s ' ' ${fhr} ${FHOUT} ${FHMAX})"
 
   # Model resolution specific parameters
   DELTIM=${DELTIM:-225}

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -117,10 +117,10 @@ FV3_predet(){
   FV3_OUTPUT_FH=""
   local fhr=${FHMIN}
   if (( FHOUT_HF > 0 && FHMAX_HF > 0 )); then
-    FV3_OUTPUT_FH="${FV3_OUTPUT_FH} $(seq -s ' ' ${FHMIN} ${FHOUT_HF} ${FHMAX_HF})"
+    FV3_OUTPUT_FH="${FV3_OUTPUT_FH} $(seq -s ' ' "${FHMIN}" "${FHOUT_HF}" "${FHMAX_HF}")"
     fhr=${FHMAX_HF}
   fi
-  FV3_OUTPUT_FH="${FV3_OUTPUT_FH} $(seq -s ' ' ${fhr} ${FHOUT} ${FHMAX})"
+  FV3_OUTPUT_FH="${FV3_OUTPUT_FH} $(seq -s ' ' "${fhr}" "${FHOUT}" "${FHMAX}")"
 
   # Model resolution specific parameters
   DELTIM=${DELTIM:-225}

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -117,15 +117,10 @@ FV3_predet(){
   FV3_OUTPUT_FH=""
   local fhr=${FHMIN}
   if (( FHOUT_HF > 0 && FHMAX_HF > 0 )); then
-    for (( fh = FHMIN; fh < FHMAX_HF; fh = fh + FHOUT_HF )); do
-      FV3_OUTPUT_FH="${FV3_OUTPUT_FH} ${fh}"
-    done
+    FV3_OUTPUT_FH="${FV3_OUTPUT_FH} $(seq ${FHMIN} ${FHOUT_HF} ${FHMAX_HF})"
     fhr=${FHMAX_HF}
   fi
-  for (( fh = fhr; fh <= FHMAX; fh = fh + FHOUT )); do
-    FV3_OUTPUT_FH="${FV3_OUTPUT_FH} ${fh}"
-  done
-
+  FV3_OUTPUT_FH="${FV3_OUTPUT_FH} $(seq ${fhr} ${FHOUT} ${FHMAX})"
 
   # Model resolution specific parameters
   DELTIM=${DELTIM:-225}


### PR DESCRIPTION
# Description
<!-- This description will become the commit message for the PR-->
<!-- Please use this format for your description:

  Describe your changes. Focus on the *what* and *why*. The *how* will be evident from the changes. In particular, be sure to note any interface changes, such as command line syntax, that will need to be communicated to users.

  At the end of your description, please be sure to add the issue this PR solves using the word "Resolves". If there are any issues that are related but not yet resolved (including in other repos), you may use "Refs".

  Resolves #1234
  Refs #4321
  Refs NOAA-EMC/repo#5678
-->
I'm running a year-long forecast, which means I get a large portion of the log file dedicated to these loops.  

`seq ${START} ${STEP} ${STOP}` will generate a sequence going from START to STOP by STEP, including STOP if relevant.  That seems to be the purpose of these loops.  It will by default separate the list with newlines, but `seq -s ' ' ${START} ${STEP} ${STOP}` will separate them with spaces instead, more closely mimicing the previous behavior.

I would like this to be two lines in the log, rather than a few hundred, and this may also be faster, though probably more for reasons of fewer writes to disk than because bash isn't designed for arithmetic.

# Type of change
<!-- Delete all except one -->
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
  - `$(...)` is a bashism, but the shebang line specifies bash.  Should I switch to backticks instead?
- Does this change require a documentation update? NO

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->
Forecast-only run with these changes on Hera.

# Checklist
- [X] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [X] I have made corresponding changes to the documentation if necessary
