### PR TITLE
Move IMS remapping files from COM_OBS to FIXgdas

### DIFF
--- a/parm/config/gfs/config.base.emc.dyn
+++ b/parm/config/gfs/config.base.emc.dyn
@@ -39,6 +39,7 @@ export FIXcice="${FIXgfs}/cice"
 export FIXmom="${FIXgfs}/mom6"
 export FIXreg2grb2="${FIXgfs}/reg2grb2"
 export FIXugwd="${FIXgfs}/ugwd"
+export FIXgdas="${FIXgfs}/gdas"
 
 ########################################################################
 

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -155,7 +155,7 @@ cd "${HOMEgfs}/ush" || exit 8
 for file in emcsfc_ice_blend.sh global_cycle_driver.sh emcsfc_snow.sh global_cycle.sh; do
   ${LINK_OR_COPY} "${HOMEgfs}/sorc/ufs_utils.fd/ush/${file}" .
 done
-for file in finddate.sh make_ntc_bull.pl make_NTC_file.pl make_tif.sh month_name.sh ; do
+for file in make_ntc_bull.pl make_NTC_file.pl make_tif.sh month_name.sh ; do
   ${LINK_OR_COPY} "${HOMEgfs}/sorc/gfs_utils.fd/ush/${file}" .
 done
 

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -190,7 +190,7 @@ if [[ -d "${HOMEgfs}/sorc/gdas.cd" ]]; then
   cd "${HOMEgfs}/fix" || exit 1
   [[ ! -d gdas ]] && mkdir -p gdas
   cd gdas || exit 1
-  for gdas_sub in fv3jedi gsibec; do
+  for gdas_sub in fv3jedi gsibec obs; do
     if [[ -d "${gdas_sub}" ]]; then
        rm -rf "${gdas_sub}"
     fi

--- a/ush/python/pygfs/task/land_analysis.py
+++ b/ush/python/pygfs/task/land_analysis.py
@@ -153,7 +153,7 @@ class LandAnalysis(Analysis):
         # create a temporary dict of all keys needed in this method
         localconf = AttrDict()
         keys = ['DATA', 'current_cycle', 'COM_OBS', 'COM_ATMOS_RESTART_PREV',
-                'OPREFIX', 'CASE', 'OCNRES', 'ntiles']
+                'OPREFIX', 'CASE', 'OCNRES', 'ntiles', 'FIXgdas']
         for key in keys:
             localconf[key] = self.task_config[key]
 

--- a/ush/syndat_getjtbul.sh
+++ b/ush/syndat_getjtbul.sh
@@ -52,8 +52,6 @@ hour=$(echo $CDATE10 | cut -c9-10)
 echo $PDYm1
 pdym1=$PDYm1
 
-#pdym1=$(sh $utilscript/finddate.sh $pdy d-1)
-
 echo " " >> $pgmout
 echo "Entering sub-shell syndat_getjtbul.sh to recover JTWC Bulletins" \
  >> $pgmout

--- a/versions/fix.ver
+++ b/versions/fix.ver
@@ -10,6 +10,7 @@ export datm_ver=20220805
 export gdas_crtm_ver=20220805
 export gdas_fv3jedi_ver=20220805
 export gdas_gsibec_ver=20221031
+export gdas_obs_ver=20240213
 export glwu_ver=20220805
 export gsi_ver=20230911
 export lut_ver=20220805


### PR DESCRIPTION
# Description

As the title says, we should not grab the IMS snow cover remapping files from `$COM_OBS`, they are fixed for a resolution, so they are in the `$FIXgdas` directory now instead. 

This PR is one of several upcoming PRs to clean up the JEDI-based snow DA.

  Resolves #2298

-->

# Type of change
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? YES
- Does this change require a documentation update? NO

# How has this been tested?
- Cycled test on Hera

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
