### PR TITLE
Copy FV3 restarts and bugfix on COM_MED_RESTART_PREV

### DIFF
--- a/jobs/JGLOBAL_FORECAST
+++ b/jobs/JGLOBAL_FORECAST
@@ -51,7 +51,8 @@ if [[ "${DO_OCN}" == "YES" ]]; then
   YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx COM_MED_RESTART COM_OCEAN_RESTART COM_OCEAN_INPUT \
     COM_OCEAN_HISTORY COM_OCEAN_ANALYSIS
   RUN="${rCDUMP}" YMD="${gPDY}" HH="${gcyc}" declare_from_tmpl -rx \
-    COM_OCEAN_RESTART_PREV:COM_OCEAN_RESTART_TMPL
+    COM_OCEAN_RESTART_PREV:COM_OCEAN_RESTART_TMPL \
+    COM_MED_RESTART_PREV:COM_MED_RESTART_TMPL
 fi
 
 if [[ "${DO_ICE}" == "YES" ]]; then

--- a/parm/config/gfs/config.base
+++ b/parm/config/gfs/config.base
@@ -302,6 +302,7 @@ export WRITE_NSFLIP=".true."
 
 # IAU related parameters
 export DOIAU="@DOIAU@"        # Enable 4DIAU for control with 3 increments
+if [[ "${MODE}" == "cycled" && "${SDATE}" == "${PDY}${cyc}" && ${EXP_WARM_START} == ".true." ]]; then export DOIAU="NO"; fi
 export IAUFHRS="3,6,9"
 export IAU_FHROT=${IAUFHRS%%,*}
 export IAU_DELTHRS=6

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -86,8 +86,18 @@ FV3_predet(){
   FHCYC=${FHCYC:-24}
   restart_interval=${restart_interval:-${FHMAX}}
   # restart_interval = 0 implies write restart at the END of the forecast i.e. at FHMAX
+  # Convert restart interval into an explicit list for FV3
   if (( restart_interval == 0 )); then
     restart_interval=${FHMAX}
+    FV3_RESTART_FH=("${restart_interval}")
+  else
+    # shellcheck disable=SC2312
+    mapfile -t FV3_RESTART_FH < <(seq "${restart_interval}" "${restart_interval}" "${FHMAX}")
+    # If the last forecast hour is not in the array, add it
+    local nrestarts=${#FV3_RESTART_FH[@]}
+    if (( FV3_RESTART_FH[nrestarts-1] != FHMAX )); then
+      FV3_RESTART_FH+=("${FHMAX}")
+    fi
   fi
 
   # Convert output settings into an explicit list for FV3

--- a/ush/parsing_model_configure_FV3.sh
+++ b/ush/parsing_model_configure_FV3.sh
@@ -24,7 +24,7 @@ local SHOUR=${model_start_date:8:2}
 # FHMAX
 local FHROT=${IAU_FHROT:-0}
 local DT_ATMOS=${DELTIM}
-local RESTART_INTERVAL="${restart_interval} -1"
+local RESTART_INTERVAL="${FV3_RESTART_FH[*]}"
 # QUILTING
 local QUILTING_RESTART=".true."
 local WRITE_GROUP=${WRITE_GROUP:-1}


### PR DESCRIPTION
# Description
This PR fixes 2 issues:
- Fixes #2524
- Fixes #2528 

Relevant for #2524
`model_configure` has an entry `restart_interval`.  In the past, an entry such as `6 -1` would translate into a restarts written at a frequency of `6h` *and* at the end of the forecast.  This has been replaced by needing to provide an explicit list of forecast hours the restarts are required.  
In the case of `gdas`, this means, if restarts are needed at `6h` and the end, the appropriate `restart_interval = 6 9`
To achieve this, `forecast_predet.sh` calculates the `FV3_RESTART_FH` list based on `restart_interval` (a frequency) and this array is used to copy restarts back to `COM` from `DATArestart`

# Type of change
<!-- Delete all except one -->
- Bug fix
- Maintenance 
- 
# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Ran a standalone first half cycle from the UFS DA ci test

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
