### PR TITLE
Update aerosol climatology to 2013-2024 mean

### DIFF
--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -498,7 +498,7 @@ FV3_predet(){
     local month mm
     for (( month = 1; month <=12; month++ )); do
       mm=$(printf %02d "${month}")
-      ${NCP} "${FIXgfs}/aer/merra2.aerclim.2003-2014.m${mm}.nc" "aeroclim.m${mm}.nc"
+      ${NCP} "${FIXgfs}/aer/merra2_1423_${mm}.nc" "aeroclim.m${mm}.nc"
     done
   fi
 

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -498,7 +498,7 @@ FV3_predet(){
     local month mm
     for (( month = 1; month <=12; month++ )); do
       mm=$(printf %02d "${month}")
-      ${NCP} "${FIXgfs}/aer/merra2_1423_${mm}.nc" "aeroclim.m${mm}.nc"
+      ${NCP} "${FIXgfs}/aer/merra2.aerclim.2014-2023.m${mm}.nc" "aeroclim.m${mm}.nc"
     done
   fi
 


### PR DESCRIPTION
# Description
use the updated 2013 to 2024 mean MERRA2 climatology  instead of 2003 to 2014 mean

Depends on #2887 
Refs: ufs-community/ufs-weather-model#2272
Refs: ufs-community/ufs-weather-model#2273

# Type of change
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)?  NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? YES (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global
  - [ ] GDAS
  - [ ] GFS-utils
  - [ ] GSI
  - [ ] GSI-monitor
  - [ ] GSI-utils
  - [ ] UFS-utils
  - [X] UFS-weather-model
  - [ ] wxflow


# How has this been tested?


# Checklist
- [X ] Any dependent changes have been merged and published
- [ X] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] My changes generate no new warnings
- [X ] New and existing tests pass with my changes
- [X ] I have made corresponding changes to the documentation if necessary
