### PR TITLE
GFSv16.3.14 - Remove ldebug flag from wave post ecf scripts

### DIFF
--- a/docs/Release_Notes.gfs.v16.3.14.md
+++ b/docs/Release_Notes.gfs.v16.3.14.md
@@ -1,0 +1,125 @@
+GFS V16.3.14 RELEASE NOTES
+
+-------
+PRELUDE
+-------
+
+This version removes the PBS `ldebug=true` flags from the wave post ecf scripts. The flag is no longer needed after recent lustre upgrades on WCOSS2.
+
+IMPLEMENTATION INSTRUCTIONS
+---------------------------
+
+The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub .com are used to manage the GFS code.  The SPA(s) handling the GFS implementation need to have permissions to clone VLab Gerrit repositories and private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are publicly readable and do not require access permissions.  Please proceed with the following steps to install the package on WCOSS2:
+
+```bash
+cd $PACKAGEROOT
+mkdir gfs.v16.3.14
+cd gfs.v16.3.14
+git clone -b EMC-v16.3.14 https://github.com/NOAA-EMC/global-workflow.git .
+cd sorc
+./checkout.sh -o
+```
+
+The checkout script extracts the following GFS components:
+
+| Component | Tag         | POC               |
+| --------- | ----------- | ----------------- |
+| MODEL     | GFS.v16.3.1   | Jun.Wang@noaa.gov |
+| GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
+| GSI       | gfsda.v16.3.12 | Andrew.Collard@noaa.gov |
+| UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
+| POST      | upp_v8.3.0 | Wen.Meng@noaa.gov |
+| WAFS      | gfs_wafs.v6.3.2 | Yali.Mao@noaa.gov |
+
+To build all the GFS components, execute:
+```bash
+./build_all.sh
+```
+The `build_all.sh` script compiles all GFS components. Runtime output from the build for each package is written to log files in directory logs. To build an individual program, for instance, gsi, use `build_gsi.sh`.
+
+Next, link the executables, fix files, parm files, etc in their final respective locations by executing:
+```bash
+./link_fv3gfs.sh nco wcoss2
+```
+
+Lastly, link the ecf scripts by moving back up to the ecf folder and executing:
+```bash
+cd ../ecf
+./setup_ecf_links.sh
+```
+VERSION FILE CHANGES
+--------------------
+
+* `versions/run.ver` - change `version=v16.3.14` and `gfs_ver=v16.3.14`
+
+SORC CHANGES
+------------
+
+* No changes from GFS v16.3.13
+
+JOBS CHANGES
+------------
+
+* No changes from GFS v16.3.13
+
+PARM/CONFIG CHANGES
+-------------------
+
+* No changes from GFS v16.3.13
+
+SCRIPT CHANGES
+--------------
+
+* No changes from GFS v16.3.13
+
+FIX CHANGES
+-----------
+
+* No changes from GFS v16.3.13
+
+MODULE CHANGES
+--------------
+
+* No changes from GFS v16.3.13
+
+CHANGES TO FILE SIZES
+---------------------
+
+* No changes from GFS v16.3.13
+
+ENVIRONMENT AND RESOURCE CHANGES
+--------------------------------
+
+* Remove `ldebug=true` from PBS statements in wave post ecf scripts.
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+---------------------------------------
+
+* Which production jobs should be tested as part of this implementation?
+  * Wave post
+* Does this change require a 30-day evaluation?
+  * No
+
+DISSEMINATION INFORMATION
+-------------------------
+
+* No changes from GFS v16.3.13
+
+HPSS ARCHIVE
+------------
+
+* No changes from GFS v16.3.13
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+---------------------------------
+
+* No changes from GFS v16.3.13
+
+DOCUMENTATION
+-------------
+
+* No changes from GFS v16.3.13
+
+PREPARED BY
+-----------
+Kate.Friedman@noaa.gov

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf
@@ -7,7 +7,6 @@
 #PBS -l select=3:ncpus=80:ompthreads=1
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true
-#PBS -l ldebug=true
 
 model=gfs
 %include <head.h>

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpntbll.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpntbll.ecf
@@ -7,7 +7,6 @@
 #PBS -l select=4:ncpus=112:ompthreads=1
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true
-#PBS -l ldebug=true
 
 model=gfs
 %include <head.h>

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf
@@ -7,7 +7,6 @@
 #PBS -l select=4:ncpus=50:ompthreads=1
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true
-#PBS -l ldebug=true
 
 model=gfs
 %include <head.h>

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.13
-export gfs_ver=v16.3.13
+export version=v16.3.14
+export gfs_ver=v16.3.14
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2


### PR DESCRIPTION
# Description

This PR removes the temporary `ldebug=true` setting in the ecf scripts for the wave post jobs in operations (GFSv16.3).

Add release notes and version change in `run.ver`.

This was implemented into operations as GFSv16.3.14.

Resolves #2431

# Type of change

Production update

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Tested in para ops.
