### PR TITLE
Increase enkfgdas_update walltime to 35mins

### DIFF
--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_update.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_update.ecf
@@ -3,7 +3,7 @@
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:30:00
+#PBS -l walltime=00:35:00
 #PBS -l select=35:mpiprocs=9:ompthreads=14:ncpus=126
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -350,7 +350,7 @@ elif [ $step = "ediag" ]; then
 
 elif [ $step = "eupd" ]; then
 
-    export wtime_eupd="00:30:00"
+    export wtime_eupd="00:35:00"
     if [ $CASE = "C768" ]; then
       export npe_eupd=480
       export nth_eupd=6

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -286,7 +286,7 @@ elif [ $step = "ediag" ]; then
 
 elif [ $step = "eupd" ]; then
 
-    export wtime_eupd="00:30:00"
+    export wtime_eupd="00:35:00"
     export npe_eupd=315
     export nth_eupd=14
     export npe_node_eupd=$(echo "$npe_node_max / $nth_eupd" | bc)


### PR DESCRIPTION
# Description

NCO increased the walltime for the `enkfgdas_update` job by 5mins (from 30mins to 35mins) ahead of implementation today.

This PR increases the walltime similarly in the relevant ecf script and also updates the two `config.resource` configs walltime settings for the eupd job.

Refs #2951

# Type of change

Production update