### PR TITLE
Add sfcprep to config.resources.nco.static

### DIFF
--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -8,7 +8,7 @@ if [ $# -ne 1 ]; then
 
     echo "Must specify an input task argument to set resource variables!"
     echo "argument can be any one of the following:"
-    echo "anal analcalc analdiag gldas fcst post vrfy metp arch echgres"
+    echo "sfcprep prep anal analcalc analdiag gldas fcst post vrfy metp arch echgres"
     echo "eobs ediag eomg eupd ecen esfc efcs epos earc"
     echo "waveinit waveprep wavepostsbs wavepostbndpnt wavepostbndpntbll wavepostpnt"
     echo "wavegempak waveawipsbulls waveawipsgridded"

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -8,7 +8,7 @@ if [ $# -ne 1 ]; then
 
     echo "Must specify an input task argument to set resource variables!"
     echo "argument can be any one of the following:"
-    echo "anal analcalc analdiag gldas fcst post vrfy metp arch echgres"
+    echo "sfcprep prep anal analcalc analdiag gldas fcst post vrfy metp arch echgres"
     echo "eobs ediag eomg eupd ecen esfc efcs epos earc"
     echo "waveinit waveprep wavepostsbs wavepostbndpnt wavepostbndpntbll wavepostpnt"
     echo "wavegempak waveawipsbulls waveawipsgridded"
@@ -24,7 +24,16 @@ echo "BEGIN: config.resources"
 
 export npe_node_max=128
 
-if [ $step = "prep" -o $step = "prepbufr" ]; then
+if [ $step = "sfcprep" ]; then
+
+    export wtime_sfcprep="00:08:00"
+    export npe_sfcprep=1
+    export nth_sfcprep=1
+    export npe_node_sfcprep=1
+    export NTASKS=$npe_sfcprep
+    export memory_sfcprep="2GB"
+
+elif [ $step = "prep" -o $step = "prepbufr" ]; then
 
     eval "export wtime_$step='00:45:00'"
     eval "export npe_$step=4"


### PR DESCRIPTION
# Description

Per a request from the NCO SPA (Diane Stokes) assigned to the GFSv16.3.20 implementation, the sfcprep block that was added to `config.resources.emc.dyn` for dev mode is now also added to `config.resources.nco.static.` This makes both resource configs consistent with each other for the emcsfc_sfc_prep job. This also removes a non-fatal error from the sourcing of `config.resources` at runtime (due to the "sfcprep" job not being in the resource config at runtime).

Will recut the hand-off tag after this PR goes into the release branch.

FYI @DianeStokes-NCO 

Refs #2913

# Type of change

Bug fix and NCO request