### PR TITLE
Changed config.atmanl to allow non-hybrid background error yamls

### DIFF
--- a/parm/config/gfs/config.atmanl
+++ b/parm/config/gfs/config.atmanl
@@ -5,17 +5,19 @@
 
 echo "BEGIN: config.atmanl"
 
-if [[ ${DOHYBVAR} = "YES" ]]; then
-    # shellcheck disable=SC2153
-    export CASE_ANL=${CASE_ENS}
-else
-    export CASE_ANL=${CASE}
-fi
 export OBS_LIST="${PARMgfs}/gdas/atm/obs/lists/gdas_prototype_3d.yaml.j2"
 export JEDIYAML="${PARMgfs}/gdas/atm/variational/3dvar_drpcg.yaml.j2"
 export STATICB_TYPE="gsibec"
-export BERROR_YAML="${PARMgfs}/gdas/atm/berror/hybvar_${STATICB_TYPE}.yaml.j2"
 export INTERP_METHOD='barycentric'
+
+if [[ ${DOHYBVAR} = "YES" ]]; then
+    # shellcheck disable=SC2153
+    export CASE_ANL=${CASE_ENS}
+    export BERROR_YAML="${PARMgfs}/gdas/atm/berror/hybvar_${STATICB_TYPE}.yaml.j2"
+else
+    export CASE_ANL=${CASE}
+    export BERROR_YAML="${PARMgfs}/gdas/atm/berror/staticb_${STATICB_TYPE}.yaml.j2"
+fi
 
 export layout_x_atmanl=@LAYOUT_X_ATMANL@
 export layout_y_atmanl=@LAYOUT_Y_ATMANL@


### PR DESCRIPTION
# Description

Makes chage so that if DOHYBVAR equals "NO", then the JEDI background error yaml is set to staticb_${STATICB_TYPE}.yaml.j2 rather than hybvar_${STATICB_TYPE}.yaml.j2. This allows GDAS to run without hybvar, which may be necessary for development purposes.

This is all accomplished by a simple switch in config.atmanl.

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Tested in cycling experiment on Hera with DOHYBVAR equal to "NO".

# Checklist
- [X] Any dependent changes have been merged and published
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [X] I have made corresponding changes to the documentation if necessary
