### PR TITLE
Fold in obsproc/v1.2 and WDQMS script error handling updates

### DIFF
--- a/docs/Release_Notes.gfs.v16.3.15.md
+++ b/docs/Release_Notes.gfs.v16.3.15.md
@@ -1,0 +1,133 @@
+GFS V16.3.15 RELEASE NOTES
+
+-------
+PRELUDE
+-------
+
+OBSPROC is updated to v1.2 in operations. This upstream dependency results in a version increase for the GFS.
+
+This OBSPROC update adds the following:
+
+* high-vertical resolution radiosonde profiles (up to 255 pressure levels) to the global and RAP prepbufr files
+* high-vertical resolution radiosonde profiles (full profiles) to the newly established global and RAP *uprair* bufr dump files
+* high-spatial and temporal resolution hurricane tailored winds for the HAFS model in the *satwhr* buff dump files
+
+It also increases the amount of msonet observations across all regional models.
+
+IMPLEMENTATION INSTRUCTIONS
+---------------------------
+
+The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub .com are used to manage the GFS code.  The SPA(s) handling the GFS implementation need to have permissions to clone VLab Gerrit repositories and private NCAR UPP_GTG repository. All NOAA-EMC organization repositories are publicly readable and do not require access permissions.  Please proceed with the following steps to install the package on WCOSS2:
+
+```bash
+cd $PACKAGEROOT
+mkdir gfs.v16.3.15
+cd gfs.v16.3.15
+git clone -b EMC-v16.3.15 https://github.com/NOAA-EMC/global-workflow.git .
+cd sorc
+./checkout.sh -o
+```
+
+The checkout script extracts the following GFS components:
+
+| Component | Tag         | POC               |
+| --------- | ----------- | ----------------- |
+| MODEL     | GFS.v16.3.1   | Jun.Wang@noaa.gov |
+| GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
+| GSI       | gfsda.v16.3.12 | Andrew.Collard@noaa.gov |
+| UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
+| POST      | upp_v8.3.0 | Wen.Meng@noaa.gov |
+| WAFS      | gfs_wafs.v6.3.2 | Yali.Mao@noaa.gov |
+
+To build all the GFS components, execute:
+```bash
+./build_all.sh
+```
+The `build_all.sh` script compiles all GFS components. Runtime output from the build for each package is written to log files in directory logs. To build an individual program, for instance, gsi, use `build_gsi.sh`.
+
+Next, link the executables, fix files, parm files, etc in their final respective locations by executing:
+```bash
+./link_fv3gfs.sh nco wcoss2
+```
+
+Lastly, link the ecf scripts by moving back up to the ecf folder and executing:
+```bash
+cd ../ecf
+./setup_ecf_links.sh
+```
+VERSION FILE CHANGES
+--------------------
+
+* `versions/run.ver` - change `version=v16.3.15`, `gfs_ver=v16.3.15`, and `obsproc_ver=v1.2`
+
+SORC CHANGES
+------------
+
+* No changes from GFS v16.3.14
+
+JOBS CHANGES
+------------
+
+* No changes from GFS v16.3.14
+
+PARM/CONFIG CHANGES
+-------------------
+
+* No changes from GFS v16.3.14
+
+SCRIPT CHANGES
+--------------
+
+* No changes from GFS v16.3.14
+
+FIX CHANGES
+-----------
+
+* No changes from GFS v16.3.14
+
+MODULE CHANGES
+--------------
+
+* No changes from GFS v16.3.14
+
+CHANGES TO FILE SIZES
+---------------------
+
+* No changes from GFS v16.3.14
+
+ENVIRONMENT AND RESOURCE CHANGES
+--------------------------------
+
+* No changes from GFS v16.3.14
+
+PRE-IMPLEMENTATION TESTING REQUIREMENTS
+---------------------------------------
+
+* Which production jobs should be tested as part of this implementation?
+  * N/A
+* Does this change require a 30-day evaluation?
+  * No
+
+DISSEMINATION INFORMATION
+-------------------------
+
+* No changes from GFS v16.3.14
+
+HPSS ARCHIVE
+------------
+
+* No changes from GFS v16.3.14
+
+JOB DEPENDENCIES AND FLOW DIAGRAM
+---------------------------------
+
+* No changes from GFS v16.3.14
+
+DOCUMENTATION
+-------------
+
+* No changes from GFS v16.3.14
+
+PREPARED BY
+-----------
+Kate.Friedman@noaa.gov

--- a/scripts/exgdas_atmos_analysis_wdqms.sh
+++ b/scripts/exgdas_atmos_analysis_wdqms.sh
@@ -47,7 +47,7 @@ cd "${DATA}" || ( echo "FATAL ERROR: Unable to cd into '${DATA}', ABORT!"; exit 
 # These should always be available
 cp "${COMIN}/${CNVSTAT}" .
 export err=$?
-(( err != 0 )) && ( msg="Unable to copy '${CNVSTAT}' from '${COMIN}'"; err_exit "${msg}" )
+(( err != 0 )) && ( msg="FATAL ERROR: Unable to copy '${CNVSTAT}' from '${COMIN}', ABORT!"; err_exit "${msg}" )
 for diagfile in "${INPUT_LIST[@]}"; do
   tar -xvf "${CNVSTAT}" "${diagfile}.gz"
   export err=$?

--- a/versions/hera.ver
+++ b/versions/hera.ver
@@ -2,7 +2,7 @@ export hpc_ver=1.2.0
 export hpc_intel_ver=18.0.5.274
 export hpc_impi_ver=2018.0.4
 
-export obsproc_run_ver=1.1.2
+export obsproc_run_ver=1.2.0
 export prepobs_run_ver=1.0.1
 
 export hpss_ver=hpss

--- a/versions/orion.ver
+++ b/versions/orion.ver
@@ -2,7 +2,7 @@ export hpc_ver=1.2.0
 export hpc_intel_ver=2018.4
 export hpc_impi_ver=2018.4
 
-export obsproc_run_ver=1.1.2
+export obsproc_run_ver=1.2.0
 export prepobs_run_ver=1.0.1
 
 export prod_util_ver=1.2.2

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,11 +1,11 @@
-export version=v16.3.14
-export gfs_ver=v16.3.14
+export version=v16.3.15
+export gfs_ver=v16.3.15
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2
 export rtofs_ver=v2.3
 export radarl2_ver=v1.2
-export obsproc_ver=v1.1
+export obsproc_ver=v1.2
 
 export PrgEnv_intel_ver=8.1.0
 export intel_ver=19.1.3.304

--- a/versions/wcoss2.ver
+++ b/versions/wcoss2.ver
@@ -2,7 +2,7 @@ export envvar_ver=1.0
 export prod_envir_ver=${prod_envir_ver:-2.0.4} # Allow override from ops ecflow
 export prod_util_ver=${prod_util_ver:-2.0.9}   # Allow override from ops ecflow
 
-export obsproc_run_ver=1.1.2
+export obsproc_run_ver=1.2.0
 export prepobs_run_ver=1.0.1
 
 export tracker_ver=v1.1.15.5


### PR DESCRIPTION
# Description

This PR merges in updates for obsproc/v1.2 (from the `release/gfs.v16.3.15` branch) and an update to `scripts/exgdas_atmos_analysis_wdqms.sh` error handling per discussion with NCO (SPA Simon).

@emilyhcliu FYI about additional script error handling update. SPA Simon requested this final edit to conform with NCO error handling standards. He approved of your prior updates, so this should be the last script update.

Will merge and recut final hand-off tag for NCO install.

Refs #2389

# Type of change

Feedback from NCO and prior version change merge in.

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

By NCO in para