### PR TITLE
Fix comment indentation

### DIFF
--- a/ci/scripts/utils/rocotostat.py
+++ b/ci/scripts/utils/rocotostat.py
@@ -95,11 +95,11 @@ if __name__ == '__main__':
         error_return = rocoto_status['UNKNOWN']
         rocoto_state = 'UNKNOWN'
     elif rocoto_status['RUNNING'] + rocoto_status['SUBMITTING'] + rocoto_status['QUEUED'] == 0:
-    #
-    #  TODO for now a STALLED state will be just a warning as it can
-    #  produce a false negative if there is a timestamp on a file dependency.
-    #
-    #   error_return = -3
+        #
+        #  TODO for now a STALLED state will be just a warning as it can
+        #  produce a false negative if there is a timestamp on a file dependency.
+        #
+        #   error_return = -3
         rocoto_state = 'STALLED'
     else:
         rocoto_state = 'RUNNING'


### PR DESCRIPTION
# Description
Corrects comment indentation to satisfy PEP-8 complaints from pynorms.

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Comment whitespace only - no testing needed.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
