### PR TITLE
Bugfix for updating label states in Jenkins

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -282,10 +282,10 @@ pipeline {
             steps {
                 script {
                     sh(script: """
-                        labels=\$(gh pr view ${env.CHANGE_ID} --repo ${repo_url} --json labels --jq '.labels[].name')
+                        labels=\$(${GH} pr view ${env.CHANGE_ID} --repo ${repo_url} --json labels --jq '.labels[].name')
                         for label in \$labels; do
                             if [[ "\$label" == *"${Machine}"* ]]; then
-                                gh pr edit ${env.CHANGE_ID} --repo ${repo_url} --remove-label "\$label"
+                                ${GH} pr edit ${env.CHANGE_ID} --repo ${repo_url} --remove-label "\$label"
                             fi
                         done
                     """, returnStatus: true)


### PR DESCRIPTION
# Description

Quick bug fix for updating state labels in CI during finalize.
(did not reference GitHub CLI executable correctly in the pipeline script)

# Type of change
<!-- Delete all except one -->
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Trivial change not tested
