### PR TITLE
Hotfix: Correctly set overwrite option when specified

### DIFF
--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -7,14 +7,13 @@ Entry point for setting up an experiment in the global-workflow
 import os
 import glob
 import shutil
-import warnings
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, SUPPRESS
 
 from hosts import Host
 
 from wxflow import parse_j2yaml
 from wxflow import AttrDict
-from wxflow import to_datetime, to_timedelta, datetime_to_YMDH
+from wxflow import to_datetime, datetime_to_YMDH
 
 
 _here = os.path.dirname(__file__)
@@ -303,7 +302,7 @@ def query_and_clean(dirname, force_clean=False):
     if os.path.exists(dirname):
         print(f'\ndirectory already exists in {dirname}')
         if force_clean:
-            overwrite = True
+            overwrite = "YES"
             print(f'removing directory ........ {dirname}\n')
         else:
             overwrite = input('Do you wish to over-write [y/N]: ')


### PR DESCRIPTION
# Description
This specifies a correct option for the `overwrite` option in `setup_expt.py` when called with the `--overwrite` flag.  As-is, the `EXPDIR` and `COMROOT` directories are not actually deleted when `--overwrite` is specified.

This also removes an unused module (`warnings`) and method (`to_timedelta`) from setup_expt.py.

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Ran setup_expt.py with `--overwrite` and verified the `EXPDIR` and `COMROOT` were actually deleted before repopulating.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added