### PR TITLE
Add overwrite to creat experiment in BASH CI

### DIFF
--- a/ci/scripts/driver.sh
+++ b/ci/scripts/driver.sh
@@ -228,7 +228,7 @@ for pr in ${pr_list}; do
         } >> "${output_ci}"
         continue
       fi
-      "${HOMEgfs}/workflow/create_experiment.py" --yaml "${HOMEgfs}/ci/cases/pr/${case}.yaml"  > "${LOGFILE_PATH}" 2>&1
+      "${HOMEgfs}/workflow/create_experiment.py" --yaml "${HOMEgfs}/ci/cases/pr/${case}.yaml" --overwrite  > "${LOGFILE_PATH}" 2>&1
       ci_status=$?
       set -e
       if [[ ${ci_status} -eq 0 ]]; then


### PR DESCRIPTION
# Description

This is a quick hotfix to the CI BASH driver script adding `--overwrite` to the create experiment script to avoid errors from restarting an experiment.

# Type of change
<!-- Delete all except one -->
- Bug fix (fixes something broken)
Experiments were failing when being restarted when a restart state was not in place during bash CI testing.

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Clone and build on WCOSS

