### PR TITLE
PW CI pipeline update5 ready for review so it can be merged and tested

### DIFF
--- a/.github/workflows/pw_aws_ci.yaml
+++ b/.github/workflows/pw_aws_ci.yaml
@@ -80,8 +80,10 @@ jobs:
           branch=$(gh pr view $pr_number --repo $repo --json headRefName --jq '.headRefName')
           repo_url=$(gh pr view $pr_number --repo $repo --json headRepository --jq '.headRepository.url')
         fi
-        echo "::set-output name=branch::$branch"
-        echo "::set-output name=repo::$repo_url"
+        {
+          echo "BRANCH=$branch"
+          echo "REPO=$repo_url"
+        } >> $GITHUB_OUTPUT
 
   checkout:
     needs: fetch-branch
@@ -97,8 +99,8 @@ jobs:
       with:
         path: ${{ github.run_id }}/HOMEgfs
         submodules: 'recursive'
-        repository: ${{ needs.fetch-branch.outputs.repo }}
-        ref: ${{ needs.fetch-branch.outputs.branch }}
+        repository: ${{ steps.git-branch.outputs.BRANCH }}
+        ref: ${{ steps.git-branch.outputs.REPO }}
 
   build-link:      
     needs: checkout

--- a/.github/workflows/pw_aws_ci.yaml
+++ b/.github/workflows/pw_aws_ci.yaml
@@ -45,10 +45,13 @@ jobs:
         repo=${{ github.repository }}
         if [ "$pr_number" -eq "0" ]; then
           branch=${{ github.event.inputs.ref }}
+          repo_url="https://github.com/${{ github.repository_owner }}/${{ github.repository }}.git"
         else
           branch=$(gh pr view $pr_number --repo $repo --json headRefName --jq '.headRefName')
+          repo_url=$(gh pr view $pr_number --repo $repo --json headRepository --jq '.headRepository.url')
         fi
         echo "::set-output name=branch::$branch"
+        echo "::set-output name=repo::$repo_url"
 
   checkout:
     needs: fetch-branch
@@ -64,6 +67,7 @@ jobs:
       with:
         path: ${{ github.run_id }}/HOMEgfs
         submodules: 'recursive'
+        repository: ${{ needs.fetch-branch.outputs.repo }}
         ref: ${{ needs.fetch-branch.outputs.branch }}
 
   build-link:      

--- a/.github/workflows/pw_aws_ci.yaml
+++ b/.github/workflows/pw_aws_ci.yaml
@@ -78,11 +78,13 @@ jobs:
           repo_url="https://github.com/${{ github.repository_owner }}/${{ github.repository }}.git"
         else
           branch=$(gh pr view $pr_number --repo $repo --json headRefName --jq '.headRefName')
-          repo_url=$(gh pr view $pr_number --repo $repo --json headRepository --jq '.headRepository.url')
+          repo_owner=$(gh pr view $pr_number --repo $repo --json headRepositoryOwner --jq '.headRepositoryOwner.login')
+          repo_name=$(gh pr view $pr_number --repo $repo --json headRepository --jq '.headRepository.name')
+          repo_url="https://github.com/$repo_owner/$repo_name.git"
         fi
         {
-          echo "BRANCH=$branch"
-          echo "REPO=$repo_url"
+          echo "branch=$branch"
+          echo "repo=$repo_url"
         } >> $GITHUB_OUTPUT
 
   checkout:
@@ -99,8 +101,8 @@ jobs:
       with:
         path: ${{ github.run_id }}/HOMEgfs
         submodules: 'recursive'
-        repository: ${{ steps.git-branch.outputs.BRANCH }}
-        ref: ${{ steps.git-branch.outputs.REPO }}
+        repository: ${{ needs.fetch-branch.outputs.branch }}
+        ref: ${{ needs.fetch-branch.outputs.repo }}
 
   build-link:      
     needs: checkout

--- a/.github/workflows/pw_aws_ci.yaml
+++ b/.github/workflows/pw_aws_ci.yaml
@@ -101,8 +101,8 @@ jobs:
       with:
         path: ${{ github.run_id }}/HOMEgfs
         submodules: 'recursive'
-        repository: ${{ needs.fetch-branch.outputs.branch }}
-        ref: ${{ needs.fetch-branch.outputs.repo }}
+        repository: ${{ needs.fetch-branch.outputs.repo }}
+        ref: ${{ needs.fetch-branch.outputs.branch }}
 
   build-link:      
     needs: checkout


### PR DESCRIPTION
# Discription

Latest updates to CI GitHub Pipeline:

- Explicitly gets owner of the repo from PRs when coming in from forked repos (was deficient on last iteration)
- Updated to more current method to GITHUB_OUTPUT for inter job variable passing

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

NOTE: Many updates where used in the PR process as the pipeline development had to occur directly in the authoritative repo on the develop branch for testing `actions/checkout@v4` when cloning from a forked repo.

# How is this tested
Once the update is made in the default develop branch the action can be tested.
We can not test this from a forked repo because said test would require a fork of a fork.

