### PR TITLE
Fix ensemble archive groups to include all members

### DIFF
--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -2661,7 +2661,7 @@ class GFSTasks(Tasks):
 
         # Integer division is floor division, but we need ceiling division
         n_groups = -(self.nmem // -self._configs['earc']['NMEM_EARCGRP'])
-        groups = ' '.join([f'{grp:02d}' for grp in range(0, n_groups+1)])
+        groups = ' '.join([f'{grp:02d}' for grp in range(0, n_groups + 1)])
 
         cycledef = 'gdas_half,gdas' if self.cdump in ['enkfgdas'] else self.cdump.replace('enkf', '')
 

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -2661,7 +2661,7 @@ class GFSTasks(Tasks):
 
         # Integer division is floor division, but we need ceiling division
         n_groups = -(self.nmem // -self._configs['earc']['NMEM_EARCGRP'])
-        groups = ' '.join([f'{grp:02d}' for grp in range(0, n_groups)])
+        groups = ' '.join([f'{grp:02d}' for grp in range(0, n_groups+1)])
 
         cycledef = 'gdas_half,gdas' if self.cdump in ['enkfgdas'] else self.cdump.replace('enkf', '')
 


### PR DESCRIPTION
# Description
The number of groups used in the ensemble archive step (earc) needs to include a task for the ensemble stat files such as the mean and the spread, resulting in `n_groups+1` tasks for `earc`.

Resolves: #2390

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Cycled test on Hera

# Checklist
- [ ] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
