### PR TITLE
Fix Index Error from WDQMS Python Script in release/gfs.v16.3.16

### DIFF
--- a/ush/wdqms.py
+++ b/ush/wdqms.py
@@ -66,6 +66,10 @@ class WDQMS:
         # Grab actual datetimes from datetime + timedelta
         df_total = self._get_datetimes(df_total)
 
+        # Drop duplicates
+        columns_to_compare = ['Station_ID', 'var_id', 'Observation_Type', 'Latitude', 'Longitude', 'Pressure', 'Time']
+        df_total = df_total.drop_duplicates(subset=columns_to_compare, keep='first')
+
         # Adjust relative humidity data
         df_total = self._genqsat(df_total)
 
@@ -474,10 +478,13 @@ class WDQMS:
             t_tmp = t_df.loc[(t_df['Station_ID'] == stn)]
             q_tmp = q_df.loc[(q_df['Station_ID'] == stn)]
 
-            t_tmp = t_tmp.loc[(np.in1d(t_tmp['Time'], q_tmp['Time'])) &
-                              (np.in1d(t_tmp['Pressure'], q_tmp['Pressure'])) &
-                              (np.in1d(t_tmp['Latitude'], q_tmp['Latitude'])) &
-                              (np.in1d(t_tmp['Longitude'], q_tmp['Longitude']))]
+            columns_to_extract = ['Latitude', 'Longitude', 'Pressure', 'Time', 'Observation', 'Obs_Minus_Forecast_adjusted']
+            columns_to_compare = ['Latitude', 'Longitude', 'Pressure', 'Time']
+
+            t_tmp = t_tmp[columns_to_extract]
+            q_tmp = q_tmp[columns_to_extract]
+
+            t_tmp = pd.merge(t_tmp, q_tmp, on=columns_to_compare, suffixes=('','_q'), how='inner')
 
             q_obs = q_tmp['Observation'].to_numpy() * 1.0e6
             q_ges = (q_tmp['Observation'].to_numpy() -

--- a/ush/wdqms.py
+++ b/ush/wdqms.py
@@ -67,8 +67,7 @@ class WDQMS:
         df_total = self._get_datetimes(df_total)
 
         # Drop duplicates
-        columns_to_compare = ['Station_ID', 'var_id', 'Observation_Type', 'Latitude', 'Longitude', 'Pressure', 'Time']
-        df_total = df_total.drop_duplicates(subset=columns_to_compare, keep='first')
+        df_total = df_total.drop_duplicates()
 
         # Adjust relative humidity data
         df_total = self._genqsat(df_total)
@@ -485,6 +484,7 @@ class WDQMS:
             q_tmp = q_tmp[columns_to_extract]
 
             t_tmp = pd.merge(t_tmp, q_tmp, on=columns_to_compare, suffixes=('','_q'), how='inner')
+            t_tmp = t_tmp[columns_to_extract].drop_duplicates()
 
             q_obs = q_tmp['Observation'].to_numpy() * 1.0e6
             q_ges = (q_tmp['Observation'].to_numpy() -


### PR DESCRIPTION
# Description
This PR fixes the Python `IndexError` reported by NCO's test for the implementation of adding WDQMS processing into global-workflow
 
Note:
1. I am having trouble opening issue to report this bug (the submit button disabled).  I will try again to open an issue related to this PR.
2. Please add @kevindougherty-noaa as reviewer

Case study for 2024040212:
1. Reproduced IndexError for MARINE processing but not for TEMP
3. Function `genqsat` failed when temperature, moisture, and  pressure do not have consistent dimensions and thus caused index error
4. The Python numpy in1d function does not work as expected.  The in1d does not match elements in the selected columns strictly row by row.  

Proposed fixes: 
1. Drop duplicates from df_total
2. Replace in1d with merge, and drop duplicates for selected columns

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Stand-alone (outside of global-workflow) test from 2024010100 - 2024041018 (404 stand-alone cycles tested)
- Cycled test on WCOSS-2 from 2024033118 to 2024040618 and 2023123118 to ? (to be determined)

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
