### PR TITLE
Add handling to select CRTM cloud optical table based on cloud scheme and update calcanal_gfs.py 

### DIFF
--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -430,7 +430,19 @@ ${NLN} ${CRTM_FIX}/NPOESS.VISsnow.EmisCoeff.bin  ./crtm_coeffs/NPOESS.VISsnow.Em
 ${NLN} ${CRTM_FIX}/NPOESS.VISwater.EmisCoeff.bin ./crtm_coeffs/NPOESS.VISwater.EmisCoeff.bin
 ${NLN} ${CRTM_FIX}/FASTEM6.MWwater.EmisCoeff.bin ./crtm_coeffs/FASTEM6.MWwater.EmisCoeff.bin
 ${NLN} ${CRTM_FIX}/AerosolCoeff.bin              ./crtm_coeffs/AerosolCoeff.bin
-${NLN} ${CRTM_FIX}/CloudCoeff.GFDLFV3.-109z-1.bin ./crtm_coeffs/CloudCoeff.bin
+${NLN} ${CRTM_FIX}/CloudCoeff.bin                ./crtm_coeffs/CloudCoeff.bin
+if [[ "$imp_physics" = "8" ]]; then
+   echo "using CRTM Thompson cloud optical table"
+   ${NLN} ${CRTM_FIX}/CloudCoeff.Thompson08.-109z-1.bin ./crtm_coeffs/CloudCoeff.bin
+elif [[ "$imp_physics" = "11" ]]; then
+   echo "using CRTM GFDL cloud optical table"
+   ${NLN} ${CRTM_FIX}/CloudCoeff.GFDLFV3.-109z-1.bin ./crtm_coeffs/CloudCoeff.bin
+else
+   echo "INVALID imp_physics = $imp_physics"
+   echo "FATAL ERROR: No valid CRTM cloud optical table found for imp_physics =  " ${imp_physics}
+   exit 1
+fi
+
 
 ##############################################################
 # Observational data

--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -430,7 +430,6 @@ ${NLN} ${CRTM_FIX}/NPOESS.VISsnow.EmisCoeff.bin  ./crtm_coeffs/NPOESS.VISsnow.Em
 ${NLN} ${CRTM_FIX}/NPOESS.VISwater.EmisCoeff.bin ./crtm_coeffs/NPOESS.VISwater.EmisCoeff.bin
 ${NLN} ${CRTM_FIX}/FASTEM6.MWwater.EmisCoeff.bin ./crtm_coeffs/FASTEM6.MWwater.EmisCoeff.bin
 ${NLN} ${CRTM_FIX}/AerosolCoeff.bin              ./crtm_coeffs/AerosolCoeff.bin
-${NLN} ${CRTM_FIX}/CloudCoeff.bin                ./crtm_coeffs/CloudCoeff.bin
 if (( imp_physics == 8 )); then
    echo "using CRTM Thompson cloud optical table"
    ${NLN} "${CRTM_FIX}/CloudCoeff.Thompson08.-109z-1.bin" ./crtm_coeffs/CloudCoeff.bin

--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -431,15 +431,15 @@ ${NLN} ${CRTM_FIX}/NPOESS.VISwater.EmisCoeff.bin ./crtm_coeffs/NPOESS.VISwater.E
 ${NLN} ${CRTM_FIX}/FASTEM6.MWwater.EmisCoeff.bin ./crtm_coeffs/FASTEM6.MWwater.EmisCoeff.bin
 ${NLN} ${CRTM_FIX}/AerosolCoeff.bin              ./crtm_coeffs/AerosolCoeff.bin
 ${NLN} ${CRTM_FIX}/CloudCoeff.bin                ./crtm_coeffs/CloudCoeff.bin
-if [[ "$imp_physics" = "8" ]]; then
+if (( imp_physics == 8 )); then
    echo "using CRTM Thompson cloud optical table"
-   ${NLN} ${CRTM_FIX}/CloudCoeff.Thompson08.-109z-1.bin ./crtm_coeffs/CloudCoeff.bin
-elif [[ "$imp_physics" = "11" ]]; then
+   ${NLN} "${CRTM_FIX}/CloudCoeff.Thompson08.-109z-1.bin" ./crtm_coeffs/CloudCoeff.bin
+elif (( imp_physics == 11 )); then
    echo "using CRTM GFDL cloud optical table"
-   ${NLN} ${CRTM_FIX}/CloudCoeff.GFDLFV3.-109z-1.bin ./crtm_coeffs/CloudCoeff.bin
+   ${NLN} "${CRTM_FIX}/CloudCoeff.GFDLFV3.-109z-1.bin" ./crtm_coeffs/CloudCoeff.bin
 else
-   echo "INVALID imp_physics = $imp_physics"
-   echo "FATAL ERROR: No valid CRTM cloud optical table found for imp_physics =  " ${imp_physics}
+   echo "INVALID imp_physics = ${imp_physics}"
+   echo "FATAL ERROR: No valid CRTM cloud optical table found for imp_physics =  ${imp_physics}"
    exit 1
 fi
 

--- a/ush/calcanl_gfs.py
+++ b/ush/calcanl_gfs.py
@@ -135,7 +135,7 @@ def calcanl_gfs(DoIAU, l4DEnsVar, Write4Danl, ComOut, APrefix,
     ExecCMDMPI1 = ExecCMDMPI.replace("$ncmd", str(1))
     ExecCMDMPI = ExecCMDMPI.replace("$ncmd", str(nFH))
     ExecCMDLevs = ExecCMDMPI.replace("$ncmd", str(levs))
-    ExecCMDMPI10 = ExecCMDMPI.replace("$ncmd", str(10))
+    ExecCMDMPI13 = ExecCMDMPI.replace("$ncmd", str(13))
 
     # are we using mpirun with lsf, srun, or aprun with Cray?
     launcher = ExecCMDMPI.split(' ')[0]
@@ -156,7 +156,7 @@ def calcanl_gfs(DoIAU, l4DEnsVar, Write4Danl, ComOut, APrefix,
             ExecCMDMPILevs_host = 'mpirun -np ' + str(levs) + ' --hostfile hosts'
             ExecCMDMPILevs_nohost = 'mpirun -np ' + str(levs)
         ExecCMDMPI1_host = 'mpirun -np 1 --hostfile hosts'
-        ExecCMDMPI10_host = 'mpirun -np 10 --hostfile hosts'
+        ExecCMDMPI13_host = 'mpirun -np 13 --hostfile hosts'
     elif launcher == 'mpiexec':
         hostfile = os.getenv('PBS_NODEFILE', '')
         with open(hostfile) as f:
@@ -175,7 +175,7 @@ def calcanl_gfs(DoIAU, l4DEnsVar, Write4Danl, ComOut, APrefix,
             ExecCMDMPILevs_host = 'mpiexec -l -n ' + str(levs)
             ExecCMDMPILevs_nohost = 'mpiexec -l -n ' + str(levs)
         ExecCMDMPI1_host = 'mpiexec -l -n 1 --cpu-bind depth --depth ' + str(NThreads)
-        ExecCMDMPI10_host = 'mpiexec -l -n 10 --cpu-bind depth --depth ' + str(NThreads)
+        ExecCMDMPI13_host = 'mpiexec -l -n 13 --cpu-bind depth --depth ' + str(NThreads)
     elif launcher == 'srun':
         nodes = os.getenv('SLURM_JOB_NODELIST', '')
         hosts_tmp = subprocess.check_output('scontrol show hostnames ' + nodes, shell=True)
@@ -200,7 +200,7 @@ def calcanl_gfs(DoIAU, l4DEnsVar, Write4Danl, ComOut, APrefix,
             ExecCMDMPILevs_host = 'srun -n ' + str(levs) + ' --verbose --export=ALL -c 1 --distribution=arbitrary --cpu-bind=cores'
             ExecCMDMPILevs_nohost = 'srun -n ' + str(levs) + ' --verbose --export=ALL'
         ExecCMDMPI1_host = 'srun -n 1 --verbose --export=ALL -c 1 --distribution=arbitrary --cpu-bind=cores'
-        ExecCMDMPI10_host = 'srun -n 10 --verbose --export=ALL -c 1 --distribution=arbitrary --cpu-bind=cores'
+        ExecCMDMPI13_host = 'srun -n 13 --verbose --export=ALL -c 1 --distribution=arbitrary --cpu-bind=cores'
     elif launcher == 'aprun':
         hostfile = os.getenv('LSB_DJOB_HOSTFILE', '')
         with open(hostfile) as f:
@@ -213,7 +213,7 @@ def calcanl_gfs(DoIAU, l4DEnsVar, Write4Danl, ComOut, APrefix,
         ExecCMDMPILevs_host = 'aprun -l hosts -d ' + str(NThreads) + ' -n ' + str(levs)
         ExecCMDMPILevs_nohost = 'aprun -d ' + str(NThreads) + ' -n ' + str(levs)
         ExecCMDMPI1_host = 'aprun -l hosts -d ' + str(NThreads) + ' -n 1'
-        ExecCMDMPI10_host = 'aprun -l hosts -d ' + str(NThreads) + ' -n 10'
+        ExecCMDMPI13_host = 'aprun -l hosts -d ' + str(NThreads) + ' -n 13'
     else:
         print('unknown MPI launcher. Failure.')
         sys.exit(1)
@@ -248,7 +248,7 @@ def calcanl_gfs(DoIAU, l4DEnsVar, Write4Danl, ComOut, APrefix,
                         ihost += 1
                         for a in range(0, 5):
                             hostfile.write(hosts[ihost] + '\n')
-                    for a in range(0, 9):  # need 9 more of the same host for the 10 tasks for chgres_inc
+                    for a in range(0, 12):  # need 9 more of the same host for the 10 tasks for chgres_inc
                         hostfile.write(hosts[ihost] + '\n')
             if launcher == 'srun':
                 os.environ['SLURM_HOSTFILE'] = CalcAnlDir + '/hosts'

--- a/ush/calcanl_gfs.py
+++ b/ush/calcanl_gfs.py
@@ -253,8 +253,8 @@ def calcanl_gfs(DoIAU, l4DEnsVar, Write4Danl, ComOut, APrefix,
             if launcher == 'srun':
                 os.environ['SLURM_HOSTFILE'] = CalcAnlDir + '/hosts'
             print('interp_inc', fh, namelist)
-            job = subprocess.Popen(ExecCMDMPI10_host + ' ' + CalcAnlDir + '/chgres_inc.x', shell=True, cwd=CalcAnlDir)
-            print(ExecCMDMPI10_host + ' ' + CalcAnlDir + '/chgres_inc.x submitted on ' + hosts[ihost])
+            job = subprocess.Popen(ExecCMDMPI13_host + ' ' + CalcAnlDir + '/chgres_inc.x', shell=True, cwd=CalcAnlDir)
+            print(ExecCMDMPI13_host + ' ' + CalcAnlDir + '/chgres_inc.x submitted on ' + hosts[ihost])
             sys.stdout.flush()
             ec = job.wait()
             if ec != 0:

--- a/ush/calcanl_gfs.py
+++ b/ush/calcanl_gfs.py
@@ -248,7 +248,7 @@ def calcanl_gfs(DoIAU, l4DEnsVar, Write4Danl, ComOut, APrefix,
                         ihost += 1
                         for a in range(0, 5):
                             hostfile.write(hosts[ihost] + '\n')
-                    for a in range(0, 12):  # need 9 more of the same host for the 10 tasks for chgres_inc
+                    for a in range(0, 12):  # need 12 more of the same host for the 13 tasks for chgres_inc
                         hostfile.write(hosts[ihost] + '\n')
             if launcher == 'srun':
                 os.environ['SLURM_HOSTFILE'] = CalcAnlDir + '/hosts'


### PR DESCRIPTION
# Description

This PR proposes updates for the following two scripts: 

1. In **scripts/exglobal_atmos_analysis.sh** --- Add handling to select CRTM cloud optical table based on cloud microphysical scheme indicated by `imp_physics'
The default scheme in the GFS forecast model is Thompson scheme (imp_physics = 8). 

2. In **/ush/calcanl_gfs.py** --- Increase the MPI number declared in the script due to increased variables to interplate increments and calculate analysis in the netcdf_io routines in GSI-utils.
Here is the related [PR #46  for GSI-utils](https://github.com/NOAA-EMC/GSI-utils/pull/46).  

# Type of change
- Maintenance (add handling)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
<!-- Please list any test you conducted, including the machine.
Cycled test on HERA

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
