### PR TITLE
Dummy PR for Hera GDASApp GW CI testing (DO NOT MERGE)

### DIFF
--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -109,17 +109,17 @@ elif [[ "${step}" = "marinebmat" ]]; then
     export APRUNCFP="${launcher} -n \$ncmd --multi-prog"
     export APRUN_MARINEBMAT="${APRUN_default}"
 
-elif [[ "${step}" = "ocnanalrun" ]]; then
+elif [[ "${step}" = "marineanlvar" ]]; then
 
     export APRUNCFP="${launcher} -n \$ncmd --multi-prog"
 
-    export APRUN_OCNANAL="${APRUN_default}"
+    export APRUN_MARINEANLVAR="${APRUN_default}"
 
-elif [[ "${step}" = "ocnanalchkpt" ]]; then
+elif [[ "${step}" = "marineanlchkpt" ]]; then
 
     export APRUNCFP="${launcher} -n \$ncmd --multi-prog"
 
-    export APRUN_OCNANAL="${APRUN_default}"
+    export APRUN_MARINEANLCHKPT="${APRUN_default}"
 
 elif [[ "${step}" = "ocnanalecen" ]]; then
 


### PR DESCRIPTION
# Description
Replace _ocnanal_ with _marineanl_ in `WCOSS2.env`

# Type of change
- [ ] Bug fix - replace incorrect environment variables in `WCOSS2.env`
- [ ] Maintenance - ensure GDASAPP GW CI works

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? YES
   - [ ] GDAS https://github.com/NOAA-EMC/GDASApp/pull/1355


# How has this been tested?
- Clone, build, and run GDASApp GW CI on Hera


# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test