### PR TITLE
Remove WCOSS2 `MPICH_COLL_OPT_OFF` eupd runtime setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,10 +52,16 @@ parm/post/nam_micro_lookup.dat
 parm/post/optics_luts_DUST.dat
 parm/post/gtg.config.gfs
 parm/post/gtg_imprintings.txt
+parm/post/optics_luts_DUST_nasa.dat
+parm/post/optics_luts_NITR_nasa.dat
 parm/post/optics_luts_SALT.dat
+parm/post/optics_luts_SALT_nasa.dat
 parm/post/optics_luts_SOOT.dat
+parm/post/optics_luts_SOOT_nasa.dat
 parm/post/optics_luts_SUSO.dat
+parm/post/optics_luts_SUSO_nasa.dat
 parm/post/optics_luts_WASO.dat
+parm/post/optics_luts_WASO_nasa.dat
 parm/post/params_grib2_tbl_new
 parm/post/post_tag_gfs128
 parm/post/post_tag_gfs65
@@ -77,6 +83,9 @@ parm/post/postcntrl_gfs_wafs.xml
 parm/post/postcntrl_gfs_wafs_anl.xml
 parm/post/postxconfig-NT-GEFS-ANL.txt
 parm/post/postxconfig-NT-GEFS-F00.txt
+parm/post/postxconfig-NT-GEFS-F00-aerosol.txt
+parm/post/postxconfig-NT-GEFS-WAFS.txt
+parm/post/postxconfig-NT-GEFS-aerosol.txt
 parm/post/postxconfig-NT-GEFS.txt
 parm/post/postxconfig-NT-GFS-ANL.txt
 parm/post/postxconfig-NT-GFS-F00-TWO.txt

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -142,7 +142,6 @@ elif [[ "${step}" = "eupd" ]]; then
 
     export OMP_PLACES=cores
     export OMP_STACKSIZE=2G
-    export MPICH_COLL_OPT_OFF=1
     export FI_OFI_RXM_SAR_LIMIT=3145728
 
     nth_max=$((npe_node_max / npe_node_eupd))


### PR DESCRIPTION
# Description

This PR removes the `MPICH_COLL_OPT_OFF=1` runtime setting for the eupd job on WCOSS2. This setting was added during the WCOSS2 GFSv16 operational port after being recommended by GDIT and GSI code manager to ensure reproducibility with the `global_enkf.x` executable. Both earlier testing by @lgannoaa and recent testing finds bit-wise reproducibility without the setting.

Additionally, some post parm files added in a recent commit are added to the `.gitignore` file (left out of prior commit to `develop`).

Resolves #1052

# Type of change

- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Low-res atmos-only cycled test on WCOSS2. Control (with setting) and test (without setting) output can be seen here on WCOSS2-Cactus:
```
Control: /lfs/h2/emc/ptmp/kate.friedman/comrot/devctrl
Test: /lfs/h2/emc/ptmp/kate.friedman/comrot/testeupd
```
Spot check comparisons in several cycles (including 4th full cycle) show identical output.
