### PR TITLE
Remove ocean daily files

### DIFF
--- a/parm/archive/master_gfs.yaml.j2
+++ b/parm/archive/master_gfs.yaml.j2
@@ -56,7 +56,6 @@ datasets:
 # Ocean forecasts
 {% filter indent(width=4) %}
 {% include "ocean_6hravg.yaml.j2" %}
-{% include "ocean_daily.yaml.j2" %}
 {% include "ocean_grib2.yaml.j2" %}
 {% include "gfs_flux_1p00.yaml.j2" %}
 {% endfilter %}

--- a/parm/archive/ocean_daily.yaml.j2
+++ b/parm/archive/ocean_daily.yaml.j2
@@ -1,8 +1,0 @@
-ocean_daily:
-    {% set head = "gfs.ocean.t" + cycle_HH + "z." %}
-    name: "OCEAN_DAILY"
-    target: "{{ ATARDIR }}/{{ cycle_YMDH }}/ocean_daily.tar"
-    required:
-        {% for fhr in range(24, FHMAX_GFS + 24, 24) %}
-        - "{{ COM_OCEAN_HISTORY | relpath(ROTDIR) }}/{{ head }}daily.f{{ '%03d' % fhr }}.nc"
-        {% endfor %}

--- a/parm/ufs/fv3/diag_table
+++ b/parm/ufs/fv3/diag_table
@@ -1,7 +1,6 @@
 "fv3_history",    0,  "hours",  1,  "hours",  "time"
 "fv3_history2d",  0,  "hours",  1,  "hours",  "time"
 "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", @[FHOUT_OCN],  "hours",  1,  "hours",  "time",  @[FHOUT_OCN],  "hours",  "@[SYEAR] @[SMONTH] @[SDAY] @[CHOUR] 0 0"
-"@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  1,  "days",   1,  "days",   "time",  1,  "days",   "@[SYEAR] @[SMONTH] @[SDAY] @[CHOUR] 0 0"
 
 ##############
 # Ocean fields
@@ -56,25 +55,6 @@
 "ocean_model", "fprec",     "fprec",         "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
 "ocean_model", "LwLatSens", "LwLatSens",     "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
 "ocean_model", "Heat_PmE",  "Heat_PmE",      "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
-
-# Daily fields
-"ocean_model", "geolon",     "geolon",     "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .false.,  "none",  2
-"ocean_model", "geolat",     "geolat",     "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .false.,  "none",  2
-"ocean_model", "geolon_c",   "geolon_c",   "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .false.,  "none",  2
-"ocean_model", "geolat_c",   "geolat_c",   "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .false.,  "none",  2
-"ocean_model", "geolon_u",   "geolon_u",   "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .false.,  "none",  2
-"ocean_model", "geolat_u",   "geolat_u",   "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .false.,  "none",  2
-"ocean_model", "geolon_v",   "geolon_v",   "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .false.,  "none",  2
-"ocean_model", "geolat_v",   "geolat_v",   "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .false.,  "none",  2
-"ocean_model", "SST",        "sst",        "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .true.,   "none",  2
-"ocean_model", "latent",     "latent",     "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .true.,   "none",  2
-"ocean_model", "sensible",   "sensible",   "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .true.,   "none",  2
-"ocean_model", "SW",         "SW",         "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .true.,   "none",  2
-"ocean_model", "LW",         "LW",         "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .true.,   "none",  2
-"ocean_model", "evap",       "evap",       "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .true.,   "none",  2
-"ocean_model", "lprec",      "lprec",      "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .true.,   "none",  2
-"ocean_model", "taux",       "taux",       "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .true.,   "none",  2
-"ocean_model", "tauy",       "tauy",       "@[MOM6_OUTPUT_DIR]/ocn_daily%4yr%2mo%2dy",  "all",  .true.,   "none",  2
 
 ###################
 # Atmosphere fields

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -455,13 +455,6 @@ MOM6_postdet() {
       dest_file="${RUN}.ocean.t${cyc}z.${interval}hr_avg.f${fhr3}.nc"
       ${NLN} "${COMOUT_OCEAN_HISTORY}/${dest_file}" "${DATA}/MOM6_OUTPUT/${source_file}"
 
-      # Daily output
-      if (( fhr > 0 & fhr % 24 == 0 )); then
-        source_file="ocn_daily_${vdate:0:4}_${vdate:4:2}_${vdate:6:2}.nc"
-        dest_file="${RUN}.ocean.t${cyc}z.daily.f${fhr3}.nc"
-        ${NLN} "${COMOUT_OCEAN_HISTORY}/${dest_file}" "${DATA}/MOM6_OUTPUT/${source_file}"
-      fi
-
       last_fhr=${fhr}
 
     done


### PR DESCRIPTION
<!-- PLEASE READ -->
<!-- Any PRs not following this template will be closed -->
<!--
    Please use a short (<60 char), descriptive title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

    PRs should meet these guidelines:
    - Each PR should address ONE topic and have an associated issue.
    - No hard-coded paths or personal directories.
    - No temporary or backup files should be committed (including logs).
    - Any code that you disabled by being commented out should be removed or reenabled.

    Please delete all these comments before submitting the PR.
-->
# Description
This PR removes the ocn_daily files that are produced by the ocean component.  These files can be recreated by averaging data that exists in the 6 hour aveaged files if needed.   

Fixes https://github.com/NOAA-EMC/global-workflow/issues/2675
Fixes https://github.com/NOAA-EMC/global-workflow/issues/2659 (by removing them and making this obsolete)

# Type of change
- removal of output

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Yes on Hera with C48_S2SW case: 
/scratch1/NCEPDEV/climate/Jessica.Meixner/removeocndaily/ocndaily01


# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
