### PR TITLE
GitHub CI Pipeline update for debugging forked PR support

### DIFF
--- a/.github/workflows/pw_aws_ci.yaml
+++ b/.github/workflows/pw_aws_ci.yaml
@@ -80,8 +80,10 @@ jobs:
           branch=$(gh pr view $pr_number --repo $repo --json headRefName --jq '.headRefName')
           repo_url=$(gh pr view $pr_number --repo $repo --json headRepository --jq '.headRepository.url')
         fi
-        echo "::set-output name=branch::$branch"
-        echo "::set-output name=repo::$repo_url"
+        {
+          echo "BRANCH=$branch"
+          echo "REPO=$repo_url"
+        } >> $GITHUB_OUTPUT
 
   checkout:
     needs: fetch-branch
@@ -97,8 +99,8 @@ jobs:
       with:
         path: ${{ github.run_id }}/HOMEgfs
         submodules: 'recursive'
-        repository: ${{ needs.fetch-branch.outputs.repo }}
-        ref: ${{ needs.fetch-branch.outputs.branch }}
+        repository: ${{ steps.git-branch.outputs.BRANCH }}
+        ref: ${{ steps.git-branch.outputs.REPO }}
 
   build-link:      
     needs: checkout

--- a/.github/workflows/pw_aws_ci.yaml
+++ b/.github/workflows/pw_aws_ci.yaml
@@ -45,10 +45,13 @@ jobs:
         repo=${{ github.repository }}
         if [ "$pr_number" -eq "0" ]; then
           branch=${{ github.event.inputs.ref }}
+          repo_url="https://github.com/${{ github.repository_owner }}/${{ github.repository }}.git"
         else
           branch=$(gh pr view $pr_number --repo $repo --json headRefName --jq '.headRefName')
+          repo_url=$(gh pr view $pr_number --repo $repo --json headRepository --jq '.headRepository.url')
         fi
         echo "::set-output name=branch::$branch"
+        echo "::set-output name=repo::$repo_url"
 
   checkout:
     needs: fetch-branch
@@ -64,6 +67,7 @@ jobs:
       with:
         path: ${{ github.run_id }}/HOMEgfs
         submodules: 'recursive'
+        repository: ${{ needs.fetch-branch.outputs.repo }}
         ref: ${{ needs.fetch-branch.outputs.branch }}
 
   build-link:      


### PR DESCRIPTION
# Description

Updating GitHub CI pipeline's bug with passing repo variables for `actions/checkout@v4` to support forked PRs.
Had to debug directly from develop in authoritative repo because did not not have fork of fork for the development tests.

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)