### PR TITLE
Do not use BUILT_semphore to force rebuilds when re-run

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -149,7 +149,7 @@ pipeline {
                                                 }
                                             }
                                             sh(script: './link_workflow.sh')
-                                            sh(script: "echo ${HOMEgfs} > BUILT_semaphor")
+                                            //sh(script: "echo ${HOMEgfs} > BUILT_semaphor")
                                         }
                                     }
                                     if (env.CHANGE_ID && system == 'gfs') {


### PR DESCRIPTION
# Description
Remove the placement of the `BUILT_semaphore` file after the build in the Jenkins Pipeline and force it to rebuild any changes after a PR is re-ran.

# Type of change
<!-- Delete all except one -->
- Bug fix (fixes something broken)
Re-Runs where not rebuilding changes as expected.


# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO