### PR TITLE
Revert MSU FIX_DIRs back to glopara

### DIFF
--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -71,8 +71,8 @@ ${LINK_OR_COPY} "${HOMEgfs}/versions/run.${machine}.ver" "${HOMEgfs}/versions/ru
 case "${machine}" in
   "wcoss2")   FIX_DIR="/lfs/h2/emc/global/noscrub/emc.global/FIX/fix" ;;
   "hera")     FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix" ;;
-  "orion")    FIX_DIR="/work/noaa/global/kfriedma/glopara/fix" ;;
-  "hercules") FIX_DIR="/work/noaa/global/kfriedma/glopara/fix" ;;
+  "orion")    FIX_DIR="/work/noaa/global/glopara/fix" ;;
+  "hercules") FIX_DIR="/work/noaa/global/glopara/fix" ;;
   "jet")      FIX_DIR="/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix" ;;
   "s4")       FIX_DIR="/data/prod/glopara/fix" ;;
   "gaea")     FIX_DIR="/gpfs/f5/ufs-ard/world-shared/global/glopara/data/fix" ;;


### PR DESCRIPTION
# Description

This PR reverts the MSU (Orion/Hercules) `FIX_DIR` paths back to the official "glopara" location. They were temporarily pointed to a different location while issues with the official set were remedied. The issue has since been fixed.

# Type of change

Undoing temporary change