### PR TITLE
Add option to link different orog/ugwd fix files for global nest

### DIFF
--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -70,13 +70,7 @@ ${LINK_OR_COPY} "${HOMEgfs}/versions/run.${machine}.ver" "${HOMEgfs}/versions/ru
 #------------------------------
 case "${machine}" in
   "wcoss2")   FIX_DIR="/lfs/h2/emc/global/noscrub/emc.global/FIX/fix" ;;
-  "hera")     
-    if [[ "${LINK_NEST:-OFF}" == "ON" ]] ; then
-      FIX_DIR="/scratch2/BMC/wrfruc/Guoqing.Ge/fix"
-    else
-      FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix"
-    fi
-    ;;
+  "hera")     FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix" ;;
   "orion")    FIX_DIR="/work/noaa/global/glopara/fix" ;;
   "hercules") FIX_DIR="/work/noaa/global/glopara/fix" ;;
   "jet")      FIX_DIR="/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix" ;;

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -10,7 +10,7 @@ function usage() {
 Builds all of the global-workflow components by calling the individual build
   scripts in sequence.
 
-Usage: ${BASH_SOURCE[0]} [-h][-o]
+Usage: ${BASH_SOURCE[0]} [-h][-o][--nest]
   -h:
     Print this help message and exit
   -o:
@@ -23,12 +23,17 @@ RUN_ENVIR="emc"
 
 # Reset option counter in case this script is sourced
 OPTIND=1
-while getopts ":ho" option; do
+while getopts ":ho-:" option; do
   case "${option}" in
     h) usage ;;
     o)
       echo "-o option received, configuring for NCO"
       RUN_ENVIR="nco";;
+    -)
+      if [[ "${OPTARG}" == "nest" ]]; then
+        LINK_NEST=ON
+      fi
+      ;;
     :)
       echo "[${BASH_SOURCE[0]}]: ${option} requires an argument"
       usage
@@ -65,7 +70,13 @@ ${LINK_OR_COPY} "${HOMEgfs}/versions/run.${machine}.ver" "${HOMEgfs}/versions/ru
 #------------------------------
 case "${machine}" in
   "wcoss2")   FIX_DIR="/lfs/h2/emc/global/noscrub/emc.global/FIX/fix" ;;
-  "hera")     FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix" ;;
+  "hera")     
+    if [[ "${LINK_NEST:-OFF}" == "ON" ]] ; then
+      FIX_DIR="/scratch2/BMC/wrfruc/Guoqing.Ge/fix"
+    else
+      FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix"
+    fi
+    ;;
   "orion")    FIX_DIR="/work/noaa/global/glopara/fix" ;;
   "hercules") FIX_DIR="/work/noaa/global/glopara/fix" ;;
   "jet")      FIX_DIR="/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix" ;;
@@ -78,6 +89,10 @@ esac
 
 # Source fix version file
 source "${HOMEgfs}/versions/fix.ver"
+# global-nest uses different versions of orog and ugwd
+if [[ "${LINK_NEST:-OFF}" == "ON" ]] ; then
+  source "${HOMEgfs}/versions/fix.nest.ver"
+fi
 
 # Link wxflow in ush/python, workflow and ci/scripts
 # TODO: This will be unnecessary when wxflow is part of the virtualenv

--- a/versions/fix.nest.ver
+++ b/versions/fix.nest.ver
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Fix file subfolder versions
+export orog_ver=global-nest.20240419
+export ugwd_ver=global-nest.20240419


### PR DESCRIPTION
<!-- PLEASE READ -->
<!-- Any PRs not following this template will be closed -->

add --nest option to link different orog/ugwd fix files for global nest

# Description
<!-- This description will become the commit message for the PR-->

The global nest runs use a different set of tiles and need a different set of orog and ugwd fix files.
The PR add an option to link correct fix files for global nest.

  Resolves #2530 
  Resovles #2529 

# Type of change
<!-- Delete all except one -->
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO (except for the global nest users)

# How has this been tested?
- Clone and build on Hera
- Forecast-only on Hera

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
