### PR TITLE
Cleanup of stale RUNDIRS from an experiment

### DIFF
--- a/parm/config/gefs/config.base
+++ b/parm/config/gefs/config.base
@@ -99,7 +99,6 @@ export EXPDIR="@EXPDIR@/${PSLOT}"
 export ROTDIR="@COMROOT@/${PSLOT}"
 
 export DATAROOT="${STMP}/RUNDIRS/${PSLOT}"  # TODO: set via prod_envir in Ops
-export RUNDIR="${DATAROOT}"  # TODO: Should be removed; use DATAROOT instead
 export ARCDIR="${NOSCRUB}/archive/${PSLOT}"
 export ATARDIR="@ATARDIR@"
 

--- a/parm/config/gfs/config.base
+++ b/parm/config/gfs/config.base
@@ -128,7 +128,6 @@ if [[ "${PDY}${cyc}" -ge "2019092100" && "${PDY}${cyc}" -le "2019110700" ]]; the
     export DUMP_SUFFIX="p"              # Use dumps from NCO GFS v15.3 parallel
 fi
 export DATAROOT="${STMP}/RUNDIRS/${PSLOT}"  # TODO: set via prod_envir in Ops
-export RUNDIR="${DATAROOT}"  # TODO: Should be removed; use DATAROOT instead
 export ARCDIR="${NOSCRUB}/archive/${PSLOT}"
 export ATARDIR="@ATARDIR@"
 
@@ -295,7 +294,7 @@ export FHOUT_GFS=3 # 3 for ops
 export FHMAX_HF_GFS=@FHMAX_HF_GFS@
 export FHOUT_HF_GFS=1
 export FHOUT_OCN_GFS=6
-export FHOUT_ICE_GFS=6   
+export FHOUT_ICE_GFS=6
 export FHMIN_WAV=0
 export FHOUT_WAV=3
 export FHMAX_HF_WAV=120

--- a/scripts/exglobal_cleanup.sh
+++ b/scripts/exglobal_cleanup.sh
@@ -2,7 +2,9 @@
 
 source "${USHgfs}/preamble.sh"
 
+###############################################################
 echo "Begin Cleanup ${DATAROOT}!"
+
 # Remove DATAoutput from the forecast model run
 # TODO: Handle this better
 DATAfcst="${DATAROOT}/${RUN}fcst.${PDY:-}${cyc}"
@@ -15,15 +17,13 @@ rm -rf "${DATAROOT}/${RUN}efcs"*"${PDY:-}${cyc}"
 purge_every_days=3
 
 # Find and delete files older than ${purge_every_days} days
-find "${DATAROOT}" -type f -mtime "+${purge_every_days}" -exec rm -f {} \;
+find "${DATAROOT}/"* -type f -mtime "+${purge_every_days}" -exec rm -f {} \;
 
 # Find and delete directories older than ${purge_every_days} days
-find "${DATAROOT}" -type d -mtime "+${purge_every_days}" -exec rmdir {} \;
+find "${DATAROOT}/"* -type d -mtime "+${purge_every_days}" -exec rm -rf {} \;
 
-# Note: The -exec rmdir {} \; will only remove empty directories
-# If you want to force remove directories along with their contents, use the following line instead:
-# find "${DATAROOT}" -type d -mtime "+${purge_every_days}" -exec rm -rf {} \;
 echo "Cleanup ${DATAROOT} completed!"
+###############################################################
 
 ###############################################################
 # Clean up previous cycles; various depths

--- a/scripts/exglobal_cleanup.sh
+++ b/scripts/exglobal_cleanup.sh
@@ -2,12 +2,28 @@
 
 source "${USHgfs}/preamble.sh"
 
+echo "Begin Cleanup ${DATAROOT}!"
 # Remove DATAoutput from the forecast model run
 # TODO: Handle this better
 DATAfcst="${DATAROOT}/${RUN}fcst.${PDY:-}${cyc}"
 if [[ -d "${DATAfcst}" ]]; then rm -rf "${DATAfcst}"; fi
 #DATAefcs="${DATAROOT}/${RUN}efcs???${PDY:-}${cyc}"
 rm -rf "${DATAROOT}/${RUN}efcs"*"${PDY:-}${cyc}"
+
+# Search and delete files/directories from DATAROOT/ older than ${purge_every_days} days
+# purge_every_days should be a positive integer
+purge_every_days=3
+
+# Find and delete files older than ${purge_every_days} days
+find "${DATAROOT}" -type f -mtime "+${purge_every_days}" -exec rm -f {} \;
+
+# Find and delete directories older than ${purge_every_days} days
+find "${DATAROOT}" -type d -mtime "+${purge_every_days}" -exec rmdir {} \;
+
+# Note: The -exec rmdir {} \; will only remove empty directories
+# If you want to force remove directories along with their contents, use the following line instead:
+# find "${DATAROOT}" -type d -mtime "+${purge_every_days}" -exec rm -rf {} \;
+echo "Cleanup ${DATAROOT} completed!"
 
 ###############################################################
 # Clean up previous cycles; various depths
@@ -67,7 +83,7 @@ for (( current_date=first_date; current_date <= last_date; \
         # shellcheck disable=SC2312
         if [[ $(tail -n 1 "${rocotolog}") =~ "This cycle is complete: Success" ]]; then
             YMD="${current_PDY}" HH="${current_cyc}" declare_from_tmpl \
-		        COMOUT_TOP:COM_TOP_TMPL
+                COMOUT_TOP:COM_TOP_TMPL
             if [[ -d "${COMOUT_TOP}" ]]; then
                 IFS=", " read -r -a exclude_list <<< "${exclude_string:-}"
                 remove_files "${COMOUT_TOP}" "${exclude_list[@]:-}"


### PR DESCRIPTION
# Description
This PR:
- removes stale temporary scratch run directories from `$DATAROOT/` every 3 days.
- should help to scrub failed attempts.
- removes an unused variable `RUNDIR` defined in `config.base`

# Type of change
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- The segment of the change was tested in an offline shell script on some older RUNDIRs from previous experiments.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
