### PR TITLE
GFSv16.3.18 - Increase the wait time for UKMet data in the WAFS blending_0p25 job

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -43,7 +43,7 @@ protocol = git
 required = True
 
 [EMC_gfs_wafs]
-tag = gfs_wafs.v6.3.2
+tag = gfs_wafs.v6.3.3
 local_path = sorc/gfs_wafs.fd
 repo_url = https://github.com/NOAA-EMC/EMC_gfs_wafs.git
 protocol = git

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -1,10 +1,10 @@
-GFS V16.3.17 RELEASE NOTES
+GFS V16.3.18 RELEASE NOTES
 
 -------
 PRELUDE
 -------
 
-Upstream RTOFS package is updated to v2.4.4, which results in an update to the GFS due to the new COM location for RTOFS wave job inputs.
+The WAFS blending 0.25 job is updated to increase the wait time for UKMet data from 900 to 1500 seconds. Additional error handling is also added.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -13,9 +13,9 @@ The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub are used t
 
 ```bash
 cd $PACKAGEROOT
-mkdir gfs.v16.3.17
-cd gfs.v16.3.17
-git clone -b EMC-v16.3.17 https://github.com/NOAA-EMC/global-workflow.git .
+mkdir gfs.v16.3.18
+cd gfs.v16.3.18
+git clone -b EMC-v16.3.18 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```
@@ -29,7 +29,7 @@ The checkout script extracts the following GFS components:
 | GSI       | gfsda.v16.3.12 | Andrew.Collard@noaa.gov |
 | UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
 | POST      | upp_v8.3.0 | Wen.Meng@noaa.gov |
-| WAFS      | gfs_wafs.v6.3.2 | Yali.Mao@noaa.gov |
+| WAFS      | gfs_wafs.v6.3.3 | Yali.Mao@noaa.gov |
 
 To build all the GFS components, execute:
 ```bash
@@ -50,75 +50,76 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* `versions/run.ver` - change `version=v16.3.17`, `gfs_ver=v16.3.17`, and `rtofs_ver=v2.4`
+* `versions/run.ver` - change `version=v16.3.18` and `gfs_ver=v16.3.18`
 
 SORC CHANGES
 ------------
 
-* No changes from GFS v16.3.16
+* No changes from GFS v16.3.17
 
 JOBS CHANGES
 ------------
 
-* No changes from GFS v16.3.16
+* No changes from GFS v16.3.17
 
 PARM/CONFIG CHANGES
 -------------------
 
-* No changes from GFS v16.3.16
+* No changes from GFS v16.3.17
 
 SCRIPT CHANGES
 --------------
 
-* No changes from GFS v16.3.16
+* `jobs/JGFS_ATMOS_WAFS_BLENDING_0P25`
+* `scripts/exgfs_atmos_wafs_blending_0p25.sh`
 
 FIX CHANGES
 -----------
 
-* No changes from GFS v16.3.16
+* No changes from GFS v16.3.17
 
 MODULE CHANGES
 --------------
 
-* No changes from GFS v16.3.16
+* No changes from GFS v16.3.17
 
 CHANGES TO FILE SIZES
 ---------------------
 
-* No changes of existing file sizes from GFS v16.3.16
+* No changes of existing file sizes from GFS v16.3.17
 
 ENVIRONMENT AND RESOURCE CHANGES
 --------------------------------
 
-* No changes from GFS v16.3.16
+* No changes from GFS v16.3.17
 
 PRE-IMPLEMENTATION TESTING REQUIREMENTS
 ---------------------------------------
 
 * Which production jobs should be tested as part of this implementation?
-  * Wave prep and wave post jobs
+  * WAFS blending 0p25 job
 * Does this change require a 30-day evaluation?
   * No
 
 DISSEMINATION INFORMATION
 -------------------------
 
-* No changes from GFS v16.3.16
+* No changes from GFS v16.3.17
 
 HPSS ARCHIVE
 ------------
 
-* No changes from GFS v16.3.16
+* No changes from GFS v16.3.17
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
 
-* No changes from GFS v16.3.16
+* No changes from GFS v16.3.17
 
 DOCUMENTATION
 -------------
 
-* No changes from GFS v16.3.16
+* No changes from GFS v16.3.17
 
 PREPARED BY
 -----------

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -87,7 +87,7 @@ if [[ ${checkout_wafs} == "YES" ]] ; then
   echo EMC_gfs_wafs checkout ...
   if [[ ! -d gfs_wafs.fd ]] ; then
     rm -f ${topdir}/checkout-gfs_wafs.log
-    git clone --recursive --branch gfs_wafs.v6.3.2 https://github.com/NOAA-EMC/EMC_gfs_wafs.git gfs_wafs.fd >> ${topdir}/checkout-gfs_wafs.log 2>&1
+    git clone --recursive --branch gfs_wafs.v6.3.3 https://github.com/NOAA-EMC/EMC_gfs_wafs.git gfs_wafs.fd >> ${topdir}/checkout-gfs_wafs.log 2>&1
     cd ${topdir}
   else
     echo 'Skip.  Directory gfs_wafs.fd already exists.'

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.17
-export gfs_ver=v16.3.17
+export version=v16.3.18
+export gfs_ver=v16.3.18
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2


### PR DESCRIPTION
# Description

The GFS is updated to v16.3.18 in operations to update the wait time for UKMet data in the WAFS blending_0p25 job. Error handling is also updated for late arriving UKMet data.  Changes were provided by NCO. A new tag was made in the WAFS repo.

Refs #2923

# Type of change

Production update

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? YES - new WAFS tag

# How has this been tested?

NCO tested in para