### PR TITLE
Change atm_jedi_fix.yaml to stage history and fv3inc fields metadata

### DIFF
--- a/parm/gdas/atm_jedi_fix.yaml.j2
+++ b/parm/gdas/atm_jedi_fix.yaml.j2
@@ -5,3 +5,5 @@ copy:
 - ['{{ FIXgfs }}/gdas/fv3jedi/fv3files/fmsmpp.nml', '{{ DATA }}/fv3jedi/fmsmpp.nml']
 - ['{{ FIXgfs }}/gdas/fv3jedi/fv3files/field_table_gfdl', '{{ DATA }}/fv3jedi/field_table']
 - ['{{ PARMgfs }}/gdas/io/fv3jedi_fieldmetadata_restart.yaml', '{{ DATA }}/fv3jedi/fv3jedi_fieldmetadata_restart.yaml']
+- ['{{ PARMgfs }}/gdas/io/fv3jedi_fieldmetadata_history.yaml', '{{ DATA }}/fv3jedi/fv3jedi_fieldmetadata_history.yaml']
+- ['{{ PARMgfs }}/gdas/io/fv3jedi_fieldmetadata_fv3inc.yaml', '{{ DATA }}/fv3jedi/fv3jedi_fieldmetadata_fv3inc.yaml']


### PR DESCRIPTION
# Description

This adds the history and fv3inc fields metadata YAMLs from GDASApp to the atm_jedi_fix.yaml so that they are staged during the atmospheric analysis init job. This is necessary to make the GDASApp CTest, test_gdasapp_atm_jjob_var_run, pass, since the GDASApp variational YAMLs now expects the history fields metadata file.

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Cory Martin will run a quick test before merging to make sure that test_gdasapp_atm_jjob_var_run now passes in GDASApp.

# Checklist
- [X] Any dependent changes have been merged and published
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
