### PR TITLE
Correct ocean `MOM.res_#` stage copy

### DIFF
--- a/parm/stage/ocean.yaml.j2
+++ b/parm/stage/ocean.yaml.j2
@@ -11,7 +11,7 @@ ocean:
         {% set COMOUT_OCEAN_RESTART_PREV_MEM = COMOUT_OCEAN_RESTART_PREV_MEM_list[imem] %}
         - ["{{ ICSDIR }}/{{ COMOUT_OCEAN_RESTART_PREV_MEM | relpath(ROTDIR) }}/{{ m_prefix }}.MOM.res.nc", "{{ COMOUT_OCEAN_RESTART_PREV_MEM }}"]
         {% if OCNRES == "025" %}
-        {% for nn in range(1, 3) %}
+        {% for nn in range(1, 3 + 1) %}
         - ["{{ ICSDIR }}/{{ COMOUT_OCEAN_RESTART_PREV_MEM | relpath(ROTDIR) }}/{{ m_prefix }}.MOM.res_{{ nn }}.nc", "{{ COMOUT_OCEAN_RESTART_PREV_MEM }}"]
         {% endfor %}
         {% endif %}

--- a/parm/stage/ocean.yaml.j2
+++ b/parm/stage/ocean.yaml.j2
@@ -11,7 +11,7 @@ ocean:
         {% set COMOUT_OCEAN_RESTART_PREV_MEM = COMOUT_OCEAN_RESTART_PREV_MEM_list[imem] %}
         - ["{{ ICSDIR }}/{{ COMOUT_OCEAN_RESTART_PREV_MEM | relpath(ROTDIR) }}/{{ m_prefix }}.MOM.res.nc", "{{ COMOUT_OCEAN_RESTART_PREV_MEM }}"]
         {% if OCNRES == "025" %}
-        {% for nn in range(1, 3 + 1) %}
+        {% for nn in range(1, 4) %}
         - ["{{ ICSDIR }}/{{ COMOUT_OCEAN_RESTART_PREV_MEM | relpath(ROTDIR) }}/{{ m_prefix }}.MOM.res_{{ nn }}.nc", "{{ COMOUT_OCEAN_RESTART_PREV_MEM }}"]
         {% endfor %}
         {% endif %}

--- a/scripts/exglobal_stage_ic.py
+++ b/scripts/exglobal_stage_ic.py
@@ -26,6 +26,9 @@ def main():
 
     stage_dict = AttrDict()
     for key in keys:
+        # Make sure OCNRES is three digits
+        if key == "OCNRES":
+            stage.task_config.OCNRES = f"{stage.task_config.OCNRES :03d}"
         stage_dict[key] = stage.task_config[key]
 
     # Also import all COM* directory and template variables


### PR DESCRIPTION
# Description

This PR corrects a bug in the staging job for ocean `MOM.res_#` IC files. The `OCNRES` value was coming in as an integer (e.g. `25`) but the `ocean.yaml.j2` file was checking for `"025"`. Correct to now set OCNRES to be three digits in staging script and also correct the for loop range to include third file.

Resolves #2864

# Type of change

- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?

Repeated the tests that the users who reported this ran.