### PR TITLE
Fix KeyError issue in ocean/ice postprocessing job.

### DIFF
--- a/scripts/exglobal_oceanice_products.py
+++ b/scripts/exglobal_oceanice_products.py
@@ -19,8 +19,7 @@ def main():
 
     # Pull out all the configuration keys needed to run the rest of steps
     keys = ['HOMEgfs', 'DATA', 'current_cycle', 'RUN', 'NET',
-            'COM_OCEAN_HISTORY', 'COM_OCEAN_GRIB',
-            'COM_ICE_HISTORY', 'COM_ICE_GRIB',
+            f'COM_{component.upper()}_HISTORY', f'COM_{component.upper()}_GRIB'
             'APRUN_OCNICEPOST',
             'component', 'forecast_hour', 'valid_datetime', 'avg_period',
             'model_grid', 'product_grids', 'oceanice_yaml']

--- a/scripts/exglobal_oceanice_products.py
+++ b/scripts/exglobal_oceanice_products.py
@@ -19,7 +19,7 @@ def main():
 
     # Pull out all the configuration keys needed to run the rest of steps
     keys = ['HOMEgfs', 'DATA', 'current_cycle', 'RUN', 'NET',
-            f'COM_{component.upper()}_HISTORY', f'COM_{component.upper()}_GRIB'
+            f'COM_{oceanice.task_config.component.upper()}_HISTORY', f'COM_{oceanice.task_config.component.upper()}_GRIB'
             'APRUN_OCNICEPOST',
             'component', 'forecast_hour', 'valid_datetime', 'avg_period',
             'model_grid', 'product_grids', 'oceanice_yaml']


### PR DESCRIPTION
# Description

The jjob for ocean and ice pp, only defines the component specific history and grib directory.  This causes an error in the exscript trying to pull keys for both ocean and ice. Fix this. Surprised this has not caused failures before today

This PR fixes this to extract out only component specific key.
Discovered in a S2SWA gefs test of PR #2387 

# Type of change
<!-- Delete all except one -->
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Visual inspection of the code.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
