### PR TITLE
Use ubuntu-22.04 on github runner

### DIFF
--- a/.github/workflows/ci_unit_tests.yaml
+++ b/.github/workflows/ci_unit_tests.yaml
@@ -4,8 +4,8 @@ on: [pull_request, push, workflow_dispatch]
 jobs:
 
   ci_pytest:
-      runs-on: ubuntu-latest
-      name: Run unit tests on CI system      
+      runs-on: ubuntu-22.04
+      name: Run unit tests on CI system
       permissions:
         checks: write
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       pull-requests: 'write'
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Build and deploy documentation
 
     steps:

--- a/.github/workflows/hera.yaml
+++ b/.github/workflows/hera.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   getlabels:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       labels: ${{ steps.id.outputs.labels }}
     steps:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   lint-shell:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     permissions:
       security-events: write

--- a/.github/workflows/orion.yaml
+++ b/.github/workflows/orion.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   getlabels:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       labels: ${{ steps.id.outputs.labels }}
     steps:
@@ -27,7 +27,7 @@ jobs:
 
   passed:
     if: contains( needs.getlabels.outputs.labels, 'CI-Orion-Passed') && github.event.pull_request.merged
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
      - getlabels
 

--- a/.github/workflows/pynorms.yaml
+++ b/.github/workflows/pynorms.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   check_norms:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Check Python coding norms with pycodestyle
 
     steps:


### PR DESCRIPTION
# Description
This PR reverts to `ubuntu-22.04` image of the GH runner.  `ubuntu-latest` is having an issue with python pip.

# Type of change
- [X] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? YES/NO
- Does this change require a documentation update? YES/NO
- Does this change require an update to any of the following submodules? YES/NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] I have made corresponding changes to the system documentation if necessary
