### PR TITLE
 Add remove RUNDIRS step in CI before creating experements

### DIFF
--- a/ci/scripts/utils/ci_utils.sh
+++ b/ci/scripts/utils/ci_utils.sh
@@ -122,7 +122,8 @@ function create_experiment () {
   source "${HOMEgfs}/ci/platforms/config.${MACHINE_ID}"
   source "${HOMEgfs}/workflow/gw_setup.sh"
 
-  # system=$(grep "system:" "${yaml_config}" | cut -d":" -f2 | tr -d " ") || true
+  # Remove RUNDIRS dir incase this is a retry
+  rm -Rf "${STMP}/RUNDIRS/${pslot}"
 
   "${HOMEgfs}/${system}/workflow/create_experiment.py" --overwrite --yaml "${yaml_config}"
 


### PR DESCRIPTION
# Description

As had been done in Bash CI we need to remove the RUNDIR in Jenkins before a creating an experiment in the event that case had beem previously ran.

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
No