### PR TITLE
Using Rocky 8 on hera

### DIFF
--- a/modulefiles/module_gwci.hera.lua
+++ b/modulefiles/module_gwci.hera.lua
@@ -2,14 +2,14 @@ help([[
 Load environment to run GFS workflow setup scripts on Hera
 ]])
 
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
 
 load(pathJoin("stack-intel", os.getenv("2021.5.0")))
 load(pathJoin("stack-intel-oneapi-mpi", os.getenv("2021.5.1")))
 
 load(pathJoin("netcdf-c", os.getenv("4.9.2")))
 load(pathJoin("netcdf-fortran", os.getenv("4.6.1")))
-load(pathJoin("nccmp","1.9.0.1"))
+load(pathJoin("nccmp","1.9.1"))
 load(pathJoin("wgrib2", "2.0.8"))
 
 whatis("Description: GFS run setup CI environment")

--- a/modulefiles/module_gwsetup.hera.lua
+++ b/modulefiles/module_gwsetup.hera.lua
@@ -4,7 +4,7 @@ Load environment to run GFS workflow setup scripts on Hera
 
 load(pathJoin("rocoto"))
 
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local python_ver=os.getenv("python_ver") or "3.11.6"

--- a/sorc/setup_case.sh
+++ b/sorc/setup_case.sh
@@ -1,19 +1,17 @@
 #!/bin/bash
 #https://global-workflow.readthedocs.io/en/latest/setup.html
 
- GLOBALWORKFLOWHOME=/scratch2/NAGAPE/epic/Wei.Huang/src/global-workflow-cloud
-
  set -x
 
+ GLOBALWORKFLOWHOME=/scratch2/NAGAPE/epic/Wei.Huang/src/global-workflow-cloud
  PSLOT=exp_c48
  CONFIGDIR=${GLOBALWORKFLOWHOME}/parm/config
- IDATE=2020060100
- EDATE=2020060200
+ IDATE=2021032312
+ EDATE=2021032312
  COMROOT=${GLOBALWORKFLOWHOME}/comroot
  EXPDIR=${GLOBALWORKFLOWHOME}/expdir
 
  cd ${GLOBALWORKFLOWHOME}/workflow
-
  source ${GLOBALWORKFLOWHOME}/workflow/gw_setup.sh
 
  ${GLOBALWORKFLOWHOME}/workflow/setup_expt.py gfs forecast-only \
@@ -22,11 +20,11 @@
         --app ATM \
         --pslot ${PSLOT} \
         --configdir ${CONFIGDIR}/gfs \
-        --resdetatmos 96 \
-        --resdetocean 1.0 \
+        --resdetatmos 48 \
         --comroot ${COMROOT} \
         --expdir ${EXPDIR}
 
+#        --resdetocean 1.0 \
 #${GLOBALWORKFLOWHOME}/workflow/setup_expt.py gfs forecast-only \
 #       --idate $IDATE \
 #       --edate $EDATE \

--- a/sorc/setup_case.sh
+++ b/sorc/setup_case.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#https://global-workflow.readthedocs.io/en/latest/setup.html
+
+ GLOBALWORKFLOWHOME=/scratch2/NAGAPE/epic/Wei.Huang/src/global-workflow-cloud
+
+ set -x
+
+ PSLOT=exp_c48
+ CONFIGDIR=${GLOBALWORKFLOWHOME}/parm/config
+ IDATE=2020060100
+ EDATE=2020060200
+ COMROOT=${GLOBALWORKFLOWHOME}/comroot
+ EXPDIR=${GLOBALWORKFLOWHOME}/expdir
+
+ cd ${GLOBALWORKFLOWHOME}/workflow
+
+ source ${GLOBALWORKFLOWHOME}/workflow/gw_setup.sh
+
+ ${GLOBALWORKFLOWHOME}/workflow/setup_expt.py gfs forecast-only \
+        --idate ${IDATE} \
+        --edate ${EDATE} \
+        --app ATM \
+        --pslot ${PSLOT} \
+        --configdir ${CONFIGDIR}/gfs \
+        --resdetatmos 96 \
+        --resdetocean 1.0 \
+        --comroot ${COMROOT} \
+        --expdir ${EXPDIR}
+
+#${GLOBALWORKFLOWHOME}/workflow/setup_expt.py gfs forecast-only \
+#       --idate $IDATE \
+#       --edate $EDATE \
+#       [--app $APP] \
+#       [--start $START] \
+#       [--gfs_cyc $GFS_CYC] \
+#       [--resdetatmos $RESDETATMOS] \
+#       [--resdetocean $RESDETOCEAN] \
+#       [--pslot $PSLOT] \
+#       [--configdir $CONFIGDIR] \
+#       [--comroot $COMROOT] \
+#       [--expdir $EXPDIR]
+
+#usage: setup_expt.py gfs forecast-only [-h] [--pslot PSLOT] [--resdetatmos RESDETATMOS] [--resdetocean RESDETOCEAN]
+#                                      [--comroot COMROOT] [--expdir EXPDIR] --idate IDATE --edate EDATE [--overwrite]
+#                                      [--start {warm,cold}] [--cdump CDUMP] [--yaml YAML] [--app {ATM,ATMA,ATMW,S2S,S2SA,S2SW,S2SWA}]
+#                                      [--gfs_cyc {1,2,4}]
+
+#${GLOBALWORKFLOWHOME}/workflow/setup_xml.py ${EXPDIR}/${PSLOT}
+

--- a/versions/build.hera.ver
+++ b/versions/build.hera.ver
@@ -1,5 +1,5 @@
 export stack_intel_ver=2021.5.0
 export stack_impi_ver=2021.5.1
-export spack_env=gsi-addon-dev
+export spack_env=gsi-addon-dev-rocky8
 source "${HOMEgfs:-}/versions/build.spack.ver"
 export spack_mod_path="/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-${spack_stack_ver}/envs/${spack_env}/install/modulefiles/Core"

--- a/versions/build.spack.ver
+++ b/versions/build.spack.ver
@@ -1,6 +1,6 @@
 export spack_stack_ver=1.6.0
 
-export cmake_ver=3.23.1
+export cmake_ver=3.28.1
 
 export jasper_ver=2.0.32
 export libpng_ver=1.6.37

--- a/versions/run.hera.ver
+++ b/versions/run.hera.ver
@@ -1,6 +1,6 @@
 export stack_intel_ver=2021.5.0
 export stack_impi_ver=2021.5.1
-export spack_env=gsi-addon-dev
+export spack_env=gsi-addon-dev-rocky8
 
 export hpss_ver=hpss
 export ncl_ver=6.6.2

--- a/versions/run.spack.ver
+++ b/versions/run.spack.ver
@@ -4,7 +4,7 @@ export python_ver=3.11.6
 export jasper_ver=2.0.32
 export libpng_ver=1.6.37
 export cdo_ver=2.2.0
-export nco_ver=5.0.6
+export nco_ver=5.1.6
 
 export hdf5_ver=1.14.0
 export netcdf_c_ver=4.9.2

--- a/versions/run.spack.ver
+++ b/versions/run.spack.ver
@@ -3,7 +3,7 @@ export python_ver=3.11.6
 
 export jasper_ver=2.0.32
 export libpng_ver=1.6.37
-export cdo_ver=2.2.0
+export cdo_ver=2.3.0
 export nco_ver=5.1.6
 
 export hdf5_ver=1.14.0


### PR DESCRIPTION
# Description
Modify module files to use Rocky 8 on hera.

  Resolves #1

# Type of change
Mainly module file changes to set the module path point to Rocky 8.
and some packs version changes
# Change characteristics
- Is this a breaking change (a change in existing functionality)? YES/NO
- Does this change require a documentation update? YES/NO

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->

# Checklist
- [ ] Any dependent changes have been merged and published
- [ x] My code follows the style guidelines of this project
- [x ] I have compiled on hera, and done a simple forecast run.


