### PR TITLE
Adding more cycles to gempak script gfs_meta_sa2.sh

### DIFF
--- a/gempak/ush/gfs_meta_sa2.sh
+++ b/gempak/ush/gfs_meta_sa2.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 #
-# Metafile Script : ukmet_gfs_meta_sa2.sh
+# Metafile Script : gfs_meta_sa2.sh
 #
 # Creates several South American gfs charts, including 500mb and psml
 # comparisons to the ecmwf and ukmet
@@ -29,14 +29,6 @@ MDL=GFS
 metatype="sa2"
 metaname="${mdl}_${metatype}_${cyc}.meta"
 device="nc | ${metaname}"
-
-#
-# IF CYCLE IS NOT 00Z OR 06Z EXIT SCRIPT.
-# Also exit if run from 00z gfs
-#
-if [[ ${cyc} != "06" ]]; then
-    exit
-fi
 
 grid1="F-GFSHPC | ${PDY:2}/${cyc}00"
 


### PR DESCRIPTION
# Description

  This PR changes gfs_meta_sa2.sh running from 06 cycle only to all cycles. This change will satisfy NCO Bugzilla #1211 request to add 00 cycle run in order to consolidate GFS and UKMET gempak jobs.
  
  Resolves #291  
  Refs: [Bugzilla #1211](http://www2.spa.ncep.noaa.gov/bugzilla/show_bug.cgi?id=1211)

# Type of change
- Bug fix (gempak jobs consolidation)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Not tested due to the few lines of change.

# Checklist
- [X] Any dependent changes have been merged and published
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [X] I have made corresponding changes to the documentation if necessary
