### PR TITLE
Add some flexibility for ocean/ice output

### DIFF
--- a/parm/config/gefs/config.base.emc.dyn
+++ b/parm/config/gefs/config.base.emc.dyn
@@ -220,9 +220,10 @@ export gfs_cyc=@gfs_cyc@ # 0: no GFS cycle, 1: 00Z only, 2: 00Z and 12Z only, 4:
 export FHMIN_GFS=0
 export FHMIN=${FHMIN_GFS}
 export FHMAX_GFS=@FHMAX_GFS@
-export FHOUT_GFS=6 # Must be 6 for S2S until #1629 is addressed; 3 for ops
+export FHOUT_GFS=6 
 export FHMAX_HF_GFS=0
 export FHOUT_HF_GFS=1
+export FHOUT_OCNICE_GFS=6
 if (( gfs_cyc != 0 )); then
     export STEP_GFS=$(( 24 / gfs_cyc ))
 else

--- a/parm/config/gefs/config.fcst
+++ b/parm/config/gefs/config.fcst
@@ -27,7 +27,7 @@ export FHMAX=${FHMAX_GFS}
 export FHOUT=${FHOUT_GFS}
 export FHMAX_HF=${FHMAX_HF_GFS}
 export FHOUT_HF=${FHOUT_HF_GFS}
-export FHOUT_OCNICE_GFS=${FHOUT_OCNICE}
+export FHOUT_OCNICE=${FHOUT_OCNICE_GFS}
 
 # Get task specific resources
 source "${EXPDIR}/config.resources" fcst

--- a/parm/config/gefs/config.fcst
+++ b/parm/config/gefs/config.fcst
@@ -27,6 +27,7 @@ export FHMAX=${FHMAX_GFS}
 export FHOUT=${FHOUT_GFS}
 export FHMAX_HF=${FHMAX_HF_GFS}
 export FHOUT_HF=${FHOUT_HF_GFS}
+export FHOUT_OCNICE_GFS=${FHOUT_OCNICE}
 
 # Get task specific resources
 source "${EXPDIR}/config.resources" fcst

--- a/parm/config/gfs/config.base.emc.dyn
+++ b/parm/config/gfs/config.base.emc.dyn
@@ -248,6 +248,7 @@ fi
 export FHMIN=0
 export FHMAX=9
 export FHOUT=3           # Will be changed to 1 in config.base if (DOHYBVAR set to NO and l4densvar set to false)
+export FHOUT_OCNICE=3
 
 # Cycle to run EnKF  (set to BOTH for both gfs and gdas)
 export EUPD_CYC="gdas"
@@ -258,9 +259,10 @@ export gfs_cyc=@gfs_cyc@ # 0: no GFS cycle, 1: 00Z only, 2: 00Z and 12Z only, 4:
 # GFS output and frequency
 export FHMIN_GFS=0
 export FHMAX_GFS=@FHMAX_GFS@
-export FHOUT_GFS=6 # Must be 6 for S2S until #1629 is addressed; 3 for ops
+export FHOUT_GFS=3 # Must be 6 for S2S until #1629 is addressed; 3 for ops
 export FHMAX_HF_GFS=0
 export FHOUT_HF_GFS=1
+export FHOUT_OCNICE_GFS=6
 if (( gfs_cyc != 0 )); then
     export STEP_GFS=$(( 24 / gfs_cyc ))
 else

--- a/parm/config/gfs/config.fcst
+++ b/parm/config/gfs/config.fcst
@@ -30,6 +30,7 @@ case ${RUN} in
     export FHOUT=${FHOUT_GFS}
     export FHMAX_HF=${FHMAX_HF_GFS}
     export FHOUT_HF=${FHOUT_HF_GFS}
+    export FHOUT_OCNICE=${FHOUT_OCNICE_GFS}
     ;;
   *gdas)
     export FHMAX_HF=0

--- a/parm/ufs/fv3/diag_table
+++ b/parm/ufs/fv3/diag_table
@@ -1,7 +1,7 @@
 "fv3_history",    0,  "hours",  1,  "hours",  "time"
 "fv3_history2d",  0,  "hours",  1,  "hours",  "time"
-"ocn%4yr%2mo%2dy%2hr",    6,  "hours",  1,  "hours",  "time",  6,  "hours",  "1901 1 1 0 0 0"
-"ocn_daily%4yr%2mo%2dy",  1,  "days",   1,  "days",   "time",  1,  "days",   "1901 1 1 0 0 0"
+"ocn%4yr%2mo%2dy%2hr", @[FHOUT_OCNICE],  "hours",  1,  "hours",  "time",  @[FHOUT_OCNICE],  "hours",  "@[SYEAR] @[SMONTH] @[SDAY] @[CHOUR] 0 0"
+"ocn_daily%4yr%2mo%2dy",  1,  "days",   1,  "days",   "time",  1,  "days",   "@[SYEAR] @[SMONTH] @[SDAY] @[CHOUR] 0 0"
 
 ##############
 # Ocean fields

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -229,7 +229,7 @@ CICE_predet(){
   # Convert output settings into an explicit list for CICE
   # Ignore "not used" warning
   # shellcheck disable=SC2034
-  CICE_OUTPUT_FH=$(seq -s ' ' "${FHMIN}" "${FHOUT}" "${FHMAX}")
+  CICE_OUTPUT_FH=$(seq -s ' ' "${FHMIN}" "${FHOUT_OCNICE}" "${FHMAX}")
 
 }
 
@@ -247,7 +247,7 @@ MOM6_predet(){
   # Convert output settings into an explicit list for MOM6
   # Ignore "not used" warning
   # shellcheck disable=SC2034
-  MOM6_OUTPUT_FH=$(seq -s ' ' "${FHMIN}" "${FHOUT}" "${FHMAX}")
+  MOM6_OUTPUT_FH=$(seq -s ' ' "${FHMIN}" "${FHOUT_OCNICE}" "${FHMAX}")
 
 }
 

--- a/ush/parsing_namelists_CICE.sh
+++ b/ush/parsing_namelists_CICE.sh
@@ -62,7 +62,7 @@ local CICE_RESTART_FILE="cice_model.res"
 local CICE_DUMPFREQ="y"  # "h","d","m" or "y" for restarts at intervals of "hours", "days", "months" or "years"
 local CICE_DUMPFREQ_N=10000  # Set this to a really large value, as cice, mom6 and cmeps restart interval is controlled by ufs.configure
 local CICE_DIAGFREQ=6
-local CICE_HISTFREQ_N="0, 0, ${FHOUT}, 1, 1"
+local CICE_HISTFREQ_N="0, 0, ${FHOUT_OCNICE}, 1, 1"
 if [[ "${RUN}" =~ "gdas" ]]; then
   local CICE_HIST_AVG=".false., .false., .false., .false., .false."   # DA needs instantaneous
 else

--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -9,6 +9,8 @@
 ## This script is a direct execution.
 #####
 
+# Disable variable not used warnings
+# shellcheck disable=SC2034
 FV3_namelists(){
 
 # setup the tables

--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -33,7 +33,15 @@ if [[ -n "${AERO_DIAG_TABLE:-}" ]]; then
   cat "${AERO_DIAG_TABLE}"
 fi
 cat "${DIAG_TABLE_APPEND}"
-} >> diag_table
+} >> diag_table_template
+
+local template=diag_table_template
+local SYEAR=${current_cycle:0:4} 
+local SMONTH=${current_cycle:4:2}
+local SDAY=${current_cycle:6:2} 
+local CHOUR=${current_cycle:8:2}
+source "${HOMEgfs}/ush/atparse.bash"
+atparse < "${template}" >> "diag_table"
 
 
 # copy data table

--- a/ush/python/pygfs/task/oceanice_products.py
+++ b/ush/python/pygfs/task/oceanice_products.py
@@ -61,7 +61,7 @@ class OceanIceProducts(Task):
         # TODO: This is a bit of a hack, but it works for now
         # FIXME: find a better way to provide the averaging period
         # This will be different for ocean and ice, so when they are made flexible, this will need to be addressed
-        avg_period = f"{self.config.FORECAST_HOUR-self.config.FHOUT_GFS:03d}-{self.config.FORECAST_HOUR:03d}"
+        avg_period = f"{self.config.FORECAST_HOUR-self.config.FHOUT_OCNICE_GFS:03d}-{self.config.FORECAST_HOUR:03d}"
 
         localdict = AttrDict(
             {'component': self.config.COMPONENT,

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -936,6 +936,7 @@ class GFSTasks(Tasks):
         if component in ['ocean', 'ice']:
             local_config['FHMAX_HF_GFS'] = config['FHMAX_GFS']
             local_config['FHOUT_HF_GFS'] = config['FHOUT_GFS']
+            local_config['FHOUT_GFS']=config['FHOUT_OCNICE_GFS']
 
         fhrs = Tasks._get_forecast_hours(cdump, local_config)
 

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -935,8 +935,10 @@ class GFSTasks(Tasks):
         # Ocean/Ice components do not have a HF output option like the atmosphere
         if component in ['ocean', 'ice']:
             local_config['FHMAX_HF_GFS'] = config['FHMAX_GFS']
-            local_config['FHOUT_HF_GFS'] = config['FHOUT_GFS']
+            local_config['FHOUT_HF_GFS'] = config['FHOUT_OCNICE_GFS']
             local_config['FHOUT_GFS']=config['FHOUT_OCNICE_GFS']
+            local_config['FHOUT_GFS']=config['FHOUT_OCNICE_GFS']
+            local_config['FHOUT']=config['FHOUT_OCNICE']
 
         fhrs = Tasks._get_forecast_hours(cdump, local_config)
 

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -938,7 +938,7 @@ class GFSTasks(Tasks):
             local_config['FHOUT_HF_GFS'] = config['FHOUT_OCNICE_GFS']
             local_config['FHOUT_GFS']=config['FHOUT_OCNICE_GFS']
             local_config['FHOUT_GFS']=config['FHOUT_OCNICE_GFS']
-            local_config['FHOUT']=config['FHOUT_OCNICE']
+            local_config['FHOUT'] = config['FHOUT_OCNICE']
 
         fhrs = Tasks._get_forecast_hours(cdump, local_config)
 

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -937,7 +937,6 @@ class GFSTasks(Tasks):
             local_config['FHMAX_HF_GFS'] = config['FHMAX_GFS']
             local_config['FHOUT_HF_GFS'] = config['FHOUT_OCNICE_GFS']
             local_config['FHOUT_GFS'] = config['FHOUT_OCNICE_GFS']
-            local_config['FHOUT_GFS'] = config['FHOUT_OCNICE_GFS']
             local_config['FHOUT'] = config['FHOUT_OCNICE']
 
         fhrs = Tasks._get_forecast_hours(cdump, local_config)

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -936,8 +936,8 @@ class GFSTasks(Tasks):
         if component in ['ocean', 'ice']:
             local_config['FHMAX_HF_GFS'] = config['FHMAX_GFS']
             local_config['FHOUT_HF_GFS'] = config['FHOUT_OCNICE_GFS']
-            local_config['FHOUT_GFS']=config['FHOUT_OCNICE_GFS']
-            local_config['FHOUT_GFS']=config['FHOUT_OCNICE_GFS']
+            local_config['FHOUT_GFS'] = config['FHOUT_OCNICE_GFS']
+            local_config['FHOUT_GFS'] = config['FHOUT_OCNICE_GFS']
             local_config['FHOUT'] = config['FHOUT_OCNICE']
 
         fhrs = Tasks._get_forecast_hours(cdump, local_config)

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -929,21 +929,7 @@ class GFSTasks(Tasks):
     @staticmethod
     def _get_ufs_postproc_grps(cdump, config, component='atmos'):
 
-        # Make a local copy of the config to avoid modifying the original
-        local_config = config.copy()
-
-        # Ocean/Ice components do not have a HF output option like the atmosphere
-        if component in ['ocean', 'ice']:
-            local_config['FHMAX_HF_GFS'] = config['FHMAX_GFS']
-            local_config['FHOUT_HF_GFS'] = config['FHOUT_OCNICE_GFS']
-            local_config['FHOUT_GFS'] = config['FHOUT_OCNICE_GFS']
-            local_config['FHOUT'] = config['FHOUT_OCNICE']
-
-        fhrs = Tasks._get_forecast_hours(cdump, local_config)
-
-        # ocean/ice components do not have fhr 0 as they are averaged output
-        if component in ['ocean', 'ice']:
-            fhrs.remove(0)
+        fhrs = Tasks._get_forecast_hours(cdump, config, component=component)
 
         nfhrs_per_grp = config.get('NFHRS_PER_GROUP', 1)
         ngrps = len(fhrs) // nfhrs_per_grp if len(fhrs) % nfhrs_per_grp == 0 else len(fhrs) // nfhrs_per_grp + 1

--- a/workflow/rocoto/tasks.py
+++ b/workflow/rocoto/tasks.py
@@ -129,8 +129,6 @@ class Tasks:
             local_config['FHMAX_HF_GFS'] = config['FHMAX_GFS']
             local_config['FHOUT_HF_GFS'] = config['FHOUT_OCNICE_GFS']
             local_config['FHOUT_GFS'] = config['FHOUT_OCNICE_GFS']
-            # ocean/ice components do not have fhr 0 as they are averaged output
-            local_config['FHMIN'] = config['FHOUT_OCNICE']
             local_config['FHOUT'] = config['FHOUT_OCNICE']
 
         fhmin = local_config['FHMIN']
@@ -148,6 +146,10 @@ class Tasks:
             fhout_hf = local_config['FHOUT_HF_GFS']
             fhrs_hf = range(fhmin, fhmax_hf + fhout_hf, fhout_hf)
             fhrs = list(fhrs_hf) + list(range(fhrs_hf[-1] + fhout, fhmax + fhout, fhout))
+
+        # ocean/ice components do not have fhr 0 as they are averaged output
+        if component in ['ocean', 'ice']:
+            fhrs.remove(0)
 
         return fhrs
 

--- a/workflow/rocoto/tasks.py
+++ b/workflow/rocoto/tasks.py
@@ -120,20 +120,32 @@ class Tasks:
                                              rocoto_conversion_dict.get)
 
     @staticmethod
-    def _get_forecast_hours(cdump, config) -> List[str]:
-        fhmin = config['FHMIN']
-        fhmax = config['FHMAX']
-        fhout = config['FHOUT']
+    def _get_forecast_hours(cdump, config, component='atmos') -> List[str]:
+        # Make a local copy of the config to avoid modifying the original
+        local_config = config.copy()
+
+        # Ocean/Ice components do not have a HF output option like the atmosphere
+        if component in ['ocean', 'ice']:
+            local_config['FHMAX_HF_GFS'] = config['FHMAX_GFS']
+            local_config['FHOUT_HF_GFS'] = config['FHOUT_OCNICE_GFS']
+            local_config['FHOUT_GFS'] = config['FHOUT_OCNICE_GFS']
+            # ocean/ice components do not have fhr 0 as they are averaged output
+            local_config['FHMIN'] = config['FHOUT_OCNICE']
+            local_config['FHOUT'] = config['FHOUT_OCNICE']
+
+        fhmin = local_config['FHMIN']
+        fhmax = local_config['FHMAX']
+        fhout = local_config['FHOUT']
 
         # Get a list of all forecast hours
         fhrs = []
         if cdump in ['gdas']:
             fhrs = list(range(fhmin, fhmax + fhout, fhout))
         elif cdump in ['gfs', 'gefs']:
-            fhmax = config['FHMAX_GFS']
-            fhout = config['FHOUT_GFS']
-            fhmax_hf = config['FHMAX_HF_GFS']
-            fhout_hf = config['FHOUT_HF_GFS']
+            fhmax = local_config['FHMAX_GFS']
+            fhout = local_config['FHOUT_GFS']
+            fhmax_hf = local_config['FHMAX_HF_GFS']
+            fhout_hf = local_config['FHOUT_HF_GFS']
             fhrs_hf = range(fhmin, fhmax_hf + fhout_hf, fhout_hf)
             fhrs = list(fhrs_hf) + list(range(fhrs_hf[-1] + fhout, fhmax + fhout, fhout))
 


### PR DESCRIPTION
<!-- PLEASE READ -->
<!-- Any PRs not following this template will be closed -->
<!--
    Please use a short (<60 char), descriptive title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

    PRs should meet these guidelines:
    - Each PR should address ONE topic and have an associated issue.
    - No hard-coded paths or personal directories.
    - No temporary or backup files should be committed (including logs).
    - Any code that you disabled by being commented out should be removed or reenabled.

    Please delete all these comments before submitting the PR.
-->
# Description
This adds functionality to have ocean/ice output frequency be separate from the atm model.   One time was created because there's an assumption in the post that these are the same.  This could be further modified to remove this assumption.  

Refs #1629 
Additional work to close above issue will be further testing and updates for GEFS.  There didn't appear to be a unique ocean/ice output task in GEFS workflow and I'm assuming we need similar updates to the GEFS workflow scripts as the GFS workflow.    This was not done in this PR as I do not think we will break GEFS as both atm & ocean/ice are the same 6 hourly frequency right now and this will allow HR3 to move on.  Happy to work with others to make sure GEFS has the same functionality in a follow-up PR later this week if desired/needed. 

Co-author: @aerorahul 

# Type of change
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
I ran a C768 HR3 free-forecast test on hera with 3 hourly atm output and 6 hourly ocean/ice output as desired.  See output here: /scratch1/NCEPDEV/climate/Jessica.Meixner/HR3/outputupdate/testout01 

Full CI testing is needed. 

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
