### PR TITLE
fix aerosols in forecast-only mode

### DIFF
--- a/workflow/applications/gfs_forecast_only.py
+++ b/workflow/applications/gfs_forecast_only.py
@@ -87,7 +87,7 @@ class GFSForecastOnlyAppConfig(AppConfig):
         tasks = ['stage_ic']
 
         if self.do_aero:
-            aero_fcst_cdump = _base.get('AERO_FCST_CDUMP', 'BOTH').lower()
+            aero_fcst_cdump = self._base.get('AERO_FCST_CDUMP', 'BOTH').lower()
             if self._base['CDUMP'] in aero_fcst_cdump or aero_fcst_cdump == "both":
                 tasks += ['aerosol_init']
 

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -854,7 +854,7 @@ class GFSTasks(Tasks):
             dep_dict = {'type': 'task', 'name': f'{self.cdump}{wave_job}'}
             dependencies.append(rocoto.add_dependency(dep_dict))
 
-        if self.app_config.do_aero and self.cdump in self.app_config.aero_fcst_cdumps:
+        if self.app_config.do_aero and self.cdump in self.app_config.aero_anl_cdumps:
             # Calculate offset based on CDUMP = gfs | gdas
             interval = None
             if self.cdump in ['gfs']:


### PR DESCRIPTION
<!-- PLEASE READ -->
<!-- Any PRs not following this template will be closed -->
<!--
    Please use a short (<60 char), descriptive title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

    PRs should meet these guidelines:
    - Each PR should address ONE topic and have an associated issue.
    - No hard-coded paths or personal directories.
    - No temporary or backup files should be committed (including logs).
    - Any code that you disabled by being commented out should be removed or reenabled.

    Please delete all these comments before submitting the PR.
-->
# Description
Aerosols in `forecast-only` mode would not generate an experiment or an xml file using the ATMA application

# Type of change
<!-- Delete all except one -->
- Bug fix (fixes something broken)


# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->
- Forecast-only on Hera
- 
# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary
