### PR TITLE
gefs build is not supported on bash orion

### DIFF
--- a/ci/cases/pr/C48_S2SWA_gefs.yaml
+++ b/ci/cases/pr/C48_S2SWA_gefs.yaml
@@ -16,3 +16,7 @@ arguments:
   idate: 2021032312
   edate: 2021032312
   yaml: {{ HOMEgfs }}/ci/cases/yamls/gefs_ci_defaults.yaml
+
+skip_ci_on_hosts:
+    - orion
+


### PR DESCRIPTION
Orion is running CI Bash which does not support gefs builds so skiphost Orion is being added to C48_S2SWA_gefs