### PR TITLE
Update the IMS pre-processing time and IMS snow data format

### DIFF
--- a/scripts/exglobal_prep_snow_obs.py
+++ b/scripts/exglobal_prep_snow_obs.py
@@ -21,6 +21,5 @@ if __name__ == '__main__':
     # Instantiate the snow prepare task
     SnowAnl = SnowAnalysis(config)
     SnowAnl.prepare_GTS()
-    SnowAnl.task_config.cyc = f'{SnowAnl.task_config.cyc:02d}'
-    if f"{ SnowAnl.task_config.cyc }" == '00':
+    if SnowAnl.task_config.cyc == 0:
         SnowAnl.prepare_IMS()

--- a/scripts/exglobal_prep_snow_obs.py
+++ b/scripts/exglobal_prep_snow_obs.py
@@ -21,5 +21,6 @@ if __name__ == '__main__':
     # Instantiate the snow prepare task
     SnowAnl = SnowAnalysis(config)
     SnowAnl.prepare_GTS()
-    if f"{ SnowAnl.task_config.cyc }" == '18':
+    SnowAnl.task_config.cyc = f'{SnowAnl.task_config.cyc:02d}'
+    if f"{ SnowAnl.task_config.cyc }" == '00':
         SnowAnl.prepare_IMS()


### PR DESCRIPTION
# Description
Since the IMS snow products was ingested at about 23:00 UTC, and the IMS snow cover data is in the ascii format. Therefore, we propose to assimilate the IMS snow cover data in the ascii format at 00z cycle. 

This PR updates the IMS snow data pre-processing time from being the 18z to the 00z cycle, and also changes to assimilate the IMS snow data in ascii format from the operational dump. 

An IMS snow data in ascii format will be staged to global dump directory for the CI test `C96_atmaerosnowDA.yaml` at: 
/scratch1/NCEPDEV/global/Jiarui.Dong/JEDI/GlobalWorkflow/para_gfs/glopara_dump/gdas.20211221/00/atmos/gdas.t00z.imssnow96.asc

This PR depends on https://github.com/NOAA-EMC/GDASApp/pull/1228

# Type of change
<!-- Delete all except one -->
- Bug fix (fixes something broken)
- New feature (adds functionality)
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
Cycled test on Hera

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
