### PR TITLE
STMP CI yaml over ride updates due to Orion-Hercules cross mounting

### DIFF
--- a/ci/cases/yamls/atmaerosnowDA_defaults_ci.yaml
+++ b/ci/cases/yamls/atmaerosnowDA_defaults_ci.yaml
@@ -4,3 +4,4 @@ base:
   DOIAU: "NO"
   DO_JEDISNOWDA: "YES"
   ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
+  STMP: {{ 'STMP' | getenv }}

--- a/ci/cases/yamls/atmaerosnowDA_defaults_ci.yaml
+++ b/ci/cases/yamls/atmaerosnowDA_defaults_ci.yaml
@@ -3,4 +3,4 @@ defaults:
 base:
   DOIAU: "NO"
   DO_JEDISNOWDA: "YES"
-  ACCOUNT: {{ 'SLURM_ACCOUNT' | getenv }}
+  ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}

--- a/ci/cases/yamls/atmaerosnowDA_defaults_ci.yaml
+++ b/ci/cases/yamls/atmaerosnowDA_defaults_ci.yaml
@@ -5,3 +5,4 @@ base:
   DO_JEDISNOWDA: "YES"
   ACCOUNT: {{ 'ACCOUNT' | getenv }}
   STMP: {{ 'STMP' | getenv }}
+  PTMP: {{ 'PTMP' | getenv }}

--- a/ci/cases/yamls/atmaerosnowDA_defaults_ci.yaml
+++ b/ci/cases/yamls/atmaerosnowDA_defaults_ci.yaml
@@ -3,5 +3,5 @@ defaults:
 base:
   DOIAU: "NO"
   DO_JEDISNOWDA: "YES"
-  ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
+  ACCOUNT: {{ 'ACCOUNT' | getenv }}
   STMP: {{ 'STMP' | getenv }}

--- a/ci/cases/yamls/gefs_ci_defaults.yaml
+++ b/ci/cases/yamls/gefs_ci_defaults.yaml
@@ -1,5 +1,5 @@
 defaults:
   !INC {{ HOMEgfs }}/parm/config/gefs/yaml/defaults.yaml
 base:
-  ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
+  ACCOUNT: {{ 'ACCOUNT' | getenv }}
   STMP: {{ 'STMP' | getenv }}

--- a/ci/cases/yamls/gefs_ci_defaults.yaml
+++ b/ci/cases/yamls/gefs_ci_defaults.yaml
@@ -3,3 +3,4 @@ defaults:
 base:
   ACCOUNT: {{ 'ACCOUNT' | getenv }}
   STMP: {{ 'STMP' | getenv }}
+  PTMP: {{ 'PTMP' | getenv }}

--- a/ci/cases/yamls/gefs_ci_defaults.yaml
+++ b/ci/cases/yamls/gefs_ci_defaults.yaml
@@ -1,4 +1,5 @@
 defaults:
   !INC {{ HOMEgfs }}/parm/config/gefs/yaml/defaults.yaml
 base:
-  ACCOUNT: {{ 'SLURM_ACCOUNT' | getenv }}
+  ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
+  STMP: {{ 'STMP' | getenv }}

--- a/ci/cases/yamls/gfs_defaults_ci.yaml
+++ b/ci/cases/yamls/gfs_defaults_ci.yaml
@@ -1,5 +1,5 @@
 defaults:
   !INC {{ HOMEgfs }}/parm/config/gfs/yaml/defaults.yaml
 base:
-  ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
+  ACCOUNT: {{ 'ACCOUNT' | getenv }}
   STMP: {{ 'STMP' | getenv }}

--- a/ci/cases/yamls/gfs_defaults_ci.yaml
+++ b/ci/cases/yamls/gfs_defaults_ci.yaml
@@ -3,3 +3,4 @@ defaults:
 base:
   ACCOUNT: {{ 'ACCOUNT' | getenv }}
   STMP: {{ 'STMP' | getenv }}
+  PTMP: {{ 'PTMP' | getenv }}

--- a/ci/cases/yamls/gfs_defaults_ci.yaml
+++ b/ci/cases/yamls/gfs_defaults_ci.yaml
@@ -1,4 +1,5 @@
 defaults:
   !INC {{ HOMEgfs }}/parm/config/gfs/yaml/defaults.yaml
 base:
-  ACCOUNT: {{ 'SLURM_ACCOUNT' | getenv }}
+  ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
+  STMP: {{ 'STMP' | getenv }}

--- a/ci/cases/yamls/gfs_extended_ci.yaml
+++ b/ci/cases/yamls/gfs_extended_ci.yaml
@@ -4,6 +4,7 @@ defaults:
 base:
   ACCOUNT: {{ 'ACCOUNT' | getenv }}
   STMP: {{ 'STMP' | getenv }}
+  PTMP: {{ 'PTMP' | getenv }}
   DO_GOES: "YES"
   DO_BUFRSND: "YES"
   DO_GEMPAK: "YES"

--- a/ci/cases/yamls/gfs_extended_ci.yaml
+++ b/ci/cases/yamls/gfs_extended_ci.yaml
@@ -2,7 +2,7 @@ defaults:
   !INC {{ HOMEgfs }}/parm/config/gfs/yaml/defaults.yaml
 
 base:
-  ACCOUNT: {{ 'SLURM_ACCOUNT' | getenv }}
+  ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
   DO_GOES: "YES"
   DO_BUFRSND: "YES"
   DO_GEMPAK: "YES"

--- a/ci/cases/yamls/gfs_extended_ci.yaml
+++ b/ci/cases/yamls/gfs_extended_ci.yaml
@@ -2,7 +2,7 @@ defaults:
   !INC {{ HOMEgfs }}/parm/config/gfs/yaml/defaults.yaml
 
 base:
-  ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
+  ACCOUNT: {{ 'ACCOUNT' | getenv }}
   STMP: {{ 'STMP' | getenv }}
   DO_GOES: "YES"
   DO_BUFRSND: "YES"

--- a/ci/cases/yamls/gfs_extended_ci.yaml
+++ b/ci/cases/yamls/gfs_extended_ci.yaml
@@ -3,6 +3,7 @@ defaults:
 
 base:
   ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
+  STMP: {{ 'STMP' | getenv }}
   DO_GOES: "YES"
   DO_BUFRSND: "YES"
   DO_GEMPAK: "YES"

--- a/ci/cases/yamls/soca_gfs_defaults_ci.yaml
+++ b/ci/cases/yamls/soca_gfs_defaults_ci.yaml
@@ -3,4 +3,5 @@ defaults:
 base:
   ACCOUNT: {{ 'ACCOUNT' | getenv }}
   STMP: {{ 'STMP' | getenv }}
+  PTMP: {{ 'PTMP' | getenv }}
   DO_JEDIOCNVAR: "YES"

--- a/ci/cases/yamls/soca_gfs_defaults_ci.yaml
+++ b/ci/cases/yamls/soca_gfs_defaults_ci.yaml
@@ -1,6 +1,6 @@
 defaults:
   !INC {{ HOMEgfs }}/parm/config/gfs/yaml/defaults.yaml
 base:
-  ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
+  ACCOUNT: {{ 'ACCOUNT' | getenv }}
   STMP: {{ 'STMP' | getenv }}
   DO_JEDIOCNVAR: "YES"

--- a/ci/cases/yamls/soca_gfs_defaults_ci.yaml
+++ b/ci/cases/yamls/soca_gfs_defaults_ci.yaml
@@ -1,5 +1,5 @@
 defaults:
   !INC {{ HOMEgfs }}/parm/config/gfs/yaml/defaults.yaml
 base:
-  ACCOUNT: {{ 'SLURM_ACCOUNT' | getenv }}
+  ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
   DO_JEDIOCNVAR: "YES"

--- a/ci/cases/yamls/soca_gfs_defaults_ci.yaml
+++ b/ci/cases/yamls/soca_gfs_defaults_ci.yaml
@@ -2,4 +2,5 @@ defaults:
   !INC {{ HOMEgfs }}/parm/config/gfs/yaml/defaults.yaml
 base:
   ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
+  STMP: {{ 'STMP' | getenv }}
   DO_JEDIOCNVAR: "YES"

--- a/ci/cases/yamls/ufs_hybatmDA_defaults.ci.yaml
+++ b/ci/cases/yamls/ufs_hybatmDA_defaults.ci.yaml
@@ -6,6 +6,7 @@ base:
   DO_JEDIATMENS: "YES"
   ACCOUNT: {{ 'ACCOUNT' | getenv }}
   STMP: {{ 'STMP' | getenv }}
+  PTMP: {{ 'PTMP' | getenv }}
 atmanl:
   LAYOUT_X_ATMANL: 4
   LAYOUT_Y_ATMANL: 4

--- a/ci/cases/yamls/ufs_hybatmDA_defaults.ci.yaml
+++ b/ci/cases/yamls/ufs_hybatmDA_defaults.ci.yaml
@@ -4,7 +4,7 @@ base:
   DOIAU: "NO"
   DO_JEDIATMVAR: "YES"
   DO_JEDIATMENS: "YES"
-  ACCOUNT: {{ 'SLURM_ACCOUNT' | getenv }}
+  ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
 atmanl:
   LAYOUT_X_ATMANL: 4
   LAYOUT_Y_ATMANL: 4

--- a/ci/cases/yamls/ufs_hybatmDA_defaults.ci.yaml
+++ b/ci/cases/yamls/ufs_hybatmDA_defaults.ci.yaml
@@ -4,7 +4,7 @@ base:
   DOIAU: "NO"
   DO_JEDIATMVAR: "YES"
   DO_JEDIATMENS: "YES"
-  ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
+  ACCOUNT: {{ 'ACCOUNT' | getenv }}
   STMP: {{ 'STMP' | getenv }}
 atmanl:
   LAYOUT_X_ATMANL: 4

--- a/ci/cases/yamls/ufs_hybatmDA_defaults.ci.yaml
+++ b/ci/cases/yamls/ufs_hybatmDA_defaults.ci.yaml
@@ -5,6 +5,7 @@ base:
   DO_JEDIATMVAR: "YES"
   DO_JEDIATMENS: "YES"
   ACCOUNT: {{ 'BATCH_ACCOUNT' | getenv }}
+  STMP: {{ 'STMP' | getenv }}
 atmanl:
   LAYOUT_X_ATMANL: 4
   LAYOUT_Y_ATMANL: 4

--- a/ci/platforms/config.hera
+++ b/ci/platforms/config.hera
@@ -4,6 +4,6 @@ export GFS_CI_ROOT=/scratch1/NCEPDEV/global/Terry.McGuinness/GFS_CI_ROOT
 export ICSDIR_ROOT=/scratch1/NCEPDEV/global/glopara/data/ICSDIR
 export STMP="/scratch1/NCEPDEV/stmp2/${USER}"
 export PTMP="/scratch1/NCEPDEV/stmp2/${USER}"
-export SLURM_ACCOUNT=nems
+export BATCH_ACCOUNT=nems
 export max_concurrent_cases=5
 export max_concurrent_pr=4

--- a/ci/platforms/config.hera
+++ b/ci/platforms/config.hera
@@ -4,6 +4,6 @@ export GFS_CI_ROOT=/scratch1/NCEPDEV/global/Terry.McGuinness/GFS_CI_ROOT
 export ICSDIR_ROOT=/scratch1/NCEPDEV/global/glopara/data/ICSDIR
 export STMP="/scratch1/NCEPDEV/stmp2/${USER}"
 export PTMP="/scratch1/NCEPDEV/stmp2/${USER}"
-export BATCH_ACCOUNT=nems
+export ACCOUNT=nems
 export max_concurrent_cases=5
 export max_concurrent_pr=4

--- a/ci/platforms/config.hercules
+++ b/ci/platforms/config.hercules
@@ -4,6 +4,6 @@ export GFS_CI_ROOT=/work2/noaa/stmp/GFS_CI_ROOT/HERCULES
 export ICSDIR_ROOT=/work/noaa/global/glopara/data/ICSDIR
 export STMP="/work2/noaa/stmp/${USER}/HERCULES"
 export PTMP="/work2/noaa/stmp/${USER}/HERCULES"
-export BATCH_ACCOUNT=nems
+export ACCOUNT=nems
 export max_concurrent_cases=5
 export max_concurrent_pr=4

--- a/ci/platforms/config.hercules
+++ b/ci/platforms/config.hercules
@@ -4,6 +4,6 @@ export GFS_CI_ROOT=/work2/noaa/stmp/GFS_CI_ROOT/HERCULES
 export ICSDIR_ROOT=/work/noaa/global/glopara/data/ICSDIR
 export STMP="/work2/noaa/stmp/${USER}/HERCULES"
 export PTMP="/work2/noaa/stmp/${USER}/HERCULES"
-export SLURM_ACCOUNT=nems
+export BATCH_ACCOUNT=nems
 export max_concurrent_cases=5
 export max_concurrent_pr=4

--- a/ci/platforms/config.orion
+++ b/ci/platforms/config.orion
@@ -4,6 +4,6 @@ export GFS_CI_ROOT=/work2/noaa/stmp/GFS_CI_ROOT/ORION
 export ICSDIR_ROOT=/work/noaa/global/glopara/data/ICSDIR
 export STMP="/work2/noaa/stmp/${USER}/ORION"
 export PTMP="/work2/noaa/stmp/${USER}/ORION"
-export BATCH_ACCOUNT=nems
+export ACCOUNT=nems
 export max_concurrent_cases=5
 export max_concurrent_pr=4

--- a/ci/platforms/config.orion
+++ b/ci/platforms/config.orion
@@ -4,6 +4,6 @@ export GFS_CI_ROOT=/work2/noaa/stmp/GFS_CI_ROOT/ORION
 export ICSDIR_ROOT=/work/noaa/global/glopara/data/ICSDIR
 export STMP="/work2/noaa/stmp/${USER}/ORION"
 export PTMP="/work2/noaa/stmp/${USER}/ORION"
-export SLURM_ACCOUNT=nems
+export BATCH_ACCOUNT=nems
 export max_concurrent_cases=5
 export max_concurrent_pr=4

--- a/ci/platforms/config.wcoss2
+++ b/ci/platforms/config.wcoss2
@@ -4,6 +4,6 @@ export GFS_CI_ROOT=/lfs/h2/emc/global/noscrub/globalworkflow.ci/GFS_CI_ROOT
 export ICSDIR_ROOT=/lfs/h2/emc/global/noscrub/emc.global/data/ICSDIR
 export STMP="/lfs/h2/emc/stmp/${USER}"
 export PTMP="/lfs/h2/emc/ptmp/${USER}"
-export BATCH_ACCOUNT=GFS-DEV
+export ACCOUNT=GFS-DEV
 export max_concurrent_cases=5
 export max_concurrent_pr=4

--- a/ci/platforms/config.wcoss2
+++ b/ci/platforms/config.wcoss2
@@ -4,6 +4,6 @@ export GFS_CI_ROOT=/lfs/h2/emc/global/noscrub/globalworkflow.ci/GFS_CI_ROOT
 export ICSDIR_ROOT=/lfs/h2/emc/global/noscrub/emc.global/data/ICSDIR
 export STMP="/lfs/h2/emc/stmp/${USER}"
 export PTMP="/lfs/h2/emc/ptmp/${USER}"
-export SLURM_ACCOUNT=GFS-DEV
+export BATCH_ACCOUNT=GFS-DEV
 export max_concurrent_cases=5
 export max_concurrent_pr=4


### PR DESCRIPTION
# Description

This hot bug fix updates how CI over rides the STMP value for Hercules and Orion cases because they are cross mounted.

Also took this moment to update SLUM to BATCH because its a misnomer.

# Type of change
- Bug fix (fixes something broken)

We had to include the updating of STMP in the over ride yaml configs in CI because the value is designated in `$HOMEgfs/workflow/hosts/$MACHINE_ID.yaml`

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Going to run CI on Orion/Hercules
