### PR TITLE
Remove the reset of upper layer humidity

### DIFF
--- a/ush/parsing_namelists_FV3.sh
+++ b/ush/parsing_namelists_FV3.sh
@@ -115,7 +115,7 @@ cat > input.nml <<EOF
   range_warn = ${range_warn:-".true."}
   reset_eta = .false.
   n_sponge = ${n_sponge:-"10"}
-  nudge_qv = ${nudge_qv:-".true."}
+  nudge_qv = ${nudge_qv:-".false."}
   nudge_dz = ${nudge_dz:-".false."}
   tau = ${tau:-10.}
   rf_cutoff = ${rf_cutoff:-"7.5e2"}


### PR DESCRIPTION
# Description
The parameter "nudge_qv" resets the upper layer humidity to HALOE climatology when cold starting.  This parameter has been set to ".true." but is no longer needed using v16+ ICs and will now be set to ".false." by default.

Resolves: #2448

# Type of change
- Removing feature

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Cycled test on Hera

# Checklist
- [ ] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
