### PR TITLE
Fix *earc jobs where the number of members isn't a multiple of 10

### DIFF
--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -681,7 +681,7 @@ if [[ ${type} == "enkfgdas" || ${type} == "enkfgfs" ]]; then
     touch "${DATA}/${RUN}_restartb_grp${n}.txt"
 
     m=1
-    while (( m <= NMEM_EARCGRP )); do
+    while (( m <= NMEM_EARCGRP && (n-1)*NMEM_EARCGRP+m <= NMEM_ENS )); do
       nm=$(((n-1)*NMEM_EARCGRP+m))
       mem=$(printf %03i ${nm})
       head="${RUN}.t${cyc}z."


### PR DESCRIPTION
# Description
This limits the earc search for ensemble members to the maximum number of members, which prevents attempting to send non-existent members to HPSS if the number of ensemble members is not a multiple of 10.

Resolves #2390

# Type of change
<!-- Delete all except one -->
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Cycled test on Hera with 12 members.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes