### PR TITLE
Rename generate_com to declare_from_tmpl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,3 +29,4 @@
 [submodule "sorc/upp.fd"]
   path = sorc/upp.fd
   url = https://github.com/NOAA-EMC/UPP.git
+  ignore = dirty

--- a/gempak/ush/gdas_meta_loop.sh
+++ b/gempak/ush/gdas_meta_loop.sh
@@ -38,7 +38,7 @@ for (( fhr=24; fhr<=144; fhr+=24 )); do
     cycles=$(seq -s ' ' -f "%02g" 0 6 "${cyc}")
     for cycle in ${cycles}; do
         #  Test with GDAS in PROD
-        YMD=${day} HH=${cyc} GRID=1p00 generate_com "COM_ATMOS_GEMPAK_1p00_past:COM_ATMOS_GEMPAK_TMPL"
+        YMD=${day} HH=${cyc} GRID=1p00 declare_from_tmpl "COM_ATMOS_GEMPAK_1p00_past:COM_ATMOS_GEMPAK_TMPL"
         export COMIN="${RUN}.${day}${cycle}"
         if [[ ! -L "${COMIN}" ]]; then
             ln -sf "${COM_ATMOS_GEMPAK_1p00_past}" "${COMIN}"

--- a/gempak/ush/gfs_meta_comp.sh
+++ b/gempak/ush/gfs_meta_comp.sh
@@ -25,7 +25,7 @@ device="nc | ${metaname}"
 export COMIN="gfs.multi"
 mkdir "${COMIN}"
 for cycle in $(seq -f "%02g" -s ' ' 0  "${STEP_GFS}" "${cyc}"); do
-    YMD=${PDY} HH=${cycle} GRID="1p00" generate_com gempak_dir:COM_ATMOS_GEMPAK_TMPL
+    YMD=${PDY} HH=${cycle} GRID="1p00" declare_from_tmpl gempak_dir:COM_ATMOS_GEMPAK_TMPL
     for file_in in "${gempak_dir}/gfs_1p00_${PDY}${cycle}f"*; do
         file_out="${COMIN}/$(basename "${file_in}")"
         if [[ ! -L "${file_out}" ]]; then
@@ -99,7 +99,7 @@ for gareas in US NP; do
         # Create symlink in DATA to sidestep gempak path limits
         HPCGFS="${RUN}.${init_time}"
         if [[ ! -L ${HPCGFS} ]]; then
-            YMD="${init_PDY}" HH="${init_cyc}" GRID="1p00" generate_com source_dir:COM_ATMOS_GEMPAK_TMPL
+            YMD="${init_PDY}" HH="${init_cyc}" GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
             ln -sf "${source_dir}" "${HPCGFS}"
         fi
 

--- a/gempak/ush/gfs_meta_mar_comp.sh
+++ b/gempak/ush/gfs_meta_mar_comp.sh
@@ -16,7 +16,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 export COMIN="gfs.multi"
 mkdir -p "${COMIN}"
 for cycle in $(seq -f "%02g" -s ' ' 0 "${STEP_GFS}" "${cyc}"); do
-    YMD=${PDY} HH=${cycle} GRID="1p00" generate_com gempak_dir:COM_ATMOS_GEMPAK_TMPL
+    YMD=${PDY} HH=${cycle} GRID="1p00" declare_from_tmpl gempak_dir:COM_ATMOS_GEMPAK_TMPL
     for file_in in "${gempak_dir}/gfs_1p00_${PDY}${cycle}f"*; do
         file_out="${COMIN}/$(basename "${file_in}")"
         if [[ ! -L "${file_out}" ]]; then
@@ -76,7 +76,7 @@ for garea in NAtl NPac; do
         # Create symlink in DATA to sidestep gempak path limits
         HPCGFS="${RUN}.${init_time}"
         if [[ ! -L ${HPCGFS} ]]; then
-            YMD="${init_PDY}" HH="${init_cyc}" GRID="1p00" generate_com source_dir:COM_ATMOS_GEMPAK_TMPL
+            YMD="${init_PDY}" HH="${init_cyc}" GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
             ln -sf "${source_dir}" "${HPCGFS}"
         fi
 

--- a/gempak/ush/gfs_meta_opc_na_ver
+++ b/gempak/ush/gfs_meta_opc_na_ver
@@ -63,7 +63,7 @@ for lookback in "${lookbacks[@]}"; do
     # Create symlink in DATA to sidestep gempak path limits
     HPCGFS="${RUN}.${init_time}"
     if [[ ! -L ${HPCGFS} ]]; then
-        YMD=${init_PDY} HH=${init_cyc} GRID="1p00" generate_com source_dir:COM_ATMOS_GEMPAK_TMPL
+        YMD=${init_PDY} HH=${init_cyc} GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
         ln -sf "${source_dir}" "${HPCGFS}"
     fi
 

--- a/gempak/ush/gfs_meta_opc_np_ver
+++ b/gempak/ush/gfs_meta_opc_np_ver
@@ -63,7 +63,7 @@ for lookback in "${lookbacks[@]}"; do
     # Create symlink in DATA to sidestep gempak path limits
     HPCGFS="${RUN}.${init_time}"
     if [[ ! -L "${HPCGFS}" ]]; then
-        YMD=${init_PDY} HH=${init_cyc} GRID="1p00" generate_com source_dir:COM_ATMOS_GEMPAK_TMPL
+        YMD=${init_PDY} HH=${init_cyc} GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
         ln -sf "${source_dir}" "${HPCGFS}"
     fi
 

--- a/gempak/ush/gfs_meta_ver.sh
+++ b/gempak/ush/gfs_meta_ver.sh
@@ -53,7 +53,7 @@ for lookback in "${lookbacks[@]}"; do
     # Create symlink in DATA to sidestep gempak path limits
     HPCGFS="${RUN}.${init_time}"
     if [[ ! -L "${HPCGFS}" ]]; then
-        YMD=${init_PDY} HH=${init_cyc} GRID="1p00" generate_com source_dir:COM_ATMOS_GEMPAK_TMPL
+        YMD=${init_PDY} HH=${init_cyc} GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
         ln -sf "${source_dir}" "${HPCGFS}"
     fi
 

--- a/jobs/JGDAS_ATMOS_ANALYSIS_DIAG
+++ b/jobs/JGDAS_ATMOS_ANALYSIS_DIAG
@@ -28,7 +28,7 @@ export OPREFIX="${CDUMP}.t${cyc}z."
 export GPREFIX="${GDUMP}.t${gcyc}z."
 export APREFIX="${RUN}.t${cyc}z."
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS
 mkdir -m 775 -p "${COM_ATMOS_ANALYSIS}"
 
 ###############################################################

--- a/jobs/JGDAS_ATMOS_CHGRES_FORENKF
+++ b/jobs/JGDAS_ATMOS_CHGRES_FORENKF
@@ -18,8 +18,8 @@ export DO_CALC_ANALYSIS=${DO_CALC_ANALYSIS:-"YES"}
 export APREFIX="${CDUMP}.t${cyc}z."
 export APREFIX_ENS="${RUN}.t${cyc}z."
 
-RUN=${CDUMP} YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_HISTORY
-MEMDIR="mem001" YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_HISTORY_MEM:COM_ATMOS_HISTORY_TMPL
+RUN=${CDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_HISTORY
+MEMDIR="mem001" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_HISTORY_MEM:COM_ATMOS_HISTORY_TMPL
 
 ###############################################################
 # Run relevant script

--- a/jobs/JGDAS_ATMOS_GEMPAK
+++ b/jobs/JGDAS_ATMOS_GEMPAK
@@ -28,12 +28,12 @@ export model=${model:-gdas}
 # Define COM directories
 ##############################################
 for grid in 0p25 1p00; do
-  GRID=${grid} YMD=${PDY} HH=${cyc} generate_com -rx "COM_ATMOS_GRIB_${grid}:COM_ATMOS_GRIB_GRID_TMPL"
+  GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COM_ATMOS_GRIB_${grid}:COM_ATMOS_GRIB_GRID_TMPL"
 done
 
 for grid in 0p25 1p00; do
   prod_dir="COM_ATMOS_GEMPAK_${grid}"
-  GRID=${grid} YMD=${PDY} HH=${cyc} generate_com -rx "COM_ATMOS_GEMPAK_${grid}:COM_ATMOS_GEMPAK_TMPL"
+  GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COM_ATMOS_GEMPAK_${grid}:COM_ATMOS_GEMPAK_TMPL"
 
   if [[ ! -d "${!prod_dir}" ]] ; then
     mkdir -m 775 -p "${!prod_dir}"

--- a/jobs/JGDAS_ATMOS_GEMPAK_META_NCDC
+++ b/jobs/JGDAS_ATMOS_GEMPAK_META_NCDC
@@ -34,15 +34,15 @@ export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 ##############################################
 # Define COM directories
 ##############################################
-GRID=1p00 YMD=${PDY} HH=${cyc} generate_com -rx "COM_ATMOS_GEMPAK_1p00:COM_ATMOS_GEMPAK_TMPL"
+GRID=1p00 YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COM_ATMOS_GEMPAK_1p00:COM_ATMOS_GEMPAK_TMPL"
 
-GRID="meta" YMD=${PDY} HH=${cyc} generate_com -rx "COM_ATMOS_GEMPAK_META:COM_ATMOS_GEMPAK_TMPL"
+GRID="meta" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COM_ATMOS_GEMPAK_META:COM_ATMOS_GEMPAK_TMPL"
 if [[ ! -d "${COM_ATMOS_GEMPAK_META}" ]]; then
   mkdir -m 775 -p "${COM_ATMOS_GEMPAK_META}"
 fi
 
 if (( cyc%12 == 0 )); then
-  GRID="gif" YMD=${PDY} HH=${cyc} generate_com -rx "COM_ATMOS_GEMPAK_GIF:COM_ATMOS_GEMPAK_TMPL"
+  GRID="gif" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COM_ATMOS_GEMPAK_GIF:COM_ATMOS_GEMPAK_TMPL"
   if [[ ! -d "${COM_ATMOS_GEMPAK_GIF}" ]]; then
     mkdir -m 775 -p "${COM_ATMOS_GEMPAK_GIF}"
   fi

--- a/jobs/JGDAS_ATMOS_VERFOZN
+++ b/jobs/JGDAS_ATMOS_VERFOZN
@@ -17,8 +17,8 @@ export gcyc=${GDATE:8:2}
 #---------------------------------------------
 # OZN_TANKDIR - WHERE OUTPUT DATA WILL RESIDE
 #
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_OZNMON
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_OZNMON
 
 export oznstat="${COM_ATMOS_ANALYSIS}/gdas.t${cyc}z.oznstat"
 export TANKverf_ozn=${TANKverf_ozn:-${COM_ATMOS_OZNMON}}

--- a/jobs/JGDAS_ATMOS_VERFRAD
+++ b/jobs/JGDAS_ATMOS_VERFRAD
@@ -18,9 +18,9 @@ export gcyc=${GDATE:8:2}
 # COMOUT - WHERE GSI OUTPUT RESIDES
 # TANKverf - WHERE OUTPUT DATA WILL RESIDE
 #############################################
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_RADMON
-YMD=${gPDY} HH=${gcyc} generate_com -rx COM_ATMOS_RADMON_PREV:COM_ATMOS_RADMON_TMPL
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_RADMON
+YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx COM_ATMOS_RADMON_PREV:COM_ATMOS_RADMON_TMPL
 
 export biascr="${COM_ATMOS_ANALYSIS}/gdas.t${cyc}z.abias"
 export radstat="${COM_ATMOS_ANALYSIS}/gdas.t${cyc}z.radstat"

--- a/jobs/JGDAS_ENKF_ARCHIVE
+++ b/jobs/JGDAS_ENKF_ARCHIVE
@@ -9,8 +9,8 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "earc" -c "base earc"
 ##############################################
 export CDUMP=${RUN/enkf}
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_TOP
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} generate_com -rx \
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_TOP
+MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
   COM_ATMOS_ANALYSIS_ENSSTAT:COM_ATMOS_ANALYSIS_TMPL \
   COM_ATMOS_HISTORY_ENSSTAT:COM_ATMOS_HISTORY_TMPL
 

--- a/jobs/JGDAS_ENKF_DIAG
+++ b/jobs/JGDAS_ENKF_DIAG
@@ -31,14 +31,14 @@ export APREFIX="${RUN}.t${cyc}z."
 export GPREFIX="${GDUMP_ENS}.t${gcyc}z."
 GPREFIX_DET="${GDUMP}.t${gcyc}z."
 
-RUN=${CDUMP} YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS
+RUN=${CDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS
+MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_OBS_PREV:COM_OBS_TMPL \
     COM_ATMOS_ANALYSIS_DET_PREV:COM_ATMOS_ANALYSIS_TMPL
 
-MEMDIR="ensstat" RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+MEMDIR="ensstat" RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
 
 

--- a/jobs/JGDAS_ENKF_ECEN
+++ b/jobs/JGDAS_ENKF_ECEN
@@ -29,13 +29,13 @@ export APREFIX_ENS="${RUN}.t${cyc}z."
 export GPREFIX="${GDUMP}.t${gcyc}z."
 export GPREFIX_ENS="${GDUMP_ENS}.t${gcyc}z."
 
-RUN=${CDUMP} YMD=${PDY} HH=${cyc} generate_com -rx \
+RUN=${CDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
   COM_ATMOS_ANALYSIS_DET:COM_ATMOS_ANALYSIS_TMPL
 
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} generate_com -rx \
+MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
   COM_ATMOS_ANALYSIS_STAT:COM_ATMOS_ANALYSIS_TMPL
 
-MEMDIR="ensstat" RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+MEMDIR="ensstat" RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
   COM_ATMOS_HISTORY_STAT_PREV:COM_ATMOS_HISTORY_TMPL
 
 

--- a/jobs/JGDAS_ENKF_SELECT_OBS
+++ b/jobs/JGDAS_ENKF_SELECT_OBS
@@ -33,17 +33,17 @@ GPREFIX_DET="${GDUMP}.t${gcyc}z."
 export GSUFFIX=".ensmean.nc"
 
 # Generate COM variables from templates
-RUN=${CDUMP} YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS
-MEMDIR='ensstat' YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS
+RUN=${CDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS
+MEMDIR='ensstat' YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS
 declare -rx COM_ATMOS_ANALYSIS_ENS="${COM_ATMOS_ANALYSIS}"
 
-RUN=${CDUMP} YMD=${PDY} HH=${cyc} generate_com -r COM_ATMOS_ANALYSIS_DET:COM_ATMOS_ANALYSIS_TMPL
+RUN=${CDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -r COM_ATMOS_ANALYSIS_DET:COM_ATMOS_ANALYSIS_TMPL
 
-MEMDIR='ensstat' RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+MEMDIR='ensstat' RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
     COM_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL \
 
-RUN="${GDUMP}" YMD=${gPDY} HH=${gcyc} generate_com -r COM_ATMOS_ANALYSIS_DET_PREV:COM_ATMOS_ANALYSIS_TMPL
+RUN="${GDUMP}" YMD=${gPDY} HH=${gcyc} declare_from_tmpl -r COM_ATMOS_ANALYSIS_DET_PREV:COM_ATMOS_ANALYSIS_TMPL
 
 mkdir -m 775 -p "${COM_ATMOS_ANALYSIS}"
 

--- a/jobs/JGDAS_ENKF_SFC
+++ b/jobs/JGDAS_ENKF_SFC
@@ -33,10 +33,10 @@ export APREFIX_ENS="${RUN}.t${cyc}z."
 export GPREFIX="${GDUMP}.t${gcyc}z."
 export GPREFIX_ENS="${GDUMP_ENS}.t${gcyc}z."
 
-RUN=${CDUMP} YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS \
+RUN=${CDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS \
   COM_ATMOS_ANALYSIS_DET:COM_ATMOS_ANALYSIS_TMPL
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
   COM_OBS_PREV:COM_OBS_TMPL \
   COM_ATMOS_ANALYSIS_DET_PREV:COM_ATMOS_ANALYSIS_TMPL
 

--- a/jobs/JGDAS_ENKF_UPDATE
+++ b/jobs/JGDAS_ENKF_UPDATE
@@ -25,10 +25,10 @@ export GDUMP_ENS="enkf${GDUMP}"
 export APREFIX="${RUN}.t${cyc}z."
 export GPREFIX="${GDUMP_ENS}.t${gcyc}z."
 
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} generate_com -rx \
+MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
   COM_ATMOS_ANALYSIS_STAT:COM_ATMOS_ANALYSIS_TMPL
 
-MEMDIR="ensstat" RUN="enkfgdas" YMD=${gPDY} HH=${gcyc} generate_com -rx \
+MEMDIR="ensstat" RUN="enkfgdas" YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
   COM_ATMOS_HISTORY_STAT_PREV:COM_ATMOS_HISTORY_TMPL
 
 

--- a/jobs/JGDAS_FIT2OBS
+++ b/jobs/JGDAS_FIT2OBS
@@ -19,8 +19,8 @@ vcyc=${CDATE:8:2}
 
 # These are used by fit2obs, so we can't change them to the standard COM variable names
 # shellcheck disable=SC2153
-YMD=${vday} HH=${vcyc} generate_com -rx COM_INA:COM_ATMOS_ANALYSIS_TMPL
-RUN=${CDUMP} YMD=${vday} HH=${vcyc} generate_com -rx COM_PRP:COM_OBS_TMPL
+YMD=${vday} HH=${vcyc} declare_from_tmpl -rx COM_INA:COM_ATMOS_ANALYSIS_TMPL
+RUN=${CDUMP} YMD=${vday} HH=${vcyc} declare_from_tmpl -rx COM_PRP:COM_OBS_TMPL
 
 # We want to defer variable expansion, so ignore warning about single quotes
 # shellcheck disable=SC2016

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_BMAT
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_BMAT
@@ -15,7 +15,7 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "ocnanalbmat" -c "base ocnanal ocnanal
 # Begin JOB SPECIFIC work
 ##############################################
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OCEAN_ANALYSIS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OCEAN_ANALYSIS
 
 mkdir -p "${COM_OCEAN_ANALYSIS}"
 

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_BMAT_VRFY
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_BMAT_VRFY
@@ -14,7 +14,7 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "ocnanalrun" -c "base ocnanal ocnanalr
 # Begin JOB SPECIFIC work
 ##############################################
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OCEAN_ANALYSIS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OCEAN_ANALYSIS
 
 mkdir -p "${COM_OCEAN_ANALYSIS}"
 

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_CHKPT
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_CHKPT
@@ -22,9 +22,9 @@ export GPREFIX="${GDUMP}.t${gcyc}z."
 export APREFIX="${CDUMP}.t${cyc}z."
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx COM_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx COM_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
 
 
 ##############################################

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_POST
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_POST
@@ -13,7 +13,7 @@ export CDATE=${CDATE:-${PDY}${cyc}}
 export GDUMP=${GDUMP:-"gdas"}
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OCEAN_ANALYSIS COM_ICE_RESTART
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OCEAN_ANALYSIS COM_ICE_RESTART
 
 mkdir -p "${COM_OCEAN_ANALYSIS}"
 mkdir -p "${COM_ICE_RESTART}"

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP
@@ -21,9 +21,9 @@ export GPREFIX="${GDUMP}.t${gcyc}z."
 export APREFIX="${CDUMP}.t${cyc}z."
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
    COM_OCEAN_HISTORY_PREV:COM_OCEAN_HISTORY_TMPL \
    COM_ICE_HISTORY_PREV:COM_ICE_HISTORY_TMPL \
    COM_ICE_RESTART_PREV:COM_ICE_RESTART_TMPL

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_VRFY
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_VRFY
@@ -14,11 +14,11 @@ GDATE=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} - ${assim_freq} hours")
 export gPDY=${GDATE:0:8}
 export gcyc=${GDATE:8:2}
 
-RUN=${GDUMP} YMD=${PDY} HH=${cyc} generate_com -rx COM_OCEAN_ANALYSIS
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx COM_OCEAN_HISTORY_PREV:COM_OCEAN_HISTORY_TMPL
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx COM_ICE_HISTORY_PREV:COM_ICE_HISTORY_TMPL
+RUN=${GDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OCEAN_ANALYSIS
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx COM_OCEAN_HISTORY_PREV:COM_OCEAN_HISTORY_TMPL
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx COM_ICE_HISTORY_PREV:COM_ICE_HISTORY_TMPL
 # To allow extraction of statistics from diag files
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS
 
 
 ##############################################

--- a/jobs/JGFS_ATMOS_AWIPS_20KM_1P0DEG
+++ b/jobs/JGFS_ATMOS_AWIPS_20KM_1P0DEG
@@ -18,8 +18,8 @@ export SENDDBN=${SENDDBN:-NO}
 export SENDAWIP=${SENDAWIP:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_WMO
-GRID="0p25" YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_WMO
+GRID="0p25" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
 
 if [[ ! -d "${COM_ATMOS_WMO}" ]] ; then
   mkdir -m 775 -p "${COM_ATMOS_WMO}"

--- a/jobs/JGFS_ATMOS_AWIPS_G2
+++ b/jobs/JGFS_ATMOS_AWIPS_G2
@@ -22,8 +22,8 @@ export SENDDBN=${SENDDBN:-NO}
 export SENDAWIP=${SENDAWIP:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_WMO
-GRID="0p25" YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_WMO
+GRID="0p25" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
 
 mkdir -m 775 -p "${COM_ATMOS_WMO}"
 

--- a/jobs/JGFS_ATMOS_CYCLONE_GENESIS
+++ b/jobs/JGFS_ATMOS_CYCLONE_GENESIS
@@ -27,8 +27,8 @@ export SCRIPTens_tracker=${SCRIPTens_tracker:-${HOMEens_tracker}/scripts}
 ##############################################
 # Define COM directories
 ##############################################
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_GENESIS
-YMD=${PDY} HH=${cyc} GRID="0p25" generate_com -rx COM_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_GENESIS
+YMD=${PDY} HH=${cyc} GRID="0p25" declare_from_tmpl -rx COM_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
 
 # The following variables are used by the tracker scripts which are outside
 #   of global-workflow and therefore can't be standardized at this time

--- a/jobs/JGFS_ATMOS_CYCLONE_TRACKER
+++ b/jobs/JGFS_ATMOS_CYCLONE_TRACKER
@@ -32,8 +32,8 @@ export USHens_tracker=${USHens_tracker:-${HOMEens_tracker}/ush}
 ##############################################
 # Define COM and Data directories
 ##############################################
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_TRACK COM_ATMOS_GENESIS
-YMD=${PDY} HH=${cyc} GRID="0p25" generate_com -rx COM_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_TRACK COM_ATMOS_GENESIS
+YMD=${PDY} HH=${cyc} GRID="0p25" declare_from_tmpl -rx COM_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
 
 if [[ ! -d "${COM_ATMOS_TRACK}" ]]; then mkdir -p "${COM_ATMOS_TRACK}"; fi
 

--- a/jobs/JGFS_ATMOS_FSU_GENESIS
+++ b/jobs/JGFS_ATMOS_FSU_GENESIS
@@ -33,8 +33,8 @@ export PYTHONPATH=${USHens_tracker}/FSUgenesisPY:${PYTHONPATH}
 ##############################################
 # Define COM and Data directories
 ##############################################
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_GENESIS
-YMD=${PDY} HH=${cyc} GRID="0p25" generate_com -rx COM_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_GENESIS
+YMD=${PDY} HH=${cyc} GRID="0p25" declare_from_tmpl -rx COM_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
 
 # The following variables are used by the tracker scripts which are outside
 #   of global-workflow and therefore can't be standardized at this time

--- a/jobs/JGFS_ATMOS_GEMPAK
+++ b/jobs/JGFS_ATMOS_GEMPAK
@@ -28,12 +28,12 @@ export SENDDBN=${SENDDBN:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
 for grid in 0p25 0p50 1p00; do
-  GRID=${grid} YMD=${PDY} HH=${cyc} generate_com -rx "COM_ATMOS_GRIB_${grid}:COM_ATMOS_GRIB_GRID_TMPL"
+  GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COM_ATMOS_GRIB_${grid}:COM_ATMOS_GRIB_GRID_TMPL"
 done
 
 for grid in 1p00 0p50 0p25 40km 35km_atl 35km_pac; do
   prod_dir="COM_ATMOS_GEMPAK_${grid}"
-  GRID=${grid} YMD=${PDY} HH=${cyc} generate_com -rx "COM_ATMOS_GEMPAK_${grid}:COM_ATMOS_GEMPAK_TMPL"
+  GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COM_ATMOS_GEMPAK_${grid}:COM_ATMOS_GEMPAK_TMPL"
 
   if [[ ! -d "${!prod_dir}" ]] ; then
     mkdir -m 775 -p "${!prod_dir}"

--- a/jobs/JGFS_ATMOS_GEMPAK_META
+++ b/jobs/JGFS_ATMOS_GEMPAK_META
@@ -52,9 +52,9 @@ export COMINnam=${COMINnam:-$(compath.py "${envir}/nam/${nam_ver}")/nam}
 export SENDDBN=${SENDDBN:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
-GRID=1p00 YMD=${PDY} HH=${cyc} generate_com -rx "COM_ATMOS_GEMPAK_1p00:COM_ATMOS_GEMPAK_TMPL"
+GRID=1p00 YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COM_ATMOS_GEMPAK_1p00:COM_ATMOS_GEMPAK_TMPL"
 
-GRID="meta" YMD=${PDY} HH=${cyc} generate_com -rx "COM_ATMOS_GEMPAK_META:COM_ATMOS_GEMPAK_TMPL"
+GRID="meta" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COM_ATMOS_GEMPAK_META:COM_ATMOS_GEMPAK_TMPL"
 if [[ ! -d "${COM_ATMOS_GEMPAK_META}" ]] ; then
   mkdir -m 775 -p "${COM_ATMOS_GEMPAK_META}"
 fi

--- a/jobs/JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF
+++ b/jobs/JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF
@@ -29,16 +29,16 @@ export COMPONENT="atmos"
 ##############################################
 # Define COM directories
 ##############################################
-YMD=${PDY} HH=${cyc} generate_com -rx "COM_OBS"
-GRID=1p00 YMD=${PDY} HH=${cyc} generate_com -rx "COM_ATMOS_GEMPAK_1p00:COM_ATMOS_GEMPAK_TMPL"
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COM_OBS"
+GRID=1p00 YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COM_ATMOS_GEMPAK_1p00:COM_ATMOS_GEMPAK_TMPL"
 
 for grid in gif upper_air; do
   gempak_dir="COM_ATMOS_GEMPAK_${grid^^}"
-  GRID=${grid} YMD=${PDY} HH=${cyc} generate_com -rx "${gempak_dir}:COM_ATMOS_GEMPAK_TMPL"
+  GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "${gempak_dir}:COM_ATMOS_GEMPAK_TMPL"
   if [[ ! -d "${!gempak_dir}" ]]; then mkdir -m 775 -p "${!gempak_dir}"; fi
 done
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_WMO
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_WMO
 if [[ ! -d "${COM_ATMOS_WMO}" ]]; then mkdir -m 775 -p "${COM_ATMOS_WMO}"; fi
 
 export SENDDBN=${SENDDBN:-NO}

--- a/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
+++ b/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
@@ -20,8 +20,8 @@ export EXT=""
 ##############################################
 # Define COM directories
 ##############################################
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_GOES
-GRID=0p25 YMD=${PDY} HH=${cyc} generate_com -rx "COM_ATMOS_GEMPAK_0p25:COM_ATMOS_GEMPAK_TMPL"
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_GOES
+GRID=0p25 YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COM_ATMOS_GEMPAK_0p25:COM_ATMOS_GEMPAK_TMPL"
 if [[ ! -d "${COM_ATMOS_GEMPAK_0p25}" ]]; then mkdir -m 775 -p "${COM_ATMOS_GEMPAK_0p25}"; fi
 
 export SENDDBN="${SENDDBN:-NO}"

--- a/jobs/JGFS_ATMOS_PGRB2_SPEC_NPOESS
+++ b/jobs/JGFS_ATMOS_PGRB2_SPEC_NPOESS
@@ -21,8 +21,8 @@ export model=${model:-gfs}
 export SENDDBN=${SENDDBN:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_MASTER COM_ATMOS_GOES
-GRID="0p50" YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_GRIB_0p50:COM_ATMOS_GRIB_GRID_TMPL
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_MASTER COM_ATMOS_GOES
+GRID="0p50" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_GRIB_0p50:COM_ATMOS_GRIB_GRID_TMPL
 
 mkdir -m 775 -p "${COM_ATMOS_GOES}"
 

--- a/jobs/JGFS_ATMOS_POSTSND
+++ b/jobs/JGFS_ATMOS_POSTSND
@@ -22,7 +22,7 @@ export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 ##############################
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_HISTORY COM_ATMOS_BUFR \
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_HISTORY COM_ATMOS_BUFR \
   COM_ATMOS_WMO COM_ATMOS_GEMPAK
 
 [[ ! -d ${COM_ATMOS_BUFR} ]] && mkdir -p "${COM_ATMOS_BUFR}"

--- a/jobs/JGFS_ATMOS_VERIFICATION
+++ b/jobs/JGFS_ATMOS_VERIFICATION
@@ -29,7 +29,7 @@ export VDATE=${VDATE:0:8}
 # shellcheck disable=SC2041
 for grid in '1p00'; do
   prod_dir="COM_ATMOS_GRIB_${grid}"
-  GRID=${grid} YMD=${PDY} HH=${cyc} generate_com -rx "${prod_dir}:COM_ATMOS_GRIB_GRID_TMPL"
+  GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "${prod_dir}:COM_ATMOS_GRIB_GRID_TMPL"
 done
 
 # TODO: If none of these are on, why are we running this job?

--- a/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
+++ b/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
@@ -20,9 +20,9 @@ GDUMP="gdas"
 ##############################################
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS COM_CHEM_ANALYSIS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS COM_CHEM_ANALYSIS
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_CHEM_ANALYSIS_PREV:COM_CHEM_ANALYSIS_TMPL \
     COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
 

--- a/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
+++ b/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
@@ -19,9 +19,9 @@ GDUMP="gdas"
 ##############################################
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS COM_CHEM_ANALYSIS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS COM_CHEM_ANALYSIS
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_CHEM_ANALYSIS_PREV:COM_CHEM_ANALYSIS_TMPL \
     COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
 

--- a/jobs/JGLOBAL_ARCHIVE
+++ b/jobs/JGLOBAL_ARCHIVE
@@ -9,7 +9,7 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "arch" -c "base arch"
 ##############################################
 export CDUMP=${RUN/enkf}
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS COM_ATMOS_BUFR COM_ATMOS_GEMPAK \
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS COM_ATMOS_BUFR COM_ATMOS_GEMPAK \
   COM_ATMOS_GENESIS COM_ATMOS_HISTORY COM_ATMOS_INPUT COM_ATMOS_MASTER COM_ATMOS_RESTART \
   COM_ATMOS_TRACK COM_ATMOS_WMO \
   COM_CHEM_HISTORY COM_CHEM_ANALYSIS\
@@ -23,7 +23,7 @@ YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS COM_ATMOS_BUFR COM_ATMO
   COM_ATMOS_OZNMON COM_ATMOS_RADMON COM_ATMOS_MINMON COM_CONF
 
 for grid in "0p25" "0p50" "1p00"; do
-  YMD=${PDY} HH=${cyc} GRID=${grid} generate_com -rx "COM_ATMOS_GRIB_${grid}:COM_ATMOS_GRIB_GRID_TMPL"
+  YMD=${PDY} HH=${cyc} GRID=${grid} declare_from_tmpl -rx "COM_ATMOS_GRIB_${grid}:COM_ATMOS_GRIB_GRID_TMPL"
 done
 
 ###############################################################

--- a/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
+++ b/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
@@ -15,7 +15,7 @@ GDUMP_ENS="enkf${GDUMP}"
 # Begin JOB SPECIFIC work
 ##############################################
 # Generate COM variable from template
-MEMDIR='ensstat' RUN=${GDUMP_ENS} YMD=${PDY} HH=${cyc} generate_com -rx \
+MEMDIR='ensstat' RUN=${GDUMP_ENS} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
     COM_ATMOS_ANALYSIS_ENS:COM_ATMOS_ANALYSIS_TMPL
 
 mkdir -m 755 -p "${COM_ATMOS_ANALYSIS_ENS}"

--- a/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
+++ b/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
@@ -17,9 +17,9 @@ GDUMP="gdas"
 # Begin JOB SPECIFIC work
 ##############################################
 # Generate COM variables from templates
-RUN=${GDUMP} YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS
+RUN=${GDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL
 
 ###############################################################

--- a/jobs/JGLOBAL_ATMOS_ANALYSIS
+++ b/jobs/JGLOBAL_ATMOS_ANALYSIS
@@ -31,13 +31,13 @@ export APREFIX="${CDUMP}.t${cyc}z."
 export GPREFIX_ENS="${GDUMP_ENS}.t${gcyc}z."
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS COM_ATMOS_ANALYSIS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS COM_ATMOS_ANALYSIS
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
     COM_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
 
-MEMDIR='ensstat' RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+MEMDIR='ensstat' RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_ATMOS_HISTORY_ENS_PREV:COM_ATMOS_HISTORY_TMPL
 
 mkdir -m 775 -p "${COM_ATMOS_ANALYSIS}"

--- a/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
+++ b/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
@@ -28,11 +28,11 @@ export GPREFIX="${GDUMP}.t${gcyc}z."
 export APREFIX="${RUN}.t${cyc}z."
 export GPREFIX_ENS="${GDUMP_ENS}.t${gcyc}z."
 
-RUN=${CDUMP} YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS
+RUN=${CDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS COM_ATMOS_RESTART
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS COM_ATMOS_RESTART
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_OBS_PREV:COM_OBS_TMPL \
     COM_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
 

--- a/jobs/JGLOBAL_ATMOS_POST_MANAGER
+++ b/jobs/JGLOBAL_ATMOS_POST_MANAGER
@@ -17,7 +17,7 @@ export RUN=${RUN:-gfs}
 ###########################
 export EXT_FCST=NO
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_HISTORY
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_HISTORY
 
 ########################################################
 # Execute the script.

--- a/jobs/JGLOBAL_ATMOS_PRODUCTS
+++ b/jobs/JGLOBAL_ATMOS_PRODUCTS
@@ -9,11 +9,11 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmos_products" -c "base atmos_produc
 ##############################################
 
 # Construct COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS COM_ATMOS_HISTORY COM_ATMOS_MASTER
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS COM_ATMOS_HISTORY COM_ATMOS_MASTER
 
 for grid in '0p25' '0p50' '1p00'; do
   prod_dir="COM_ATMOS_GRIB_${grid}"
-  GRID=${grid} YMD=${PDY} HH=${cyc} generate_com -rx "${prod_dir}:COM_ATMOS_GRIB_GRID_TMPL"
+  GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "${prod_dir}:COM_ATMOS_GRIB_GRID_TMPL"
   if [[ ! -d "${!prod_dir}" ]]; then mkdir -m 775 -p "${!prod_dir}"; fi
 done
 

--- a/jobs/JGLOBAL_ATMOS_SFCANL
+++ b/jobs/JGLOBAL_ATMOS_SFCANL
@@ -25,10 +25,10 @@ export OPREFIX="${CDUMP}.t${cyc}z."
 export GPREFIX="${GDUMP}.t${gcyc}z."
 export APREFIX="${CDUMP}.t${cyc}z."
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS COM_ATMOS_ANALYSIS COM_ATMOS_RESTART \
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS COM_ATMOS_ANALYSIS COM_ATMOS_RESTART \
     COM_SNOW_ANALYSIS
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_OBS_PREV:COM_OBS_TMPL \
     COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
 

--- a/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
+++ b/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
@@ -29,7 +29,7 @@ export TANK_TROPCY=${TANK_TROPCY:-${DCOMROOT}}   # path to tropical cyclone reco
 ##############################################
 # Define COM directories
 ##############################################
-generate_com COM_OBS
+declare_from_tmpl COM_OBS
 if [[ ! -d "${COM_OBS}" ]]; then mkdir -p "${COM_OBS}"; fi
 
 export CRES=$(echo ${CASE} | cut -c2-)

--- a/jobs/JGLOBAL_ATMOS_UPP
+++ b/jobs/JGLOBAL_ATMOS_UPP
@@ -12,7 +12,7 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "upp" -c "base upp"
 ##############################################
 
 # Construct COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS COM_ATMOS_HISTORY COM_ATMOS_MASTER
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS COM_ATMOS_HISTORY COM_ATMOS_MASTER
 if [[ ! -d ${COM_ATMOS_MASTER} ]]; then mkdir -m 775 -p "${COM_ATMOS_MASTER}"; fi
 
 

--- a/jobs/JGLOBAL_ATMOS_VMINMON
+++ b/jobs/JGLOBAL_ATMOS_VMINMON
@@ -17,9 +17,9 @@ export gcyc=${GDATE:8:2}
 #############################################
 # TANKverf - WHERE OUTPUT DATA WILL RESIDE
 #############################################
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_MINMON
-YMD=${gPDY} HH=${gcyc} generate_com -rx COM_ATMOS_MINMON_PREV:COM_ATMOS_MINMON_TMPL
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_MINMON
+YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx COM_ATMOS_MINMON_PREV:COM_ATMOS_MINMON_TMPL
 
 export gsistat="${COM_ATMOS_ANALYSIS}/${RUN}.t${cyc}z.gsistat"
 export M_TANKverf=${M_TANKverf:-${COM_ATMOS_MINMON}}

--- a/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
+++ b/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
@@ -20,9 +20,9 @@ GDUMP="gdas"
 ##############################################
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
     COM_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL \
     COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL

--- a/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
+++ b/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
@@ -20,14 +20,14 @@ GDUMP_ENS="enkf${GDUMP}"
 ##############################################
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS COM_ATMOS_ANALYSIS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS COM_ATMOS_ANALYSIS
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
     COM_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL \
     COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
 
-MEMDIR='ensstat' RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+MEMDIR='ensstat' RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_ATMOS_HISTORY_ENS_PREV:COM_ATMOS_HISTORY_TMPL
 
 mkdir -m 775 -p "${COM_ATMOS_ANALYSIS}"

--- a/jobs/JGLOBAL_ATM_PREP_IODA_OBS
+++ b/jobs/JGLOBAL_ATM_PREP_IODA_OBS
@@ -12,7 +12,7 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "prepatmiodaobs" -c "base prepatmiodao
 # Begin JOB SPECIFIC work
 ##############################################
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS
 
 
 ###############################################################

--- a/jobs/JGLOBAL_FORECAST
+++ b/jobs/JGLOBAL_FORECAST
@@ -24,34 +24,34 @@ declare -rx gPDY="${GDATE:0:8}"
 declare -rx gcyc="${GDATE:8:2}"
 
 # Construct COM variables from templates (see config.com)
-YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_RESTART COM_ATMOS_INPUT COM_ATMOS_ANALYSIS \
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_RESTART COM_ATMOS_INPUT COM_ATMOS_ANALYSIS \
   COM_ATMOS_HISTORY COM_ATMOS_MASTER COM_TOP COM_CONF
 
-RUN=${rCDUMP} YMD="${gPDY}" HH="${gcyc}" generate_com -rx \
+RUN=${rCDUMP} YMD="${gPDY}" HH="${gcyc}" declare_from_tmpl -rx \
   COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
 
 if [[ ${DO_WAVE} == "YES" ]]; then
-  YMD=${PDY} HH=${cyc} generate_com -rx COM_WAVE_RESTART COM_WAVE_PREP COM_WAVE_HISTORY
-  RUN=${rCDUMP} YMD="${gPDY}" HH="${gcyc}" generate_com -rx \
+  YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_WAVE_RESTART COM_WAVE_PREP COM_WAVE_HISTORY
+  RUN=${rCDUMP} YMD="${gPDY}" HH="${gcyc}" declare_from_tmpl -rx \
     COM_WAVE_RESTART_PREV:COM_WAVE_RESTART_TMPL
   declare -rx RUNwave="${RUN}wave"
 fi
 
 if [[ ${DO_OCN} == "YES" ]]; then
-  YMD=${PDY} HH=${cyc} generate_com -rx COM_MED_RESTART COM_OCEAN_RESTART COM_OCEAN_INPUT \
+  YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_MED_RESTART COM_OCEAN_RESTART COM_OCEAN_INPUT \
     COM_OCEAN_HISTORY COM_OCEAN_ANALYSIS
-  RUN=${rCDUMP} YMD="${gPDY}" HH="${gcyc}" generate_com -rx \
+  RUN=${rCDUMP} YMD="${gPDY}" HH="${gcyc}" declare_from_tmpl -rx \
     COM_OCEAN_RESTART_PREV:COM_OCEAN_RESTART_TMPL
 fi
 
 if [[ ${DO_ICE} == "YES" ]]; then
-  YMD=${PDY} HH=${cyc} generate_com -rx COM_ICE_HISTORY COM_ICE_INPUT COM_ICE_RESTART
-  RUN=${rCDUMP} YMD="${gPDY}" HH="${gcyc}" generate_com -rx \
+  YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ICE_HISTORY COM_ICE_INPUT COM_ICE_RESTART
+  RUN=${rCDUMP} YMD="${gPDY}" HH="${gcyc}" declare_from_tmpl -rx \
     COM_ICE_RESTART_PREV:COM_ICE_RESTART_TMPL
 fi
 
 if [[ ${DO_AERO} == "YES" ]]; then
-  YMD=${PDY} HH=${cyc} generate_com -rx COM_CHEM_HISTORY
+  YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_CHEM_HISTORY
 fi
 
 

--- a/jobs/JGLOBAL_OCEANICE_PRODUCTS
+++ b/jobs/JGLOBAL_OCEANICE_PRODUCTS
@@ -9,9 +9,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "oceanice_products" -c "base oceanice_
 ##############################################
 
 # Construct COM variables from templates
-YMD="${PDY}" HH="${cyc}" generate_com -rx "COM_${COMPONENT^^}_HISTORY"
-YMD="${PDY}" HH="${cyc}" generate_com -rx "COM_${COMPONENT^^}_GRIB"
-YMD="${PDY}" HH="${cyc}" generate_com -rx "COM_${COMPONENT^^}_NETCDF"
+YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx "COM_${COMPONENT^^}_HISTORY"
+YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx "COM_${COMPONENT^^}_GRIB"
+YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx "COM_${COMPONENT^^}_NETCDF"
 
 ###############################################################
 # Run exglobal script

--- a/jobs/JGLOBAL_PREP_OCEAN_OBS
+++ b/jobs/JGLOBAL_PREP_OCEAN_OBS
@@ -8,7 +8,7 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "prepoceanobs" -c "base prepoceanobs"
 ##############################################
 
 export COMIN_OBS="${DATA}"
-YMD=${PDY} HH=${cyc} generate_com -rx COMOUT_OBS:COM_OBS_TMPL
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMOUT_OBS:COM_OBS_TMPL
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/jobs/JGLOBAL_PREP_SNOW_OBS
+++ b/jobs/JGLOBAL_PREP_SNOW_OBS
@@ -18,9 +18,9 @@ GDUMP="gdas"
 # Begin JOB SPECIFIC work
 ##############################################
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
 
 ###############################################################

--- a/jobs/JGLOBAL_SNOW_ANALYSIS
+++ b/jobs/JGLOBAL_SNOW_ANALYSIS
@@ -18,9 +18,9 @@ GDUMP="gdas"
 # Begin JOB SPECIFIC work
 ##############################################
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS COM_SNOW_ANALYSIS COM_CONF
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS COM_SNOW_ANALYSIS COM_CONF
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
 
 mkdir -m 775 -p "${COM_SNOW_ANALYSIS}" "${COM_CONF}"

--- a/jobs/JGLOBAL_WAVE_GEMPAK
+++ b/jobs/JGLOBAL_WAVE_GEMPAK
@@ -13,7 +13,7 @@ export DBN_ALERT_TYPE=GFS_WAVE_GEMPAK
 export SENDDBN=${SENDDBN:-YES}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_WAVE_GRID COM_WAVE_GEMPAK
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_WAVE_GRID COM_WAVE_GEMPAK
 
 if [[ ! -d ${COM_WAVE_GEMPAK} ]]; then mkdir -p "${COM_WAVE_GEMPAK}"; fi
 

--- a/jobs/JGLOBAL_WAVE_INIT
+++ b/jobs/JGLOBAL_WAVE_INIT
@@ -10,7 +10,7 @@ export errchk=${errchk:-err_chk}
 export MP_PULSE=0
 
 # Set COM Paths
-YMD=${PDY} HH=${cyc} generate_com -rx COM_WAVE_PREP
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_WAVE_PREP
 
 mkdir -m 775 -p ${COM_WAVE_PREP}
 

--- a/jobs/JGLOBAL_WAVE_POST_BNDPNT
+++ b/jobs/JGLOBAL_WAVE_POST_BNDPNT
@@ -9,7 +9,7 @@ export errchk=${errchk:-err_chk}
 export MP_PULSE=0
 
 # Set COM Paths and GETGES environment
-YMD=${PDY} HH=${cyc} generate_com -rx COM_WAVE_PREP COM_WAVE_HISTORY COM_WAVE_STATION
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_WAVE_PREP COM_WAVE_HISTORY COM_WAVE_STATION
 
 if [[ ! -d ${COM_WAVE_STATION} ]]; then mkdir -p "${COM_WAVE_STATION}"; fi
 

--- a/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
+++ b/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
@@ -13,7 +13,7 @@ export CDATE=${PDY}${cyc}
 export MP_PULSE=0
 
 # Set COM Paths and GETGES environment
-YMD=${PDY} HH=${cyc} generate_com -rx COM_WAVE_PREP COM_WAVE_HISTORY COM_WAVE_STATION
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_WAVE_PREP COM_WAVE_HISTORY COM_WAVE_STATION
 
 if [[ ! -d ${COM_WAVE_STATION} ]]; then mkdir -p "${COM_WAVE_STATION}"; fi
 

--- a/jobs/JGLOBAL_WAVE_POST_PNT
+++ b/jobs/JGLOBAL_WAVE_POST_PNT
@@ -9,7 +9,7 @@ export errchk=${errchk:-err_chk}
 export MP_PULSE=0
 
 # Set COM Paths and GETGES environment
-YMD=${PDY} HH=${cyc} generate_com -rx COM_WAVE_PREP COM_WAVE_HISTORY COM_WAVE_STATION
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_WAVE_PREP COM_WAVE_HISTORY COM_WAVE_STATION
 
 if [[ ! -d ${COM_WAVE_STATION} ]]; then mkdir -p "${COM_WAVE_STATION}"; fi
 

--- a/jobs/JGLOBAL_WAVE_POST_SBS
+++ b/jobs/JGLOBAL_WAVE_POST_SBS
@@ -9,7 +9,7 @@ export errchk=${errchk:-err_chk}
 export MP_PULSE=0
 
 # Set COM Paths and GETGES environment
-YMD=${PDY} HH=${cyc} generate_com -rx COM_WAVE_PREP COM_WAVE_HISTORY COM_WAVE_GRID
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_WAVE_PREP COM_WAVE_HISTORY COM_WAVE_GRID
 
 mkdir -p "${COM_WAVE_GRID}"
 

--- a/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
+++ b/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
@@ -13,7 +13,7 @@ export SENDDBN_NTC=${SENDDBN_NTC:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_WAVE_STATION COM_WAVE_WMO
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_WAVE_STATION COM_WAVE_WMO
 
 if [[ ! -d ${COM_WAVE_WMO} ]]; then mkdir -p "${COM_WAVE_WMO}"; fi
 

--- a/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
+++ b/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
@@ -13,7 +13,7 @@ export SENDDBN_NTC=${SENDDBN_NTC:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
-YMD=${PDY} HH=${cyc} generate_com -rx COM_WAVE_GRID COM_WAVE_WMO
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_WAVE_GRID COM_WAVE_WMO
 
 if [[ ! -d ${COM_WAVE_WMO} ]]; then mkdir -p "${COM_WAVE_WMO}"; fi
 

--- a/jobs/JGLOBAL_WAVE_PREP
+++ b/jobs/JGLOBAL_WAVE_PREP
@@ -17,8 +17,8 @@ export MP_PULSE=0
 export CDO=${CDO_ROOT}/bin/cdo
 
 # Set COM Paths and GETGES environment
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS COM_WAVE_PREP
-generate_com -rx COM_RTOFS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS COM_WAVE_PREP
+declare_from_tmpl -rx COM_RTOFS
 [[ ! -d ${COM_WAVE_PREP} ]] && mkdir -m 775 -p "${COM_WAVE_PREP}"
 
 # Execute the Script

--- a/jobs/rocoto/prep.sh
+++ b/jobs/rocoto/prep.sh
@@ -27,9 +27,9 @@ GDUMP="gdas"
 
 export OPREFIX="${CDUMP}.t${cyc}z."
 
-YMD=${PDY} HH=${cyc} DUMP=${CDUMP} generate_com -rx COM_OBS COM_OBSDMP
+YMD=${PDY} HH=${cyc} DUMP=${CDUMP} declare_from_tmpl -rx COM_OBS COM_OBSDMP
 
-RUN=${GDUMP} DUMP=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} DUMP=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_OBS_PREV:COM_OBS_TMPL \
     COM_OBSDMP_PREV:COM_OBSDMP_TMPL
 
@@ -96,8 +96,8 @@ if [[ ${MAKE_PREPBUFR} = "YES" ]]; then
     export job="j${CDUMP}_prep_${cyc}"
     export COMIN=${COM_OBS}
     export COMOUT=${COM_OBS}
-    RUN="gdas" YMD=${PDY} HH=${cyc} generate_com -rx COMINgdas:COM_ATMOS_HISTORY_TMPL
-    RUN="gfs" YMD=${PDY} HH=${cyc} generate_com -rx COMINgfs:COM_ATMOS_HISTORY_TMPL
+    RUN="gdas" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMINgdas:COM_ATMOS_HISTORY_TMPL
+    RUN="gfs" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMINgfs:COM_ATMOS_HISTORY_TMPL
     if [[ ${ROTDIR_DUMP} = "NO" ]]; then
         export COMSP=${COMSP:-"${COM_OBSDMP}/${CDUMP}.t${cyc}z."}
     else

--- a/parm/config/gfs/config.com
+++ b/parm/config/gfs/config.com
@@ -5,11 +5,11 @@ echo "BEGIN: config.com"
 
 # These are just templates. All templates must use single quotations so variable
 #   expansion does not occur when this file is sourced. Substitution happens later
-#   during runtime. It is recommended to use the helper function `generate_com()`,
+#   during runtime. It is recommended to use the helper function `declare_from_tmpl()`,
 #   to do this substitution, which is defined in `ush/preamble.sh`.
 #
-#   Syntax for generate_com():
-#       generate_com [-rx] $var1[:$tmpl1] [$var2[:$tmpl2]] [...]]
+#   Syntax for declare_from_tmpl():
+#       declare_from_tmpl [-rx] $var1[:$tmpl1] [$var2[:$tmpl2]] [...]]
 #
 #       options:
 #           -r: Make variable read-only (same as `decalre -r`)
@@ -20,14 +20,14 @@ echo "BEGIN: config.com"
 #
 #   Examples:
 #       # Current cycle and RUN
-#       YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS
+#       YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS
 #
 #       # Previous cycle and gdas
-#       RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+#       RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 #           COM_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
 #
 #       # Current cycle and COM for first member
-#       MEMDIR='mem001' YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_HISTORY
+#       MEMDIR='mem001' YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_HISTORY
 #
 
 #

--- a/scripts/exgdas_enkf_ecen.sh
+++ b/scripts/exgdas_enkf_ecen.sh
@@ -118,10 +118,10 @@ for imem in $(seq 1 $NMEM_ENS); do
    gmemchar="mem"$(printf %03i $smem)
    memchar="mem"$(printf %03i $imem)
 
-   MEMDIR=${memchar} YMD=${PDY} HH=${cyc} generate_com -x \
+   MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl -x \
       COM_ATMOS_ANALYSIS_MEM:COM_ATMOS_ANALYSIS_TMPL
 
-   MEMDIR=${gmemchar} RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} generate_com -x \
+   MEMDIR=${gmemchar} RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -x \
       COM_ATMOS_HISTORY_MEM_PREV:COM_ATMOS_HISTORY_TMPL
 
    ${NLN} "${COM_ATMOS_HISTORY_MEM_PREV}/${GPREFIX_ENS}atmf00${FHR}${ENKF_SUFFIX}.nc" "./atmges_${memchar}"

--- a/scripts/exgdas_enkf_post.sh
+++ b/scripts/exgdas_enkf_post.sh
@@ -70,7 +70,7 @@ export OMP_NUM_THREADS=$NTHREADS_EPOS
 # Forecast ensemble member files
 for imem in $(seq 1 $NMEM_ENS); do
    memchar="mem"$(printf %03i "${imem}")
-   MEMDIR=${memchar} YMD=${PDY} HH=${cyc} generate_com -x COM_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL
+   MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl -x COM_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL
 
    for fhr in $(seq $FHMIN $FHOUT $FHMAX); do
       fhrchar=$(printf %03i $fhr)
@@ -80,7 +80,7 @@ for imem in $(seq 1 $NMEM_ENS); do
 done
 
 # Forecast ensemble mean and smoothed files
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_HISTORY_STAT:COM_ATMOS_HISTORY_TMPL
+MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_HISTORY_STAT:COM_ATMOS_HISTORY_TMPL
 if [[ ! -d "${COM_ATMOS_HISTORY_STAT}" ]]; then mkdir -p "${COM_ATMOS_HISTORY_STAT}"; fi
 
 for fhr in $(seq $FHMIN $FHOUT $FHMAX); do
@@ -90,7 +90,7 @@ for fhr in $(seq $FHMIN $FHOUT $FHMAX); do
    if [ $SMOOTH_ENKF = "YES" ]; then
       for imem in $(seq 1 $NMEM_ENS); do
          memchar="mem"$(printf %03i "${imem}")
-         MEMDIR="${memchar}" YMD=${PDY} HH=${cyc} generate_com -x COM_ATMOS_HISTORY
+         MEMDIR="${memchar}" YMD=${PDY} HH=${cyc} declare_from_tmpl -x COM_ATMOS_HISTORY
          ${NLN} "${COM_ATMOS_HISTORY}/${PREFIX}atmf${fhrchar}${ENKF_SUFFIX}.nc" "atmf${fhrchar}${ENKF_SUFFIX}_${memchar}"
       done
    fi

--- a/scripts/exgdas_enkf_sfc.sh
+++ b/scripts/exgdas_enkf_sfc.sh
@@ -148,13 +148,13 @@ if [ $DOIAU = "YES" ]; then
             cmem=$(printf %03i $imem)
             memchar="mem$cmem"
 
-            MEMDIR=${memchar} YMD=${PDY} HH=${cyc} generate_com \
+            MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl \
                 COM_ATMOS_RESTART_MEM:COM_ATMOS_RESTART_TMPL
 
-            MEMDIR=${gmemchar} RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} generate_com \
+            MEMDIR=${gmemchar} RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl \
                 COM_ATMOS_RESTART_MEM_PREV:COM_ATMOS_RESTART_TMPL
 
-            MEMDIR=${memchar} YMD=${PDY} HH=${cyc} generate_com \
+            MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl \
                 COM_ATMOS_ANALYSIS_MEM:COM_ATMOS_ANALYSIS_TMPL
 
             [[ ${TILE_NUM} -eq 1 ]] && mkdir -p "${COM_ATMOS_RESTART_MEM}"
@@ -195,10 +195,10 @@ if [ $DOSFCANL_ENKF = "YES" ]; then
             cmem=$(printf %03i $imem)
             memchar="mem$cmem"
 
-            MEMDIR=${memchar} YMD=${PDY} HH=${cyc} generate_com \
+            MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl \
                 COM_ATMOS_RESTART_MEM:COM_ATMOS_RESTART_TMPL
 
-            RUN="${GDUMP_ENS}" MEMDIR=${gmemchar} YMD=${gPDY} HH=${gcyc} generate_com \
+            RUN="${GDUMP_ENS}" MEMDIR=${gmemchar} YMD=${gPDY} HH=${gcyc} declare_from_tmpl \
                 COM_ATMOS_RESTART_MEM_PREV:COM_ATMOS_RESTART_TMPL
 
             [[ ${TILE_NUM} -eq 1 ]] && mkdir -p "${COM_ATMOS_RESTART_MEM}"

--- a/scripts/exgdas_enkf_update.sh
+++ b/scripts/exgdas_enkf_update.sh
@@ -191,10 +191,10 @@ for imem in $(seq 1 $NMEM_ENS); do
    gmemchar="mem"$(printf %03i $smem)
    memchar="mem"$(printf %03i $imem)
 
-   MEMDIR=${gmemchar} RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} generate_com -x \
+   MEMDIR=${gmemchar} RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -x \
       COM_ATMOS_HISTORY_MEM_PREV:COM_ATMOS_HISTORY_TMPL
 
-   MEMDIR=${memchar} YMD=${PDY} HH=${cyc} generate_com -x \
+   MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl -x \
       COM_ATMOS_ANALYSIS_MEM:COM_ATMOS_ANALYSIS_TMPL
 
    if [ $lobsdiag_forenkf = ".false." ]; then

--- a/scripts/exgfs_wave_init.sh
+++ b/scripts/exgfs_wave_init.sh
@@ -213,7 +213,7 @@ source "${USHgfs}/preamble.sh"
 # Copy to other members if needed
 if (( NMEM_ENS > 0 )); then
   for mem in $(seq -f "%03g" 1 "${NMEM_ENS}"); do
-    MEMDIR="mem${mem}" YMD=${PDY} HH=${cyc} generate_com COM_WAVE_PREP_MEM:COM_WAVE_PREP_TMPL
+    MEMDIR="mem${mem}" YMD=${PDY} HH=${cyc} declare_from_tmpl COM_WAVE_PREP_MEM:COM_WAVE_PREP_TMPL
     mkdir -p "${COM_WAVE_PREP_MEM}"
     for grdID in ${grdALL}; do
       ${NLN} "${COM_WAVE_PREP}/${RUN}wave.mod_def.${grdID}" "${COM_WAVE_PREP_MEM}/"

--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -528,7 +528,7 @@ if [ ${DOHYBVAR} = "YES" ]; then
 
    for imem in $(seq 1 ${NMEM_ENS}); do
       memchar="mem$(printf %03i "${imem}")"
-      MEMDIR=${memchar} RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} generate_com COM_ATMOS_HISTORY
+      MEMDIR=${memchar} RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl COM_ATMOS_HISTORY
 
       for fhr in ${fhrs}; do
          ${NLN} ${COM_ATMOS_HISTORY}/${GPREFIX_ENS}atmf0${fhr}${ENKF_SUFFIX}.nc ./ensemble_data/sigf${fhr}_ens_${memchar}

--- a/scripts/exglobal_cleanup.sh
+++ b/scripts/exglobal_cleanup.sh
@@ -59,7 +59,7 @@ for (( current_date=first_date; current_date <= last_date; \
         # TODO: This needs to be revamped to not look at the rocoto log.
         # shellcheck disable=SC2312
         if [[ $(tail -n 1 "${rocotolog}") =~ "This cycle is complete: Success" ]]; then
-            YMD="${current_PDY}" HH="${current_cyc}" generate_com COM_TOP
+            YMD="${current_PDY}" HH="${current_cyc}" declare_from_tmpl COM_TOP
             if [[ -d "${COM_TOP}" ]]; then
                 IFS=", " read -r -a exclude_list <<< "${exclude_string:-}"
                 remove_files "${COM_TOP}" "${exclude_list[@]:-}"

--- a/scripts/exglobal_stage_ic.sh
+++ b/scripts/exglobal_stage_ic.sh
@@ -31,7 +31,7 @@ for MEMDIR in "${MEMDIR_ARRAY[@]}"; do
   # Stage atmosphere initial conditions to ROTDIR
   if [[ ${EXP_WARM_START:-".false."} = ".true." ]]; then
     # Stage the FV3 restarts to ROTDIR (warm start)
-    RUN=${rCDUMP} YMD=${gPDY} HH=${gcyc} generate_com COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
+    RUN=${rCDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
     [[ ! -d "${COM_ATMOS_RESTART_PREV}" ]] && mkdir -p "${COM_ATMOS_RESTART_PREV}"
     for ftype in coupler.res fv_core.res.nc; do
       src="${BASE_CPLIC}/${CPL_ATMIC:-}/${PDY}${cyc}/${MEMDIR}/atmos/${PDY}.${cyc}0000.${ftype}"
@@ -53,7 +53,7 @@ for MEMDIR in "${MEMDIR_ARRAY[@]}"; do
     done
   else
     # Stage the FV3 cold-start initial conditions to ROTDIR
-    YMD=${PDY} HH=${cyc} generate_com COM_ATMOS_INPUT
+    YMD=${PDY} HH=${cyc} declare_from_tmpl COM_ATMOS_INPUT
     [[ ! -d "${COM_ATMOS_INPUT}" ]] && mkdir -p "${COM_ATMOS_INPUT}"
     src="${BASE_CPLIC}/${CPL_ATMIC:-}/${PDY}${cyc}/${MEMDIR}/atmos/gfs_ctrl.nc"
     tgt="${COM_ATMOS_INPUT}/gfs_ctrl.nc"
@@ -75,7 +75,7 @@ for MEMDIR in "${MEMDIR_ARRAY[@]}"; do
 
   # Stage ocean initial conditions to ROTDIR (warm start)
   if [[ "${DO_OCN:-}" = "YES" ]]; then
-    RUN=${rCDUMP} YMD=${gPDY} HH=${gcyc} generate_com COM_OCEAN_RESTART_PREV:COM_OCEAN_RESTART_TMPL
+    RUN=${rCDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl COM_OCEAN_RESTART_PREV:COM_OCEAN_RESTART_TMPL
     [[ ! -d "${COM_OCEAN_RESTART_PREV}" ]] && mkdir -p "${COM_OCEAN_RESTART_PREV}"
     src="${BASE_CPLIC}/${CPL_OCNIC:-}/${PDY}${cyc}/${MEMDIR}/ocean/${PDY}.${cyc}0000.MOM.res.nc"
     tgt="${COM_OCEAN_RESTART_PREV}/${PDY}.${cyc}0000.MOM.res.nc"
@@ -119,7 +119,7 @@ for MEMDIR in "${MEMDIR_ARRAY[@]}"; do
     # TODO: No mediator is presumably involved in an ATMA configuration
     if [[ ${EXP_WARM_START:-".false."} = ".true." ]]; then
       # Stage the mediator restarts to ROTDIR (warm start/restart the coupled model)
-      RUN=${rCDUMP} YMD=${gPDY} HH=${gcyc} generate_com COM_MED_RESTART_PREV:COM_MED_RESTART_TMPL
+      RUN=${rCDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl COM_MED_RESTART_PREV:COM_MED_RESTART_TMPL
       [[ ! -d "${COM_MED_RESTART_PREV}" ]] && mkdir -p "${COM_MED_RESTART_PREV}"
       src="${BASE_CPLIC}/${CPL_MEDIC:-}/${PDY}${cyc}/${MEMDIR}/med/${PDY}.${cyc}0000.ufs.cpld.cpl.r.nc"
       tgt="${COM_MED_RESTART_PREV}/${PDY}.${cyc}0000.ufs.cpld.cpl.r.nc"
@@ -137,7 +137,7 @@ for MEMDIR in "${MEMDIR_ARRAY[@]}"; do
 
   # Stage ice initial conditions to ROTDIR (warm start)
   if [[ "${DO_ICE:-}" = "YES" ]]; then
-    RUN=${rCDUMP} YMD=${gPDY} HH=${gcyc} generate_com COM_ICE_RESTART_PREV:COM_ICE_RESTART_TMPL
+    RUN=${rCDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl COM_ICE_RESTART_PREV:COM_ICE_RESTART_TMPL
     [[ ! -d "${COM_ICE_RESTART_PREV}" ]] && mkdir -p "${COM_ICE_RESTART_PREV}"
     src="${BASE_CPLIC}/${CPL_ICEIC:-}/${PDY}${cyc}/${MEMDIR}/ice/${PDY}.${cyc}0000.cice_model.res.nc"
     tgt="${COM_ICE_RESTART_PREV}/${PDY}.${cyc}0000.cice_model.res.nc"
@@ -149,7 +149,7 @@ for MEMDIR in "${MEMDIR_ARRAY[@]}"; do
 
   # Stage the WW3 initial conditions to ROTDIR (warm start; TODO: these should be placed in $RUN.$gPDY/$gcyc)
   if [[ "${DO_WAVE:-}" = "YES" ]]; then
-    YMD=${PDY} HH=${cyc} generate_com COM_WAVE_RESTART
+    YMD=${PDY} HH=${cyc} declare_from_tmpl COM_WAVE_RESTART
     [[ ! -d "${COM_WAVE_RESTART}" ]] && mkdir -p "${COM_WAVE_RESTART}"
     for grdID in ${waveGRD}; do # TODO: check if this is a bash array; if so adjust
       src="${BASE_CPLIC}/${CPL_WAVIC:-}/${PDY}${cyc}/${MEMDIR}/wave/${PDY}.${cyc}0000.restart.${grdID}"

--- a/ush/bash_utils.sh
+++ b/ush/bash_utils.sh
@@ -1,22 +1,21 @@
 #! /usr/bin/env bash
 
-function generate_com() {
+function declare_from_tmpl() {
     #
-    # Generate a list COM variables from a template by substituting in env variables.
+    # Define variables from corresponding templates by substituting in env variables.
     #
-    # Each argument must have a corresponding template with the name ${ARG}_TMPL. Any 
-    #   variables in the template are replaced with their values. Undefined variables
-    #   are just removed without raising an error.
+    # Each template must already be defined. Any variables in the template are replaced
+    #   with their values. Undefined variables are just removed WITHOUT raising an error.
     #
     # Accepts as options `-r` and `-x`, which do the same thing as the same options in
     #   `declare`. Variables are automatically marked as `-g` so the variable is visible
     #   in the calling script.
     #
     # Syntax:
-    #   generate_com [-rx] $var1[:$tmpl1] [$var2[:$tmpl2]] [...]]
+    #   declare_from_tmpl [-rx] $var1[:$tmpl1] [$var2[:$tmpl2]] [...]]
     #
     #   options:
-    #       -r: Make variable read-only (same as `decalre -r`)
+    #       -r: Make variable read-only (same as `declare -r`)
     #       -x: Mark variable for export (same as `declare -x`)
     #   var1, var2, etc: Variable names whose values will be generated from a template
     #                    and declared
@@ -24,14 +23,14 @@ function generate_com() {
     #
     #   Examples:
     #       # Current cycle and RUN, implicitly using template COM_ATMOS_ANALYSIS_TMPL
-    #       YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_ANALYSIS
+    #       YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS
     #
     #       # Previous cycle and gdas using an explicit template
-    #       RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+    #       RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     #           COM_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
     #
     #       # Current cycle and COM for first member
-    #       MEMDIR='mem001' YMD=${PDY} HH=${cyc} generate_com -rx COM_ATMOS_HISTORY
+    #       MEMDIR='mem001' YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_HISTORY
     #
     if [[ ${DEBUG_WORKFLOW:-"NO"} == "NO" ]]; then set +x; fi
     local opts="-g"
@@ -52,14 +51,14 @@ function generate_com() {
             template="${com_var}_TMPL"
         fi
         if [[ ! -v "${template}" ]]; then
-            echo "FATAL ERROR in generate_com: Requested template ${template} not defined!"
+            echo "FATAL ERROR in declare_from_tmpl: Requested template ${template} not defined!"
             exit 2
         fi
         value=$(echo "${!template}" | envsubst)
         # shellcheck disable=SC2086
         declare ${opts} "${com_var}"="${value}"
         # shellcheck disable=
-        echo "generate_com :: ${com_var}=${value}"
+        echo "declare_from_tmpl :: ${com_var}=${value}"
     done
     set_trace
 }
@@ -122,6 +121,6 @@ function detect_py_ver() {
 }
 # shellcheck disable=
 
-declare -xf generate_com
+declare -xf declare_from_tmpl
 declare -xf wait_for_file
 declare -xf detect_py

--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -698,7 +698,7 @@ if [[ ${type} == "enkfgdas" || ${type} == "enkfgfs" ]]; then
       mem=$(printf %03i ${nm})
       head="${RUN}.t${cyc}z."
 
-      MEMDIR="mem${mem}" YMD=${PDY} HH=${cyc} generate_com \
+      MEMDIR="mem${mem}" YMD=${PDY} HH=${cyc} declare_from_tmpl \
         COM_ATMOS_ANALYSIS_MEM:COM_ATMOS_ANALYSIS_TMPL \
         COM_ATMOS_RESTART_MEM:COM_ATMOS_RESTART_TMPL \
         COM_ATMOS_HISTORY_MEM:COM_ATMOS_HISTORY_TMPL


### PR DESCRIPTION
# Description
The `generate_com` function is renamed to `declare_from_tmpl`. NCO requested the change, and the new name more accurately represents the functionality.

Resolves #2344

# Type of change
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Cycled test on Orion

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
