### PR TITLE
Fold in GFSv16.3.20 changes from NCO para install

### DIFF
--- a/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_emcsfc_sfc_prep.ecf
+++ b/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_emcsfc_sfc_prep.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:08:00
-#PBS -l select=1:ncpus=1:mem=2GB
+#PBS -l select=1:ncpus=1:mem=10GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_emcsfc_sfc_prep.ecf
+++ b/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_emcsfc_sfc_prep.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:07:00
-#PBS -l select=1:ncpus=1:mem=2GB
+#PBS -l select=1:ncpus=1:mem=10GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
@@ -3,7 +3,7 @@
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:30:00
+#PBS -l walltime=00:40:00
 #PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=15GB
 #PBS -l place=vscatter
 #PBS -l debug=true

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -44,7 +44,7 @@ if [ $step = "sfcprep" ]; then
     export nth_sfcprep=1
     export npe_node_sfcprep=1
     export NTASKS=$npe_sfcprep
-    export memory_sfcprep="2GB"
+    export memory_sfcprep="10GB"
 
 elif [ $step = "prep" -o $step = "prepbufr" ]; then
 
@@ -274,7 +274,7 @@ elif [ $step = "wafsgrib20p25" ]; then
 
 elif [ $step = "wafsblending0p25" ]; then
 
-    export wtime_wafsblending0p25="00:30:00"
+    export wtime_wafsblending0p25="00:40:00"
     export npe_wafsblending0p25=1
     export npe_node_wafsblending0p25=$npe_wafsblending0p25
     export nth_wafsblending0p25=1

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -31,7 +31,7 @@ if [ $step = "sfcprep" ]; then
     export nth_sfcprep=1
     export npe_node_sfcprep=1
     export NTASKS=$npe_sfcprep
-    export memory_sfcprep="2GB"
+    export memory_sfcprep="10GB"
 
 elif [ $step = "prep" -o $step = "prepbufr" ]; then
 
@@ -234,7 +234,7 @@ elif [ $step = "wafsgrib20p25" ]; then
 
 elif [ $step = "wafsblending0p25" ]; then
 
-    export wtime_wafsblending0p25="00:30:00"
+    export wtime_wafsblending0p25="00:40:00"
     export npe_wafsblending0p25=1
     export npe_node_wafsblending0p25=$npe_wafsblending0p25
     export nth_wafsblending0p25=1


### PR DESCRIPTION
# Description

This PR folds in local changes made by NCO in the `gfs.v16.3.20` para install. These changes are already known, were made in prior ops versions manually, and are now being pulled into the current release package. The changes are:

- Increase memory request for emcsfc_sfc_prep jobs
- Increase walltime for wafs_blending_0p25 job

Refs #2913

# Type of change

Production update

# How has this been tested?

Already in GFS.v16.3.19 prod install and tested in GFS.v16.3.20 in para.