### PR TITLE
Update fbwind for COM refactor

### DIFF
--- a/jobs/JGFS_ATMOS_FBWIND
+++ b/jobs/JGFS_ATMOS_FBWIND
@@ -17,33 +17,34 @@ export COMPONENT="atmos"
 ##############################################
 # Define COM directories
 ##############################################
-export COMIN=${COMIN:-$(compath.py ${envir}/${NET}/${gfs_ver})/${RUN}.${PDY}/${cyc}/${COMPONENT}}
-export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${gfs_ver}/${RUN}.${PDY})/${cyc}/${COMPONENT}}
-export COMOUTwmo=${COMOUTwmo:-${COMOUT}/wmo}
+
+GRID="0p25" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMIN_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMOUT:COM_ATMOS_WMO_TMPL
+if [[ ! -d "${COMOUT}" ]]; then
+  mkdir -m 775 -p "${COMOUT}"
+fi
 
 export SENDDBN=${SENDDBN:-NO}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
-mkdir -m 775 -p ${COMOUT} ${COMOUTwmo}
-
 
 ########################################################
 # Execute the script.
-${SCRgfs}/exgfs_atmos_fbwind.sh
+"${SCRgfs}/exgfs_atmos_fbwind.sh"
 export err=$?;err_chk
 ########################################################
 
 ############################################
 # print exec I/O output
 ############################################
-if [ -e "${pgmout}" ] ; then
-  cat ${pgmout}
+if [[ -e "${pgmout}" ]] ; then
+  cat "${pgmout}"
 fi
 
 ###################################
 # Remove temp directories
 ###################################
-if [ "${KEEPDATA}" != "YES" ] ; then
-  rm -rf ${DATA}
+if [[ "${KEEPDATA}" != "YES" ]] ; then
+  rm -rf "${DATA}"
 fi
 

--- a/scripts/exgfs_atmos_fbwind.sh
+++ b/scripts/exgfs_atmos_fbwind.sh
@@ -22,7 +22,7 @@ cd "${DATA}" || exit 2
 # Set up Here Files.
 ######################
 
-job_name="${job/[jpt]gfs/gfs}"
+outfile_name="${COMOUT}/${RUN}.atmos.t${cyc}z.fbwind.pacific.ascii"
 
 set +x
 echo " "
@@ -68,11 +68,11 @@ cp "${PARMgfs}/product/fbwnd_pacific.stnlist" fbwnd_pacific.stnlist
 "${EXECgfs}/fbwndgfs.x" < fbwnd_pacific.stnlist >> "${pgmout}" 2> errfile
 export err=$?; err_chk
 
-cp tran.fbwnd_pacific "${COMOUT}/tran.fbwnd_pacific.${job_name}"
+cp tran.fbwnd_pacific "${outfile_name}"
 
 if [[ "${SENDDBN}" == 'YES' ]]; then
   # Should this really be in a SENDDBN block?
-  "${USHgfs}/make_ntc_bull.pl" WMOBH NONE KWNO NONE tran.fbwnd_pacific "${COMOUT}/tran.fbwnd_pacific.${job_name}"
+  "${USHgfs}/make_ntc_bull.pl" WMOBH NONE KWNO NONE tran.fbwnd_pacific "${outfile_name}"
 fi
 
 #####################################################################

--- a/scripts/exgfs_atmos_fbwind.sh
+++ b/scripts/exgfs_atmos_fbwind.sh
@@ -68,14 +68,6 @@ cp "${PARMgfs}/product/fbwnd_pacific.stnlist" fbwnd_pacific.stnlist
 "${EXECgfs}/fbwndgfs.x" < fbwnd_pacific.stnlist >> "${pgmout}" 2> errfile
 export err=$?; err_chk
 
-cp tran.fbwnd_pacific "${outfile_name}"
-
-if [[ "${SENDDBN}" == 'YES' ]]; then
-  # Should this really be in a SENDDBN block?
-  "${USHgfs}/make_ntc_bull.pl" WMOBH NONE KWNO NONE tran.fbwnd_pacific "${outfile_name}"
-fi
-
-#####################################################################
-
+"${USHgfs}/make_ntc_bull.pl" WMOBH NONE KWNO NONE tran.fbwnd_pacific "${outfile_name}"
 
 ############################### END OF SCRIPT #######################


### PR DESCRIPTION
# Description
Updates fbwind job for the COM refactor and some other cleanup.

This works on WCOSS but not on Orion. There seems to be a problem with either `grbindex` or `GETGB()` on Orion that causes the executable to be unable to read the grib1 index file. The grib1 data file produced there seems fine. Haven't checked Hera yet, maybe there is a problem with the spack-stack build of `grbindex`.

Resolves: #2160
Refs: #289

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Cycled test with AWIPS on on WCOSS
- Cycled test with AWIPS on on Orion

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
