### PR TITLE
Update rocoto task names

### DIFF
--- a/parm/archive/enkf.yaml.j2
+++ b/parm/archive/enkf.yaml.j2
@@ -4,15 +4,15 @@ enkf:
     required:
         # Logs
         {% for mem in range(1, nmem_ens + 1) %}
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}fcst_mem{{ '%03d' % mem }}.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_fcst_mem{{ '%03d' % mem }}.log"
         {% endfor %}
         {% for fhr in range(fhmin, fhmax + 1, fhout) %}
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}epos{{ '%03d' % (fhr - fhmin) }}.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_epos{{ '%03d' % (fhr - fhmin) }}.log"
         {% endfor %}
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}echgres.log"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}esfc.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_echgres.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_esfc.log"
         {% for grp in range(IAUFHRS | length) %}
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}ecen{{ '%03d' % grp }}.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_ecen{{ '%03d' % grp }}.log"
         {% endfor %}
 
         {% if lobsdiag_forenkf %}
@@ -33,7 +33,7 @@ enkf:
         {% endif %}
 
         {% for step in steps %}
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}{{ step }}.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_{{ step }}.log"
         {% endfor %}
 
         # Ensemble mean and spread

--- a/parm/archive/gdas.yaml.j2
+++ b/parm/archive/gdas.yaml.j2
@@ -5,33 +5,33 @@ gdas:
     required:
         {% if MODE == "cycled" %}
         # Cycled logs
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}atmanlprod.log"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}prep.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_atmanlprod.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_prep.log"
             {% if DO_JEDIATMVAR %}
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}prepatmiodaobs.log"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}atmanlinit.log"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}atmanlprod.log"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}atmanlfinal.log"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}atmanlfv3inc.log"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}atmanlvar.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_prepatmiodaobs.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_atmanlinit.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_atmanlprod.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_atmanlfinal.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_atmanlfv3inc.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_atmanlvar.log"
             {% else %}
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}anal.log"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}analdiag.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_anal.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_analdiag.log"
             {% endif %}
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}atmanlupp.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_atmanlupp.log"
             {% if DO_JEDIOCNVAR %}
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}prepoceanobs.log"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}marineanlinit.log"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}marinebmat.log"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}marineanlvar.log"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}marineanlfinal.log"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}marineanlchkpt.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_prepoceanobs.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_marineanlinit.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_marinebmat.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_marineanlvar.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_marineanlfinal.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_marineanlchkpt.log"
                 {% if DOHYBVAR %}
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}ocnanalecen.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_ocnanalecen.log"
                 {% endif %}
             {% endif %}
             {% if DO_VRFY_OCEANDA %}
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}ocnanalvrfy.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_ocnanalvrfy.log"
             {% endif %}
 
         # Analysis GRIB2 (sub-sampled) data
@@ -85,7 +85,7 @@ gdas:
         - "{{ COMIN_ATMOS_OZNMON | relpath(ROTDIR) }}/time/bad_pen.{{ cycle_YMDH }}"
         - "{{ COMIN_ATMOS_OZNMON | relpath(ROTDIR) }}/time/stdout.time.tar.gz"
         - "{{ COMIN_ATMOS_OZNMON | relpath(ROTDIR) }}/horiz/stdout.horiz.tar.gz"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}verfozn.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_verfozn.log"
             {% endif %}
 
         # Radiance verification
@@ -94,7 +94,7 @@ gdas:
         - "{{ COMIN_ATMOS_RADMON | relpath(ROTDIR) }}/radmon_bcoef.tar.gz"
         - "{{ COMIN_ATMOS_RADMON | relpath(ROTDIR) }}/radmon_bcor.tar.gz"
         - "{{ COMIN_ATMOS_RADMON | relpath(ROTDIR) }}/radmon_time.tar.gz"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}verfrad.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_verfrad.log"
             {% endif %}
 
         # Minimization monitor
@@ -104,18 +104,18 @@ gdas:
         - "{{ COMIN_ATMOS_MINMON | relpath(ROTDIR) }}/{{ cycle_YMDH }}.gnorms.ieee_d"
         - "{{ COMIN_ATMOS_MINMON | relpath(ROTDIR) }}/{{ cycle_YMDH }}.reduction.ieee_d"
         - "{{ COMIN_ATMOS_MINMON | relpath(ROTDIR) }}/gnorm_data.txt"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}vminmon.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_vminmon.log"
             {% endif %}
         {% endif %}  # End of cycled data
 
         # Forecast and post logs
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}fcst_seg0.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_fcst_seg0.log"
 
         {% for fhr in range(0, FHMAX + 1, 3) %}
             {% set fhr3 = '%03d' % fhr %}
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}atmos_prod_f{{ fhr3 }}.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_atmos_prod_f{{ fhr3 }}.log"
             {% if not WRITE_DOPOST %}
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}atmos_upp_f{{ fhr3 }}.log"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_atmos_upp_f{{ fhr3 }}.log"
             {% endif %}  ## not WRITE_DOPOST
         # Forecast GRIB2 data
         - "{{ COMIN_ATMOS_GRIB_0p25 | relpath(ROTDIR) }}/{{ head }}pgrb2.0p25.f{{ fhr3 }}"

--- a/parm/archive/gfsa.yaml.j2
+++ b/parm/archive/gfsa.yaml.j2
@@ -6,7 +6,7 @@ gfsa:
         # Logs
         # TODO explicitly name all logs to include
         {% for log in glob("logs/" ~ cycle_YMDH ~ "/gfs*.log") %}
-        {% if not "gfsarch.log" in log %}
+        {% if not "gfs_arch.log" in log %}
         - "{{ log }}"
         {% endif %}
         {% endfor %}

--- a/workflow/rocoto/gefs_tasks.py
+++ b/workflow/rocoto/gefs_tasks.py
@@ -12,7 +12,7 @@ class GEFSTasks(Tasks):
     def stage_ic(self):
 
         resources = self.get_resource('stage_ic')
-        task_name = f'stage_ic'
+        task_name = f'gefs_stage_ic'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'envars': self.envars,
@@ -29,7 +29,7 @@ class GEFSTasks(Tasks):
     def waveinit(self):
 
         resources = self.get_resource('waveinit')
-        task_name = f'wave_init'
+        task_name = f'gefs_wave_init'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'envars': self.envars,
@@ -45,12 +45,12 @@ class GEFSTasks(Tasks):
 
     def prep_emissions(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'stage_ic'}
+        dep_dict = {'type': 'task', 'name': f'gefs_stage_ic'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('prep_emissions')
-        task_name = 'prep_emissions'
+        task_name = 'gefs_prep_emissions'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'envars': self.envars,
@@ -66,15 +66,15 @@ class GEFSTasks(Tasks):
 
     def fcst(self):
         dependencies = []
-        dep_dict = {'type': 'task', 'name': f'stage_ic'}
+        dep_dict = {'type': 'task', 'name': f'gefs_stage_ic'}
         dependencies.append(rocoto.add_dependency(dep_dict))
 
         if self.app_config.do_wave:
-            dep_dict = {'type': 'task', 'name': f'wave_init'}
+            dep_dict = {'type': 'task', 'name': f'gefs_wave_init'}
             dependencies.append(rocoto.add_dependency(dep_dict))
 
         if self.app_config.do_aero:
-            dep_dict = {'type': 'task', 'name': f'prep_emissions'}
+            dep_dict = {'type': 'task', 'name': f'gefs_prep_emissions'}
             dependencies.append(rocoto.add_dependency(dep_dict))
 
         dependencies = rocoto.create_dependency(dep_condition='and', dep=dependencies)
@@ -87,7 +87,7 @@ class GEFSTasks(Tasks):
             fcst_vars.append(rocoto.create_envar(name=key, value=str(value)))
 
         resources = self.get_resource('fcst')
-        task_name = f'fcst_mem000_seg#seg#'
+        task_name = f'gefs_fcst_mem000_seg#seg#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -100,7 +100,7 @@ class GEFSTasks(Tasks):
                      }
 
         seg_var_dict = {'seg': ' '.join([f"{seg}" for seg in range(0, num_fcst_segments)])}
-        metatask_dict = {'task_name': f'fcst_mem000',
+        metatask_dict = {'task_name': f'gefs_fcst_mem000',
                          'is_serial': True,
                          'var_dict': seg_var_dict,
                          'task_dict': task_dict
@@ -112,15 +112,15 @@ class GEFSTasks(Tasks):
 
     def efcs(self):
         dependencies = []
-        dep_dict = {'type': 'task', 'name': f'stage_ic'}
+        dep_dict = {'type': 'task', 'name': f'gefs_stage_ic'}
         dependencies.append(rocoto.add_dependency(dep_dict))
 
         if self.app_config.do_wave:
-            dep_dict = {'type': 'task', 'name': f'wave_init'}
+            dep_dict = {'type': 'task', 'name': f'gefs_wave_init'}
             dependencies.append(rocoto.add_dependency(dep_dict))
 
         if self.app_config.do_aero:
-            dep_dict = {'type': 'task', 'name': f'prep_emissions'}
+            dep_dict = {'type': 'task', 'name': f'gefs_prep_emissions'}
             dependencies.append(rocoto.add_dependency(dep_dict))
 
         dependencies = rocoto.create_dependency(dep_condition='and', dep=dependencies)
@@ -144,7 +144,7 @@ class GEFSTasks(Tasks):
             for key, value in efcsenvars_dict.items():
                 efcsenvars.append(rocoto.create_envar(name=key, value=str(value)))
 
-            task_name = f'fcst_mem{member}_seg#seg#'
+            task_name = f'gefs_fcst_mem{member}_seg#seg#'
             task_dict = {'task_name': task_name,
                          'resources': resources,
                          'dependency': dependencies,
@@ -157,7 +157,7 @@ class GEFSTasks(Tasks):
                          }
 
             seg_var_dict = {'seg': ' '.join([f"{seg}" for seg in range(0, num_fcst_segments)])}
-            seg_metatask_dict = {'task_name': f'fcst_mem{member}',
+            seg_metatask_dict = {'task_name': f'gefs_fcst_mem{member}',
                                  'is_serial': True,
                                  'var_dict': seg_var_dict,
                                  'task_dict': task_dict
@@ -170,7 +170,7 @@ class GEFSTasks(Tasks):
         # Keeping this in hopes the kludge is no longer necessary at some point
         #
         # member_var_dict = {'member': ' '.join([f"{mem:03d}" for mem in range(1, self.nmem + 1)])}
-        # mem_metatask_dict = {'task_name': 'fcst_ens',
+        # mem_metatask_dict = {'task_name': 'gefs_fcst_ens',
         #                      'is_serial': False,
         #                      'var_dict': member_var_dict,
         #                      'task_dict': seg_metatask_dict
@@ -215,7 +215,7 @@ class GEFSTasks(Tasks):
         data = f'{history_path}/{history_file_tmpl}'
         dep_dict = {'type': 'data', 'data': data, 'age': 120}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'metatask', 'name': 'fcst_mem#member#'}
+        dep_dict = {'type': 'metatask', 'name': 'gefs_fcst_mem#member#'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps, dep_condition='or')
 
@@ -227,7 +227,7 @@ class GEFSTasks(Tasks):
         for key, value in postenvar_dict.items():
             postenvars.append(rocoto.create_envar(name=key, value=str(value)))
 
-        task_name = f'{component}_prod_mem#member#_f#fhr#'
+        task_name = f'gefs_{component}_prod_mem#member#_f#fhr#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -254,12 +254,12 @@ class GEFSTasks(Tasks):
             fhrs_next = fhrs[1:] + [fhrs[-1] + (fhrs[-1] - fhrs[-2])]
             fhr_var_dict['fhr_next'] = ' '.join([f"{fhr:03d}" for fhr in fhrs_next])
 
-        fhr_metatask_dict = {'task_name': f'{component}_prod_#member#',
+        fhr_metatask_dict = {'task_name': f'gefs_{component}_prod_#member#',
                              'task_dict': task_dict,
                              'var_dict': fhr_var_dict}
 
         member_var_dict = {'member': ' '.join([f"{mem:03d}" for mem in range(0, self.nmem + 1)])}
-        member_metatask_dict = {'task_name': f'{component}_prod',
+        member_metatask_dict = {'task_name': f'gefs_{component}_prod',
                                 'task_dict': fhr_metatask_dict,
                                 'var_dict': member_var_dict}
 
@@ -273,7 +273,7 @@ class GEFSTasks(Tasks):
 
         deps = []
         for member in range(0, self.nmem + 1):
-            task = f'atmos_prod_mem{member:03d}_f#fhr#'
+            task = f'gefs_atmos_prod_mem{member:03d}_f#fhr#'
             dep_dict = {'type': 'task', 'name': task}
             deps.append(rocoto.add_dependency(dep_dict))
 
@@ -284,7 +284,7 @@ class GEFSTasks(Tasks):
         for key, value in postenvar_dict.items():
             postenvars.append(rocoto.create_envar(name=key, value=str(value)))
 
-        task_name = f'atmos_ensstat_f#fhr#'
+        task_name = f'gefs_atmos_ensstat_f#fhr#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -304,7 +304,7 @@ class GEFSTasks(Tasks):
 
         fhr_var_dict = {'fhr': ' '.join([f"{fhr:03d}" for fhr in fhrs])}
 
-        fhr_metatask_dict = {'task_name': f'atmos_ensstat',
+        fhr_metatask_dict = {'task_name': f'gefs_atmos_ensstat',
                              'task_dict': task_dict,
                              'var_dict': fhr_var_dict}
 
@@ -314,8 +314,7 @@ class GEFSTasks(Tasks):
 
     def wavepostsbs(self):
         deps = []
-
-        dep_dict = {'type': 'metatask', 'name': f'fcst_mem#member#'}
+        dep_dict = {'type': 'metatask', 'name': f'gefs_fcst_mem#member#'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
@@ -328,7 +327,7 @@ class GEFSTasks(Tasks):
 
         resources = self.get_resource('wavepostsbs')
 
-        task_name = f'wave_post_grid_mem#member#'
+        task_name = f'gefs_wave_post_grid_mem#member#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -341,7 +340,7 @@ class GEFSTasks(Tasks):
                      }
 
         member_var_dict = {'member': ' '.join([str(mem).zfill(3) for mem in range(0, self.nmem + 1)])}
-        member_metatask_dict = {'task_name': 'wave_post_grid',
+        member_metatask_dict = {'task_name': 'gefs_wave_post_grid',
                                 'task_dict': task_dict,
                                 'var_dict': member_var_dict
                                 }
@@ -352,7 +351,7 @@ class GEFSTasks(Tasks):
 
     def wavepostbndpnt(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'fcst_mem#member#'}
+        dep_dict = {'type': 'metatask', 'name': f'gefs_fcst_mem#member#'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
@@ -364,7 +363,7 @@ class GEFSTasks(Tasks):
             wave_post_bndpnt_envars.append(rocoto.create_envar(name=key, value=str(value)))
 
         resources = self.get_resource('wavepostbndpnt')
-        task_name = f'wave_post_bndpnt_mem#member#'
+        task_name = f'gefs_wave_post_bndpnt_mem#member#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -377,7 +376,7 @@ class GEFSTasks(Tasks):
                      }
 
         member_var_dict = {'member': ' '.join([str(mem).zfill(3) for mem in range(0, self.nmem + 1)])}
-        member_metatask_dict = {'task_name': 'wave_post_bndpnt',
+        member_metatask_dict = {'task_name': 'gefs_wave_post_bndpnt',
                                 'task_dict': task_dict,
                                 'var_dict': member_var_dict
                                 }
@@ -397,7 +396,7 @@ class GEFSTasks(Tasks):
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
 
-        dep_dict = {'type': 'metatask', 'name': f'fcst_mem#member#'}
+        dep_dict = {'type': 'metatask', 'name': f'gefs_fcst_mem#member#'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='or', dep=deps)
 
@@ -409,7 +408,7 @@ class GEFSTasks(Tasks):
             wave_post_bndpnt_bull_envars.append(rocoto.create_envar(name=key, value=str(value)))
 
         resources = self.get_resource('wavepostbndpntbll')
-        task_name = f'wave_post_bndpnt_bull_mem#member#'
+        task_name = f'gefs_wave_post_bndpnt_bull_mem#member#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -422,7 +421,7 @@ class GEFSTasks(Tasks):
                      }
 
         member_var_dict = {'member': ' '.join([str(mem).zfill(3) for mem in range(0, self.nmem + 1)])}
-        member_metatask_dict = {'task_name': 'wave_post_bndpnt_bull',
+        member_metatask_dict = {'task_name': 'gefs_wave_post_bndpnt_bull',
                                 'task_dict': task_dict,
                                 'var_dict': member_var_dict
                                 }
@@ -433,10 +432,10 @@ class GEFSTasks(Tasks):
 
     def wavepostpnt(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'fcst_mem#member#'}
+        dep_dict = {'type': 'metatask', 'name': f'gefs_fcst_mem#member#'}
         deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_wave_bnd:
-            dep_dict = {'type': 'task', 'name': f'wave_post_bndpnt_bull_mem#member#'}
+            dep_dict = {'type': 'task', 'name': f'gefs_wave_post_bndpnt_bull_mem#member#'}
             deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
@@ -448,7 +447,7 @@ class GEFSTasks(Tasks):
             wave_post_pnt_envars.append(rocoto.create_envar(name=key, value=str(value)))
 
         resources = self.get_resource('wavepostpnt')
-        task_name = f'wave_post_pnt_mem#member#'
+        task_name = f'gefs_wave_post_pnt_mem#member#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -461,7 +460,7 @@ class GEFSTasks(Tasks):
                      }
 
         member_var_dict = {'member': ' '.join([str(mem).zfill(3) for mem in range(0, self.nmem + 1)])}
-        member_metatask_dict = {'task_name': 'wave_post_pnt',
+        member_metatask_dict = {'task_name': 'gefs_wave_post_pnt',
                                 'task_dict': task_dict,
                                 'var_dict': member_var_dict
                                 }
@@ -476,13 +475,13 @@ class GEFSTasks(Tasks):
             dep_dict = {'type': 'task', 'name': 'wave_post_grid_mem#member#'}
             deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_ocean:
-            dep_dict = {'type': 'metatask', 'name': 'ocean_prod_#member#'}
+            dep_dict = {'type': 'metatask', 'name': 'gefs_ocean_prod_#member#'}
             deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_ice:
-            dep_dict = {'type': 'metatask', 'name': 'ice_prod_#member#'}
+            dep_dict = {'type': 'metatask', 'name': 'gefs_ice_prod_#member#'}
             deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_atm:
-            dep_dict = {'type': 'metatask', 'name': 'atmos_prod_#member#'}
+            dep_dict = {'type': 'metatask', 'name': 'gefs_atmos_prod_#member#'}
             deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         extractvars_envars = self.envars.copy()
@@ -493,7 +492,7 @@ class GEFSTasks(Tasks):
             extractvars_envars.append(rocoto.create_envar(name=key, value=str(value)))
 
         resources = self.get_resource('extractvars')
-        task_name = f'extractvars_mem#member#'
+        task_name = f'gefs_extractvars_mem#member#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -506,7 +505,7 @@ class GEFSTasks(Tasks):
                      }
 
         member_var_dict = {'member': ' '.join([str(mem).zfill(3) for mem in range(0, self.nmem + 1)])}
-        member_metatask_dict = {'task_name': 'extractvars',
+        member_metatask_dict = {'task_name': 'gefs_extractvars',
                                 'task_dict': task_dict,
                                 'var_dict': member_var_dict
                                 }
@@ -517,28 +516,28 @@ class GEFSTasks(Tasks):
 
     def arch(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': 'atmos_prod'}
+        dep_dict = {'type': 'metatask', 'name': 'gefs_atmos_prod'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'metatask', 'name': 'atmos_ensstat'}
+        dep_dict = {'type': 'metatask', 'name': 'gefs_atmos_ensstat'}
         deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_ice:
-            dep_dict = {'type': 'metatask', 'name': 'ice_prod'}
+            dep_dict = {'type': 'metatask', 'name': 'gefs_ice_prod'}
             deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_ocean:
-            dep_dict = {'type': 'metatask', 'name': 'ocean_prod'}
+            dep_dict = {'type': 'metatask', 'name': 'gefs_ocean_prod'}
             deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_wave:
-            dep_dict = {'type': 'metatask', 'name': 'wave_post_grid'}
+            dep_dict = {'type': 'metatask', 'name': 'gefs_wave_post_grid'}
             deps.append(rocoto.add_dependency(dep_dict))
-            dep_dict = {'type': 'metatask', 'name': 'wave_post_pnt'}
+            dep_dict = {'type': 'metatask', 'name': 'gefs_wave_post_pnt'}
             deps.append(rocoto.add_dependency(dep_dict))
             if self.app_config.do_wave_bnd:
-                dep_dict = {'type': 'metatask', 'name': 'wave_post_bndpnt'}
+                dep_dict = {'type': 'metatask', 'name': 'gefs_wave_post_bndpnt'}
                 deps.append(rocoto.add_dependency(dep_dict))
-                dep_dict = {'type': 'metatask', 'name': 'wave_post_bndpnt_bull'}
+                dep_dict = {'type': 'metatask', 'name': 'gefs_wave_post_bndpnt_bull'}
                 deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_extractvars:
-            dep_dict = {'type': 'metatask', 'name': 'extractvars'}
+            dep_dict = {'type': 'metatask', 'name': 'gefs_extractvars'}
             deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps, dep_condition='and')
 
@@ -566,30 +565,30 @@ class GEFSTasks(Tasks):
             deps.append(rocoto.add_dependency(dep_dict))
             dependencies = rocoto.create_dependency(dep=deps)
         else:
-            dep_dict = {'type': 'metatask', 'name': 'atmos_prod'}
+            dep_dict = {'type': 'metatask', 'name': 'gefs_atmos_prod'}
             deps.append(rocoto.add_dependency(dep_dict))
-            dep_dict = {'type': 'metatask', 'name': 'atmos_ensstat'}
+            dep_dict = {'type': 'metatask', 'name': 'gefs_atmos_ensstat'}
             deps.append(rocoto.add_dependency(dep_dict))
             if self.app_config.do_ice:
-                dep_dict = {'type': 'metatask', 'name': 'ice_prod'}
+                dep_dict = {'type': 'metatask', 'name': 'gefs_ice_prod'}
                 deps.append(rocoto.add_dependency(dep_dict))
             if self.app_config.do_ocean:
-                dep_dict = {'type': 'metatask', 'name': 'ocean_prod'}
+                dep_dict = {'type': 'metatask', 'name': 'gefs_ocean_prod'}
                 deps.append(rocoto.add_dependency(dep_dict))
             if self.app_config.do_wave:
-                dep_dict = {'type': 'metatask', 'name': 'wave_post_grid'}
+                dep_dict = {'type': 'metatask', 'name': 'gefs_wave_post_grid'}
                 deps.append(rocoto.add_dependency(dep_dict))
-                dep_dict = {'type': 'metatask', 'name': 'wave_post_pnt'}
+                dep_dict = {'type': 'metatask', 'name': 'gefs_wave_post_pnt'}
                 deps.append(rocoto.add_dependency(dep_dict))
                 if self.app_config.do_wave_bnd:
-                    dep_dict = {'type': 'metatask', 'name': 'wave_post_bndpnt'}
+                    dep_dict = {'type': 'metatask', 'name': 'gefs_wave_post_bndpnt'}
                     deps.append(rocoto.add_dependency(dep_dict))
-                    dep_dict = {'type': 'metatask', 'name': 'wave_post_bndpnt_bull'}
+                    dep_dict = {'type': 'metatask', 'name': 'gefs_wave_post_bndpnt_bull'}
                     deps.append(rocoto.add_dependency(dep_dict))
             dependencies = rocoto.create_dependency(dep=deps, dep_condition='and')
 
         resources = self.get_resource('cleanup')
-        task_name = 'cleanup'
+        task_name = 'gefs_cleanup'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'envars': self.envars,

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -21,7 +21,7 @@ class GFSTasks(Tasks):
         cycledef = 'gdas_half' if self.run in ['gdas', 'enkfgdas'] else self.run
 
         resources = self.get_resource('stage_ic')
-        task_name = f'{self.run}stage_ic'
+        task_name = f'{self.run}_stage_ic'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'envars': self.envars,
@@ -48,7 +48,7 @@ class GFSTasks(Tasks):
         gfs_enkf = True if self.app_config.do_hybvar and 'gfs' in self.app_config.eupd_runs else False
 
         deps = []
-        dep_dict = {'type': 'metatask', 'name': 'gdasatmos_prod', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
+        dep_dict = {'type': 'metatask', 'name': 'gdas_atmos_prod', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
         deps.append(rocoto.add_dependency(dep_dict))
         data = f'{atm_hist_path}/gdas.t@Hz.atmf009.nc'
         dep_dict = {'type': 'data', 'data': data, 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
@@ -63,7 +63,7 @@ class GFSTasks(Tasks):
             cycledef = 'gdas'
 
         resources = self.get_resource('prep')
-        task_name = f'{self.run}prep'
+        task_name = f'{self.run}_prep'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -86,14 +86,14 @@ class GFSTasks(Tasks):
         cycledef = 'gdas_half,gdas' if self.run in ['gdas'] else self.run
         if self.app_config.mode in ['cycled']:
             deps = []
-            dep_dict = {'type': 'task', 'name': f'{self.run}prep'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_prep'}
             deps.append(rocoto.add_dependency(dep_dict))
             if self.run in ['gdas']:
                 dep_dict = {'type': 'cycleexist', 'condition': 'not', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
                 deps.append(rocoto.add_dependency(dep_dict))
             dependencies = rocoto.create_dependency(dep_condition='or', dep=deps)
 
-        task_name = f'{self.run}waveinit'
+        task_name = f'{self.run}_waveinit'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -112,12 +112,12 @@ class GFSTasks(Tasks):
     def waveprep(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}waveinit'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_waveinit'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         cycledef = 'gdas_half,gdas' if self.run in ['gdas'] else self.run
         resources = self.get_resource('waveprep')
-        task_name = f'{self.run}waveprep'
+        task_name = f'{self.run}_waveprep'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -168,7 +168,7 @@ class GFSTasks(Tasks):
 
         cycledef = 'gfs_seq'
         resources = self.get_resource('aerosol_init')
-        task_name = f'{self.run}aerosol_init'
+        task_name = f'{self.run}_aerosol_init'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -186,17 +186,17 @@ class GFSTasks(Tasks):
 
     def anal(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}prep'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_prep'}
         deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_hybvar:
-            dep_dict = {'type': 'metatask', 'name': 'enkfgdasepmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
+            dep_dict = {'type': 'metatask', 'name': 'enkfgdas_epmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
             deps.append(rocoto.add_dependency(dep_dict))
             dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         else:
             dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('anal')
-        task_name = f'{self.run}anal'
+        task_name = f'{self.run}_anal'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -216,19 +216,19 @@ class GFSTasks(Tasks):
 
         deps = []
         if self.app_config.do_jediatmvar:
-            dep_dict = {'type': 'task', 'name': f'{self.run}atmanlfinal'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_atmanlfinal'}
         else:
-            dep_dict = {'type': 'task', 'name': f'{self.run}anal'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_anal'}
         deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_jedisnowda:
-            dep_dict = {'type': 'task', 'name': f'{self.run}snowanl'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_snowanl'}
             deps.append(rocoto.add_dependency(dep_dict))
             dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         else:
             dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('sfcanl')
-        task_name = f'{self.run}sfcanl'
+        task_name = f'{self.run}_sfcanl'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -248,19 +248,19 @@ class GFSTasks(Tasks):
 
         deps = []
         if self.app_config.do_jediatmvar:
-            dep_dict = {'type': 'task', 'name': f'{self.run}atmanlfinal'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_atmanlfinal'}
         else:
-            dep_dict = {'type': 'task', 'name': f'{self.run}anal'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_anal'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'task', 'name': f'{self.run}sfcanl'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_sfcanl'}
         deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_hybvar and self.run in ['gdas']:
-            dep_dict = {'type': 'task', 'name': 'enkfgdasechgres', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
+            dep_dict = {'type': 'task', 'name': 'enkfgdas_echgres', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
             deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('analcalc')
-        task_name = f'{self.run}analcalc'
+        task_name = f'{self.run}_analcalc'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -279,12 +279,12 @@ class GFSTasks(Tasks):
     def analdiag(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}anal'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_anal'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('analdiag')
-        task_name = f'{self.run}analdiag'
+        task_name = f'{self.run}_analdiag'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -303,12 +303,12 @@ class GFSTasks(Tasks):
     def prepatmiodaobs(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}prep'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_prep'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('prepatmiodaobs')
-        task_name = f'{self.run}prepatmiodaobs'
+        task_name = f'{self.run}_prepatmiodaobs'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -327,10 +327,10 @@ class GFSTasks(Tasks):
     def atmanlinit(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}prepatmiodaobs'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_prepatmiodaobs'}
         deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_hybvar:
-            dep_dict = {'type': 'metatask', 'name': 'enkfgdasepmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
+            dep_dict = {'type': 'metatask', 'name': 'enkfgdas_epmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
             deps.append(rocoto.add_dependency(dep_dict))
             dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         else:
@@ -344,7 +344,7 @@ class GFSTasks(Tasks):
             cycledef = 'gdas'
 
         resources = self.get_resource('atmanlinit')
-        task_name = f'{self.run}atmanlinit'
+        task_name = f'{self.run}_atmanlinit'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -363,12 +363,12 @@ class GFSTasks(Tasks):
     def atmanlvar(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}atmanlinit'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_atmanlinit'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('atmanlvar')
-        task_name = f'{self.run}atmanlvar'
+        task_name = f'{self.run}_atmanlvar'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -387,12 +387,12 @@ class GFSTasks(Tasks):
     def atmanlfv3inc(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}atmanlvar'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_atmanlvar'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('atmanlfv3inc')
-        task_name = f'{self.run}atmanlfv3inc'
+        task_name = f'{self.run}_atmanlfv3inc'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -411,12 +411,12 @@ class GFSTasks(Tasks):
     def atmanlfinal(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}atmanlfv3inc'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_atmanlfv3inc'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('atmanlfinal')
-        task_name = f'{self.run}atmanlfinal'
+        task_name = f'{self.run}_atmanlfinal'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -434,12 +434,12 @@ class GFSTasks(Tasks):
 
     def prepobsaero(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}prep'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_prep'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('prepobsaero')
-        task_name = f'{self.run}prepobsaero'
+        task_name = f'{self.run}_prepobsaero'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -458,12 +458,12 @@ class GFSTasks(Tasks):
     def aeroanlgenb(self):
 
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}fcst'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('aeroanlgenb')
-        task_name = f'{self.run}aeroanlgenb'
+        task_name = f'{self.run}_aeroanlgenb'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -482,18 +482,18 @@ class GFSTasks(Tasks):
     def aeroanlinit(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': 'gdasaeroanlgenb', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
+        dep_dict = {'type': 'task', 'name': 'gdas_aeroanlgenb', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'task', 'name': f'{self.run}prep'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_prep'}
         deps.append(rocoto.add_dependency(dep_dict))
 
         if self.app_config.do_prep_obs_aero:
-            dep_dict = {'type': 'task', 'name': f'{self.run}prepobsaero'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_prepobsaero'}
             deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('aeroanlinit')
-        task_name = f'{self.run}aeroanlinit'
+        task_name = f'{self.run}_aeroanlinit'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -513,18 +513,18 @@ class GFSTasks(Tasks):
 
         deps = []
         dep_dict = {
-            'type': 'task', 'name': f'gdasaeroanlgenb',
+            'type': 'task', 'name': f'gdas_aeroanlgenb',
             'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}",
         }
         deps.append(rocoto.add_dependency(dep_dict))
         dep_dict = {
-            'type': 'task', 'name': f'{self.run}aeroanlinit',
+            'type': 'task', 'name': f'{self.run}_aeroanlinit',
         }
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('aeroanlvar')
-        task_name = f'{self.run}aeroanlvar'
+        task_name = f'{self.run}_aeroanlvar'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -543,12 +543,12 @@ class GFSTasks(Tasks):
     def aeroanlfinal(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}aeroanlvar'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_aeroanlvar'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('aeroanlfinal')
-        task_name = f'{self.run}aeroanlfinal'
+        task_name = f'{self.run}_aeroanlfinal'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -567,12 +567,12 @@ class GFSTasks(Tasks):
     def prepsnowobs(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}prep'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_prep'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('prepsnowobs')
-        task_name = f'{self.run}prepsnowobs'
+        task_name = f'{self.run}_prepsnowobs'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -591,12 +591,12 @@ class GFSTasks(Tasks):
     def snowanl(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}prepsnowobs'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_prepsnowobs'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('snowanl')
-        task_name = f'{self.run}snowanl'
+        task_name = f'{self.run}_snowanl'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -614,16 +614,16 @@ class GFSTasks(Tasks):
     def esnowrecen(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run.replace("enkf","")}prepsnowobs'}
+        dep_dict = {'type': 'task', 'name': f'{self.run.replace("enkf","")}_prepsnowobs'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'task', 'name': f'{self.run.replace("enkf","")}snowanl'}
+        dep_dict = {'type': 'task', 'name': f'{self.run.replace("enkf","")}_snowanl'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}epmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_epmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('esnowrecen')
-        task_name = f'{self.run}esnowrecen'
+        task_name = f'{self.run}_esnowrecen'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -649,7 +649,7 @@ class GFSTasks(Tasks):
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('prepoceanobs')
-        task_name = f'{self.run}prepoceanobs'
+        task_name = f'{self.run}_prepoceanobs'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -676,7 +676,7 @@ class GFSTasks(Tasks):
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('marinebmat')
-        task_name = f'{self.run}marinebmat'
+        task_name = f'{self.run}_marinebmat'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -695,16 +695,16 @@ class GFSTasks(Tasks):
     def marineanlinit(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}prepoceanobs'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_prepoceanobs'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'task', 'name': f'{self.run}marinebmat'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_marinebmat'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'metatask', 'name': 'gdasfcst', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
+        dep_dict = {'type': 'metatask', 'name': 'gdas_fcst', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('marineanlinit')
-        task_name = f'{self.run}marineanlinit'
+        task_name = f'{self.run}_marineanlinit'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -723,12 +723,12 @@ class GFSTasks(Tasks):
     def marineanlvar(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}marineanlinit'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_marineanlinit'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('marineanlvar')
-        task_name = f'{self.run}marineanlvar'
+        task_name = f'{self.run}_marineanlvar'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -747,12 +747,12 @@ class GFSTasks(Tasks):
     def ocnanalecen(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}marineanlvar'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_marineanlvar'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('ocnanalecen')
-        task_name = f'{self.run}ocnanalecen'
+        task_name = f'{self.run}_ocnanalecen'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -772,9 +772,9 @@ class GFSTasks(Tasks):
 
         deps = []
         if self.app_config.do_hybvar:
-            dep_dict = {'type': 'task', 'name': f'{self.run}ocnanalecen'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_ocnanalecen'}
         else:
-            dep_dict = {'type': 'task', 'name': f'{self.run}marineanlvar'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_marineanlvar'}
         deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_mergensst:
             data = f'&ROTDIR;/{self.run}.@Y@m@d/@H/atmos/{self.run}.t@Hz.sfcanl.nc'
@@ -783,7 +783,7 @@ class GFSTasks(Tasks):
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('marineanlchkpt')
-        task_name = f'{self.run}marineanlchkpt'
+        task_name = f'{self.run}_marineanlchkpt'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -802,12 +802,12 @@ class GFSTasks(Tasks):
     def marineanlfinal(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}marineanlchkpt'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_marineanlchkpt'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('marineanlfinal')
-        task_name = f'{self.run}marineanlfinal'
+        task_name = f'{self.run}_marineanlfinal'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -826,12 +826,12 @@ class GFSTasks(Tasks):
     def ocnanalvrfy(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}marineanlfinal'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_marineanlfinal'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('ocnanalvrfy')
-        task_name = f'{self.run}ocnanalvrfy'
+        task_name = f'{self.run}_ocnanalvrfy'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -864,12 +864,12 @@ class GFSTasks(Tasks):
     def _fcst_forecast_only(self):
         dependencies = []
 
-        dep_dict = {'type': 'task', 'name': f'{self.run}stage_ic'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_stage_ic'}
         dependencies.append(rocoto.add_dependency(dep_dict))
 
         if self.app_config.do_wave and self.run in self.app_config.wave_runs:
             wave_job = 'waveprep' if self.app_config.model_app in ['ATMW'] else 'waveinit'
-            dep_dict = {'type': 'task', 'name': f'{self.run}{wave_job}'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_{wave_job}'}
             dependencies.append(rocoto.add_dependency(dep_dict))
 
         if self.app_config.do_aero and \
@@ -883,7 +883,7 @@ class GFSTasks(Tasks):
                 interval = self._base['INTERVAL']
             offset = timedelta_to_HMS(-interval)
             deps = []
-            dep_dict = {'type': 'task', 'name': f'{self.run}aerosol_init'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_aerosol_init'}
             deps.append(rocoto.add_dependency(dep_dict))
             dep_dict = {'type': 'cycleexist', 'condition': 'not', 'offset': offset}
             deps.append(rocoto.add_dependency(dep_dict))
@@ -902,7 +902,7 @@ class GFSTasks(Tasks):
             fcst_vars.append(rocoto.create_envar(name=key, value=str(value)))
 
         resources = self.get_resource('fcst')
-        task_name = f'{self.run}fcst_seg#seg#'
+        task_name = f'{self.run}_fcst_seg#seg#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -915,7 +915,7 @@ class GFSTasks(Tasks):
                      }
 
         seg_var_dict = {'seg': ' '.join([f"{seg}" for seg in range(0, num_fcst_segments)])}
-        metatask_dict = {'task_name': f'{self.run}fcst',
+        metatask_dict = {'task_name': f'{self.run}_fcst',
                          'is_serial': True,
                          'var_dict': seg_var_dict,
                          'task_dict': task_dict
@@ -927,31 +927,31 @@ class GFSTasks(Tasks):
 
     def _fcst_cycled(self):
 
-        dep_dict = {'type': 'task', 'name': f'{self.run}sfcanl'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_sfcanl'}
         dep = rocoto.add_dependency(dep_dict)
         dependencies = rocoto.create_dependency(dep=dep)
 
         if self.app_config.do_jediocnvar:
-            dep_dict = {'type': 'task', 'name': f'{self.run}marineanlfinal'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_marineanlfinal'}
             dependencies.append(rocoto.add_dependency(dep_dict))
 
         if self.app_config.do_aero and self.run in self.app_config.aero_anl_runs:
-            dep_dict = {'type': 'task', 'name': f'{self.run}aeroanlfinal'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_aeroanlfinal'}
             dependencies.append(rocoto.add_dependency(dep_dict))
 
         if self.app_config.do_jedisnowda:
-            dep_dict = {'type': 'task', 'name': f'{self.run}snowanl'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_snowanl'}
             dependencies.append(rocoto.add_dependency(dep_dict))
 
         dependencies = rocoto.create_dependency(dep_condition='and', dep=dependencies)
 
         if self.run in ['gdas']:
-            dep_dict = {'type': 'task', 'name': f'{self.run}stage_ic'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_stage_ic'}
             dependencies.append(rocoto.add_dependency(dep_dict))
             dependencies = rocoto.create_dependency(dep_condition='or', dep=dependencies)
 
         if self.app_config.do_wave and self.run in self.app_config.wave_runs:
-            dep_dict = {'type': 'task', 'name': f'{self.run}waveprep'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_waveprep'}
             dependencies.append(rocoto.add_dependency(dep_dict))
             dependencies = rocoto.create_dependency(dep_condition='and', dep=dependencies)
 
@@ -968,7 +968,7 @@ class GFSTasks(Tasks):
             fcst_vars.append(rocoto.create_envar(name=key, value=str(value)))
 
         resources = self.get_resource('fcst')
-        task_name = f'{self.run}fcst_seg#seg#'
+        task_name = f'{self.run}_fcst_seg#seg#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -981,7 +981,7 @@ class GFSTasks(Tasks):
                      }
 
         seg_var_dict = {'seg': ' '.join([f"{seg}" for seg in range(0, num_fcst_segments)])}
-        metatask_dict = {'task_name': f'{self.run}fcst',
+        metatask_dict = {'task_name': f'{self.run}_fcst',
                          'is_serial': True,
                          'var_dict': seg_var_dict,
                          'task_dict': task_dict
@@ -1011,7 +1011,7 @@ class GFSTasks(Tasks):
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps, dep_condition='and')
         resources = self.get_resource('upp')
-        task_name = f'{self.run}atmanlupp'
+        task_name = f'{self.run}_atmanlupp'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1040,7 +1040,7 @@ class GFSTasks(Tasks):
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
         resources = self.get_resource('atmos_products')
-        task_name = f'{self.run}atmanlprod'
+        task_name = f'{self.run}_atmanlprod'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1089,7 +1089,7 @@ class GFSTasks(Tasks):
         cycledef = 'gdas_half,gdas' if self.run in ['gdas'] else self.run
         resources = self.get_resource('upp')
 
-        task_name = f'{self.run}{task_id}_f#fhr#'
+        task_name = f'{self.run}_{task_id}_f#fhr#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1104,7 +1104,7 @@ class GFSTasks(Tasks):
         fhrs = self._get_forecast_hours(self.run, self._configs['upp'])
         fhr_var_dict = {'fhr': ' '.join([f"{fhr:03d}" for fhr in fhrs])}
 
-        metatask_dict = {'task_name': f'{self.run}{task_id}',
+        metatask_dict = {'task_name': f'{self.run}_{task_id}',
                          'task_dict': task_dict,
                          'var_dict': fhr_var_dict
                          }
@@ -1149,14 +1149,14 @@ class GFSTasks(Tasks):
         data = f'{history_path}/{history_file_tmpl}'
         dep_dict = {'type': 'data', 'data': data, 'age': 120}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}fcst'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps, dep_condition='or')
 
         cycledef = 'gdas_half,gdas' if self.run in ['gdas'] else self.run
         resources = self.get_resource(component_dict['config'])
 
-        task_name = f'{self.run}{component}_prod_f#fhr#'
+        task_name = f'{self.run}_{component}_prod_f#fhr#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1178,7 +1178,7 @@ class GFSTasks(Tasks):
         if component in ['ocean']:
             fhrs_next = fhrs[1:] + [fhrs[-1] + (fhrs[-1] - fhrs[-2])]
             fhr_var_dict['fhr_next'] = ' '.join([f"{fhr:03d}" for fhr in fhrs_next])
-        metatask_dict = {'task_name': f'{self.run}{component}_prod',
+        metatask_dict = {'task_name': f'{self.run}_{component}_prod',
                          'task_dict': task_dict,
                          'var_dict': fhr_var_dict}
 
@@ -1188,12 +1188,12 @@ class GFSTasks(Tasks):
 
     def wavepostsbs(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}fcst'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('wavepostsbs')
-        task_name = f'{self.run}wavepostsbs'
+        task_name = f'{self.run}_wavepostsbs'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1211,12 +1211,12 @@ class GFSTasks(Tasks):
 
     def wavepostbndpnt(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}fcst'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('wavepostbndpnt')
-        task_name = f'{self.run}wavepostbndpnt'
+        task_name = f'{self.run}_wavepostbndpnt'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1245,7 +1245,7 @@ class GFSTasks(Tasks):
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('wavepostbndpntbll')
-        task_name = f'{self.run}wavepostbndpntbll'
+        task_name = f'{self.run}_wavepostbndpntbll'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1263,15 +1263,15 @@ class GFSTasks(Tasks):
 
     def wavepostpnt(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}fcst'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_wave_bnd:
-            dep_dict = {'type': 'task', 'name': f'{self.run}wavepostbndpntbll'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_wavepostbndpntbll'}
             deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('wavepostpnt')
-        task_name = f'{self.run}wavepostpnt'
+        task_name = f'{self.run}_wavepostpnt'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1289,12 +1289,12 @@ class GFSTasks(Tasks):
 
     def wavegempak(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}wavepostsbs'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_wavepostsbs'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('wavegempak')
-        task_name = f'{self.run}wavegempak'
+        task_name = f'{self.run}_wavegempak'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1312,14 +1312,14 @@ class GFSTasks(Tasks):
 
     def waveawipsbulls(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}wavepostsbs'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_wavepostsbs'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'task', 'name': f'{self.run}wavepostpnt'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_wavepostpnt'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('waveawipsbulls')
-        task_name = f'{self.run}waveawipsbulls'
+        task_name = f'{self.run}_waveawipsbulls'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1337,12 +1337,12 @@ class GFSTasks(Tasks):
 
     def waveawipsgridded(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}wavepostsbs'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_wavepostsbs'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('waveawipsgridded')
-        task_name = f'{self.run}waveawipsgridded'
+        task_name = f'{self.run}_waveawipsgridded'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1360,12 +1360,12 @@ class GFSTasks(Tasks):
 
     def postsnd(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}fcst'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('postsnd')
-        task_name = f'{self.run}postsnd'
+        task_name = f'{self.run}_postsnd'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1402,7 +1402,7 @@ class GFSTasks(Tasks):
         # prematurely starting with partial files. Unfortunately, the
         # ability to "group" post would make this more convoluted than
         # it should be and not worth the complexity.
-        task_name = f'{self.run}fbwind'
+        task_name = f'{self.run}_fbwind'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1457,7 +1457,7 @@ class GFSTasks(Tasks):
     def awips_20km_1p0deg(self):
 
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}atmos_prod'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_atmos_prod'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
@@ -1474,7 +1474,7 @@ class GFSTasks(Tasks):
 
         resources = self.get_resource('awips')
 
-        task_name = f'{self.run}awips_20km_1p0deg#{varname1}#'
+        task_name = f'{self.run}_awips_20km_1p0deg#{varname1}#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1486,7 +1486,7 @@ class GFSTasks(Tasks):
                      'maxtries': '&MAXTRIES;'
                      }
 
-        metatask_dict = {'task_name': f'{self.run}awips_20km_1p0deg',
+        metatask_dict = {'task_name': f'{self.run}_awips_20km_1p0deg',
                          'task_dict': task_dict,
                          'var_dict': var_dict
                          }
@@ -1498,7 +1498,7 @@ class GFSTasks(Tasks):
     def gempak(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}atmos_prod_f#fhr#'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_atmos_prod_f#fhr#'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
@@ -1508,7 +1508,7 @@ class GFSTasks(Tasks):
             gempak_vars.append(rocoto.create_envar(name=key, value=str(value)))
 
         resources = self.get_resource('gempak')
-        task_name = f'{self.run}gempak_f#fhr#'
+        task_name = f'{self.run}_gempak_f#fhr#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1523,7 +1523,7 @@ class GFSTasks(Tasks):
         fhrs = self._get_forecast_hours(self.run, self._configs['gempak'])
         fhr_var_dict = {'fhr': ' '.join([f"{fhr:03d}" for fhr in fhrs])}
 
-        fhr_metatask_dict = {'task_name': f'{self.run}gempak',
+        fhr_metatask_dict = {'task_name': f'{self.run}_gempak',
                              'task_dict': task_dict,
                              'var_dict': fhr_var_dict}
 
@@ -1533,12 +1533,12 @@ class GFSTasks(Tasks):
 
     def gempakmeta(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}gempak'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_gempak'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('gempak')
-        task_name = f'{self.run}gempakmeta'
+        task_name = f'{self.run}_gempakmeta'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1556,12 +1556,12 @@ class GFSTasks(Tasks):
 
     def gempakmetancdc(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}gempak'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_gempak'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('gempak')
-        task_name = f'{self.run}gempakmetancdc'
+        task_name = f'{self.run}_gempakmetancdc'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1579,12 +1579,12 @@ class GFSTasks(Tasks):
 
     def gempakncdcupapgif(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}gempak'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_gempak'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('gempak')
-        task_name = f'{self.run}gempakncdcupapgif'
+        task_name = f'{self.run}_gempakncdcupapgif'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1602,7 +1602,7 @@ class GFSTasks(Tasks):
 
     def gempakpgrb2spec(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}npoess_pgrb2_0p5deg'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_npoess_pgrb2_0p5deg'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
@@ -1612,7 +1612,7 @@ class GFSTasks(Tasks):
             gempak_vars.append(rocoto.create_envar(name=key, value=str(value)))
 
         resources = self.get_resource('gempak')
-        task_name = f'{self.run}gempakgrb2spec_f#fhr#'
+        task_name = f'{self.run}_gempakgrb2spec_f#fhr#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1636,7 +1636,7 @@ class GFSTasks(Tasks):
         fhrs = self._get_forecast_hours(self.run, local_config)
         fhr_var_dict = {'fhr': ' '.join([f"{fhr:03d}" for fhr in fhrs])}
 
-        fhr_metatask_dict = {'task_name': f'{self.run}gempakgrb2spec',
+        fhr_metatask_dict = {'task_name': f'{self.run}_gempakgrb2spec',
                              'task_dict': task_dict,
                              'var_dict': fhr_var_dict}
 
@@ -1647,14 +1647,14 @@ class GFSTasks(Tasks):
     def npoess_pgrb2_0p5deg(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}atmanlprod'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_atmanlprod'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}goesupp'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_goesupp'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps, dep_condition='and')
 
         resources = self.get_resource('npoess')
-        task_name = f'{self.run}npoess_pgrb2_0p5deg'
+        task_name = f'{self.run}_npoess_pgrb2_0p5deg'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1672,12 +1672,12 @@ class GFSTasks(Tasks):
 
     def verfozn(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}analdiag'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_analdiag'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('verfozn')
-        task_name = f'{self.run}verfozn'
+        task_name = f'{self.run}_verfozn'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1695,12 +1695,12 @@ class GFSTasks(Tasks):
 
     def verfrad(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}analdiag'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_analdiag'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('verfrad')
-        task_name = f'{self.run}verfrad'
+        task_name = f'{self.run}_verfrad'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1718,12 +1718,12 @@ class GFSTasks(Tasks):
 
     def vminmon(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}anal'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_anal'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('vminmon')
-        task_name = f'{self.run}vminmon'
+        task_name = f'{self.run}_vminmon'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1741,12 +1741,12 @@ class GFSTasks(Tasks):
 
     def tracker(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}atmos_prod'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_atmos_prod'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('tracker')
-        task_name = f'{self.run}tracker'
+        task_name = f'{self.run}_tracker'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1764,12 +1764,12 @@ class GFSTasks(Tasks):
 
     def genesis(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}atmos_prod'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_atmos_prod'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('genesis')
-        task_name = f'{self.run}genesis'
+        task_name = f'{self.run}_genesis'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1787,12 +1787,12 @@ class GFSTasks(Tasks):
 
     def genesis_fsu(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}atmos_prod'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_atmos_prod'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('genesis_fsu')
-        task_name = f'{self.run}genesis_fsu'
+        task_name = f'{self.run}_genesis_fsu'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1810,12 +1810,12 @@ class GFSTasks(Tasks):
 
     def fit2obs(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}atmos_prod'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_atmos_prod'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('fit2obs')
-        task_name = f'{self.run}fit2obs'
+        task_name = f'{self.run}_fit2obs'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1833,7 +1833,7 @@ class GFSTasks(Tasks):
 
     def metp(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}arch'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_arch'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
@@ -1853,7 +1853,7 @@ class GFSTasks(Tasks):
 
         resources = self.get_resource('metp')
 
-        task_name = f'{self.run}metp#{varname1}#'
+        task_name = f'{self.run}_metp#{varname1}#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1865,7 +1865,7 @@ class GFSTasks(Tasks):
                      'maxtries': '&MAXTRIES;'
                      }
 
-        metatask_dict = {'task_name': f'{self.run}metp',
+        metatask_dict = {'task_name': f'{self.run}_metp',
                          'is_serial': True,
                          'task_dict': task_dict,
                          'var_dict': var_dict,
@@ -1877,12 +1877,12 @@ class GFSTasks(Tasks):
 
     def mos_stn_prep(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}atmos_prod'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_atmos_prod'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('mos_stn_prep')
-        task_name = f'{self.run}mos_stn_prep'
+        task_name = f'{self.run}_mos_stn_prep'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1900,12 +1900,12 @@ class GFSTasks(Tasks):
 
     def mos_grd_prep(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}atmos_prod'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_atmos_prod'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('mos_grd_prep')
-        task_name = f'{self.run}mos_grd_prep'
+        task_name = f'{self.run}_mos_grd_prep'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1923,12 +1923,12 @@ class GFSTasks(Tasks):
 
     def mos_ext_stn_prep(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}atmos_prod'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_atmos_prod'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('mos_ext_stn_prep')
-        task_name = f'{self.run}mos_ext_stn_prep'
+        task_name = f'{self.run}_mos_ext_stn_prep'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1946,12 +1946,12 @@ class GFSTasks(Tasks):
 
     def mos_ext_grd_prep(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}atmos_prod'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_atmos_prod'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('mos_ext_grd_prep')
-        task_name = f'{self.run}mos_ext_grd_prep'
+        task_name = f'{self.run}_mos_ext_grd_prep'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1969,12 +1969,12 @@ class GFSTasks(Tasks):
 
     def mos_stn_fcst(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_stn_prep'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_stn_prep'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('mos_stn_fcst')
-        task_name = f'{self.run}mos_stn_fcst'
+        task_name = f'{self.run}_mos_stn_fcst'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -1992,15 +1992,15 @@ class GFSTasks(Tasks):
 
     def mos_grd_fcst(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_stn_prep'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_stn_prep'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_grd_prep'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_grd_prep'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('mos_grd_fcst')
-        task_name = f'{self.run}mos_grd_fcst'
+        task_name = f'{self.run}_mos_grd_fcst'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2018,15 +2018,15 @@ class GFSTasks(Tasks):
 
     def mos_ext_stn_fcst(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_ext_stn_prep'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_ext_stn_prep'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_stn_prdgen'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_stn_prdgen'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('mos_ext_stn_fcst')
-        task_name = f'{self.run}mos_ext_stn_fcst'
+        task_name = f'{self.run}_mos_ext_stn_fcst'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2044,18 +2044,18 @@ class GFSTasks(Tasks):
 
     def mos_ext_grd_fcst(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_ext_stn_prep'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_ext_stn_prep'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_ext_grd_prep'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_ext_grd_prep'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_grd_fcst'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_grd_fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('mos_ext_grd_fcst')
-        task_name = f'{self.run}mos_ext_grd_fcst'
+        task_name = f'{self.run}_mos_ext_grd_fcst'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2073,12 +2073,12 @@ class GFSTasks(Tasks):
 
     def mos_stn_prdgen(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_stn_fcst'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_stn_fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('mos_stn_prdgen')
-        task_name = f'{self.run}mos_stn_prdgen'
+        task_name = f'{self.run}_mos_stn_prdgen'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2096,15 +2096,15 @@ class GFSTasks(Tasks):
 
     def mos_grd_prdgen(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_grd_fcst'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_grd_fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_stn_prdgen'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_stn_prdgen'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('mos_grd_prdgen')
-        task_name = f'{self.run}mos_grd_prdgen'
+        task_name = f'{self.run}_mos_grd_prdgen'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2122,15 +2122,15 @@ class GFSTasks(Tasks):
 
     def mos_ext_stn_prdgen(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_ext_stn_fcst'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_ext_stn_fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_stn_prdgen'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_stn_prdgen'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('mos_ext_stn_prdgen')
-        task_name = f'{self.run}mos_ext_stn_prdgen'
+        task_name = f'{self.run}_mos_ext_stn_prdgen'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2148,18 +2148,18 @@ class GFSTasks(Tasks):
 
     def mos_ext_grd_prdgen(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_ext_grd_fcst'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_ext_grd_fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_grd_prdgen'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_grd_prdgen'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_ext_stn_prdgen'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_ext_stn_prdgen'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('mos_ext_grd_prdgen')
-        task_name = f'{self.run}mos_ext_grd_prdgen'
+        task_name = f'{self.run}_mos_ext_grd_prdgen'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2177,12 +2177,12 @@ class GFSTasks(Tasks):
 
     def mos_wx_prdgen(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_grd_prdgen'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_grd_prdgen'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('mos_wx_prdgen')
-        task_name = f'{self.run}mos_wx_prdgen'
+        task_name = f'{self.run}_mos_wx_prdgen'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2200,15 +2200,15 @@ class GFSTasks(Tasks):
 
     def mos_wx_ext_prdgen(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_ext_grd_prdgen'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_ext_grd_prdgen'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
-        dep_dict = {'type': 'task', 'name': f'{self.run}mos_wx_prdgen'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_mos_wx_prdgen'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('mos_wx_ext_prdgen')
-        task_name = f'{self.run}mos_wx_ext_prdgen'
+        task_name = f'{self.run}_mos_wx_ext_prdgen'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2228,53 +2228,53 @@ class GFSTasks(Tasks):
         deps = []
         if self.app_config.mode in ['cycled']:
             if self.run in ['gfs']:
-                dep_dict = {'type': 'task', 'name': f'{self.run}atmanlprod'}
+                dep_dict = {'type': 'task', 'name': f'{self.run}_atmanlprod'}
                 deps.append(rocoto.add_dependency(dep_dict))
                 if self.app_config.do_vminmon:
-                    dep_dict = {'type': 'task', 'name': f'{self.run}vminmon'}
+                    dep_dict = {'type': 'task', 'name': f'{self.run}_vminmon'}
                     deps.append(rocoto.add_dependency(dep_dict))
             elif self.run in ['gdas']:
-                dep_dict = {'type': 'task', 'name': f'{self.run}atmanlprod'}
+                dep_dict = {'type': 'task', 'name': f'{self.run}_atmanlprod'}
                 deps.append(rocoto.add_dependency(dep_dict))
                 if self.app_config.do_fit2obs:
-                    dep_dict = {'type': 'task', 'name': f'{self.run}fit2obs'}
+                    dep_dict = {'type': 'task', 'name': f'{self.run}_fit2obs'}
                     deps.append(rocoto.add_dependency(dep_dict))
                 if self.app_config.do_verfozn:
-                    dep_dict = {'type': 'task', 'name': f'{self.run}verfozn'}
+                    dep_dict = {'type': 'task', 'name': f'{self.run}_verfozn'}
                     deps.append(rocoto.add_dependency(dep_dict))
                 if self.app_config.do_verfrad:
-                    dep_dict = {'type': 'task', 'name': f'{self.run}verfrad'}
+                    dep_dict = {'type': 'task', 'name': f'{self.run}_verfrad'}
                     deps.append(rocoto.add_dependency(dep_dict))
                 if self.app_config.do_vminmon:
-                    dep_dict = {'type': 'task', 'name': f'{self.run}vminmon'}
+                    dep_dict = {'type': 'task', 'name': f'{self.run}_vminmon'}
                     deps.append(rocoto.add_dependency(dep_dict))
         if self.run in ['gfs'] and self.app_config.do_tracker:
-            dep_dict = {'type': 'task', 'name': f'{self.run}tracker'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_tracker'}
             deps.append(rocoto.add_dependency(dep_dict))
         if self.run in ['gfs'] and self.app_config.do_genesis:
-            dep_dict = {'type': 'task', 'name': f'{self.run}genesis'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_genesis'}
             deps.append(rocoto.add_dependency(dep_dict))
         if self.run in ['gfs'] and self.app_config.do_genesis_fsu:
-            dep_dict = {'type': 'task', 'name': f'{self.run}genesis_fsu'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_genesis_fsu'}
             deps.append(rocoto.add_dependency(dep_dict))
         # Post job dependencies
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}atmos_prod'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_atmos_prod'}
         deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_wave:
-            dep_dict = {'type': 'task', 'name': f'{self.run}wavepostsbs'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_wavepostsbs'}
             deps.append(rocoto.add_dependency(dep_dict))
-            dep_dict = {'type': 'task', 'name': f'{self.run}wavepostpnt'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_wavepostpnt'}
             deps.append(rocoto.add_dependency(dep_dict))
             if self.app_config.do_wave_bnd:
-                dep_dict = {'type': 'task', 'name': f'{self.run}wavepostbndpnt'}
+                dep_dict = {'type': 'task', 'name': f'{self.run}_wavepostbndpnt'}
                 deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_ocean:
             if self.run in ['gfs']:
-                dep_dict = {'type': 'metatask', 'name': f'{self.run}ocean_prod'}
+                dep_dict = {'type': 'metatask', 'name': f'{self.run}_ocean_prod'}
                 deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_ice:
             if self.run in ['gfs']:
-                dep_dict = {'type': 'metatask', 'name': f'{self.run}ice_prod'}
+                dep_dict = {'type': 'metatask', 'name': f'{self.run}_ice_prod'}
                 deps.append(rocoto.add_dependency(dep_dict))
         # MOS job dependencies
         if self.run in ['gfs'] and self.app_config.do_mos:
@@ -2283,13 +2283,13 @@ class GFSTasks(Tasks):
                         "stn_prdgen", "grd_prdgen", "ext_stn_prdgen", "ext_grd_prdgen",
                         "wx_prdgen", "wx_ext_prdgen"]
             for job in mos_jobs:
-                dep_dict = {'type': 'task', 'name': f'{self.run}mos_{job}'}
+                dep_dict = {'type': 'task', 'name': f'{self.run}_mos_{job}'}
                 deps.append(rocoto.add_dependency(dep_dict))
 
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('arch')
-        task_name = f'{self.run}arch'
+        task_name = f'{self.run}_arch'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2309,35 +2309,35 @@ class GFSTasks(Tasks):
     def cleanup(self):
         deps = []
         if 'enkf' in self.run:
-            dep_dict = {'type': 'metatask', 'name': f'{self.run}eamn'}
+            dep_dict = {'type': 'metatask', 'name': f'{self.run}_eamn'}
             deps.append(rocoto.add_dependency(dep_dict))
         else:
-            dep_dict = {'type': 'task', 'name': f'{self.run}arch'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_arch'}
             deps.append(rocoto.add_dependency(dep_dict))
 
         if self.app_config.do_gempak:
             if self.run in ['gdas']:
-                dep_dict = {'type': 'task', 'name': f'{self.run}gempakmetancdc'}
+                dep_dict = {'type': 'task', 'name': f'{self.run}_gempakmetancdc'}
                 deps.append(rocoto.add_dependency(dep_dict))
             elif self.run in ['gfs']:
-                dep_dict = {'type': 'task', 'name': f'{self.run}gempakmeta'}
+                dep_dict = {'type': 'task', 'name': f'{self.run}_gempakmeta'}
                 deps.append(rocoto.add_dependency(dep_dict))
-                dep_dict = {'type': 'task', 'name': f'{self.run}gempakncdcupapgif'}
+                dep_dict = {'type': 'task', 'name': f'{self.run}_gempakncdcupapgif'}
                 deps.append(rocoto.add_dependency(dep_dict))
                 if self.app_config.do_goes:
-                    dep_dict = {'type': 'metatask', 'name': f'{self.run}gempakgrb2spec'}
+                    dep_dict = {'type': 'metatask', 'name': f'{self.run}_gempakgrb2spec'}
                     deps.append(rocoto.add_dependency(dep_dict))
-                    dep_dict = {'type': 'task', 'name': f'{self.run}npoess_pgrb2_0p5deg'}
+                    dep_dict = {'type': 'task', 'name': f'{self.run}_npoess_pgrb2_0p5deg'}
                     deps.append(rocoto.add_dependency(dep_dict))
 
         if self.app_config.do_metp and self.run in ['gfs']:
-            dep_dict = {'type': 'metatask', 'name': f'{self.run}metp'}
+            dep_dict = {'type': 'metatask', 'name': f'{self.run}_metp'}
             deps.append(rocoto.add_dependency(dep_dict))
 
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('cleanup')
-        task_name = f'{self.run}cleanup'
+        task_name = f'{self.run}_cleanup'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2356,14 +2356,14 @@ class GFSTasks(Tasks):
     # Start of ensemble tasks
     def eobs(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run.replace("enkf","")}prep'}
+        dep_dict = {'type': 'task', 'name': f'{self.run.replace("enkf","")}_prep'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'metatask', 'name': 'enkfgdasepmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
+        dep_dict = {'type': 'metatask', 'name': 'enkfgdas_epmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('eobs')
-        task_name = f'{self.run}eobs'
+        task_name = f'{self.run}_eobs'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2381,7 +2381,7 @@ class GFSTasks(Tasks):
 
     def eomg(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}eobs'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_eobs'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
@@ -2393,7 +2393,7 @@ class GFSTasks(Tasks):
             eomgenvars.append(rocoto.create_envar(name=key, value=str(value)))
 
         resources = self.get_resource('eomg')
-        task_name = f'{self.run}eomg_mem#member#'
+        task_name = f'{self.run}_eomg_mem#member#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2406,7 +2406,7 @@ class GFSTasks(Tasks):
                      }
 
         member_var_dict = {'member': ' '.join([str(mem).zfill(3) for mem in range(1, self.nmem + 1)])}
-        metatask_dict = {'task_name': f'{self.run}eomg',
+        metatask_dict = {'task_name': f'{self.run}_eomg',
                          'var_dict': member_var_dict,
                          'task_dict': task_dict,
                          }
@@ -2417,12 +2417,12 @@ class GFSTasks(Tasks):
 
     def ediag(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}eobs'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_eobs'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('ediag')
-        task_name = f'{self.run}ediag'
+        task_name = f'{self.run}_ediag'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2441,14 +2441,14 @@ class GFSTasks(Tasks):
     def eupd(self):
         deps = []
         if self.app_config.lobsdiag_forenkf:
-            dep_dict = {'type': 'task', 'name': f'{self.run}ediag'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_ediag'}
         else:
-            dep_dict = {'type': 'metatask', 'name': f'{self.run}eomg'}
+            dep_dict = {'type': 'metatask', 'name': f'{self.run}_eomg'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('eupd')
-        task_name = f'{self.run}eupd'
+        task_name = f'{self.run}_eupd'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2466,15 +2466,15 @@ class GFSTasks(Tasks):
 
     def atmensanlinit(self):
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run.replace("enkf","")}prepatmiodaobs'}
+        dep_dict = {'type': 'task', 'name': f'{self.run.replace("enkf","")}_prepatmiodaobs'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'metatask', 'name': 'enkfgdasepmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
+        dep_dict = {'type': 'metatask', 'name': 'enkfgdas_epmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         cycledef = "gdas"
         resources = self.get_resource('atmensanlinit')
-        task_name = f'{self.run}atmensanlinit'
+        task_name = f'{self.run}_atmensanlinit'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2493,14 +2493,14 @@ class GFSTasks(Tasks):
     def atmensanlobs(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}atmensanlinit'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_atmensanlinit'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'metatask', 'name': 'enkfgdasepmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
+        dep_dict = {'type': 'metatask', 'name': 'enkfgdas_epmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('atmensanlobs')
-        task_name = f'{self.run}atmensanlobs'
+        task_name = f'{self.run}_atmensanlobs'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2519,14 +2519,14 @@ class GFSTasks(Tasks):
     def atmensanlsol(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}atmensanlobs'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_atmensanlobs'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'metatask', 'name': 'enkfgdasepmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
+        dep_dict = {'type': 'metatask', 'name': 'enkfgdas_epmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('atmensanlsol')
-        task_name = f'{self.run}atmensanlsol'
+        task_name = f'{self.run}_atmensanlsol'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2545,14 +2545,14 @@ class GFSTasks(Tasks):
     def atmensanlletkf(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}atmensanlinit'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_atmensanlinit'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'metatask', 'name': 'enkfgdasepmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
+        dep_dict = {'type': 'metatask', 'name': 'enkfgdas_epmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('atmensanlletkf')
-        task_name = f'{self.run}atmensanlletkf'
+        task_name = f'{self.run}_atmensanlletkf'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2572,16 +2572,16 @@ class GFSTasks(Tasks):
 
         deps = []
         if self.app_config.lobsdiag_forenkf:
-            dep_dict = {'type': 'task', 'name': f'{self.run}atmensanlsol'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_atmensanlsol'}
         else:
-            dep_dict = {'type': 'task', 'name': f'{self.run}atmensanlletkf'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_atmensanlletkf'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'metatask', 'name': 'enkfgdasepmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
+        dep_dict = {'type': 'metatask', 'name': 'enkfgdas_epmn', 'offset': f"-{timedelta_to_HMS(self._base['cycle_interval'])}"}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('atmensanlfv3inc')
-        task_name = f'{self.run}atmensanlfv3inc'
+        task_name = f'{self.run}_atmensanlfv3inc'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2600,12 +2600,12 @@ class GFSTasks(Tasks):
     def atmensanlfinal(self):
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run}atmensanlfv3inc'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_atmensanlfv3inc'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
         resources = self.get_resource('atmensanlfinal')
-        task_name = f'{self.run}atmensanlfinal'
+        task_name = f'{self.run}_atmensanlfinal'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2647,12 +2647,12 @@ class GFSTasks(Tasks):
             return grp, dep, lst
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run.replace("enkf","")}analcalc'}
+        dep_dict = {'type': 'task', 'name': f'{self.run.replace("enkf","")}_analcalc'}
         deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_jediatmens:
-            dep_dict = {'type': 'task', 'name': f'{self.run}atmensanlfinal'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_atmensanlfinal'}
         else:
-            dep_dict = {'type': 'task', 'name': f'{self.run}eupd'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_eupd'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
@@ -2668,7 +2668,7 @@ class GFSTasks(Tasks):
 
         resources = self.get_resource('ecen')
 
-        task_name = f'{self.run}ecen#{varname1}#'
+        task_name = f'{self.run}_ecen#{varname1}#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2680,7 +2680,7 @@ class GFSTasks(Tasks):
                      'maxtries': '&MAXTRIES;'
                      }
 
-        metatask_dict = {'task_name': f'{self.run}ecmn',
+        metatask_dict = {'task_name': f'{self.run}_ecmn',
                          'var_dict': var_dict,
                          'task_dict': task_dict
                          }
@@ -2693,20 +2693,20 @@ class GFSTasks(Tasks):
         # eupd_run = 'gdas' if 'gdas' in self.app_config.eupd_runs else 'gfs'
 
         deps = []
-        dep_dict = {'type': 'task', 'name': f'{self.run.replace("enkf","")}analcalc'}
+        dep_dict = {'type': 'task', 'name': f'{self.run.replace("enkf","")}_analcalc'}
         deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_jediatmens:
-            dep_dict = {'type': 'task', 'name': f'{self.run}atmensanlfinal'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_atmensanlfinal'}
         else:
-            dep_dict = {'type': 'task', 'name': f'{self.run}eupd'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_eupd'}
         deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_jedisnowda:
-            dep_dict = {'type': 'task', 'name': f'{self.run}esnowrecen'}
+            dep_dict = {'type': 'task', 'name': f'{self.run}_esnowrecen'}
             deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         resources = self.get_resource('esfc')
-        task_name = f'{self.run}esfc'
+        task_name = f'{self.run}_esfc'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2725,12 +2725,12 @@ class GFSTasks(Tasks):
     def efcs(self):
 
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}ecmn'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_ecmn'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'task', 'name': f'{self.run}esfc'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_esfc'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
-        dep_dict = {'type': 'task', 'name': f'{self.run}stage_ic'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_stage_ic'}
         dependencies.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='or', dep=dependencies)
 
@@ -2744,7 +2744,7 @@ class GFSTasks(Tasks):
         cycledef = 'gdas_half,gdas' if self.run in ['enkfgdas'] else self.run.replace('enkf', '')
         resources = self.get_resource('efcs')
 
-        task_name = f'{self.run}fcst_mem#member#'
+        task_name = f'{self.run}_fcst_mem#member#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2757,7 +2757,7 @@ class GFSTasks(Tasks):
                      }
 
         member_var_dict = {'member': ' '.join([str(mem).zfill(3) for mem in range(1, self.nmem + 1)])}
-        metatask_dict = {'task_name': f'{self.run}fcst',
+        metatask_dict = {'task_name': f'{self.run}_fcst',
                          'var_dict': member_var_dict,
                          'task_dict': task_dict
                          }
@@ -2771,16 +2771,16 @@ class GFSTasks(Tasks):
         self._is_this_a_gdas_task(self.run, 'echgres')
 
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run.replace("enkf","")}fcst'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run.replace("enkf","")}_fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
-        dep_dict = {'type': 'task', 'name': f'{self.run}fcst_mem001'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_fcst_mem001'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         cycledef = 'gdas_half,gdas' if self.run in ['enkfgdas'] else self.run
 
         resources = self.get_resource('echgres')
-        task_name = f'{self.run}echgres'
+        task_name = f'{self.run}_echgres'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2821,7 +2821,7 @@ class GFSTasks(Tasks):
             return grp, dep, lst
 
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}fcst'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_fcst'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
@@ -2839,7 +2839,7 @@ class GFSTasks(Tasks):
 
         resources = self.get_resource('epos')
 
-        task_name = f'{self.run}epos#{varname1}#'
+        task_name = f'{self.run}_epos#{varname1}#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2851,7 +2851,7 @@ class GFSTasks(Tasks):
                      'maxtries': '&MAXTRIES;'
                      }
 
-        metatask_dict = {'task_name': f'{self.run}epmn',
+        metatask_dict = {'task_name': f'{self.run}_epmn',
                          'var_dict': var_dict,
                          'task_dict': task_dict
                          }
@@ -2863,7 +2863,7 @@ class GFSTasks(Tasks):
     def earc(self):
 
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}epmn'}
+        dep_dict = {'type': 'metatask', 'name': f'{self.run}_epmn'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
@@ -2878,7 +2878,7 @@ class GFSTasks(Tasks):
 
         var_dict = {'grp': groups}
 
-        task_name = f'{self.run}earc#grp#'
+        task_name = f'{self.run}_earc#grp#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
@@ -2890,7 +2890,7 @@ class GFSTasks(Tasks):
                      'maxtries': '&MAXTRIES;'
                      }
 
-        metatask_dict = {'task_name': f'{self.run}eamn',
+        metatask_dict = {'task_name': f'{self.run}_eamn',
                          'var_dict': var_dict,
                          'task_dict': task_dict
                          }


### PR DESCRIPTION
# Description
Updates the GEFS task names to include the `$RUN` so they are consistent with the task names in the GFS system. This is one step towards abstracting out common elements.

Also adds an underscore between the RUN and task name for *all* tasks to make them more readable.

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
- Cycled test on Hercules
- GEFS test on Hercules

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] I have made corresponding changes to the system documentation if necessary
