### PR TITLE
Update JGLOBAL_FORECAST for octal error

### DIFF
--- a/jobs/JGLOBAL_FORECAST
+++ b/jobs/JGLOBAL_FORECAST
@@ -1,8 +1,8 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-if (( ${ENSMEM:-0} > 0 )); then
-  source "${HOMEgfs}/ush/jjob_header.sh" -e "efcs" -c "base fcst efcs"
+if (( 10#${ENSMEM:-0} > 0 )); then
+source "${HOMEgfs}/ush/jjob_header.sh" -e "efcs" -c "base fcst efcs"
 else
   source "${HOMEgfs}/ush/jjob_header.sh" -e "fcst" -c "base fcst"
 fi

--- a/jobs/JGLOBAL_FORECAST
+++ b/jobs/JGLOBAL_FORECAST
@@ -2,7 +2,7 @@
 
 source "${HOMEgfs}/ush/preamble.sh"
 if (( 10#${ENSMEM:-0} > 0 )); then
-source "${HOMEgfs}/ush/jjob_header.sh" -e "efcs" -c "base fcst efcs"
+  source "${HOMEgfs}/ush/jjob_header.sh" -e "efcs" -c "base fcst efcs"
 else
   source "${HOMEgfs}/ush/jjob_header.sh" -e "fcst" -c "base fcst"
 fi


### PR DESCRIPTION
# Description

This hotfix PR corrects for an octal error in the `JGLOBAL_FORECAST` job script when processing certain member numbers by adding "10#" to ENSMEM value > 0 check at the top of the script.

This was uncovered in a test on Hera when members 008, 009, 018, and 019 failed due to incorrect resolution fix files being used (`NetCDF: Index exceeds dimension bound` error at runtime). The following error was traced in the logs:
```
/scratch1/NCEPDEV/global/Kate.Friedman/git/feature-remove_finddate/jobs/JGLOBAL_FORECAST: line 4: ((: 008: value too great for ba
se (error token is "008")
```

# Type of change

- Bug fix (fixes something broken)


# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Cycled test on Hera