### PR TITLE
Makes running ocean DA vrfy task optional 

### DIFF
--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_VRFY
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_VRFY
@@ -29,13 +29,21 @@ YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS
 export PYTHONPATH=${HOMEgfs}/sorc/gdas.cd/ush/:${HOMEgfs}/sorc/gdas.cd/ush/eva:${PYTHONPATH}
 export PYTHONPATH=${HOMEgfs}/sorc/gdas.cd/ush/soca:${PYTHONPATH}
 
-###############################################################
-# Run relevant script
+if [[ ${DO_VRFYOCNDA} == "YES" ]]; then
 
-EXSCRIPT=${GDASOCNVRFYPY:-${HOMEgfs}/sorc/gdas.cd/scripts/exgdas_global_marine_analysis_vrfy.py}
-${EXSCRIPT}
-status=$?
-[[ ${status} -ne 0 ]] && exit "${status}"
+  ###############################################################
+  # Run relevant script
+
+  EXSCRIPT=${GDASOCNVRFYPY:-${HOMEgfs}/sorc/gdas.cd/scripts/exgdas_global_marine_analysis_vrfy.py}
+  ${EXSCRIPT}
+  status=$?
+  [[ ${status} -ne 0 ]] && exit "${status}"
+
+else
+
+  echo "DO_VRFYOCNDA not set to YES. Exiting."
+
+fi
 
 ##############################################
 # End JOB SPECIFIC work

--- a/parm/config/gfs/config.base.emc.dyn
+++ b/parm/config/gfs/config.base.emc.dyn
@@ -378,6 +378,7 @@ export binary_diag=".false."
 # Verification options
 export DO_METP="NO"          # Run METPLUS jobs - set METPLUS settings in config.metp; not supported with spack-stack
 export DO_FIT2OBS="YES"      # Run fit to observations package
+export DO_VRFYOCNDA="NO"     # Run ocean DA plotting
 
 # Archiving options
 export HPSSARCH="@HPSSARCH@"        # save data to HPSS archive


### PR DESCRIPTION
# Description

This adds the option `DO_VRFYOCNDA` in `config.base` and sets the default to `NO`, which causes the task's ex-script not to run. This task is fiddly and of interest mostly to WCDA developers, and so can be safely removed from most CI tests.

Attempts to address an issue in https://github.com/NOAA-EMC/global-workflow/pull/1963

# Type of change

- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? YES
- Does this change require a documentation update? NO

# How has this been tested?

Tested, so far, with SOCA workflow tests in GDASApp

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
