### PR TITLE
Activate snow DA test on WCOSS

### DIFF
--- a/ci/cases/pr/C96_atmaerosnowDA.yaml
+++ b/ci/cases/pr/C96_atmaerosnowDA.yaml
@@ -19,4 +19,3 @@ arguments:
 skip_ci_on_hosts:
   - orion
   - hercules
-  - wcoss2


### PR DESCRIPTION
# Description
Activate the snow DA test on WCOSS.

Excluding the GEFS test, which cannot be turned on due to the different model executable, the only remaining test not turned on for WCOSS is the 3DVarAOWCDA test.

# Type of change
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- C96_atmaerosnowDA run on WCOSS

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
