### PR TITLE
Hotfix: Fix generate_workflows.sh optional build flags

### DIFF
--- a/workflow/generate_workflows.sh
+++ b/workflow/generate_workflows.sh
@@ -2,7 +2,7 @@
 
 ###
 function _usage() {
-   cat <<-EOF
+   cat << EOF
    This script automates the experiment setup process for the global workflow.
    Options are also available to update submodules, build the workflow (with
    specific build flags), specicy which YAMLs and YAML directory to run, and
@@ -204,8 +204,7 @@ else
    echo "The RUNTESTS directory ${_runtests} already exists."
    echo "Would you like to remove it?"
    _attempts=0
-   while read -r _from_stdin
-   do
+   while read -r _from_stdin; do
       if [[ "${_from_stdin^^}" =~ Y ]]; then
          rm -rf "${_runtests}"
          mkdir -p "${_runtests}"

--- a/workflow/generate_workflows.sh
+++ b/workflow/generate_workflows.sh
@@ -390,7 +390,7 @@ if [[ "${_build}" == "true" ]]; then
    printf "Building via build_all.sh %s\n\n" "${_build_flags}"
    # Let the output of build_all.sh go to stdout regardless of verbose options
    #shellcheck disable=SC2086,SC2248
-   ${HOMEgfs}/sorc/build_all.sh ${_verbose_flag} ${_build_flags}
+   ${HOMEgfs}/sorc/build_all.sh ${_build_flags} ${_verbose_flag}
 fi
 
 # Link the workflow silently unless there's an error


### PR DESCRIPTION
# Description
The build flags used when invoking build_all.sh from generate_workflows.sh did were after the verbose flag, which caused them to be ignored if any of the verbose flags (-v, -V, -d) were not set when calling generate_workflows.sh as the `build_all.sh` verbose flag would be set to `--`.  This fixes the issue by changing the order of the flags sent to `build_all.sh`.

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Build test on Hercules.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes