### PR TITLE
Add the restart capability to job JGFS_ATMOS_POSTSND

### DIFF
--- a/jobs/JGFS_ATMOS_POSTSND
+++ b/jobs/JGFS_ATMOS_POSTSND
@@ -29,6 +29,10 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_HISTORY COM_ATMOS_BUFR \
 [[ ! -d ${COM_ATMOS_GEMPAK} ]] && mkdir -p "${COM_ATMOS_GEMPAK}"
 [[ ! -d ${COM_ATMOS_WMO} ]] && mkdir -p "${COM_ATMOS_WMO}"
 
+# Create a restart directory in ptmp to hold temporary output from the job JGFS_ATMOS_POSTSND
+
+export DATA_ATMOS_RESTART=${DATAROOT}/${RUN}.${PDY}/${cyc}/products/atmos/restart
+if [[ ! -d ${DATA_ATMOS_RESTART} ]]; then mkdir -p ${DATA_ATMOS_RESTART}; fi
 
 ########################################################
 # Execute the script.

--- a/jobs/JGFS_ATMOS_POSTSND
+++ b/jobs/JGFS_ATMOS_POSTSND
@@ -32,7 +32,7 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_HISTORY COM_ATMOS_BUFR \
 # Create a restart directory in ptmp to hold temporary output from the job JGFS_ATMOS_POSTSND
 
 export DATA_ATMOS_RESTART=${DATAROOT}/${RUN}.${PDY}/${cyc}/products/atmos/restart
-if [[ ! -d ${DATA_ATMOS_RESTART} ]]; then mkdir -p ${DATA_ATMOS_RESTART}; fi
+if [[ ! -d ${DATA_ATMOS_RESTART} ]]; then mkdir -p "${DATA_ATMOS_RESTART}"; fi
 
 ########################################################
 # Execute the script.

--- a/scripts/exgfs_atmos_postsnd.sh
+++ b/scripts/exgfs_atmos_postsnd.sh
@@ -57,7 +57,7 @@ export RESTART_postsnd="NO"
 
 nrestarts=$(find "$DATA_ATMOS_RESTART" -maxdepth 1 -type f -name '*.bufr.logf*' | wc -l)
 
-echo ${nrestarts}
+echo "${nrestarts}"
 
 if (( nrestarts == 0 )); then
   echo "No restarts found in '${DATA_ATMOS_RESTART}', RESTART_postsnd='${RESTART_postsnd}'"
@@ -118,7 +118,10 @@ done
 ##############################################################
 cd "${COM_ATMOS_BUFR}" || exit 2
 tar -cf - . | /usr/bin/gzip > "${RUN}.${cycle}.bufrsnd.tar.gz"
-cd "${DATA}" || exit 2
+cd "${DATA}"
+if [ $? -ne 0 ]; then
+    exit 2
+fi
 
 ########################################
 # Send the single tar file to OSO

--- a/scripts/exgfs_atmos_postsnd.sh
+++ b/scripts/exgfs_atmos_postsnd.sh
@@ -133,7 +133,7 @@ fi
 # add appropriate WMO Headers.
 ########################################
 rm -rf poe_col
-for (( m = 1; m <10 ; m++ )); do
+for (( m = 1; m <= NUM_SND_COLLECTIVES ; m++ )); do
     echo "sh ${USHgfs}/gfs_sndp.sh ${m} " >> poe_col
 done
 

--- a/scripts/exgfs_atmos_postsnd.sh
+++ b/scripts/exgfs_atmos_postsnd.sh
@@ -18,6 +18,7 @@
 #   7) 2018-07-18       Guang Ping Lou Generalize this version to other platforms
 #   8) 2019-10-18       Guang Ping Lou Transition to reading in NetCDF model data
 #   9) 2019-12-18       Guang Ping Lou generalizing to reading in NetCDF or nemsio
+#  10) 2024_05_15       Bo Cui  Add restart capability
 ################################################################
 
 source "${USHgfs}/preamble.sh"
@@ -48,9 +49,28 @@ GETDIM="${USHgfs}/getncdimlen"
 LEVS=$(${GETDIM} "${COM_ATMOS_HISTORY}/${RUN}.${cycle}.atmf000.${atmfm}" pfull)
 declare -x LEVS
 
+# Assume there was no run before and hence this is not a RESTART for job postsnd
+
+export RESTART_postsnd="NO"
+
+# However, if there was a run before, a directory DATA_ATMOS_RESTART must exist with data in it.
+
+nrestarts=$(find "$DATA_ATMOS_RESTART" -maxdepth 1 -type f -name '*.bufr.logf*' | wc -l)
+
+echo ${nrestarts}
+
+if (( nrestarts == 0 )); then
+  echo "No restarts found in '${DATA_ATMOS_RESTART}', RESTART_postsnd='${RESTART_postsnd}'"
+
+else 
+  echo "Restarts found in '${DATA_ATMOS_RESTART}', RESTART_postsnd='YES'"
+  export RESTART_postsnd="YES"
+fi
+
 ### Loop for the hour and wait for the sigma and surface flux file:
 export FSTART=$STARTHOUR
 #
+
 while [ $FSTART -lt $ENDHOUR ]
 do
 export FINT=$NINT1

--- a/scripts/exgfs_atmos_postsnd.sh
+++ b/scripts/exgfs_atmos_postsnd.sh
@@ -55,7 +55,7 @@ export RESTART_postsnd="NO"
 
 # However, if there was a run before, a directory DATA_ATMOS_RESTART must exist with data in it.
 
-nrestarts=$(find "$DATA_ATMOS_RESTART" -maxdepth 1 -type f -name '*.bufr.logf*' | wc -l)
+nrestarts=$(find "$DATA_ATMOS_RESTART" -maxdepth 1 -type f -name '*.bufr.logf*' | wc -l || true)
 
 echo "${nrestarts}"
 
@@ -118,10 +118,7 @@ done
 ##############################################################
 cd "${COM_ATMOS_BUFR}" || exit 2
 tar -cf - . | /usr/bin/gzip > "${RUN}.${cycle}.bufrsnd.tar.gz"
-cd "${DATA}"
-if [ $? -ne 0 ]; then
-    exit 2
-fi
+cd "${DATA}" || exit
 
 ########################################
 # Send the single tar file to OSO
@@ -136,7 +133,7 @@ fi
 # add appropriate WMO Headers.
 ########################################
 rm -rf poe_col
-for (( m = 1; m <= NUM_SND_COLLECTIVES ; m++ )); do
+for (( m = 1; m <10 ; m++ )); do
     echo "sh ${USHgfs}/gfs_sndp.sh ${m} " >> poe_col
 done
 

--- a/scripts/exgfs_atmos_postsnd.sh
+++ b/scripts/exgfs_atmos_postsnd.sh
@@ -105,12 +105,12 @@ export FINT=$NINT1
    done
 
 ## 1-hourly output before $NEND1, 3-hourly output after
-   if [ $FEND -gt $NEND1 ]; then
-     export FINT=$NINT3
+   if [[ "${FEND}" -gt "${NEND1}" ]]; then
+     export FINT="${NINT3}"
    fi
-   ${USHgfs}/gfs_bufr.sh
+   "${USHgfs}/gfs_bufr.sh"
   
-   export FSTART=$FEND
+   export FSTART="${FEND}"
 done
 
 ##############################################################

--- a/ush/gfs_bufr.sh
+++ b/ush/gfs_bufr.sh
@@ -101,14 +101,14 @@ if [[ ${RESTART_postsnd} == "YES" ]]; then
 
     echo "Copy job postsnd files from restart directory"
 
-    cp -p ${DATA_ATMOS_RESTART}/${RUN}.${cycle}.bufr.logf${FEND}.${logfm} .
+    cp -p "${DATA_ATMOS_RESTART}/${RUN}.${cycle}.bufr.logf${FEND}.${logfm}" .
     while IFS= read -r fortname; do
 #     echo "Copy job postsnd files from restart directory: $fortname"
-      cp -p ${DATA_ATMOS_RESTART}/${RUN}.${cycle}.bufr_${fortname} ${fortname}
-    done < ${RUN}.${cycle}.bufr.logf${FEND}.${logfm}
+      cp -p "${DATA_ATMOS_RESTART}/${RUN}.${cycle}.bufr_${fortname}" ${fortname}
+    done < "${RUN}.${cycle}.bufr.logf${FEND}.${logfm}"
     err=0
 
-    if [ ${FEND} -eq ${ENDHOUR} ]; then
+    if [[ ${FEND} -eq ${ENDHOUR} ]]; then
       ${APRUN_POSTSND} "${EXECgfs}/${pgm}" < gfsparm > "out_gfs_bufr_${FEND}"
       export err=$?
     fi
@@ -128,7 +128,7 @@ else
   export err=$?
 fi
 
-if [ $err -ne 0 ]; then
+if [[ $err -ne 0 ]]; then
    echo "GFS postsnd job error, Please check files "
    echo "${COM_ATMOS_HISTORY}/${RUN}.${cycle}.atmf${hh2}.${atmfm}"
    echo "${COM_ATMOS_HISTORY}/${RUN}.${cycle}.sfcf${hh2}.${atmfm}"
@@ -138,10 +138,16 @@ else
 
   # Count the number of restart files
   nrestarts=$(find ./ -maxdepth 1 -type f -name 'fort.*' | wc -l)
-  echo "Number of restart fort.* files found: ${nrestarts}"
+  find_exit_code=$?
+  if [ $find_exit_code -ne 0 ]; then
+    # handle the error, set the number of restart file is 0
+    nrestarts=0
+  else
+    echo "Number of restart fort.* files found: ${nrestarts}"
+  fi
 
   # Check if there are restart files
-  if [ "$nrestarts" -gt 0 ]; then
+  if [[ "${nrestarts}" -gt 0 ]]; then
     echo "Copying GFS postsnd files to restart directory..."
 
     # Exclude specific files and save the rest to a log file
@@ -153,8 +159,8 @@ else
     # Loop through files in the directory
     for file in fort.*; do
       # Check if the file is not fort.1 or fort.7 or fort.8
-      if [[ $file != "fort.1" && $file != "fort.7" && $file != "fort.8" ]]; then
-        files+=("$file")
+      if [[ ${file} != "fort.1" && $file != "fort.7" && $file != "fort.8" ]]; then
+        files+=("${file}")
       fi
     done
 

--- a/ush/gfs_bufr.sh
+++ b/ush/gfs_bufr.sh
@@ -18,6 +18,7 @@
 # 2018-05-30  Guang Ping Lou: Make sure all files are available.
 # 2019-10-10  Guang Ping Lou: Read in NetCDF files
 # 2024-03-03 Bo Cui: Add options to use different bufr table for different resolution NetCDF files
+# 2024_05_15 Bo Cui: Add restart capability
 # echo "History: February 2003 - First implementation of this utility script"
 #
 source "${USHgfs}/preamble.sh"
@@ -88,19 +89,88 @@ case "${CASE}" in
         ${NLN} "${PARMgfs}/product/bufr_ij9km.txt"  fort.7
         ;;
     *)
-        echo "WARNING: No bufr table for this resolution, using the one for C768"
-        ${NLN} "${PARMgfs}/product/bufr_ij13km.txt" fort.7
+        echo "FATAL ERROR: Unrecognized bufr_ij*km.txt For CASE ${CASE}, ABORT!"
+        exit 1
         ;;
 esac
 
-${APRUN_POSTSND} "${EXECgfs}/${pgm}" < gfsparm > "out_gfs_bufr_${FEND}"
-export err=$?
+
+if [[ ${RESTART_postsnd} == "YES" ]]; then
+
+  if [ -f "${DATA_ATMOS_RESTART}/${RUN}.${cycle}.bufr.logf${FEND}.${logfm}" ]; then
+
+    echo "Copy job postsnd files from restart directory"
+
+    cp -p ${DATA_ATMOS_RESTART}/${RUN}.${cycle}.bufr.logf${FEND}.${logfm} .
+    while IFS= read -r fortname; do
+#     echo "Copy job postsnd files from restart directory: $fortname"
+      cp -p ${DATA_ATMOS_RESTART}/${RUN}.${cycle}.bufr_${fortname} ${fortname}
+    done < ${RUN}.${cycle}.bufr.logf${FEND}.${logfm}
+    err=0
+
+    if [ ${FEND} -eq ${ENDHOUR} ]; then
+      ${APRUN_POSTSND} "${EXECgfs}/${pgm}" < gfsparm > "out_gfs_bufr_${FEND}"
+      export err=$?
+    fi
+
+  else
+
+    echo "No more job postsnd restart file found in '${DATA_ATMOS_RESTART}'"
+    export RESTART_postsnd="NO"
+    echo "set RESTART_postsnd='${RESTART_postsnd}'"
+    ${APRUN_POSTSND} "${EXECgfs}/${pgm}" < gfsparm > "out_gfs_bufr_${FEND}"
+    export err=$?
+  fi
+
+else
+
+  ${APRUN_POSTSND} "${EXECgfs}/${pgm}" < gfsparm > "out_gfs_bufr_${FEND}"
+  export err=$?
+fi
 
 if [ $err -ne 0 ]; then
    echo "GFS postsnd job error, Please check files "
    echo "${COM_ATMOS_HISTORY}/${RUN}.${cycle}.atmf${hh2}.${atmfm}"
    echo "${COM_ATMOS_HISTORY}/${RUN}.${cycle}.sfcf${hh2}.${atmfm}"
    err_chk
+
+else
+
+  # Count the number of restart files
+  nrestarts=$(find ./ -maxdepth 1 -type f -name 'fort.*' | wc -l)
+  echo "Number of restart fort.* files found: ${nrestarts}"
+
+  # Check if there are restart files
+  if [ "$nrestarts" -gt 0 ]; then
+    echo "Copying GFS postsnd files to restart directory..."
+
+    # Exclude specific files and save the rest to a log file
+    #ls fort.* | grep -v -e 'fort\.1' -e 'fort\.7' -e 'fort\.8' > "${RUN}.${cycle}.bufr.logf${FEND}.${logfm}"
+    
+    # Initialize an empty array to store fort file names
+    files=()
+
+    # Loop through files in the directory
+    for file in fort.*; do
+      # Check if the file is not fort.1 or fort.7 or fort.8
+      if [[ $file != "fort.1" && $file != "fort.7" && $file != "fort.8" ]]; then
+        files+=("$file")
+      fi
+    done
+
+    # Write the list of fort files to the log file
+    printf "%s\n" "${files[@]}" > "${RUN}.${cycle}.bufr.logf${FEND}.${logfm}"
+
+    # Copy each restart file to the restart directory
+    while IFS= read -r fortname; do
+    # echo "Copying restart file: $fortname"
+      cp -p "${fortname}" "${DATA_ATMOS_RESTART}/${RUN}.${cycle}.bufr_${fortname}"
+    done < "${RUN}.${cycle}.bufr.logf${FEND}.${logfm}"
+  fi
+
+    # Copy the log file to the restart directory
+    cp -p "${RUN}.${cycle}.bufr.logf${FEND}.${logfm}" "${DATA_ATMOS_RESTART}/"
+
 fi
 
 exit ${err}

--- a/ush/gfs_bufr.sh
+++ b/ush/gfs_bufr.sh
@@ -104,7 +104,7 @@ if [[ ${RESTART_postsnd} == "YES" ]]; then
     cp -p "${DATA_ATMOS_RESTART}/${RUN}.${cycle}.bufr.logf${FEND}.${logfm}" .
     while IFS= read -r fortname; do
 #     echo "Copy job postsnd files from restart directory: $fortname"
-      cp -p "${DATA_ATMOS_RESTART}/${RUN}.${cycle}.bufr_${fortname}" ${fortname}
+      cp -p "${DATA_ATMOS_RESTART}/${RUN}.${cycle}.bufr_${fortname}" "${fortname}"
     done < "${RUN}.${cycle}.bufr.logf${FEND}.${logfm}"
     err=0
 
@@ -137,14 +137,9 @@ if [[ $err -ne 0 ]]; then
 else
 
   # Count the number of restart files
-  nrestarts=$(find ./ -maxdepth 1 -type f -name 'fort.*' | wc -l)
-  find_exit_code=$?
-  if [ $find_exit_code -ne 0 ]; then
-    # handle the error, set the number of restart file is 0
-    nrestarts=0
-  else
-    echo "Number of restart fort.* files found: ${nrestarts}"
-  fi
+  nrestarts=0
+  nrestarts=$(find ./ -maxdepth 1 -type f -name 'fort.*' | wc -l || true)
+  echo "Number of restart fort.* files found: ${nrestarts}"
 
   # Check if there are restart files
   if [[ "${nrestarts}" -gt 0 ]]; then
@@ -159,7 +154,7 @@ else
     # Loop through files in the directory
     for file in fort.*; do
       # Check if the file is not fort.1 or fort.7 or fort.8
-      if [[ ${file} != "fort.1" && $file != "fort.7" && $file != "fort.8" ]]; then
+      if [[ "${file}" != "fort.1" && "${file}" != "fort.7" && "${file}" != "fort.8" ]]; then
         files+=("${file}")
       fi
     done

--- a/ush/gfs_bufr.sh
+++ b/ush/gfs_bufr.sh
@@ -103,7 +103,6 @@ if [[ ${RESTART_postsnd} == "YES" ]]; then
 
     cp -p "${DATA_ATMOS_RESTART}/${RUN}.${cycle}.bufr.logf${FEND}.${logfm}" .
     while IFS= read -r fortname; do
-#     echo "Copy job postsnd files from restart directory: $fortname"
       cp -p "${DATA_ATMOS_RESTART}/${RUN}.${cycle}.bufr_${fortname}" "${fortname}"
     done < "${RUN}.${cycle}.bufr.logf${FEND}.${logfm}"
     err=0


### PR DESCRIPTION
# Description
<!-- This description will become the commit message for the PR-->
 This PR will add the restart capability to job JGFS_ATMOS_POSTSND.  This job will create a restart directory under ptmp ($DATAROOT). Some log files and midterm products are saved and will be used once a re-run starts. 

  Resolves #1257

# Type of change
<!-- Delete all except one -->
 - New feature (adds functionality)
 
# Change characteristics
- Is this a breaking change (a change in existing functionality)?  NO
- Does this change require a documentation update?  NO

# How has this been tested?
 - Cycled test on WCOSS2
 
# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
