### PR TITLE
Address issues in creating XML for GFS forecast-only with app S2SWA

### DIFF
--- a/workflow/applications/applications.py
+++ b/workflow/applications/applications.py
@@ -79,12 +79,18 @@ class AppConfig(ABC, metaclass=AppConfigInit):
                 self.wave_cdumps = [wave_cdump]
 
         self.aero_anl_cdumps = None
+        self.aero_fcst_cdumps = None
         if self.do_aero:
             aero_anl_cdump = _base.get('AERO_ANL_CDUMP', 'BOTH').lower()
             if aero_anl_cdump in ['both']:
                 self.aero_anl_cdumps = ['gfs', 'gdas']
             elif aero_anl_cdump in ['gfs', 'gdas']:
                 self.aero_anl_cdumps = [aero_anl_cdump]
+            aero_fcst_cdump = _base.get('AERO_FCST_CDUMP', None).lower()
+            if aero_fcst_cdump in ['both']:
+                self.aero_fcst_cdumps = ['gfs', 'gdas']
+            elif aero_fcst_cdump in ['gfs', 'gdas']:
+                self.aero_fcst_cdumps = [aero_fcst_cdump]
 
     def _init_finalize(self, conf: Configuration):
         print("Finalizing initialize")

--- a/workflow/applications/gfs_forecast_only.py
+++ b/workflow/applications/gfs_forecast_only.py
@@ -25,7 +25,8 @@ class GFSForecastOnlyAppConfig(AppConfig):
             configs += ['atmos_products']
 
             if self.do_aero:
-                configs += ['aerosol_init']
+                if self._base['EXP_WARM_START'] in ['.false.']:
+                    configs += ['aerosol_init']
 
             if self.do_tracker:
                 configs += ['tracker']
@@ -87,9 +88,10 @@ class GFSForecastOnlyAppConfig(AppConfig):
         tasks = ['stage_ic']
 
         if self.do_aero:
-            aero_fcst_cdump = _base.get('AERO_FCST_CDUMP', 'BOTH').lower()
+            aero_fcst_cdump = self._base.get('AERO_FCST_CDUMP', 'BOTH').lower()
             if self._base['CDUMP'] in aero_fcst_cdump or aero_fcst_cdump == "both":
-                tasks += ['aerosol_init']
+                if self._base['EXP_WARM_START'] in ['.false.']:
+                    tasks += ['aerosol_init']
 
         if self.do_wave:
             tasks += ['waveinit']

--- a/workflow/applications/gfs_forecast_only.py
+++ b/workflow/applications/gfs_forecast_only.py
@@ -25,7 +25,7 @@ class GFSForecastOnlyAppConfig(AppConfig):
             configs += ['atmos_products']
 
             if self.do_aero:
-                if self._base['EXP_WARM_START'] in ['.false.']:
+                if not self._base['EXP_WARM_START']:
                     configs += ['aerosol_init']
 
             if self.do_tracker:
@@ -90,7 +90,7 @@ class GFSForecastOnlyAppConfig(AppConfig):
         if self.do_aero:
             aero_fcst_cdump = self._base.get('AERO_FCST_CDUMP', 'BOTH').lower()
             if self._base['CDUMP'] in aero_fcst_cdump or aero_fcst_cdump == "both":
-                if self._base['EXP_WARM_START'] in ['.false.']:
+                if not self._base['EXP_WARM_START']:
                     tasks += ['aerosol_init']
 
         if self.do_wave:

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -856,7 +856,9 @@ class GFSTasks(Tasks):
             dep_dict = {'type': 'task', 'name': f'{self.cdump}{wave_job}'}
             dependencies.append(rocoto.add_dependency(dep_dict))
 
-        if self.app_config.do_aero and self.cdump in self.app_config.aero_fcst_cdumps:
+        if self.app_config.do_aero and \
+           self.cdump in self.app_config.aero_fcst_cdumps and \
+           self._base['EXP_WARM_START'] in ['.false.']:
             # Calculate offset based on CDUMP = gfs | gdas
             interval = None
             if self.cdump in ['gfs']:

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -858,7 +858,7 @@ class GFSTasks(Tasks):
 
         if self.app_config.do_aero and \
            self.cdump in self.app_config.aero_fcst_cdumps and \
-           self._base['EXP_WARM_START'] in ['.false.']:
+           not self._base['EXP_WARM_START']:
             # Calculate offset based on CDUMP = gfs | gdas
             interval = None
             if self.cdump in ['gfs']:


### PR DESCRIPTION
# Description
This bugfix PR:
- fixes an issue where a user is unable to generate the XML for a GFS forecast-only experiment with APP=S2SWA

Specifically, the changes are related to defining `aero_fcst_cdumps`.  
Following `setup_expt.py`, the user will have to set `AERO_FCST_CDUMPS="gdas|gfs|both" depending on their use case in `config.base`.

Cristiana Stan initially reported this issue.
@bbakernoaa encountered a similar issue recently.

# Type of change
- Bug fix (fixes something broken)
- 
# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
- Generated an experiment XML for GFS forecast-only with APP=S2SWA.  APP=S2SWA is not used in the GFS HR experiments (S2SW is used).  
- S2SWA is tested in the GEFS test.  GEFS is not impacted with this change.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
