### PR TITLE
Link ensemble analysis increment files to COMROOT for warm_start

### DIFF
--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -231,6 +231,18 @@ def fill_ROTDIR_cycled(host, inputs):
             src_file = os.path.join(src_dir, fname)
             if os.path.exists(src_file):
                 os.symlink(src_file, os.path.join(dst_dir, fname))
+        if inputs.nens > 0:
+            current_cycle_dir = f'enkf{inputs.cdump}.{idatestr[:8]}/{idatestr[8:]}'
+            for ii in range(1, inputs.nens + 1):
+                memdir = f'mem{ii:03d}'
+                src_dir = os.path.join(inputs.icsdir, current_cycle_dir, memdir, src_atm_anl_dir)
+                dst_dir = os.path.join(rotdir, current_cycle_dir, memdir, dst_atm_anl_dir)
+                makedirs_if_missing(dst_dir)
+                for ftype in ['ratmi003.nc', 'ratminc.nc', 'ratmi009.nc']:
+                    fname = f'enkf{inputs.cdump}.t{idatestr[8:]}z.{ftype}'
+                    src_file = os.path.join(src_dir, fname)
+                    if os.path.exists(src_file):
+                        os.symlink(src_file, os.path.join(dst_dir, fname))
 
     return
 


### PR DESCRIPTION
# Description
Scripting is added to `setup_expt.py` to link ensemble analysis increment files to COMROOT for warm_start experiments.

Resolves #2552


# Type of change
- Bug fix (fixes something broken)


# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Clone and build on Orion
- Run C96C48_ufs_hybatmDA on Orion


# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
