### PR TITLE
Remove implicit symlink names

### DIFF
--- a/gempak/ush/gdas_ecmwf_meta_ver.sh
+++ b/gempak/ush/gdas_ecmwf_meta_ver.sh
@@ -24,7 +24,7 @@ fi
 
 export COMIN="gdas.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 vergrid="F-GDAS | ${PDY:2}/0600"
 fcsthr="0600f006"
@@ -49,7 +49,7 @@ for area in ${areas}; do
         sdatenum=$(date --utc +%y%m%d -d "${PDY} ${cyc2} - ${fhr} hours")
 
         if [[ ! -L "ecmwf.20${sdatenum}" ]]; then
-            ln -sf "${COMINecmwf}/ecmwf.20${sdatenum}/gempak" "ecmwf.20${sdatenum}"
+            ${NLN} "${COMINecmwf}/ecmwf.20${sdatenum}/gempak" "ecmwf.20${sdatenum}"
         fi
         gdfile="ecmwf.20${sdatenum}/ecmwf_glob_20${sdatenum}12"
 

--- a/gempak/ush/gdas_meta_loop.sh
+++ b/gempak/ush/gdas_meta_loop.sh
@@ -13,7 +13,7 @@ device="nc | gdasloop.meta"
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L "${COMIN}" ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 if [[ "${envir}" == "para" ]] ; then
@@ -41,7 +41,7 @@ for (( fhr=24; fhr<=144; fhr+=24 )); do
         YMD=${day} HH=${cyc} GRID=1p00 declare_from_tmpl "COM_ATMOS_GEMPAK_1p00_past:COM_ATMOS_GEMPAK_TMPL"
         export COMIN="${RUN}.${day}${cycle}"
         if [[ ! -L "${COMIN}" ]]; then
-            ln -sf "${COM_ATMOS_GEMPAK_1p00_past}" "${COMIN}"
+            ${NLN} "${COM_ATMOS_GEMPAK_1p00_past}" "${COMIN}"
         fi
         gdfile="${COMIN}/gdas_1p00_${day}${cycle}f000"
 

--- a/gempak/ush/gdas_meta_na.sh
+++ b/gempak/ush/gdas_meta_na.sh
@@ -13,7 +13,7 @@ device="nc | gdas.meta"
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L "${COMIN}" ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 if [[ "${envir}" == "para" ]] ; then

--- a/gempak/ush/gdas_ukmet_meta_ver.sh
+++ b/gempak/ush/gdas_ukmet_meta_ver.sh
@@ -23,7 +23,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # SET CURRENT CYCLE AS THE VERIFICATION GRIDDED FILE.
 export COMIN="gdas.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 vergrid="F-GDAS | ${PDY:2}/0600"
 fcsthr="0600f006"
@@ -54,7 +54,7 @@ for area in ${areas}; do
         cyclenum=${stime:6}
 
         if [[ ! -L "ukmet.20${sdatenum}" ]]; then
-            ln -sf "${COMINukmet}/ukmet.20${sdatenum}/gempak" "ukmet.20${sdatenum}"
+            ${NLN} "${COMINukmet}/ukmet.20${sdatenum}/gempak" "ukmet.20${sdatenum}"
         fi
         gdfile="ukmet.20${sdatenum}/ukmet_20${sdatenum}${cyclenum}${dgdattim}"
 

--- a/gempak/ush/gfs_meta_ak.sh
+++ b/gempak/ush/gfs_meta_ak.sh
@@ -20,7 +20,7 @@ device="nc | gfs.meta.ak"
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 fend=F216

--- a/gempak/ush/gfs_meta_bwx.sh
+++ b/gempak/ush/gfs_meta_bwx.sh
@@ -21,7 +21,7 @@ device="nc | ${metaname}"
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 fend=F180

--- a/gempak/ush/gfs_meta_comp.sh
+++ b/gempak/ush/gfs_meta_comp.sh
@@ -29,14 +29,14 @@ for cycle in $(seq -f "%02g" -s ' ' 0  "${STEP_GFS}" "${cyc}"); do
     for file_in in "${gempak_dir}/gfs_1p00_${PDY}${cycle}f"*; do
         file_out="${COMIN}/$(basename "${file_in}")"
         if [[ ! -L "${file_out}" ]]; then
-            ln -sf "${file_in}" "${file_out}"
+            ${NLN} "${file_in}" "${file_out}"
         fi
     done
 done
 
 export HPCNAM="nam.${PDY}"
 if [[ ! -L ${HPCNAM} ]]; then
-    ln -sf "${COMINnam}/nam.${PDY}/gempak" "${HPCNAM}"
+    ${NLN} "${COMINnam}/nam.${PDY}/gempak" "${HPCNAM}"
 fi
 
 #
@@ -100,7 +100,7 @@ for gareas in US NP; do
         HPCGFS="${RUN}.${init_time}"
         if [[ ! -L ${HPCGFS} ]]; then
             YMD="${init_PDY}" HH="${init_cyc}" GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
-            ln -sf "${source_dir}" "${HPCGFS}"
+            ${NLN} "${source_dir}" "${HPCGFS}"
         fi
 
         if [[ ${init_PDY} == "${PDY}" ]]; then
@@ -230,7 +230,7 @@ EOF
         ukmet_cyc=${ukmet_date:8:2}
         export HPCUKMET=ukmet.${ukmet_PDY}
         if [[ ! -L "${HPCUKMET}" ]]; then
-            ln -sf "${COMINukmet}/ukmet.${ukmet_PDY}/gempak" "${HPCUKMET}"
+            ${NLN} "${COMINukmet}/ukmet.${ukmet_PDY}/gempak" "${HPCUKMET}"
         fi
         grid2="F-UKMETHPC | ${ukmet_PDY:2}/${ukmet_date}"
 

--- a/gempak/ush/gfs_meta_crb.sh
+++ b/gempak/ush/gfs_meta_crb.sh
@@ -23,7 +23,7 @@ device="nc | ${metaname}"
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 # DEFINE YESTERDAY
@@ -254,13 +254,13 @@ if [[ ${cyc} == 00 ]] ; then
     HPCECMWF_m1=ecmwf.${PDY}
     export HPCUKMET=ukmet.${PDYm1}
     if [[ ! -L "${HPCECMWF}" ]]; then
-        ln -sf "${COMINecmwf}ecmwf.${PDY}/gempak" "${HPCECMWF}"
+        ${NLN} "${COMINecmwf}ecmwf.${PDY}/gempak" "${HPCECMWF}"
     fi
     if [[ ! -L "${HPCECMWF_m1}" ]]; then
-        ln -sf "${COMINecmwf}ecmwf.${PDYm1}/gempak" "${HPCECMWF_m1}"
+        ${NLN} "${COMINecmwf}ecmwf.${PDYm1}/gempak" "${HPCECMWF_m1}"
     fi
     if [[ ! -L "${HPCUKMET}" ]]; then
-        ln -sf "${COMINukmet}/ukmet.${PDYm1}/gempak" "${HPCUKMET}"
+        ${NLN} "${COMINukmet}/ukmet.${PDYm1}/gempak" "${HPCUKMET}"
     fi
 
     grid1="F-${MDL} | ${PDY:2}/${cyc}00"

--- a/gempak/ush/gfs_meta_hi.sh
+++ b/gempak/ush/gfs_meta_hi.sh
@@ -17,7 +17,7 @@ device="nc | mrfhi.meta"
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 if [[ "${envir}" = "prod" ]] ; then

--- a/gempak/ush/gfs_meta_hur.sh
+++ b/gempak/ush/gfs_meta_hur.sh
@@ -23,7 +23,7 @@ device="nc | ${metaname}"
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 #
@@ -307,13 +307,13 @@ if [[ ${cyc} -eq 00 ]] ; then
     HPCECMWF_m1=ecmwf.${PDY}
     export HPCUKMET=ukmet.${PDYm1}
     if [[ ! -L "${HPCECMWF}" ]]; then
-        ln -sf "${COMINecmwf}ecmwf.${PDY}/gempak" "${HPCECMWF}"
+        ${NLN} "${COMINecmwf}ecmwf.${PDY}/gempak" "${HPCECMWF}"
     fi
     if [[ ! -L "${HPCECMWF_m1}" ]]; then
         Ln -sf "${COMINecmwf}ecmwf.${PDYm1}/gempak" "${HPCECMWF_m1}"
     fi
     if [[ ! -L "${HPCUKMET}" ]]; then
-        ln -sf "${COMINukmet}/ukmet.${PDYm1}/gempak" "${HPCUKMET}"
+        ${NLN} "${COMINukmet}/ukmet.${PDYm1}/gempak" "${HPCUKMET}"
     fi
     grid1="F-${MDL} | ${PDY:2}/${cyc}00"
     grid2="${HPCECMWF_m1}/ecmwf_glob_${PDYm1}12"

--- a/gempak/ush/gfs_meta_mar_atl.sh
+++ b/gempak/ush/gfs_meta_mar_atl.sh
@@ -17,7 +17,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 mdl=gfs

--- a/gempak/ush/gfs_meta_mar_comp.sh
+++ b/gempak/ush/gfs_meta_mar_comp.sh
@@ -20,7 +20,7 @@ for cycle in $(seq -f "%02g" -s ' ' 0 "${STEP_GFS}" "${cyc}"); do
     for file_in in "${gempak_dir}/gfs_1p00_${PDY}${cycle}f"*; do
         file_out="${COMIN}/$(basename "${file_in}")"
         if [[ ! -L "${file_out}" ]]; then
-            ln -sf "${file_in}" "${file_out}"
+            ${NLN} "${file_in}" "${file_out}"
         fi
     done
 done
@@ -31,7 +31,7 @@ done
 #
 export HPCNAM="nam.${PDY}"
 if [[ ! -L ${HPCNAM} ]]; then
-    ln -sf "${COMINnam}/nam.${PDY}/gempak" "${HPCNAM}"
+    ${NLN} "${COMINnam}/nam.${PDY}/gempak" "${HPCNAM}"
 fi
 
 mdl=gfs
@@ -77,7 +77,7 @@ for garea in NAtl NPac; do
         HPCGFS="${RUN}.${init_time}"
         if [[ ! -L ${HPCGFS} ]]; then
             YMD="${init_PDY}" HH="${init_cyc}" GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
-            ln -sf "${source_dir}" "${HPCGFS}"
+            ${NLN} "${source_dir}" "${HPCGFS}"
         fi
 
         case ${cyc} in
@@ -222,7 +222,7 @@ EOF
 
         export HPCUKMET="ukmet.${ukmet_PDY}"
         if [[ ! -L "${HPCUKMET}" ]]; then
-            ln -sf "${COMINukmet}/ukmet.${ukmet_PDY}/gempak" "${HPCUKMET}"
+            ${NLN} "${COMINukmet}/ukmet.${ukmet_PDY}/gempak" "${HPCUKMET}"
         fi
         grid2="F-UKMETHPC | ${ukmet_PDY:2}/${ukmet_date}"
 
@@ -310,7 +310,7 @@ EOF
 
         HPCECMWF=ecmwf.${PDY}
         if [[ ! -L "${HPCECMWF}" ]]; then
-            ln -sf "${COMINecmwf}/ecmwf.${ecmwf_PDY}/gempak" "${HPCECMWF}"
+            ${NLN} "${COMINecmwf}/ecmwf.${ecmwf_PDY}/gempak" "${HPCECMWF}"
         fi
         grid2="${HPCECMWF}/ecmwf_glob_${ecmwf_date}"
 

--- a/gempak/ush/gfs_meta_mar_pac.sh
+++ b/gempak/ush/gfs_meta_mar_pac.sh
@@ -17,7 +17,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 mdl=gfs

--- a/gempak/ush/gfs_meta_mar_ql.sh
+++ b/gempak/ush/gfs_meta_mar_ql.sh
@@ -17,7 +17,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 mdl=gfs

--- a/gempak/ush/gfs_meta_mar_skewt.sh
+++ b/gempak/ush/gfs_meta_mar_skewt.sh
@@ -17,7 +17,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 mdl=gfs

--- a/gempak/ush/gfs_meta_mar_ver.sh
+++ b/gempak/ush/gfs_meta_mar_ver.sh
@@ -17,7 +17,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 mdl=gfs

--- a/gempak/ush/gfs_meta_nhsh.sh
+++ b/gempak/ush/gfs_meta_nhsh.sh
@@ -15,7 +15,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 if [[ "${envir}" == "para" ]] ; then

--- a/gempak/ush/gfs_meta_opc_na_ver
+++ b/gempak/ush/gfs_meta_opc_na_ver
@@ -17,7 +17,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 mdl=gfs
@@ -64,7 +64,7 @@ for lookback in "${lookbacks[@]}"; do
     HPCGFS="${RUN}.${init_time}"
     if [[ ! -L ${HPCGFS} ]]; then
         YMD=${init_PDY} HH=${init_cyc} GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
-        ln -sf "${source_dir}" "${HPCGFS}"
+        ${NLN} "${source_dir}" "${HPCGFS}"
     fi
 
     grid="F-${MDL2} | ${init_PDY}/${init_cyc}00"

--- a/gempak/ush/gfs_meta_opc_np_ver
+++ b/gempak/ush/gfs_meta_opc_np_ver
@@ -17,7 +17,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 mdl=gfs
@@ -64,7 +64,7 @@ for lookback in "${lookbacks[@]}"; do
     HPCGFS="${RUN}.${init_time}"
     if [[ ! -L "${HPCGFS}" ]]; then
         YMD=${init_PDY} HH=${init_cyc} GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
-        ln -sf "${source_dir}" "${HPCGFS}"
+        ${NLN} "${source_dir}" "${HPCGFS}"
     fi
 
     grid="F-${MDL2} | ${init_PDY}/${init_cyc}00"

--- a/gempak/ush/gfs_meta_precip.sh
+++ b/gempak/ush/gfs_meta_precip.sh
@@ -17,7 +17,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 #

--- a/gempak/ush/gfs_meta_qpf.sh
+++ b/gempak/ush/gfs_meta_qpf.sh
@@ -17,7 +17,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 mdl=gfs

--- a/gempak/ush/gfs_meta_sa.sh
+++ b/gempak/ush/gfs_meta_sa.sh
@@ -17,7 +17,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 mdl=gfs

--- a/gempak/ush/gfs_meta_sa2.sh
+++ b/gempak/ush/gfs_meta_sa2.sh
@@ -20,7 +20,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 #
 export HPCGFS="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${HPCGFS} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${HPCGFS}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${HPCGFS}"
 fi
 
 mdl=gfs
@@ -38,10 +38,10 @@ PDYm1="$(date --utc +%Y%m%d -d "${PDY} ${cyc} - 24 hours")"
 HPCECMWF="ecmwf.${PDYm1}"
 HPCUKMET="ukmet.${PDY}"
 if [[ ! -L "${HPCECMWF}" ]]; then
-    ln -sf "${COMINecmwf}/ecmwf.${PDYm1}/gempak" "${HPCECMWF}"
+    ${NLN} "${COMINecmwf}/ecmwf.${PDYm1}/gempak" "${HPCECMWF}"
 fi
 if [[ ! -L "${HPCUKMET}" ]]; then
-    ln -sf "${COMINukmet}/ukmet.${PDY}/gempak" "${HPCUKMET}"
+    ${NLN} "${COMINukmet}/ukmet.${PDY}/gempak" "${HPCUKMET}"
 fi
 
 "${GEMEXE}/gdplot2_nc" << EOF

--- a/gempak/ush/gfs_meta_trop.sh
+++ b/gempak/ush/gfs_meta_trop.sh
@@ -17,7 +17,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 mdl=gfs

--- a/gempak/ush/gfs_meta_us.sh
+++ b/gempak/ush/gfs_meta_us.sh
@@ -17,7 +17,7 @@ cp "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 device="nc | gfs.meta"

--- a/gempak/ush/gfs_meta_usext.sh
+++ b/gempak/ush/gfs_meta_usext.sh
@@ -16,7 +16,7 @@ cp "${HOMEgfs}/gempak/fix/ak_sfstns.tbl" alaska.tbl
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 device="nc | mrf.meta"

--- a/gempak/ush/gfs_meta_ver.sh
+++ b/gempak/ush/gfs_meta_ver.sh
@@ -21,7 +21,7 @@ device="nc | ${metaname}"
 #
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L ${COMIN} ]]; then
-    ln -sf "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
+    ${NLN} "${COM_ATMOS_GEMPAK_1p00}" "${COMIN}"
 fi
 
 # SET CURRENT CYCLE AS THE VERIFICATION GRIDDED FILE.
@@ -54,7 +54,7 @@ for lookback in "${lookbacks[@]}"; do
     HPCGFS="${RUN}.${init_time}"
     if [[ ! -L "${HPCGFS}" ]]; then
         YMD=${init_PDY} HH=${init_cyc} GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
-        ln -sf "${source_dir}" "${HPCGFS}"
+        ${NLN} "${source_dir}" "${HPCGFS}"
     fi
 
     grid="F-${MDL2} | ${init_PDY}/${init_cyc}00"

--- a/parm/config/gfs/config.base
+++ b/parm/config/gfs/config.base
@@ -78,6 +78,12 @@ export DO_VERFRAD="YES"    # Radiance data assimilation monitoring
 export DO_VMINMON="YES"    # GSI minimization monitoring
 export DO_MOS="NO"         # GFS Model Output Statistics - Only supported on WCOSS2
 
+if [[ ${machine} == "HERCULES" ]]; then
+    # TODO - Monitor jobs are not yet able to build on Hercules
+    export DO_VERFOZN="NO"
+    export DO_VERFRAD="NO"
+fi
+
 # NO for retrospective parallel; YES for real-time parallel
 #  arch.sh uses REALTIME for MOS.  Need to set REALTIME=YES
 #  if want MOS written to HPSS.   Should update arch.sh to

--- a/parm/config/gfs/config.base
+++ b/parm/config/gfs/config.base
@@ -78,12 +78,6 @@ export DO_VERFRAD="YES"    # Radiance data assimilation monitoring
 export DO_VMINMON="YES"    # GSI minimization monitoring
 export DO_MOS="NO"         # GFS Model Output Statistics - Only supported on WCOSS2
 
-if [[ ${machine} == "HERCULES" ]]; then
-    # TODO - Monitor jobs are not yet able to build on Hercules
-    export DO_VERFOZN="NO"
-    export DO_VERFRAD="NO"
-fi
-
 # NO for retrospective parallel; YES for real-time parallel
 #  arch.sh uses REALTIME for MOS.  Need to set REALTIME=YES
 #  if want MOS written to HPSS.   Should update arch.sh to

--- a/scripts/exgdas_atmos_chgres_forenkf.sh
+++ b/scripts/exgdas_atmos_chgres_forenkf.sh
@@ -36,9 +36,6 @@ bPDY=$(echo $BDATE | cut -c1-8)
 bcyc=$(echo $BDATE | cut -c9-10)
 
 # Utilities
-export NCP=${NCP:-"/bin/cp"}
-export NMV=${NMV:-"/bin/mv"}
-export NLN=${NLN:-"/bin/ln -sf"}
 export CHGRP_CMD=${CHGRP_CMD:-"chgrp ${group_name:-rstprod}"}
 export NCLEN=${NCLEN:-${USHgfs}/getncdimlen}
 

--- a/scripts/exgdas_enkf_ecen.sh
+++ b/scripts/exgdas_enkf_ecen.sh
@@ -29,8 +29,6 @@ export CASE=${CASE:-384}
 ntiles=${ntiles:-6}
 
 # Utilities
-NCP=${NCP:-"/bin/cp -p"}
-NLN=${NLN:-"/bin/ln -sf"}
 NCLEN=${NCLEN:-${USHgfs}/getncdimlen}
 
 # Scripts

--- a/scripts/exgdas_enkf_post.sh
+++ b/scripts/exgdas_enkf_post.sh
@@ -22,10 +22,6 @@ source "${USHgfs}/preamble.sh"
 # Directories.
 pwd=$(pwd)
 
-# Utilities
-NCP=${NCP:-"/bin/cp"}
-NLN=${NLN:-"/bin/ln -sf"}
-
 APRUN_EPOS=${APRUN_EPOS:-${APRUN:-""}}
 NTHREADS_EPOS=${NTHREADS_EPOS:-1}
 

--- a/scripts/exgdas_enkf_select_obs.sh
+++ b/scripts/exgdas_enkf_select_obs.sh
@@ -22,9 +22,6 @@ source "${USHgfs}/preamble.sh"
 # Directories.
 pwd=$(pwd)
 
-# Utilities
-export NLN=${NLN:-"/bin/ln -sf"}
-
 # Scripts.
 ANALYSISSH=${ANALYSISSH:-${SCRgfs}/exglobal_atmos_analysis.sh}
 

--- a/scripts/exgdas_enkf_sfc.sh
+++ b/scripts/exgdas_enkf_sfc.sh
@@ -30,8 +30,6 @@ export CASE=${CASE:-384}
 ntiles=${ntiles:-6}
 
 # Utilities
-NCP=${NCP:-"/bin/cp -p"}
-NLN=${NLN:-"/bin/ln -sf"}
 NCLEN=${NCLEN:-${USHgfs}/getncdimlen}
 
 # Scripts

--- a/scripts/exgdas_enkf_update.sh
+++ b/scripts/exgdas_enkf_update.sh
@@ -23,8 +23,6 @@ source "${USHgfs}/preamble.sh"
 pwd=$(pwd)
 
 # Utilities
-NCP=${NCP:-"/bin/cp -p"}
-NLN=${NLN:-"/bin/ln -sf"}
 NCLEN=${NCLEN:-${USHgfs}/getncdimlen}
 USE_CFP=${USE_CFP:-"NO"}
 CFP_MP=${CFP_MP:-"NO"}

--- a/scripts/exgfs_atmos_wafs_gcip.sh
+++ b/scripts/exgfs_atmos_wafs_gcip.sh
@@ -72,7 +72,7 @@ if [ $RUN = "gfs" ] ; then
   cpreq $PARMgfs/wafs_gcip_gfs.cfg $configFile
 
   modelFile=modelfile.grb
-#  ln -sf $masterFile $modelFile
+#  ${NLN} $masterFile $modelFile
   $WGRIB2 $masterFile | egrep ":HGT:|:VVEL:|:CLMR:|:TMP:|:SPFH:|:RWMR:|:SNMR:|:GRLE:|:ICMR:|:RH:" | egrep "00 mb:|25 mb:|50 mb:|75 mb:|:HGT:surface" | $WGRIB2 -i $masterFile -grib $modelFile
 
   # metar / ships / lightning / pireps

--- a/scripts/exgfs_wave_init.sh
+++ b/scripts/exgfs_wave_init.sh
@@ -216,7 +216,7 @@ if (( NMEM_ENS > 0 )); then
     MEMDIR="mem${mem}" YMD=${PDY} HH=${cyc} declare_from_tmpl COM_WAVE_PREP_MEM:COM_WAVE_PREP_TMPL
     mkdir -p "${COM_WAVE_PREP_MEM}"
     for grdID in ${grdALL}; do
-      ${NLN} "${COM_WAVE_PREP}/${RUN}wave.mod_def.${grdID}" "${COM_WAVE_PREP_MEM}/"
+      ${NLN} "${COM_WAVE_PREP}/${RUN}wave.mod_def.${grdID}" "${COM_WAVE_PREP_MEM}/${RUN}wave.mod_def.${grdID}"
     done
   done
 fi

--- a/scripts/exgfs_wave_post_gridded_sbs.sh
+++ b/scripts/exgfs_wave_post_gridded_sbs.sh
@@ -270,7 +270,7 @@ source "${USHgfs}/preamble.sh"
           err=3; export err;${errchk}
           exit $err
         fi
-        ln -s ${gfile} ./out_grd.${wavGRD}
+        ${NLN} ${gfile} ./out_grd.${wavGRD}
       done
 
       if [ "$DOGRI_WAV" = 'YES' ]

--- a/scripts/exgfs_wave_post_pnt.sh
+++ b/scripts/exgfs_wave_post_pnt.sh
@@ -247,10 +247,10 @@ source "${USHgfs}/preamble.sh"
         -e "s/FORMAT/F/g" \
                                ww3_outp_spec.inp.tmpl > ww3_outp.inp
 
-    ln -s mod_def.$waveuoutpGRD mod_def.ww3
+    ${NLN} mod_def.$waveuoutpGRD mod_def.ww3
     HMS="${cyc}0000"
     if [[ -f "${COM_WAVE_HISTORY}/${WAV_MOD_TAG}.out_pnt.${waveuoutpGRD}.${PDY}.${HMS}" ]]; then
-      ln -s "${COM_WAVE_HISTORY}/${WAV_MOD_TAG}.out_pnt.${waveuoutpGRD}.${PDY}.${HMS}" \
+      ${NLN} "${COM_WAVE_HISTORY}/${WAV_MOD_TAG}.out_pnt.${waveuoutpGRD}.${PDY}.${HMS}" \
         "./out_pnt.${waveuoutpGRD}"
     else
       echo '*************************************************** '
@@ -263,8 +263,8 @@ source "${USHgfs}/preamble.sh"
     fi
 
     rm -f buoy_tmp.loc buoy_log.ww3 ww3_oup.inp
-    ln -fs ./out_pnt.${waveuoutpGRD} ./out_pnt.ww3
-    ln -fs ./mod_def.${waveuoutpGRD} ./mod_def.ww3
+    ${NLN} ./out_pnt.${waveuoutpGRD} ./out_pnt.ww3
+    ${NLN} ./mod_def.${waveuoutpGRD} ./mod_def.ww3
     export pgm=ww3_outp;. prep_step
     ${EXECgfs}/ww3_outp > buoy_lst.loc 2>&1
     export err=$?;err_chk
@@ -371,7 +371,7 @@ source "${USHgfs}/preamble.sh"
     pfile="${COM_WAVE_HISTORY}/${WAV_MOD_TAG}.out_pnt.${waveuoutpGRD}.${YMD}.${HMS}"
     if [ -f  ${pfile} ]
     then
-      ln -fs ${pfile} ./out_pnt.${waveuoutpGRD}
+      ${NLN} ${pfile} ./out_pnt.${waveuoutpGRD}
     else
       echo " FATAL ERROR : NO RAW POINT OUTPUT FILE out_pnt.$waveuoutpGRD.${YMD}.${HMS} "
       echo ' '

--- a/scripts/exgfs_wave_prdgen_gridded.sh
+++ b/scripts/exgfs_wave_prdgen_gridded.sh
@@ -151,13 +151,13 @@ grids=${grids:-ak_10m at_10m ep_10m wc_10m glo_30m}
      GRIBIN=$RUNwave.$cycle.$grdID.f${fhr}.clipped.grib2
      GRIBIN_chk=$GRIBIN.idx
 
-     ln -s $GRIBIN gribfile.$grdID.f${fhr}
+     ${NLN} $GRIBIN gribfile.$grdID.f${fhr}
 
      #
 # 1.d Input template files
      parmfile=${PARMgfs}/wave/grib2_${RUNwave}.$grdOut.f${fhr}
      if [ -f $parmfile ]; then
-       ln -s $parmfile awipsgrb.$grdID.f${fhr}
+       ${NLN} $parmfile awipsgrb.$grdID.f${fhr}
      else
        echo '*** ERROR : NO template  grib2_${RUNwave}.$grdID.f${fhr} *** '
        echo "$RUNwave $grdID $fhr prdgen $date $cycle : GRIB template file missing." >> $wavelog

--- a/scripts/exglobal_atmos_analysis_calc.sh
+++ b/scripts/exglobal_atmos_analysis_calc.sh
@@ -29,9 +29,6 @@ CDUMP=${CDUMP:-"gdas"}
 GDUMP=${GDUMP:-"gdas"}
 
 # Utilities
-export NCP=${NCP:-"/bin/cp"}
-export NMV=${NMV:-"/bin/mv"}
-export NLN=${NLN:-"/bin/ln -sf"}
 export CHGRP_CMD=${CHGRP_CMD:-"chgrp ${group_name:-rstprod}"}
 export NCLEN=${NCLEN:-${USHgfs}/getncdimlen}
 COMPRESS=${COMPRESS:-gzip}

--- a/scripts/exglobal_atmos_sfcanl.sh
+++ b/scripts/exglobal_atmos_sfcanl.sh
@@ -33,9 +33,6 @@ bPDY=${BDATE:0:8}
 bcyc=${BDATE:8:2}
 
 # Utilities
-export NCP=${NCP:-"/bin/cp"}
-export NMV=${NMV:-"/bin/mv"}
-export NLN=${NLN:-"/bin/ln -sf"}
 export CHGRP_CMD=${CHGRP_CMD:-"chgrp ${group_name:-rstprod}"}
 export NCLEN=${NCLEN:-${USHgfs}/getncdimlen}
 COMPRESS=${COMPRESS:-gzip}

--- a/scripts/exglobal_diag.sh
+++ b/scripts/exglobal_diag.sh
@@ -30,9 +30,6 @@ CDUMP=${CDUMP:-"gdas"}
 GDUMP=${GDUMP:-"gdas"}
 
 # Utilities
-export NCP=${NCP:-"/bin/cp"}
-export NMV=${NMV:-"/bin/mv"}
-export NLN=${NLN:-"/bin/ln -sf"}
 export CHGRP_CMD=${CHGRP_CMD:-"chgrp ${group_name:-rstprod}"}
 export NCLEN=${NCLEN:-${USHgfs}/getncdimlen}
 export CATEXEC=${CATEXEC:-${ncdiag_ROOT:-${gsi_ncdiag_ROOT}}/bin/ncdiag_cat_serial.x}

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -160,12 +160,8 @@ fi
 if [[ "${_build_gsi}" == "YES" || "${_build_ufsda}" == "YES" ]] ; then
    build_jobs["gsi_utils"]=1
    build_opts["gsi_utils"]="${_verbose_opt} ${_build_debug}"
-   if [[ "${MACHINE_ID}" == "hercules" ]]; then
-      echo "NOTE: The GSI Monitor is not supported on Hercules.  Disabling build."
-   else
-      build_jobs["gsi_monitor"]=1
-      build_opts["gsi_monitor"]="${_verbose_opt} ${_build_debug}"
-   fi
+   build_jobs["gsi_monitor"]=1
+   build_opts["gsi_monitor"]="${_verbose_opt} ${_build_debug}"
 fi
 
 # Go through all builds and adjust CPU counts down if necessary

--- a/ush/gaussian_sfcanl.sh
+++ b/ush/gaussian_sfcanl.sh
@@ -122,7 +122,6 @@ SIGLEVEL=${SIGLEVEL:-${FIXgfs}/am/global_hyblev.l${LEVSP1}.txt}
 CDATE=${CDATE:?}
 
 #  Other variables.
-export NLN=${NLN:-"/bin/ln -sf"}
 export PGMOUT=${PGMOUT:-${pgmout:-'&1'}}
 export PGMERR=${PGMERR:-${pgmerr:-'&2'}}
 export REDOUT=${REDOUT:-'1>'}
@@ -133,17 +132,9 @@ export REDERR=${REDERR:-'2>'}
 #  Preprocessing
 ${INISCRIPT:-}
 pwd=$(pwd)
-if [[ -d $DATA ]]
-then
-   mkdata=NO
-else
-   mkdir -p $DATA
-   mkdata=YES
-fi
-cd $DATA||exit 99
+cd "${DATA}" || exit 99
 [[ -d "${COM_ATMOS_ANALYSIS}" ]] || mkdir -p "${COM_ATMOS_ANALYSIS}"
 [[ -d "${COM_ATMOS_RESTART}" ]] || mkdir -p "${COM_ATMOS_RESTART}"
-cd $DATA
 
 ################################################################################
 #  Make surface analysis
@@ -207,6 +198,5 @@ $ERRSCRIPT||exit 2
 ################################################################################
 #  Postprocessing
 cd $pwd
-[[ $mkdata = YES ]]&&rmdir $DATA
 
 exit ${err}

--- a/ush/getdump.sh
+++ b/ush/getdump.sh
@@ -31,7 +31,7 @@ prefix="$CDUMP.t${cyc}z."
 cd $SOURCE_DIR
 if [ -s ${prefix}updated.status.tm00.bufr_d ]; then
     for file in $(ls ${prefix}*); do
-	ln -fs $SOURCE_DIR/$file $TARGET_DIR/$file
+	${NLN} $SOURCE_DIR/$file $TARGET_DIR/$file
     done
 else
     echo "***ERROR*** ${prefix}updated.status.tm00.bufr_d NOT FOUND in $SOURCE_DIR"

--- a/ush/gfs_bufr.sh
+++ b/ush/gfs_bufr.sh
@@ -72,24 +72,24 @@ for (( hr = 10#${FSTART}; hr <= 10#${FEND}; hr = hr + 10#${FINT} )); do
       fi
    done
    #------------------------------------------------------------------
-   ln -sf "${COM_ATMOS_HISTORY}/${RUN}.${cycle}.atmf${hh3}.${atmfm}" "sigf${hh2}" 
-   ln -sf "${COM_ATMOS_HISTORY}/${RUN}.${cycle}.sfcf${hh3}.${atmfm}" "flxf${hh2}"
+   ${NLN} "${COM_ATMOS_HISTORY}/${RUN}.${cycle}.atmf${hh3}.${atmfm}" "sigf${hh2}"
+   ${NLN} "${COM_ATMOS_HISTORY}/${RUN}.${cycle}.sfcf${hh3}.${atmfm}" "flxf${hh2}"
 done
 
 #  define input BUFR table file.
-ln -sf "${PARMgfs}/product/bufr_gfs_${CLASS}.tbl" fort.1
-ln -sf "${STNLIST:-${PARMgfs}/product/bufr_stalist.meteo.gfs}" fort.8
+${NLN} "${PARMgfs}/product/bufr_gfs_${CLASS}.tbl" fort.1
+${NLN} "${STNLIST:-${PARMgfs}/product/bufr_stalist.meteo.gfs}" fort.8
 
 case "${CASE}" in
     "C768")
-        ln -sf "${PARMgfs}/product/bufr_ij13km.txt" fort.7
+        ${NLN} "${PARMgfs}/product/bufr_ij13km.txt" fort.7
         ;;
     "C1152")
-        ln -sf "${PARMgfs}/product/bufr_ij9km.txt"  fort.7
+        ${NLN} "${PARMgfs}/product/bufr_ij9km.txt"  fort.7
         ;;
     *)
         echo "WARNING: No bufr table for this resolution, using the one for C768"
-        ln -sf "${PARMgfs}/product/bufr_ij13km.txt" fort.7
+        ${NLN} "${PARMgfs}/product/bufr_ij13km.txt" fort.7
         ;;
 esac
 

--- a/ush/gfs_bufr_netcdf.sh
+++ b/ush/gfs_bufr_netcdf.sh
@@ -94,8 +94,8 @@ do
       fi
    done
 #------------------------------------------------------------------
-   ln -sf $COMIN/${RUN}.${cycle}.atmf${hh2}.nc sigf${hh} 
-   ln -sf $COMIN/${RUN}.${cycle}.${SFCF}f${hh2}.nc flxf${hh}
+   ${NLN} $COMIN/${RUN}.${cycle}.atmf${hh2}.nc sigf${hh}
+   ${NLN} $COMIN/${RUN}.${cycle}.${SFCF}f${hh2}.nc flxf${hh}
 
    hh=$( expr $hh + $FINT )
    if test $hh -lt 10
@@ -105,9 +105,9 @@ do
 done  
 
 #  define input BUFR table file.
-ln -sf ${PARMgfs}/product/bufr_gfs_${CLASS}.tbl fort.1
-ln -sf ${STNLIST:-${PARMgfs}/product/bufr_stalist.meteo.gfs} fort.8
-ln -sf ${PARMgfs}/product/bufr_ij13km.txt fort.7
+${NLN} ${PARMgfs}/product/bufr_gfs_${CLASS}.tbl fort.1
+${NLN} ${STNLIST:-${PARMgfs}/product/bufr_stalist.meteo.gfs} fort.8
+${NLN} ${PARMgfs}/product/bufr_ij13km.txt fort.7
 
 ${APRUN_POSTSND} "${EXECgfs}/${pgm}" < gfsparm > "out_gfs_bufr_${FEND}"
 export err=$?

--- a/ush/link_crtm_fix.sh
+++ b/ush/link_crtm_fix.sh
@@ -22,16 +22,16 @@ for what in "amsre_aqua" "imgr_g11" "imgr_g12" "imgr_g13" \
 	"ssmi_f13" "ssmi_f14" "ssmi_f15" "ssmis_f16" \
 	"ssmis_f17" "ssmis_f18" "ssmis_f19" "ssmis_f20" \
 	"tmi_trmm" "v.seviri_m10" "imgr_insat3d" "abi_gr" "ahi_himawari8" ; do
-	ln -s "${CRTM_FIX}/${what}.TauCoeff.bin" "${what}.TauCoeff.bin"
-	ln -s "${CRTM_FIX}/${what}.SpcCoeff.bin" "${what}.SpcCoeff.bin"
+	${NLN} "${CRTM_FIX}/${what}.TauCoeff.bin" "${what}.TauCoeff.bin"
+	${NLN} "${CRTM_FIX}/${what}.SpcCoeff.bin" "${what}.SpcCoeff.bin"
 done
 
 for what in 'Aerosol' 'Cloud' ; do
-	ln -s "${CRTM_FIX}/${what}Coeff.bin" "${what}Coeff.bin"
+	${NLN} "${CRTM_FIX}/${what}Coeff.bin" "${what}Coeff.bin"
 done
 
 for what in "${CRTM_FIX}/"*Emis* ; do
-	ln -s "${what}" "$(basename "${what}")"
+	${NLN} "${what}" "$(basename "${what}")"
 done
 
 exit 0

--- a/ush/link_crtm_fix.sh
+++ b/ush/link_crtm_fix.sh
@@ -22,16 +22,16 @@ for what in "amsre_aqua" "imgr_g11" "imgr_g12" "imgr_g13" \
 	"ssmi_f13" "ssmi_f14" "ssmi_f15" "ssmis_f16" \
 	"ssmis_f17" "ssmis_f18" "ssmis_f19" "ssmis_f20" \
 	"tmi_trmm" "v.seviri_m10" "imgr_insat3d" "abi_gr" "ahi_himawari8" ; do
-	ln -s "${CRTM_FIX}/${what}.TauCoeff.bin" .
-	ln -s "${CRTM_FIX}/${what}.SpcCoeff.bin" .
+	ln -s "${CRTM_FIX}/${what}.TauCoeff.bin" "${what}.TauCoeff.bin"
+	ln -s "${CRTM_FIX}/${what}.SpcCoeff.bin" "${what}.SpcCoeff.bin"
 done
 
 for what in 'Aerosol' 'Cloud' ; do
-	ln -s "${CRTM_FIX}/${what}Coeff.bin" .
+	ln -s "${CRTM_FIX}/${what}Coeff.bin" "${what}Coeff.bin"
 done
 
-for what in  ${CRTM_FIX}/*Emis* ; do
-	ln -s ${what} .
+for what in "${CRTM_FIX}/"*Emis* ; do
+	ln -s "${what}" "$(basename "${what}")"
 done
 
 exit 0

--- a/ush/tropcy_relocate.sh
+++ b/ush/tropcy_relocate.sh
@@ -531,10 +531,10 @@ else
      rm fort.*
    fi
 
-   ln -sf $DATA/tcvitals.now1      fort.11
-   ln -sf $DATA/model_track.all    fort.30
-   ln -sf $DATA/rel_inform1        fort.62
-   ln -sf $DATA/tcvitals.relocate0 fort.65
+   ${NLN} $DATA/tcvitals.now1      fort.11
+   ${NLN} $DATA/model_track.all    fort.30
+   ${NLN} $DATA/rel_inform1        fort.62
+   ${NLN} $DATA/tcvitals.relocate0 fort.65
 
    i1=20
    i2=53
@@ -548,8 +548,8 @@ else
        tpref=p$fhr
      fi
 
-     ln -sf $DATA/sg${tpref}prep          fort.$i1
-     ln -sf $DATA/sg${tpref}prep.relocate fort.$i2
+     ${NLN} $DATA/sg${tpref}prep          fort.$i1
+     ${NLN} $DATA/sg${tpref}prep.relocate fort.$i2
 
      i1=$((i1+1))
      i2=$((i2+BKGFREQ))

--- a/ush/tropcy_relocate_extrkr.sh
+++ b/ush/tropcy_relocate_extrkr.sh
@@ -592,8 +592,8 @@ if [ -s fort.*  ]; then
   rm fort.*
 fi
 
-ln -s -f ${vdir}/vitals.${symd}${dishh}                  fort.31
-ln -s -f ${vdir}/vitals.upd.${cmodel}.${symd}${dishh}    fort.51
+${NLN} ${vdir}/vitals.${symd}${dishh}                  fort.31
+${NLN} ${vdir}/vitals.upd.${cmodel}.${symd}${dishh}    fort.51
 
 ##$XLF_LINKSSH
 #if [ -z $XLF_LINKSSH ] ; then
@@ -1528,19 +1528,19 @@ if [ -s fort.*  ]; then
   rm fort.*
 fi
 
-ln -s -f ${gribfile}                                   fort.11
-ln -s -f ${vdir}/tmp.gfs.atcfunix.${symdh}             fort.14
-ln -s -f ${vdir}/vitals.upd.${cmodel}.${symd}${dishh}  fort.12
-ln -s -f ${ixfile}                                     fort.31
-ln -s -f ${vdir}/trak.${cmodel}.all.${symdh}           fort.61
-ln -s -f ${vdir}/trak.${cmodel}.atcf.${symdh}          fort.62
-ln -s -f ${vdir}/trak.${cmodel}.radii.${symdh}         fort.63
-ln -s -f ${vdir}/trak.${cmodel}.atcfunix.${symdh}      fort.64
+${NLN} ${gribfile}                                   fort.11
+${NLN} ${vdir}/tmp.gfs.atcfunix.${symdh}             fort.14
+${NLN} ${vdir}/vitals.upd.${cmodel}.${symd}${dishh}  fort.12
+${NLN} ${ixfile}                                     fort.31
+${NLN} ${vdir}/trak.${cmodel}.all.${symdh}           fort.61
+${NLN} ${vdir}/trak.${cmodel}.atcf.${symdh}          fort.62
+${NLN} ${vdir}/trak.${cmodel}.radii.${symdh}         fort.63
+${NLN} ${vdir}/trak.${cmodel}.atcfunix.${symdh}      fort.64
 
 if [ $BKGFREQ -eq 1 ]; then
-  ln -s -f ${FIXgfs}/am/${cmodel}.tracker_leadtimes_hrly fort.15
+  ${NLN} ${FIXgfs}/am/${cmodel}.tracker_leadtimes_hrly fort.15
 elif [ $BKGFREQ -eq 3 ]; then
-  ln -s -f ${FIXgfs}/am/${cmodel}.tracker_leadtimes      fort.15
+  ${NLN} ${FIXgfs}/am/${cmodel}.tracker_leadtimes      fort.15
 fi
 
 ##$XLF_LINKSSH

--- a/ush/wafs_mkgbl.sh
+++ b/ush/wafs_mkgbl.sh
@@ -69,7 +69,7 @@ do
 #      To solve Bugzilla #408: remove the dependency of grib1 files in gfs wafs job in next GFS upgrade
 #      Reason: It's not efficent if simply converting from grib2 to grib1 (costs 6 seconds with 415 records)
 #      Solution: Need to grep 'selected fields on selected levels' before CNVGRIB (costs 1 second with 92 records)
-       ln -s $COMIN/${RUN}.${cycle}.pgrb2.1p00.f$fhr3  pgrb2f${hour}
+       ${NLN} $COMIN/${RUN}.${cycle}.pgrb2.1p00.f$fhr3  pgrb2f${hour}
        $WGRIB2 pgrb2f${hour} | grep -F -f $FIXgfs/grib_wafs.grb2to1.list | $WGRIB2 -i pgrb2f${hour} -grib pgrb2f${hour}.tmp
 #       on Cray, IOBUF_PARAMS has to used to speed up CNVGRIB
 #       export IOBUF_PARAMS='*:size=32M:count=4:verbose'

--- a/ush/wave_grib2_sbs.sh
+++ b/ush/wave_grib2_sbs.sh
@@ -110,8 +110,8 @@ if [[ ! -s "${COM_WAVE_GRID}/${outfile}.idx" ]]; then
 
   # 0.e Links to working directory
 
-  ln -s "${DATA}/mod_def.${grdID}" "mod_def.ww3"
-  ln -s "${DATA}/output_${ymdh}0000/out_grd.${grdID}" "out_grd.ww3"
+  ${NLN} "${DATA}/mod_def.${grdID}" "mod_def.ww3"
+  ${NLN} "${DATA}/output_${ymdh}0000/out_grd.${grdID}" "out_grd.ww3"
 
   # --------------------------------------------------------------------------- #
   # 1.  Generate GRIB file with all data

--- a/ush/wave_grid_interp_sbs.sh
+++ b/ush/wave_grid_interp_sbs.sh
@@ -87,14 +87,14 @@ source "${USHgfs}/preamble.sh"
   if [ ! -f ${DATA}/${grdID}_interp.inp.tmpl ]; then
     cp "${PARMgfs}/wave/${grdID}_interp.inp.tmpl" "${DATA}/${grdID}_interp.inp.tmpl"
   fi
-  ln -sf "${DATA}/${grdID}_interp.inp.tmpl" "${grdID}_interp.inp.tmpl"
+  ${NLN} "${DATA}/${grdID}_interp.inp.tmpl" "${grdID}_interp.inp.tmpl"
 
   for ID in ${waveGRD}; do
-    ln -sf "${DATA}/output_${ymdh}0000/out_grd.${ID}" "out_grd.${ID}"
+    ${NLN} "${DATA}/output_${ymdh}0000/out_grd.${ID}" "out_grd.${ID}"
   done
 
   for ID in ${waveGRD} ${grdID}; do
-    ln -sf "${DATA}/mod_def.${ID}" "mod_def.${ID}"
+    ${NLN} "${DATA}/mod_def.${ID}" "mod_def.${ID}"
   done
 
 # --------------------------------------------------------------------------- #
@@ -128,7 +128,7 @@ source "${USHgfs}/preamble.sh"
 # Check and link weights file
   if [ -f ${DATA}/ww3_gint.WHTGRIDINT.bin.${grdID} ]
   then
-    ln -s ${DATA}/ww3_gint.WHTGRIDINT.bin.${grdID} ./WHTGRIDINT.bin
+    ${NLN} ${DATA}/ww3_gint.WHTGRIDINT.bin.${grdID} ./WHTGRIDINT.bin
   fi
 
 # 1.b Run interpolation code

--- a/ush/wave_grid_interp_sbs.sh
+++ b/ush/wave_grid_interp_sbs.sh
@@ -85,18 +85,16 @@ source "${USHgfs}/preamble.sh"
   rm -f ${DATA}/output_${ymdh}0000/out_grd.$grdID
 
   if [ ! -f ${DATA}/${grdID}_interp.inp.tmpl ]; then
-    cp ${PARMgfs}/wave/${grdID}_interp.inp.tmpl ${DATA}
+    cp "${PARMgfs}/wave/${grdID}_interp.inp.tmpl" "${DATA}/${grdID}_interp.inp.tmpl"
   fi
-  ln -sf ${DATA}/${grdID}_interp.inp.tmpl .
+  ln -sf "${DATA}/${grdID}_interp.inp.tmpl" "${grdID}_interp.inp.tmpl"
 
-  for ID in $waveGRD
-  do
-    ln -sf ${DATA}/output_${ymdh}0000/out_grd.$ID .
+  for ID in ${waveGRD}; do
+    ln -sf "${DATA}/output_${ymdh}0000/out_grd.${ID}" "out_grd.${ID}"
   done
 
-  for ID in $waveGRD $grdID
-  do
-    ln -sf ${DATA}/mod_def.$ID .
+  for ID in ${waveGRD} ${grdID}; do
+    ln -sf "${DATA}/mod_def.${ID}" "mod_def.${ID}"
   done
 
 # --------------------------------------------------------------------------- #

--- a/ush/wave_grid_moddef.sh
+++ b/ush/wave_grid_moddef.sh
@@ -82,12 +82,12 @@ source "${USHgfs}/preamble.sh"
   set_trace
  
   rm -f ww3_grid.inp 
-  ln -sf ../ww3_grid.inp.$grdID ww3_grid.inp
+  ${NLN} ../ww3_grid.inp.$grdID ww3_grid.inp
 
   if [ -f ../${grdID}.msh ]
   then
      rm -f ${grdID}.msh 
-     ln -sf ../${grdID}.msh ${grdID}.msh 
+     ${NLN} ../${grdID}.msh ${grdID}.msh
   fi
 
 

--- a/ush/wave_outp_spec.sh
+++ b/ush/wave_outp_spec.sh
@@ -135,8 +135,8 @@ source "${USHgfs}/preamble.sh"
 
 # 0.f Links to mother directory
 
-  ln -s ${DATA}/output_${ymdh}0000/mod_def.${waveuoutpGRD} ./mod_def.ww3
-  ln -s ${DATA}/output_${ymdh}0000/out_pnt.${waveuoutpGRD} ./out_pnt.ww3
+  ${NLN} ${DATA}/output_${ymdh}0000/mod_def.${waveuoutpGRD} ./mod_def.ww3
+  ${NLN} ${DATA}/output_${ymdh}0000/out_pnt.${waveuoutpGRD} ./out_pnt.ww3
 
 # --------------------------------------------------------------------------- #
 # 2.  Generate spectral data file

--- a/ush/wave_prnc_cur.sh
+++ b/ush/wave_prnc_cur.sh
@@ -71,8 +71,8 @@ else
 fi
 
 rm -f cur.nc
-ln -s "cur_glo_uv_${PDY}_${fext}${fh3}_5min.nc" "cur.nc"
-ln -s "${DATA}/mod_def.${WAVECUR_FID}" ./mod_def.ww3
+${NLN} "cur_glo_uv_${PDY}_${fext}${fh3}_5min.nc" "cur.nc"
+${NLN} "${DATA}/mod_def.${WAVECUR_FID}" ./mod_def.ww3
 
 export pgm=ww3_prnc;. prep_step
 ${EXECgfs}/ww3_prnc 1> prnc_${WAVECUR_FID}_${ymdh_rtofs}.out 2>&1

--- a/ush/wave_prnc_ice.sh
+++ b/ush/wave_prnc_ice.sh
@@ -36,7 +36,7 @@ source "${USHgfs}/preamble.sh"
   rm -rf ice
   mkdir ice
   cd ice
-  ln -s "${DATA}/postmsg" postmsg
+  ${NLN} "${DATA}/postmsg" postmsg
 
 # 0.b Define directories and the search path.
 #     The tested variables should be exported by the postprocessor script.
@@ -71,7 +71,7 @@ source "${USHgfs}/preamble.sh"
 
 # 0.c Links to working directory
 
-  ln -s ${DATA}/mod_def.$WAVEICE_FID mod_def.ww3
+  ${NLN} ${DATA}/mod_def.$WAVEICE_FID mod_def.ww3
 
 # --------------------------------------------------------------------------- #
 # 1.  Get the necessary files

--- a/ush/wave_prnc_ice.sh
+++ b/ush/wave_prnc_ice.sh
@@ -36,7 +36,7 @@ source "${USHgfs}/preamble.sh"
   rm -rf ice
   mkdir ice
   cd ice
-  ln -s ${DATA}/postmsg .
+  ln -s "${DATA}/postmsg" postmsg
 
 # 0.b Define directories and the search path.
 #     The tested variables should be exported by the postprocessor script.


### PR DESCRIPTION
# Description
Lustre has a defect under Rocky 9 that results in symlink sometimes failing when the link name is not explicit. This updates all link creation to use explicit names.

`config.base` is updated to turn off two monitor jobs on Hercules because the executables are not yet built there. This, combined with the previous change, should make workflow available for use on Hercules.

Also removes the redundant utility names for NCP, NLN, etc. in the gdas scripts that are already defined in `config.base`.

Resolves #2131
Resolves #2522

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- [x] Cycled atm-only test on Hercules
- [x] Forecast-only S2SWA test on Hercules
- [ ] Full product test on WCOSS2

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
