### PR TITLE
Release notes created and version updated for potential PlanetiQ data ARFC

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.3.12
+tag = gfsda.v16.3.19
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -4,7 +4,7 @@ GFS V16.3.19 RELEASE NOTES
 PRELUDE
 -------
 
-PlanetiQ RO data has added noise and is placed into monitor mode.
+PlanetiQ RO data has added noise and is placed into monitor mode until its impact on the cycled analysis forecast system can be assessed.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -1,10 +1,10 @@
-GFS V16.3.18 RELEASE NOTES
+GFS V16.3.19 RELEASE NOTES
 
 -------
 PRELUDE
 -------
 
-The WAFS blending 0.25 job is updated to increase the wait time for UKMet data from 900 to 1500 seconds. Additional error handling is also added.
+PlanetiQ RO data has added noise and is placed into monitor mode.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -13,9 +13,9 @@ The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub are used t
 
 ```bash
 cd $PACKAGEROOT
-mkdir gfs.v16.3.18
-cd gfs.v16.3.18
-git clone -b EMC-v16.3.18 https://github.com/NOAA-EMC/global-workflow.git .
+mkdir gfs.v16.3.19
+cd gfs.v16.3.19
+git clone -b EMC-v16.3.19 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```
@@ -50,77 +50,77 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* `versions/run.ver` - change `version=v16.3.18` and `gfs_ver=v16.3.18`
+* `versions/run.ver` - change `version=v16.3.19` and `gfs_ver=v16.3.19`
 
 SORC CHANGES
 ------------
 
-* No changes from GFS v16.3.17
+* No changes from GFS v16.3.18
 
 JOBS CHANGES
 ------------
 
-* No changes from GFS v16.3.17
+* No changes from GFS v16.3.18
 
 PARM/CONFIG CHANGES
 -------------------
 
-* No changes from GFS v16.3.17
+* No changes from GFS v16.3.18
 
 SCRIPT CHANGES
 --------------
 
-* `jobs/JGFS_ATMOS_WAFS_BLENDING_0P25`
-* `scripts/exgfs_atmos_wafs_blending_0p25.sh`
+* No changes from GFS v16.3.18
 
 FIX CHANGES
 -----------
 
-* No changes from GFS v16.3.17
+* No changes from GFS v16.3.18
 
 MODULE CHANGES
 --------------
 
-* No changes from GFS v16.3.17
+* No changes from GFS v16.3.18
 
 CHANGES TO FILE SIZES
 ---------------------
 
-* No changes of existing file sizes from GFS v16.3.17
+* No changes of existing file sizes from GFS v16.3.18
 
 ENVIRONMENT AND RESOURCE CHANGES
 --------------------------------
 
-* No changes from GFS v16.3.17
+* No changes from GFS v16.3.18
 
 PRE-IMPLEMENTATION TESTING REQUIREMENTS
 ---------------------------------------
 
 * Which production jobs should be tested as part of this implementation?
-  * WAFS blending 0p25 job
+  * Analysis
 * Does this change require a 30-day evaluation?
   * No
 
 DISSEMINATION INFORMATION
 -------------------------
 
-* No changes from GFS v16.3.17
+* No changes from GFS v16.3.18
 
 HPSS ARCHIVE
 ------------
 
-* No changes from GFS v16.3.17
+* No changes from GFS v16.3.18
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
 
-* No changes from GFS v16.3.17
+* No changes from GFS v16.3.18
 
 DOCUMENTATION
 -------------
 
-* No changes from GFS v16.3.17
+* No changes from GFS v16.3.18
 
 PREPARED BY
 -----------
 Kate.Friedman@noaa.gov
+Russ.Treadon@noaa.gov

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -75,7 +75,7 @@ SCRIPT CHANGES
 FIX CHANGES
 -----------
 
-* No changes from GFS v16.3.18
+* Updated `global_convinfo.txt` file in GSI package
 
 MODULE CHANGES
 --------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -26,7 +26,7 @@ The checkout script extracts the following GFS components:
 | --------- | ----------- | ----------------- |
 | MODEL     | GFS.v16.3.1   | Jun.Wang@noaa.gov |
 | GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
-| GSI       | gfsda.v16.3.12 | Andrew.Collard@noaa.gov |
+| GSI       | gfsda.v16.3.19 | Andrew.Collard@noaa.gov |
 | UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
 | POST      | upp_v8.3.0 | Wen.Meng@noaa.gov |
 | WAFS      | gfs_wafs.v6.3.3 | Yali.Mao@noaa.gov |

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -35,7 +35,7 @@ fi
 echo gsi checkout ...
 if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
-    git clone --recursive --branch gfsda.v16.3.12 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
+    git clone --recursive --branch gfsda.v16.3.19 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
     git submodule update --init
     cd ${topdir}

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.18
-export gfs_ver=v16.3.18
+export version=v16.3.19
+export gfs_ver=v16.3.19
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2


### PR DESCRIPTION
# Description

This PR makes needed updates in the release branch for an ARFC for PlanetiQ data going into monitor mode.

~~PR is draft until decision on change in ops is decided and if so, new GSI tag is provided. Awaiting word from DA team via @RussTreadon-NOAA.~~

Refs #2951

# Type of change

Operational ARFC

# Change characteristics

- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? YES - updated release notes
- Does this change require an update to any of the following submodules? YES

  - [x] GSI - awaiting new tag and related issue number