### PR TITLE
Add CCPP suite and FASTER option to UFS build

### DIFF
--- a/parm/config/gfs/config.base
+++ b/parm/config/gfs/config.base
@@ -184,7 +184,6 @@ export DO_AERO="NO"
 export WAVE_CDUMP="" # When to include wave suite: gdas, gfs, or both
 export DOBNDPNT_WAVE="NO"
 export FRAC_GRID=".true."
-export CCPP_SUITE="FV3_GFS_v17_p8_ugwpv1"
 
 # Set operational resolution
 export OPS_RES="C768" # Do not change # TODO: Why is this needed and where is it used?

--- a/parm/config/gfs/config.base
+++ b/parm/config/gfs/config.base
@@ -184,6 +184,7 @@ export DO_AERO="NO"
 export WAVE_CDUMP="" # When to include wave suite: gdas, gfs, or both
 export DOBNDPNT_WAVE="NO"
 export FRAC_GRID=".true."
+export CCPP_SUITE="FV3_GFS_v17_p8_ugwpv1"
 
 # Set operational resolution
 export OPS_RES="C768" # Do not change # TODO: Why is this needed and where is it used?

--- a/parm/config/gfs/config.ufs
+++ b/parm/config/gfs/config.ufs
@@ -241,7 +241,7 @@ export cplice=".false."
 export cplchm=".false."
 export cplwav=".false."
 export cplwav2atm=".false."
-export CCPP_SUITE="FV3_GFS_v17_p8_ugwpv1"
+export CCPP_SUITE="${CCPP_SUITE:-FV3_GFS_v17_p8_ugwpv1}"
 model_list="atm"
 
 # Mediator specific settings

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -16,7 +16,7 @@ function _usage() {
 Builds all of the global-workflow components by calling the individual build
   scripts in sequence.
 
-Usage: ${BASH_SOURCE[0]} [-a UFS_app][-c build_config][-d][-h][-j n][-v][-w][-f]
+Usage: ${BASH_SOURCE[0]} [-a UFS_app][-c build_config][-d][-f][-h][-j n][-v][-w]
   -a UFS_app:
     Build a specific UFS app instead of the default
   -d:
@@ -55,7 +55,7 @@ _build_job_max=20
 _quick_kill="NO"
 # Reset option counter in case this script is sourced
 OPTIND=1
-while getopts ":a:dghj:kuvwf" option; do
+while getopts ":a:dfghj:kuvw" option; do
   case "${option}" in
     a) _build_ufs_opt+="-a ${OPTARG} ";;
     f) _build_ufs_opt+="-j ";;

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -21,6 +21,8 @@ Usage: ${BASH_SOURCE[0]} [-a UFS_app][-c build_config][-d][-f][-h][-j n][-v][-w]
     Build a specific UFS app instead of the default
   -d:
     Build in debug mode
+  -f:
+    Build the UFS model using the -DFASTER=ON option
   -g:
     Build GSI
   -h:
@@ -35,8 +37,6 @@ Usage: ${BASH_SOURCE[0]} [-a UFS_app][-c build_config][-d][-f][-h][-j n][-v][-w]
     Execute all build scripts with -v option to turn on verbose where supported
   -w:
     Use structured wave grid
-  -f:
-    Build the UFS model using the -DFASTER=ON option
 EOF
   exit 1
 }

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -58,7 +58,7 @@ OPTIND=1
 while getopts ":a:dfghj:kuvw" option; do
   case "${option}" in
     a) _build_ufs_opt+="-a ${OPTARG} ";;
-    f) _build_ufs_opt+="-j ";;
+    f) _build_ufs_opt+="-f ";;
     d) _build_debug="-d" ;;
     g) _build_gsi="YES" ;;
     h) _usage;;

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -16,7 +16,7 @@ function _usage() {
 Builds all of the global-workflow components by calling the individual build
   scripts in sequence.
 
-Usage: ${BASH_SOURCE[0]} [-a UFS_app][-c build_config][-d][-h][-j n][-v][-w]
+Usage: ${BASH_SOURCE[0]} [-a UFS_app][-c build_config][-d][-h][-j n][-v][-w][-f]
   -a UFS_app:
     Build a specific UFS app instead of the default
   -d:
@@ -35,6 +35,8 @@ Usage: ${BASH_SOURCE[0]} [-a UFS_app][-c build_config][-d][-h][-j n][-v][-w]
     Execute all build scripts with -v option to turn on verbose where supported
   -w:
     Use structured wave grid
+  -f:
+    Build the UFS model using the -DFASTER=ON option
 EOF
   exit 1
 }
@@ -53,9 +55,10 @@ _build_job_max=20
 _quick_kill="NO"
 # Reset option counter in case this script is sourced
 OPTIND=1
-while getopts ":a:dghj:kuvw" option; do
+while getopts ":a:dghj:kuvwf" option; do
   case "${option}" in
     a) _build_ufs_opt+="-a ${OPTARG} ";;
+    f) _build_ufs_opt+="-j ";;
     d) _build_debug="-d" ;;
     g) _build_gsi="YES" ;;
     h) _usage;;

--- a/sorc/build_ufs.sh
+++ b/sorc/build_ufs.sh
@@ -12,10 +12,10 @@ while getopts ":da:fj:vw" option; do
   case "${option}" in
     d) BUILD_TYPE="Debug";;
     a) APP="${OPTARG}";;
+    f) FASTER="ON";;
     j) BUILD_JOBS="${OPTARG}";;
     v) export BUILD_VERBOSE="YES";;
     w) PDLIB="OFF";;
-    f) FASTER="ON";;
     :)
       echo "[${BASH_SOURCE[0]}]: ${option} requires an argument"
       ;;

--- a/sorc/build_ufs.sh
+++ b/sorc/build_ufs.sh
@@ -5,16 +5,17 @@ cwd=$(pwd)
 
 # Default settings
 APP="S2SWA"
-CCPP_SUITES="FV3_GFS_v17_p8_ugwpv1,FV3_GFS_v17_coupled_p8_ugwpv1"  # TODO: does the g-w need to build with all these CCPP_SUITES?
+CCPP_SUITES="FV3_GFS_v17_p8_ugwpv1,FV3_GFS_v17_coupled_p8_ugwpv1,FV3_global_nest_v1"  # TODO: does the g-w need to build with all these CCPP_SUITES?
 PDLIB="ON"
 
-while getopts ":da:j:vw" option; do
+while getopts ":da:j:vwf" option; do
   case "${option}" in
     d) BUILD_TYPE="Debug";;
     a) APP="${OPTARG}";;
     j) BUILD_JOBS="${OPTARG}";;
     v) export BUILD_VERBOSE="YES";;
     w) PDLIB="OFF";;
+    f) FASTER="ON";;
     :)
       echo "[${BASH_SOURCE[0]}]: ${option} requires an argument"
       ;;
@@ -31,7 +32,11 @@ source "./tests/module-setup.sh"
 
 MAKE_OPT="-DAPP=${APP} -D32BIT=ON -DCCPP_SUITES=${CCPP_SUITES}"
 [[ ${PDLIB:-"OFF"} = "ON" ]] && MAKE_OPT+=" -DPDLIB=ON"
-[[ ${BUILD_TYPE:-"Release"} = "Debug" ]] && MAKE_OPT+=" -DDEBUG=ON"
+if [[ ${BUILD_TYPE:-"Release"} = "DEBUG" ]] ; then
+    MAKE_OPT+=" -DDEBUG=ON"
+elif [[ "${FASTER:-OFF}" == ON ]] ; then
+    MAKE_OPT+=" -DFASTER=ON"
+fi
 COMPILE_NR=0
 CLEAN_BEFORE=YES
 CLEAN_AFTER=NO

--- a/sorc/build_ufs.sh
+++ b/sorc/build_ufs.sh
@@ -8,7 +8,7 @@ APP="S2SWA"
 CCPP_SUITES="FV3_GFS_v17_p8_ugwpv1,FV3_GFS_v17_coupled_p8_ugwpv1,FV3_global_nest_v1"  # TODO: does the g-w need to build with all these CCPP_SUITES?
 PDLIB="ON"
 
-while getopts ":da:j:vwf" option; do
+while getopts ":da:fj:vw" option; do
   case "${option}" in
     d) BUILD_TYPE="Debug";;
     a) APP="${OPTARG}";;


### PR DESCRIPTION
# Description

This PR updates related build scripts to (1) include the global-nest physics in the compilation step (2) be able to use the -DFASTER=ON compiling option through the "-f" command line switch.

Resolves #2520 

# Type of change
<!-- Delete all except one -->
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update?  NO (except for global-nest users)

# How has this been tested?
- Clone and build on Hera
- Forecast-only on Hera

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary

## CONTRIBUTORS:
@SamuelTrahanNOAA 