### PR TITLE
Hotfix for bug in template names.

### DIFF
--- a/parm/archive/master_enkf.yaml.j2
+++ b/parm/archive/master_enkf.yaml.j2
@@ -62,9 +62,9 @@ datasets:
 # This must be done in a namespace to overcome jinja scoping
 #  Variables set inside of a for loop are lost at the end of the loop
 #  unless they are part of a namespace
-{% set com_ns = namespace(COMIN_ATMOS_ANALYSIS_MEM = COMIN_ATMOS_ANALYSIS_TMPL,
-                          COMIN_ATMOS_HISTORY_MEM = COMIN_ATMOS_HISTORY_TMPL,
-                          COMIN_ATMOS_RESTART_MEM = COMIN_ATMOS_RESTART_TMPL) %}
+{% set com_ns = namespace(COMIN_ATMOS_ANALYSIS_MEM = COM_ATMOS_ANALYSIS_TMPL,
+                          COMIN_ATMOS_HISTORY_MEM = COM_ATMOS_HISTORY_TMPL,
+                          COMIN_ATMOS_RESTART_MEM = COM_ATMOS_RESTART_TMPL) %}
 
 {% for key in tmpl_dict.keys() %}
 {% set search_term = '${' + key + '}' %}


### PR DESCRIPTION
# Description

This PR is a hotfix for an incorrectly named (e.g., non-existent) `COM/` template.

  Resolves #2696 
  Refs #2451 

# Type of change

- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

CI/CD will test.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
