### PR TITLE
Fix rocoto forecast hour determination for GEFS

### DIFF
--- a/ci/cases/pr/C48_S2SWA_gefs.yaml
+++ b/ci/cases/pr/C48_S2SWA_gefs.yaml
@@ -16,8 +16,3 @@ arguments:
   idate: 2021032312
   edate: 2021032312
   yaml: {{ HOMEgfs }}/ci/cases/yamls/gefs_ci_defaults.yaml
-
-skip_ci_on_hosts:
-  - hera
-  - orion
-  - hercules

--- a/parm/config/gfs/config.stage_ic
+++ b/parm/config/gfs/config.stage_ic
@@ -8,7 +8,7 @@ echo "BEGIN: config.stage_ic"
 source "${EXPDIR}/config.resources" stage_ic
 
 case "${CASE}" in
-  "C48" | "C96")
+  "C48" | "C96" | "C192")
     export CPL_ATMIC="workflow_${CASE}_refactored"
     export CPL_ICEIC="workflow_${CASE}_refactored"
     export CPL_OCNIC="workflow_${CASE}_refactored"

--- a/workflow/rocoto/tasks.py
+++ b/workflow/rocoto/tasks.py
@@ -132,12 +132,12 @@ class Tasks:
             local_config['FHOUT'] = config['FHOUT_OCNICE']
 
         fhmin = local_config['FHMIN']
-        fhmax = local_config['FHMAX']
-        fhout = local_config['FHOUT']
 
         # Get a list of all forecast hours
         fhrs = []
         if cdump in ['gdas']:
+            fhmax = local_config['FHMAX']
+            fhout = local_config['FHOUT']
             fhrs = list(range(fhmin, fhmax + fhout, fhout))
         elif cdump in ['gfs', 'gefs']:
             fhmax = local_config['FHMAX_GFS']


### PR DESCRIPTION
# Description
The function that generates the list of forecast hours for rocoto was trying to use variables that are not defined for GEFS, causing workflow generation to fail. The function is updated to not try to load these variables before loading the ones actually used for GFS/ GEFS.

Also turns GEFS CI test back on and adds an entry to stage C192 ICs (note: these have not been placed in the centralized location.)

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
CI only

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
