### PR TITLE
Eliminate race conditions and remove DATAROOT last in cleanup

### DIFF
--- a/scripts/exglobal_cleanup.sh
+++ b/scripts/exglobal_cleanup.sh
@@ -11,14 +11,6 @@ DATAfcst="${DATAROOT}/${RUN}fcst.${PDY:-}${cyc}"
 if [[ -d "${DATAfcst}" ]]; then rm -rf "${DATAfcst}"; fi
 #DATAefcs="${DATAROOT}/${RUN}efcs???${PDY:-}${cyc}"
 rm -rf "${DATAROOT}/${RUN}efcs"*"${PDY:-}${cyc}"
-
-# In XML, DATAROOT is defined as:
-#DATAROOT="${STMP}/RUNDIRS/${PSLOT}/${RUN}.${PDY}${cyc}"
-# cleanup is only executed after the entire cycle is successfully completed.
-# removing DATAROOT should be possible if that is the case.
-rm -rf "${DATAROOT}"
-
-echo "Cleanup ${DATAROOT} completed!"
 ###############################################################
 
 if [[ "${CLEANUP_COM:-YES}" == NO ]] ; then
@@ -113,3 +105,13 @@ if (( GDATE < RDATE )); then
 fi
 deletion_target="${ROTDIR}/${RUN}.${RDATE:0:8}"
 if [[ -d ${deletion_target} ]]; then rm -rf "${deletion_target}"; fi
+
+# Finally, delete DATAROOT.
+# This will also delete the working directory, so save it until the end.
+# In XML, DATAROOT is defined as:
+#DATAROOT="${STMP}/RUNDIRS/${PSLOT}/${RUN}.${PDY}${cyc}"
+# cleanup is only executed after the entire cycle is successfully completed.
+# removing DATAROOT should be possible if that is the case.
+rm -rf "${DATAROOT}"
+
+echo "Cleanup ${DATAROOT} completed!"

--- a/scripts/exglobal_cleanup.sh
+++ b/scripts/exglobal_cleanup.sh
@@ -41,10 +41,10 @@ function remove_files() {
     find_exclude_string="${find_exclude_string[*]/%-or}"
     # Remove all regular files that do not match
     # shellcheck disable=SC2086
-    find "${directory}" -type f -not \( ${find_exclude_string} \) -delete
+    find "${directory}" -type f -not \( ${find_exclude_string} \) -ignore_readdir_race -delete
     # Remove all symlinks that do not match
     # shellcheck disable=SC2086
-    find "${directory}" -type l -not \( ${find_exclude_string} \) -delete
+    find "${directory}" -type l -not \( ${find_exclude_string} \) -ignore_readdir_race -delete
     # Remove any empty directories
     find "${directory}" -type d -empty -delete
 }

--- a/scripts/exglobal_cleanup.sh
+++ b/scripts/exglobal_cleanup.sh
@@ -106,6 +106,9 @@ fi
 deletion_target="${ROTDIR}/${RUN}.${RDATE:0:8}"
 if [[ -d ${deletion_target} ]]; then rm -rf "${deletion_target}"; fi
 
+# sync and wait to avoid filesystem synchronization issues
+sync && sleep 1
+
 # Finally, delete DATAROOT.
 # This will also delete the working directory, so save it until the end.
 # In XML, DATAROOT is defined as:


### PR DESCRIPTION
# Description
This changes the order of the cleanup job so that the working directory is deleted at the end.  It also adds the `-ignore_readdir_race` flag to `find` to prevent errors if a file was deleted after the list of files was collected.  This can happen if two consecutive cycles run the cleanup job at the same time.

Resolves #2880 
# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
A 5-cycle test on WCOSS2

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes