### PR TITLE
Set METplus process count in config.metp; add verif-global support for Rocky 9

### DIFF
--- a/parm/config/gfs/config.metp
+++ b/parm/config/gfs/config.metp
@@ -8,6 +8,8 @@ echo "BEGIN: config.metp"
 # Get task specific resources
 . "${EXPDIR}/config.resources" metp
 
+export nproc=${npe_metp:-1}
+
 export RUN_GRID2GRID_STEP1="YES" # Run grid-to-grid verification using METplus
 export RUN_GRID2OBS_STEP1="YES"  # Run grid-to-obs verification using METplus
 export RUN_PRECIP_STEP1="YES"    # Run precip verification using METplus


### PR DESCRIPTION
# Description
This fixes resource assignment for verif-global and checks that metp* jobs produce data.  Additionally, this adds support for Orion Rocky 9 for the EMC_Verif-Global submodule.

Resolves #2759, #2694
# Type of change
- Bug fix (fixes something broken)
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Cycled test on Hera (ongoing)
Cycled test on Orion (TBD)

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes