### PR TITLE
Return ocnanalrun npes resource setting back to previous value

### DIFF
--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -376,7 +376,7 @@ case ${step} in
     npes=16
     case ${OCNRES} in
       "025")
-        npes=40
+        npes=480
         memory_ocnanalrun="96GB"
         ;;
       "050")


### PR DESCRIPTION
# Description

Variable `npes` in  `ocnanalrun`  entry of `config.resources` was erroneously changed in https://github.com/NOAA-EMC/global-workflow/pull/2299 and this PR changes it back.

Resolves https://github.com/NOAA-EMC/GDASApp/issues/962

# Type of change

- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

It hasn't

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
