### PR TITLE
Fixed test on UNAVAILBLE in python Rocoto check

### DIFF
--- a/ci/scripts/driver.sh
+++ b/ci/scripts/driver.sh
@@ -12,7 +12,6 @@ set -eux
 # development branch for the global-workflow repo.  It then stages tests directories per
 # PR number and calls clone-build_ci.sh to perform a clone and full build from the PR.
 # It then is ready to run a suite of regression tests with various configurations
-# no op for CI self test
 #######################################################################################
 
 export REPO_URL=${REPO_URL:-"git@github.com:NOAA-EMC/global-workflow.git"}

--- a/ci/scripts/driver.sh
+++ b/ci/scripts/driver.sh
@@ -12,6 +12,7 @@ set -eux
 # development branch for the global-workflow repo.  It then stages tests directories per
 # PR number and calls clone-build_ci.sh to perform a clone and full build from the PR.
 # It then is ready to run a suite of regression tests with various configurations
+# no op for CI self test
 #######################################################################################
 
 export REPO_URL=${REPO_URL:-"git@github.com:NOAA-EMC/global-workflow.git"}

--- a/ci/scripts/utils/rocotostat.py
+++ b/ci/scripts/utils/rocotostat.py
@@ -136,7 +136,7 @@ def rocoto_statcount(rocotostat):
     rocotostat_output = [line.split()[0:4] for line in rocotostat_output]
     rocotostat_output = [line for line in rocotostat_output if len(line) != 1]
 
-    status_cases = ['SUCCEEDED', 'FAIL', 'DEAD', 'RUNNING', 'SUBMITTING', 'QUEUED', 'UNAVAILABLE']
+    status_cases = ['SUCCEEDED', 'FAIL', 'DEAD', 'RUNNING', 'SUBMITTING', 'QUEUED', 'UNAVAILABLE', 'UNKNOWN']
 
     rocoto_status = {}
     status_counts = Counter(case for sublist in rocotostat_output for case in sublist)
@@ -214,14 +214,14 @@ if __name__ == '__main__':
     elif rocoto_status['DEAD'] > 0:
         error_return = rocoto_status['FAIL'] + rocoto_status['DEAD']
         rocoto_state = 'FAIL'
-    elif 'UNAVAILABLE' in rocoto_status or 'UNKNOWN' in rocoto_status:
+    elif rocoto_status['UNAVAILABLE'] > 0 or rocoto_status['UNKNOWN'] > 0:
         rocoto_status = attempt_multiple_times(lambda: rocoto_statcount(rocotostat), 2, 120, ProcessError)
         error_return = 0
         rocoto_state = 'RUNNING'
-        if 'UNAVAILABLE' in rocoto_status:
+        if rocoto_status['UNAVAILABLE'] > 0:
             error_return = rocoto_status['UNAVAILABLE']
             rocoto_state = 'UNAVAILABLE'
-        if 'UNKNOWN' in rocoto_status:
+        if rocoto_status['UNKNOWN'] > 0:
             error_return += rocoto_status['UNKNOWN']
             rocoto_state = 'UNKNOWN'
     elif is_stalled(rocoto_status):


### PR DESCRIPTION
# Description

Update the test for UNAVAILABLE from inclusion to count: `if ['UNAVAILABLE'] > 0`
in `rocotocheck.py `script.

# Type of change
- Bug fix (fixes something broken)

The test for UNAVAILABLE was for inclusion so the tool was always return the state UNAVAILABLE until DONE

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Ran tool on EXPDIR that had zero UNAVAILABLE and UNKNOWN states
