### PR TITLE
Added -u to the build_all script for CI testing using the bash system

### DIFF
--- a/ci/scripts/clone-build_ci.sh
+++ b/ci/scripts/clone-build_ci.sh
@@ -74,7 +74,7 @@ set +e
 source "${HOMEgfs}/ush/module-setup.sh"
 export BUILD_JOBS=8
 rm -rf log.build
-./build_all.sh -gk  >> log.build 2>&1
+./build_all.sh -guk  >> log.build 2>&1
 build_status=$?
 
 DATE=$(date +'%D %r')


### PR DESCRIPTION
# Description

This PR simply updates the line to build from `build_all.sh -kg` to `build_all.sh -kug` for when CI is used with the Bash system currently on WCOSS.

# Type of change
<!-- Delete all except one -->
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? YES
- Does this change require a documentation update? NO
