### PR TITLE
Add Hercules support for the GSI monitor

### DIFF
--- a/modulefiles/module_base.hercules.lua
+++ b/modulefiles/module_base.hercules.lua
@@ -9,7 +9,6 @@ load(pathJoin("stack-intel", (os.getenv("stack_intel_ver") or "None")))
 load(pathJoin("stack-intel-oneapi-mpi", (os.getenv("stack_impi_ver") or "None")))
 load(pathJoin("intel-oneapi-mkl", (os.getenv("intel_mkl_ver") or "None")))
 load(pathJoin("python", (os.getenv("python_ver") or "None")))
-load(pathJoin("perl", (os.getenv("perl_ver") or "None")))
 
 load(pathJoin("jasper", (os.getenv("jasper_ver") or "None")))
 load(pathJoin("libpng", (os.getenv("libpng_ver") or "None")))

--- a/parm/config/gfs/config.base.emc.dyn
+++ b/parm/config/gfs/config.base.emc.dyn
@@ -57,16 +57,9 @@ export DO_NPOESS="NO"      # NPOESS products
 export DO_TRACKER="YES"    # Hurricane track verification
 export DO_GENESIS="YES"    # Cyclone genesis verification
 export DO_GENESIS_FSU="NO" # Cyclone genesis verification (FSU)
-# The monitor is not yet supported on Hercules
-if [[ "${machine}" == "HERCULES" ]]; then
-   export DO_VERFOZN="NO"     # Ozone data assimilation monitoring
-   export DO_VERFRAD="NO"     # Radiance data assimilation monitoring
-   export DO_VMINMON="NO"     # GSI minimization monitoring
-else
-   export DO_VERFOZN="YES"    # Ozone data assimilation monitoring
-   export DO_VERFRAD="YES"    # Radiance data assimilation monitoring
-   export DO_VMINMON="YES"    # GSI minimization monitoring
-fi
+export DO_VERFOZN="YES"    # Ozone data assimilation monitoring
+export DO_VERFRAD="YES"    # Radiance data assimilation monitoring
+export DO_VMINMON="YES"    # GSI minimization monitoring
 export DO_MOS="NO"         # GFS Model Output Statistics - Only supported on WCOSS2
 
 # NO for retrospective parallel; YES for real-time parallel

--- a/versions/run.hercules.ver
+++ b/versions/run.hercules.ver
@@ -3,7 +3,5 @@ export stack_impi_ver=2021.9.0
 export intel_mkl_ver=2023.1.0
 export spack_env=gsi-addon-env
 
-export perl_ver=5.36.0
-
 source "${HOMEgfs:-}/versions/run.spack.ver"
 export spack_mod_path="/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-${spack_stack_ver}/envs/${spack_env}/install/modulefiles/Core"


### PR DESCRIPTION
# Description
This updates the GSI monitor hash and updates the modulefiles to add support for the monitor on Hercules.

Fixes #1588 
# Type of change
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Cycled tests on Hercules and Hera.  No changes are made to monitor outputs on Hera.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes