### PR TITLE
Run METplus serially and correct the name of prod tasks

### DIFF
--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -889,8 +889,8 @@ case ${step} in
     threads_per_task=1
     walltime_gdas="03:00:00"
     walltime_gfs="06:00:00"
-    ntasks=4
-    tasks_per_node=4
+    ntasks=1
+    tasks_per_node=1
     export memory="80G"
     ;;
 

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -1104,7 +1104,7 @@ class GFSTasks(Tasks):
         data = f'{history_path}/{history_file_tmpl}'
         dep_dict = {'type': 'data', 'data': data, 'age': 120}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'task', 'name': f'{self.cdump}fcst'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps, dep_condition='or')
 

--- a/workflow/rocoto/tasks.py
+++ b/workflow/rocoto/tasks.py
@@ -24,7 +24,7 @@ class Tasks:
                    'prepsnowobs', 'snowanl',
                    'fcst',
                    'atmanlupp', 'atmanlprod', 'atmupp', 'goesupp',
-                   'atmosprod', 'oceanprod', 'iceprod',
+                   'atmos_prod', 'oceanprod', 'iceprod',
                    'verfozn', 'verfrad', 'vminmon',
                    'metp',
                    'tracker', 'genesis', 'genesis_fsu',

--- a/workflow/rocoto/tasks.py
+++ b/workflow/rocoto/tasks.py
@@ -24,7 +24,7 @@ class Tasks:
                    'prepsnowobs', 'snowanl',
                    'fcst',
                    'atmanlupp', 'atmanlprod', 'atmupp', 'goesupp',
-                   'atmos_prod', 'oceanprod', 'iceprod',
+                   'atmos_prod', 'ocean_prod', 'ice_prod',
                    'verfozn', 'verfrad', 'vminmon',
                    'metp',
                    'tracker', 'genesis', 'genesis_fsu',


### PR DESCRIPTION
# Description
Adds 3 hot fixes:

- METplus v9.1.3 has a bug in it that sometimes attempts to create multiple copies of the same directory when running in parallel, causing a Python error and downstream problems.  This PR makes METplus run in serial mode, preventing such issues.
- Corrects the name of the atmos_prod, ocean_prod, and ice_prod tasks in workflow/rocoto/tasks.py (was accidentally changed to e.g. atmosprod)

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? YES (For experiments running more than ~20 cycles, the gfsmetpg2o job may time out.)
- Does this change require a documentation update? NO

# How has this been tested?
CI unit tests for the atmos_prod fix, will run CI.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes