### PR TITLE
Fixes sea ice archiving

### DIFF
--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -576,12 +576,11 @@ if [[ ${type} == "gdas" ]]; then
     rm -rf "${DATA}/gdasice_restart.txt"
     touch "${DATA}/gdasice_restart.txt"
 
-    head="gdas.t${cyc}z."
+    head="gdas.ice.t${cyc}z."
 
     #...........................
     {
       echo "${COM_ICE_HISTORY/${ROTDIR}\//}/${head}*"
-      echo "${COM_ICE_INPUT/${ROTDIR}\//}/ice_in"
     } >> "${DATA}/gdasice.txt"
 
     echo "${COM_ICE_RESTART/${ROTDIR}\//}/*" >> "${DATA}/gdasice_restart.txt"


### PR DESCRIPTION

# Description

Removes/changes sea ice output files that are failing to be added to list for archiving, causing `gdasarch` to fail in WCDA cycling. 

Resolves https://github.com/NOAA-EMC/GDASApp/issues/1044

# Type of change

- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

# Checklist
- [ ] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
