### PR TITLE
Consolidate `npe_node_max`

### DIFF
--- a/env/AWSPW.env
+++ b/env/AWSPW.env
@@ -14,7 +14,6 @@ fi
 
 step=$1
 
-export npe_node_max=36
 export launcher="mpiexec.hydra"
 export mpmd_opt=""
 

--- a/env/CONTAINER.env
+++ b/env/CONTAINER.env
@@ -14,7 +14,6 @@ fi
 
 step=$1
 
-export npe_node_max=40
 export launcher="mpirun"
 export mpmd_opt="--multi-prog"
 

--- a/env/HERA.env
+++ b/env/HERA.env
@@ -14,8 +14,6 @@ fi
 
 step=$1
 
-# TODO: Removing `npe_node_max`.
-#export npe_node_max=40
 export launcher="srun -l --export=ALL"
 export mpmd_opt="--multi-prog --output=mpmd.%j.%t.out"
 

--- a/env/HERA.env
+++ b/env/HERA.env
@@ -14,7 +14,8 @@ fi
 
 step=$1
 
-export npe_node_max=40
+# TODO: Removing `npe_node_max`.
+#export npe_node_max=40
 export launcher="srun -l --export=ALL"
 export mpmd_opt="--multi-prog --output=mpmd.%j.%t.out"
 

--- a/env/HERCULES.env
+++ b/env/HERCULES.env
@@ -12,7 +12,6 @@ fi
 
 step=$1
 
-export npe_node_max=80
 export launcher="srun -l --export=ALL"
 export mpmd_opt="--multi-prog --output=mpmd.%j.%t.out"
 

--- a/env/JET.env
+++ b/env/JET.env
@@ -14,13 +14,6 @@ fi
 
 step=$1
 
-if [[ "${PARTITION_BATCH}" = "xjet" ]]; then
-  export npe_node_max=24
-elif [[ "${PARTITION_BATCH}" = "vjet" ]]; then
-  export npe_node_max=16
-elif [[ "${PARTITION_BATCH}" = "kjet" ]]; then
-  export npe_node_max=40
-fi
 export launcher="srun -l --epilog=/apps/local/bin/report-mem --export=ALL"
 export mpmd_opt="--multi-prog --output=mpmd.%j.%t.out"
 

--- a/env/ORION.env
+++ b/env/ORION.env
@@ -14,7 +14,6 @@ fi
 
 step=$1
 
-export npe_node_max=40
 export launcher="srun -l --export=ALL"
 export mpmd_opt="--multi-prog --output=mpmd.%j.%t.out"
 

--- a/env/S4.env
+++ b/env/S4.env
@@ -13,13 +13,7 @@ if [[ $# -ne 1 ]]; then
 fi
 
 step=$1
-PARTITION_BATCH=${PARTITION_BATCH:-"s4"}
 
-if [[ ${PARTITION_BATCH} = "s4" ]]; then
-   export npe_node_max=32
-elif [[ ${PARTITION_BATCH} = "ivy" ]]; then
-   export npe_node_max=20
-fi
 export launcher="srun -l --export=ALL"
 export mpmd_opt="--multi-prog --output=mpmd.%j.%t.out"
 

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -18,8 +18,6 @@ step=$1
 export launcher="mpiexec -l"
 export mpmd_opt="--cpu-bind verbose,core cfp"
 
-export npe_node_max=128
-
 if [[ "${step}" = "prep" ]] || [[ "${step}" = "prepbufr" ]]; then
 
     nth_max=$((npe_node_max / npe_node_prep))

--- a/parm/config/gefs/config.ufs
+++ b/parm/config/gefs/config.ufs
@@ -68,54 +68,6 @@ if [[ "${skip_mom6}" == "false" ]] || [[ "${skip_cice6}" == "false" ]] || [[ "${
   skip_mediator=false
 fi
 
-case "${machine}" in
-  "WCOSS2")
-    npe_node_max=128
-    ;;
-  "HERA" | "ORION" )
-    npe_node_max=40
-    ;;
-  "HERCULES" )
-    npe_node_max=80
-    ;;
-  "JET")
-    case "${PARTITION_BATCH}" in
-      "xjet")
-        npe_node_max=24
-        ;;
-      "vjet" | "sjet")
-        npe_node_max=16
-        ;;
-      "kjet")
-        npe_node_max=40
-        ;;
-      *)
-        echo "FATAL ERROR: Unsupported ${machine} PARTITION_BATCH = ${PARTITION_BATCH}, ABORT!"
-        exit 1
-        ;;
-    esac
-    ;;
-  "S4")
-    case "${PARTITION_BATCH}" in
-      "s4")
-        npe_node_max=32
-        ;;
-      "ivy")
-        npe_node_max=20
-        ;;
-      *)
-        echo "FATAL ERROR: Unsupported ${machine} PARTITION_BATCH = ${PARTITION_BATCH}, ABORT!"
-        exit 1
-        ;;
-    esac
-    ;;
-  *)
-    echo "FATAL ERROR: Unrecognized machine ${machine}"
-    exit 14
-    ;;
-esac
-export npe_node_max
-
 # (Standard) Model resolution dependent variables
 case "${fv3_res}" in
     "C48")

--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -32,7 +32,6 @@ step=$1
 
 echo "BEGIN: config.resources"
 
-# TODO: Removing `npe_node_max` declaration.
 case ${machine} in
   "WCOSS2")   npe_node_max=128;;
   "HERA")     npe_node_max=40;;

--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -33,43 +33,43 @@ step=$1
 echo "BEGIN: config.resources"
 
 # TODO: Removing `npe_node_max` declaration.
-#case ${machine} in
-#  "WCOSS2")   npe_node_max=128;;
-#  "HERA")     npe_node_max=40;;
-#  "ORION")    npe_node_max=40;;
-#  "HERCULES") npe_node_max=80;;
-#  "JET")
-#    case ${PARTITION_BATCH} in
-#      "xjet")          npe_node_max=24;;
-#      "vjet" | "sjet") npe_node_max=16;;
-#      "kjet")          npe_node_max=40;;
-#      *)
-#        echo "FATAL ERROR: Unknown partition ${PARTITION_BATCH} specified for ${machine}"
-#        exit 3
-#    esac
-#    ;;
-#  "S4")
-#    case ${PARTITION_BATCH} in
-#      "s4")  npe_node_max=32;;
-#      "ivy") npe_node_max=20;;
-#      *)
-#        echo "FATAL ERROR: Unknown partition ${PARTITION_BATCH} specified for ${machine}"
-#        exit 3
-#    esac
-#    ;;
-#  "AWSPW")
-#    export PARTITION_BATCH="compute"
-#    npe_node_max=40
-#    ;;
-#  "CONTAINER")
-#    npe_node_max=1
-#    ;;
-#  *)
-#    echo "FATAL ERROR: Unknown machine encountered by ${BASH_SOURCE[0]}"
-#    exit 2
-#    ;;
-#esac
-#export npe_node_max
+case ${machine} in
+  "WCOSS2")   npe_node_max=128;;
+  "HERA")     npe_node_max=40;;
+  "ORION")    npe_node_max=40;;
+  "HERCULES") npe_node_max=80;;
+  "JET")
+    case ${PARTITION_BATCH} in
+      "xjet")          npe_node_max=24;;
+      "vjet" | "sjet") npe_node_max=16;;
+      "kjet")          npe_node_max=40;;
+      *)
+        echo "FATAL ERROR: Unknown partition ${PARTITION_BATCH} specified for ${machine}"
+        exit 3
+    esac
+    ;;
+  "S4")
+    case ${PARTITION_BATCH} in
+      "s4")  npe_node_max=32;;
+      "ivy") npe_node_max=20;;
+      *)
+        echo "FATAL ERROR: Unknown partition ${PARTITION_BATCH} specified for ${machine}"
+        exit 3
+    esac
+    ;;
+  "AWSPW")
+    export PARTITION_BATCH="compute"
+    npe_node_max=40
+    ;;
+  "CONTAINER")
+    npe_node_max=1
+    ;;
+  *)
+    echo "FATAL ERROR: Unknown machine encountered by ${BASH_SOURCE[0]}"
+    exit 2
+    ;;
+esac
+export npe_node_max
 
 case ${step} in
   "prep")

--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -32,43 +32,44 @@ step=$1
 
 echo "BEGIN: config.resources"
 
-case ${machine} in
-  "WCOSS2")   npe_node_max=128;;
-  "HERA")     npe_node_max=40;;
-  "ORION")    npe_node_max=40;;
-  "HERCULES") npe_node_max=80;;
-  "JET")
-    case ${PARTITION_BATCH} in
-      "xjet")          npe_node_max=24;;
-      "vjet" | "sjet") npe_node_max=16;;
-      "kjet")          npe_node_max=40;;
-      *)
-        echo "FATAL ERROR: Unknown partition ${PARTITION_BATCH} specified for ${machine}"
-        exit 3
-    esac
-    ;;
-  "S4")
-    case ${PARTITION_BATCH} in
-      "s4")  npe_node_max=32;;
-      "ivy") npe_node_max=20;;
-      *)
-        echo "FATAL ERROR: Unknown partition ${PARTITION_BATCH} specified for ${machine}"
-        exit 3
-    esac
-    ;;
-  "AWSPW")
-    export PARTITION_BATCH="compute"
-    npe_node_max=40
-    ;;
-  "CONTAINER")
-    npe_node_max=1
-    ;;
-  *)
-    echo "FATAL ERROR: Unknown machine encountered by ${BASH_SOURCE[0]}"
-    exit 2
-    ;;
-esac
-export npe_node_max
+# TODO: Removing `npe_node_max` declaration.
+#case ${machine} in
+#  "WCOSS2")   npe_node_max=128;;
+#  "HERA")     npe_node_max=40;;
+#  "ORION")    npe_node_max=40;;
+#  "HERCULES") npe_node_max=80;;
+#  "JET")
+#    case ${PARTITION_BATCH} in
+#      "xjet")          npe_node_max=24;;
+#      "vjet" | "sjet") npe_node_max=16;;
+#      "kjet")          npe_node_max=40;;
+#      *)
+#        echo "FATAL ERROR: Unknown partition ${PARTITION_BATCH} specified for ${machine}"
+#        exit 3
+#    esac
+#    ;;
+#  "S4")
+#    case ${PARTITION_BATCH} in
+#      "s4")  npe_node_max=32;;
+#      "ivy") npe_node_max=20;;
+#      *)
+#        echo "FATAL ERROR: Unknown partition ${PARTITION_BATCH} specified for ${machine}"
+#        exit 3
+#    esac
+#    ;;
+#  "AWSPW")
+#    export PARTITION_BATCH="compute"
+#    npe_node_max=40
+#    ;;
+#  "CONTAINER")
+#    npe_node_max=1
+#    ;;
+#  *)
+#    echo "FATAL ERROR: Unknown machine encountered by ${BASH_SOURCE[0]}"
+#    exit 2
+#    ;;
+#esac
+#export npe_node_max
 
 case ${step} in
   "prep")

--- a/parm/config/gfs/config.ufs
+++ b/parm/config/gfs/config.ufs
@@ -68,55 +68,6 @@ if [[ "${skip_mom6}" == "false" ]] || [[ "${skip_cice6}" == "false" ]] || [[ "${
   skip_mediator=false
 fi
 
-# TODO: Removing `npe_node_max` here.
-#case "${machine}" in
-#  "WCOSS2")
-#    npe_node_max=128
-#    ;;
-#  "HERA" | "ORION" )
-#    npe_node_max=40
-#    ;;
-#  "HERCULES" )
-#    npe_node_max=80
-#    ;;
-#  "JET")
-#    case "${PARTITION_BATCH}" in
-#      "xjet")
-#        npe_node_max=24
-#        ;;
-#      "vjet" | "sjet")
-#        npe_node_max=16
-#        ;;
-#      "kjet")
-#        npe_node_max=40
-#        ;;
-#      *)
-#        echo "FATAL ERROR: Unsupported ${machine} PARTITION_BATCH = ${PARTITION_BATCH}, ABORT!"
-#        exit 1
-#        ;;
-#    esac
-#    ;;
-#  "S4")
-#    case "${PARTITION_BATCH}" in
-#      "s4")
-#        npe_node_max=32
-#        ;;
-#      "ivy")
-#        npe_node_max=20
-#        ;;
-#      *)
-#        echo "FATAL ERROR: Unsupported ${machine} PARTITION_BATCH = ${PARTITION_BATCH}, ABORT!"
-#        exit 1
-#        ;;
-#    esac
-#    ;;
-#  *)
-#    echo "FATAL ERROR: Unrecognized machine ${machine}"
-#    exit 14
-#    ;;
-#esac
-#export npe_node_max
-
 # (Standard) Model resolution dependent variables
 case "${fv3_res}" in
     "C48")

--- a/parm/config/gfs/config.ufs
+++ b/parm/config/gfs/config.ufs
@@ -68,53 +68,54 @@ if [[ "${skip_mom6}" == "false" ]] || [[ "${skip_cice6}" == "false" ]] || [[ "${
   skip_mediator=false
 fi
 
-case "${machine}" in
-  "WCOSS2")
-    npe_node_max=128
-    ;;
-  "HERA" | "ORION" )
-    npe_node_max=40
-    ;;
-  "HERCULES" )
-    npe_node_max=80
-    ;;
-  "JET")
-    case "${PARTITION_BATCH}" in
-      "xjet")
-        npe_node_max=24
-        ;;
-      "vjet" | "sjet")
-        npe_node_max=16
-        ;;
-      "kjet")
-        npe_node_max=40
-        ;;
-      *)
-        echo "FATAL ERROR: Unsupported ${machine} PARTITION_BATCH = ${PARTITION_BATCH}, ABORT!"
-        exit 1
-        ;;
-    esac
-    ;;
-  "S4")
-    case "${PARTITION_BATCH}" in
-      "s4")
-        npe_node_max=32
-        ;;
-      "ivy")
-        npe_node_max=20
-        ;;
-      *)
-        echo "FATAL ERROR: Unsupported ${machine} PARTITION_BATCH = ${PARTITION_BATCH}, ABORT!"
-        exit 1
-        ;;
-    esac
-    ;;
-  *)
-    echo "FATAL ERROR: Unrecognized machine ${machine}"
-    exit 14
-    ;;
-esac
-export npe_node_max
+# TODO: Removing `npe_node_max` here.
+#case "${machine}" in
+#  "WCOSS2")
+#    npe_node_max=128
+#    ;;
+#  "HERA" | "ORION" )
+#    npe_node_max=40
+#    ;;
+#  "HERCULES" )
+#    npe_node_max=80
+#    ;;
+#  "JET")
+#    case "${PARTITION_BATCH}" in
+#      "xjet")
+#        npe_node_max=24
+#        ;;
+#      "vjet" | "sjet")
+#        npe_node_max=16
+#        ;;
+#      "kjet")
+#        npe_node_max=40
+#        ;;
+#      *)
+#        echo "FATAL ERROR: Unsupported ${machine} PARTITION_BATCH = ${PARTITION_BATCH}, ABORT!"
+#        exit 1
+#        ;;
+#    esac
+#    ;;
+#  "S4")
+#    case "${PARTITION_BATCH}" in
+#      "s4")
+#        npe_node_max=32
+#        ;;
+#      "ivy")
+#        npe_node_max=20
+#        ;;
+#      *)
+#        echo "FATAL ERROR: Unsupported ${machine} PARTITION_BATCH = ${PARTITION_BATCH}, ABORT!"
+#        exit 1
+#        ;;
+#    esac
+#    ;;
+#  *)
+#    echo "FATAL ERROR: Unrecognized machine ${machine}"
+#    exit 14
+#    ;;
+#esac
+#export npe_node_max
 
 # (Standard) Model resolution dependent variables
 case "${fv3_res}" in


### PR DESCRIPTION
# Description
This PR addresses issue #2133. The following is accomplished:

- The environment variable `npe_node_max` is removed from all files beneath `global-workflow/env`;
- The environment variable `npe_node_max` is removed from `parm/config/gefs/config.ufs` and `parm/config/gfs/config.ufs`;
- The environment variable `npe_node_max` is maintained only within `parm/config/gefs/config.resources` and `parm/config/gfs/config.resources`.

  Resolves #2133 

# Type of change
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Tested for RDHPCS Hera C48 ATM configuration. The Rocoto status is as follows:

```
       CYCLE                    TASK                       JOBID               STATE         EXIT STATUS     TRIES      DURATION
================================================================================================================================
202103231200             gfsstage_ic                    55350726           SUCCEEDED                   0         1          10.0
202103231200                 gfsfcst                    55350743           SUCCEEDED                   0         1         290.0
202103231200    gfsatmprod_f000-f012         druby://hfe06:41305          SUBMITTING                   -         0           0.0
202103231200                 gfsarch                           -                   -                   -         -             -
202103231200              gfscleanup                           -                   -                   -         -             -
```

The above indicates that the correct number of PEs for the respective platform (RDHPCS Hera) is determined from `parm/config/gfs/config.resources` and the global-workflow is able to carry out the specified tasks.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
