### PR TITLE
Add Gaea C5 to CI

### DIFF
--- a/ci/cases/pr/C48mx500_3DVarAOWCDA.yaml
+++ b/ci/cases/pr/C48mx500_3DVarAOWCDA.yaml
@@ -19,5 +19,6 @@ arguments:
 
 skip_ci_on_hosts:
   - wcoss2
+  - gaea
   - orion
   - hercules

--- a/ci/cases/pr/C96C48_ufs_hybatmDA.yaml
+++ b/ci/cases/pr/C96C48_ufs_hybatmDA.yaml
@@ -19,6 +19,7 @@ arguments:
 
 skip_ci_on_hosts:
   - hera
+  - gaea
   - orion
   - hercules
   

--- a/ci/cases/pr/C96_atm3DVar_extended.yaml
+++ b/ci/cases/pr/C96_atm3DVar_extended.yaml
@@ -18,5 +18,6 @@ arguments:
 
 skip_ci_on_hosts:
   - hera
+  - gaea
   - orion
   - hercules

--- a/ci/cases/pr/C96_atmaerosnowDA.yaml
+++ b/ci/cases/pr/C96_atmaerosnowDA.yaml
@@ -18,4 +18,5 @@ arguments:
 
 skip_ci_on_hosts:
   - orion
+  - gaea
   - hercules

--- a/ci/platforms/config.gaea
+++ b/ci/platforms/config.gaea
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+export GFS_CI_ROOT=/gpfs/f5/epic/proj-shared/global/GFS_CI_ROOT
+export ICSDIR_ROOT=/gpfs/f5/epic/proj-shared/global/glopara/data/ICSDIR
+export STMP="/gpfs/f5/epic/scratch/${USER}"
+export SLURM_ACCOUNT=ufs-ard
+export max_concurrent_cases=5
+export max_concurrent_pr=4

--- a/ci/scripts/check_ci.sh
+++ b/ci/scripts/check_ci.sh
@@ -21,7 +21,7 @@ REPO_URL=${REPO_URL:-"git@github.com:NOAA-EMC/global-workflow.git"}
 
 source "${HOMEgfs}/ush/detect_machine.sh"
 case ${MACHINE_ID} in
-  hera | orion | hercules | wcoss2)
+  hera | orion | hercules | wcoss2 | gaea)
    echo "Running Automated Testing on ${MACHINE_ID}"
    source "${HOMEgfs}/ci/platforms/config.${MACHINE_ID}"
    ;;

--- a/ci/scripts/driver.sh
+++ b/ci/scripts/driver.sh
@@ -30,7 +30,7 @@ export PS4='+ $(basename ${BASH_SOURCE})[${LINENO}]'
 
 source "${ROOT_DIR}/ush/detect_machine.sh"
 case ${MACHINE_ID} in
-  hera | orion | hercules | wcoss2)
+  hera | orion | hercules | wcoss2 | gaea)
     echo "Running Automated Testing on ${MACHINE_ID}"
     source "${ROOT_DIR}/ci/platforms/config.${MACHINE_ID}"
     ;;

--- a/ci/scripts/driver_weekly.sh
+++ b/ci/scripts/driver_weekly.sh
@@ -38,7 +38,7 @@ export PS4='+ $(basename ${BASH_SOURCE[0]})[${LINENO}]'
 
 source "${ROOT_DIR}/ush/detect_machine.sh"
 case ${MACHINE_ID} in
-  hera | orion | hercules | wcoss2)
+  hera | orion | hercules | wcoss2 | gaea)
     echo "Running Automated Testing on ${MACHINE_ID}"
     source "${ROOT_DIR}/ci/platforms/config.${MACHINE_ID}"
     ;;

--- a/ci/scripts/run_ci.sh
+++ b/ci/scripts/run_ci.sh
@@ -20,7 +20,7 @@ export PS4='+ $(basename ${BASH_SOURCE})[${LINENO}]'
 
 source "${HOMEgfs}/ush/detect_machine.sh"
 case ${MACHINE_ID} in
-  hera | orion | hercules | wcoss2)
+  hera | orion | hercules | wcoss2 | gaea)
    echo "Running Automated Testing on ${MACHINE_ID}"
    source "${HOMEgfs}/ci/platforms/config.${MACHINE_ID}"
    ;;

--- a/ci/scripts/utils/launch_java_agent.sh
+++ b/ci/scripts/utils/launch_java_agent.sh
@@ -74,7 +74,7 @@ host=$(hostname)
 
 source "${HOMEgfs}/ush/detect_machine.sh"
 case ${MACHINE_ID} in
-  hera | orion | hercules | wcoss2)
+  hera | orion | hercules | wcoss2 | gaea)
     echo "Launch Jenkins Java Controler on ${MACHINE_ID}";;
   *)
     echo "Unsupported platform. Exiting with error."


### PR DESCRIPTION
# Description
Adds gaea as a recognized machine in the CI system.

# Type of change
<!-- Delete all except one -->
- New CI test for Gaea C5 system 


# Change characteristics
- Is this a breaking change (a change in existing functionality)? YES/NO
- Does this change require a documentation update? YES/NO
- Does this change require an update to any of the following submodules? YES/NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global
  - [ ] GDAS
  - [ ] GFS-utils
  - [ ] GSI
  - [ ] GSI-monitor
  - [ ] GSI-utils
  - [ ] UFS-utils
  - [ ] UFS-weather-model
  - [ ] wxflow


# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
