### PR TITLE
Update GSI tag to gfsda.v16.3.20 for saildrone data

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.3.19
+tag = gfsda.v16.3.20
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -4,7 +4,9 @@ GFS V16.3.20 RELEASE NOTES
 PRELUDE
 -------
 
-The upstream OBSPROC package is updated to v1.3. Along with this, the GFS is switching to use the AFWA global snow file due to the hemispheric snow files being phased out.
+The upstream OBSPROC package is updated to v1.3. Along with this are the following companion updates:
+* workflow and UFS_UTILS package updates to use the new AFWA global snow file due to the hemispheric snow files being phased out
+* updated GSI code and convinfo file for saildrone observations
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -26,7 +28,7 @@ The checkout script extracts the following GFS components:
 | --------- | ----------- | ----------------- |
 | MODEL     | GFS.v16.3.1   | Jun.Wang@noaa.gov |
 | GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
-| GSI       | gfsda.v16.3.19 | Andrew.Collard@noaa.gov |
+| GSI       | gfsda.v16.3.20 | Andrew.Collard@noaa.gov |
 | UFS_UTILS | ops-gfsv16.3.20 | George.Gayno@noaa.gov |
 | POST      | upp_v8.3.0 | Wen.Meng@noaa.gov |
 | WAFS      | gfs_wafs.v6.3.3 | Yali.Mao@noaa.gov |
@@ -56,6 +58,7 @@ SORC CHANGES
 ------------
 
 * New UFS_UTILS tag - `emcsfc_snow2mdl` program and associated scripts are updated to process global AFWA snow data
+* New GSI tag - `src/gsi/read_prepbufr.f90` code update for new saildrone subtype
 
 JOBS CHANGES
 ------------
@@ -75,7 +78,7 @@ SCRIPT CHANGES
 FIX CHANGES
 -----------
 
-* No changes from GFS v16.3.19
+* GSI `global_convinfo.txt` fix update for saildrone
 
 MODULE CHANGES
 --------------
@@ -101,7 +104,7 @@ PRE-IMPLEMENTATION TESTING REQUIREMENTS
 ---------------------------------------
 
 * Which production jobs should be tested as part of this implementation?
-  * emcsfc_sfc_prep job
+  * emcsfc_sfc_prep and analysis
 * Does this change require a 30-day evaluation?
   * No
 
@@ -129,3 +132,4 @@ PREPARED BY
 -----------
 Kate.Friedman@noaa.gov
 George.Gayno@noaa.gov
+Andrew.Collard@noaa.gov

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -35,7 +35,7 @@ fi
 echo gsi checkout ...
 if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
-    git clone --recursive --branch gfsda.v16.3.19 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
+    git clone --recursive --branch gfsda.v16.3.20 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
     git submodule update --init
     cd ${topdir}


### PR DESCRIPTION
# Description

This PR updates the GSI tag in the GFSv16.3.20 release branch to `gfsda.v16.3.20` for handling saildrone data within the `obsproc/v1.3` update. A new tag is set and release notes are updated.

Refs #2913

# Type of change

Production component update

# How has this been tested?

Tested by @ADCollard