### PR TITLE
Workflow updates for GLDAS fixes

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -15,7 +15,7 @@ protocol = git
 required = True
 
 [GLDAS]
-tag = gldas_gfsv16_release.v.2.1.0
+tag = gldas_gfsv16_release.v.2.1.1
 local_path = sorc/gldas.fd
 repo_url = https://github.com/NOAA-EMC/GLDAS.git
 protocol = git

--- a/docs/Release_Notes.gfs.v16.3.17.md
+++ b/docs/Release_Notes.gfs.v16.3.17.md
@@ -1,0 +1,128 @@
+GFS V16.3.17 RELEASE NOTES
+
+-------
+PRELUDE
+-------
+
+Update to the GLDAS job to better handle loss of CPC gauge input data. Also, remove the GLDAS job from the 06z, 12z, and 18z cycles; it should only run during the 00z.
+
+IMPLEMENTATION INSTRUCTIONS
+---------------------------
+
+The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub .com are used to manage the GFS code.  The SPA(s) handling the GFS implementation need to have permissions to clone VLab Gerrit repositories and private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are publicly readable and do not require access permissions.  Please proceed with the following steps to install the package on WCOSS2:
+
+```bash
+cd $PACKAGEROOT
+mkdir gfs.v16.3.17
+cd gfs.v16.3.17
+git clone -b EMC-v16.3.17 https://github.com/NOAA-EMC/global-workflow.git .
+cd sorc
+./checkout.sh -o
+```
+
+The checkout script extracts the following GFS components:
+
+| Component | Tag         | POC               |
+| --------- | ----------- | ----------------- |
+| MODEL     | GFS.v16.3.1   | Jun.Wang@noaa.gov |
+| GLDAS     | gldas_gfsv16_release.v.2.1.1 | Helin.Wei@noaa.gov |
+| GSI       | gfsda.v16.3.12 | Andrew.Collard@noaa.gov |
+| UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
+| POST      | upp_v8.3.0 | Wen.Meng@noaa.gov |
+| WAFS      | gfs_wafs.v6.3.2 | Yali.Mao@noaa.gov |
+
+To build all the GFS components, execute:
+```bash
+./build_all.sh
+```
+The `build_all.sh` script compiles all GFS components. Runtime output from the build for each package is written to log files in directory logs. To build an individual program, for instance, gsi, use `build_gsi.sh`.
+
+Next, link the executables, fix files, parm files, etc in their final respective locations by executing:
+```bash
+./link_fv3gfs.sh nco wcoss2
+```
+
+Lastly, link the ecf scripts by moving back up to the ecf folder and executing:
+```bash
+cd ../ecf
+./setup_ecf_links.sh
+```
+VERSION FILE CHANGES
+--------------------
+
+* `versions/run.ver` - change `version=v16.3.17` and `gfs_ver=v16.3.17`
+
+SORC CHANGES
+------------
+
+* No changes from GFS v16.3.16
+
+JOBS CHANGES
+------------
+
+* No changes from GFS v16.3.16
+
+PARM/CONFIG CHANGES
+-------------------
+
+* No changes from GFS v16.3.16
+
+SCRIPT CHANGES
+--------------
+
+* `scripts/exgdas_atmos_gldas.sh` - remove EMC-specific default path
+* `ush/gldas_forcing.sh` and `ush/gldas_get_data.sh` - improve fatal error messaging and exit number
+
+FIX CHANGES
+-----------
+
+* No changes from GFS v16.3.16
+
+MODULE CHANGES
+--------------
+
+* No changes from GFS v16.3.16
+
+CHANGES TO FILE SIZES
+---------------------
+
+* No changes from GFS v16.3.16
+
+ENVIRONMENT AND RESOURCE CHANGES
+--------------------------------
+
+* No changes from GFS v16.3.16
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+---------------------------------------
+
+* Which production jobs should be tested as part of this implementation?
+  * GLDAS
+* Does this change require a 30-day evaluation?
+  * No
+
+DISSEMINATION INFORMATION
+-------------------------
+
+* No changes from GFS v16.3.16
+
+HPSS ARCHIVE
+------------
+
+* No changes from GFS v16.3.16
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+---------------------------------
+
+* Remove `gldas` job from 06z, 12z, and 18z cycles.
+* Remove `gldas` job as trigger for forecast job.
+
+DOCUMENTATION
+-------------
+
+* No changes from GFS v16.3.16
+
+PREPARED BY
+-----------
+Kate.Friedman@noaa.gov
+Helin.Wei@noaa.gov

--- a/ecf/defs/gfs_v16_3.def
+++ b/ecf/defs/gfs_v16_3.def
@@ -4866,10 +4866,6 @@ suite gfs_v16_3
                     trigger /gfs_v16_3/primary/06/obsproc/v1.0/gdas/atmos/dump/jobsproc_gdas_atmos_dump:release_sfcprep
                 endfamily
               endfamily
-              family init
-                task jgdas_atmos_gldas
-                  trigger ../analysis/jgdas_atmos_analysis == complete
-              endfamily
               family analysis
                 task jgdas_atmos_analysis
                   trigger /gfs_v16_3/primary/06/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../obsproc/prep/jgdas_atmos_emcsfc_sfc_prep == complete
@@ -4998,7 +4994,7 @@ suite gfs_v16_3
               endfamily
             endfamily
             task jgdas_forecast
-              trigger ./atmos/analysis/jgdas_atmos_analysis:release_fcst and ./wave/prep/jgdas_wave_prep == complete and ./atmos/init/jgdas_atmos_gldas == complete
+              trigger ./atmos/analysis/jgdas_atmos_analysis:release_fcst and ./wave/prep/jgdas_wave_prep == complete
           endfamily
           family enkfgdas
             edit RUN 'gdas'
@@ -7493,10 +7489,6 @@ suite gfs_v16_3
                     trigger /gfs_v16_3/primary/12/obsproc/v1.0/gdas/atmos/dump/jobsproc_gdas_atmos_dump:release_sfcprep
                 endfamily
               endfamily
-              family init
-                task jgdas_atmos_gldas
-                  trigger ../analysis/jgdas_atmos_analysis == complete
-              endfamily
               family analysis
                 task jgdas_atmos_analysis
                   trigger /gfs_v16_3/primary/12/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../obsproc/prep/jgdas_atmos_emcsfc_sfc_prep == complete
@@ -7625,7 +7617,7 @@ suite gfs_v16_3
               endfamily
             endfamily
             task jgdas_forecast
-              trigger ./atmos/analysis/jgdas_atmos_analysis:release_fcst and ./wave/prep/jgdas_wave_prep == complete and ./atmos/init/jgdas_atmos_gldas == complete
+              trigger ./atmos/analysis/jgdas_atmos_analysis:release_fcst and ./wave/prep/jgdas_wave_prep == complete
           endfamily
           family enkfgdas
             edit RUN 'gdas'
@@ -10120,10 +10112,6 @@ suite gfs_v16_3
                     trigger /gfs_v16_3/primary/18/obsproc/v1.0/gdas/atmos/dump/jobsproc_gdas_atmos_dump:release_sfcprep
                 endfamily
               endfamily
-              family init
-                task jgdas_atmos_gldas
-                  trigger ../analysis/jgdas_atmos_analysis == complete
-              endfamily
               family analysis
                 task jgdas_atmos_analysis
                   trigger /gfs_v16_3/primary/18/obsproc/v1.0/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../obsproc/prep/jgdas_atmos_emcsfc_sfc_prep == complete
@@ -10252,7 +10240,7 @@ suite gfs_v16_3
               endfamily
             endfamily
             task jgdas_forecast
-              trigger ./atmos/analysis/jgdas_atmos_analysis:release_fcst and ./wave/prep/jgdas_wave_prep == complete and ./atmos/init/jgdas_atmos_gldas == complete
+              trigger ./atmos/analysis/jgdas_atmos_analysis:release_fcst and ./wave/prep/jgdas_wave_prep == complete
           endfamily
           family enkfgdas
             edit RUN 'gdas'

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -46,7 +46,7 @@ fi
 echo gldas checkout ...
 if [[ ! -d gldas.fd ]] ; then
     rm -f ${topdir}/checkout-gldas.log
-    git clone --branch gldas_gfsv16_release.v.2.1.0 https://github.com/NOAA-EMC/GLDAS  gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
+    git clone --branch gldas_gfsv16_release.v.2.1.1 https://github.com/NOAA-EMC/GLDAS  gldas.fd >> ${topdir}/checkout-gldas.fd.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory gldas.fd already exists.'

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.16
-export gfs_ver=v16.3.16
+export version=v16.3.17
+export gfs_ver=v16.3.17
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2


### PR DESCRIPTION
# Description

This PR brings in the workflow updates to address GLDAS enhancements requested by NCO. GLDAS script updates come in via a new GLDAS repo tag [gldas_gfsv16_release.v.2.1.1](https://github.com/NOAA-EMC/GLDAS/releases/tag/gldas_gfsv16_release.v.2.1.1).

Workflow side updates:

- New GLDAS tag `gldas_gfsv16_release.v.2.1.1`
- Update ecFlow definition file to remove the `jgdas_atmos_gldas` job from the 06z, 12z, and 18z cycles; includes removing it from the forecast job triggers for those cycles as well
- Created release notes
- Updated GFS version to v16.3.17 (tentative, will adjust after receiving confirmation from NCO)

Refs #2503

# Type of change

Production update

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

Visual inspection, not yet tested on WCOSS2.