### PR TITLE
Add new UPP links to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,8 +80,6 @@ parm/ufs/MOM6_data_table.IN
 parm/ufs/ice_in.IN
 parm/ufs/ufs.configure.*.IN
 parm/ufs/post_itag_gfs
-parm/ufs/postxconfig-NT-gfs.txt
-parm/ufs/postxconfig-NT-gfs_FH00.txt
 parm/wafs
 
 # Ignore sorc and logs folders from externals

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,9 @@ parm/ufs/MOM_input_*.IN
 parm/ufs/MOM6_data_table.IN
 parm/ufs/ice_in.IN
 parm/ufs/ufs.configure.*.IN
+parm/ufs/post_itag_gfs
+parm/ufs/postxconfig-NT-gfs.txt
+parm/ufs/postxconfig-NT-gfs_FH00.txt
 parm/wafs
 
 # Ignore sorc and logs folders from externals

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -213,12 +213,7 @@ declare -a ufs_templates=("model_configure.IN" "input_global_nest.nml.IN"\
                           "ufs.configure.s2swa_esmf.IN" \
                           "ufs.configure.leapfrog_atm_wav.IN" \
                           "ufs.configure.leapfrog_atm_wav_esmf.IN" \
-                          "post_itag_gfs" \
-                          "postxconfig-NT-gfs.txt" \
-                          "postxconfig-NT-gfs_FH00.txt")
-                          # TODO: The above postxconfig files in the UFSWM are not the same as the ones in UPP
-                          # TODO: GEFS postxconfig files also need to be received from UFSWM
-                          # See forecast_predet.sh where the UPP versions are used.  They will need to be replaced with these.
+                          "post_itag_gfs")
 for file in "${ufs_templates[@]}"; do
   [[ -s "${file}" ]] && rm -f "${file}"
   ${LINK_OR_COPY} "${HOMEgfs}/sorc/ufs_model.fd/tests/parm/${file}" .


### PR DESCRIPTION
# Description
This adds 3 missing links from the UPP into parm/ufs to .gitignore.

Resolves #2901 

# Type of change
- Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global
  - [ ] GDAS
  - [ ] GFS-utils
  - [ ] GSI
  - [ ] GSI-monitor
  - [ ] GSI-utils
  - [ ] UFS-utils
  - [ ] UFS-weather-model
  - [ ] wxflow

# How has this been tested?
`git status` after running `link_workflow.sh` on Hera.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes