### PR TITLE
The soca fix path is needed in config.prepoceanobs

### DIFF
--- a/parm/config/gfs/config.prepoceanobs
+++ b/parm/config/gfs/config.prepoceanobs
@@ -6,6 +6,7 @@ echo "BEGIN: config.prepoceanobs"
 
 export OCNOBS2IODAEXEC=${HOMEgfs}/sorc/gdas.cd/build/bin/gdas_obsprovider2ioda.x
 
+export SOCA_INPUT_FIX_DIR=@SOCA_INPUT_FIX_DIR@
 export OBS_YAML_DIR=${HOMEgfs}/sorc/gdas.cd/parm/soca/obs/config
 export OBSPREP_YAML=@OBSPREP_YAML@
 export OBS_LIST=@SOCA_OBS_LIST@

--- a/parm/config/gfs/yaml/defaults.yaml
+++ b/parm/config/gfs/yaml/defaults.yaml
@@ -40,7 +40,9 @@ ocnanal:
   SABER_BLOCKS_YAML: ""
   NICAS_RESOL: 1
   NICAS_GRID_SIZE: 15000
+
 prepoceanobs:
+  SOCA_INPUT_FIX_DIR: "/scratch2/NCEPDEV/ocean/Guillaume.Vernieres/data/static/72x35x25/soca"  # TODO: These need to go to glopara fix space.
   SOCA_OBS_LIST: "${PARMgfs}/gdas/soca/obs/obs_list.yaml"  # TODO: This is also repeated in ocnanal
   OBSPREP_YAML: "${PARMgfs}/gdas/soca/obsprep/obsprep_config.yaml"
   DMPDIR: "/scratch1/NCEPDEV/global/glopara/data/experimental_obs"


### PR DESCRIPTION
# Description
Give the prepoceanobs task access to SOCA_INPUT_FIX_DIR, which will be needed for some of the obs processing.

# Type of change
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? **NO**
- Does this change require a documentation update? **NO**

# How has this been tested?
Ran the ocean obs prep job 

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
