### PR TITLE
Add ability to compress ocean and ice products

### DIFF
--- a/parm/archive/gefs_extracted_ice.yaml.j2
+++ b/parm/archive/gefs_extracted_ice.yaml.j2
@@ -13,6 +13,12 @@ gefs_ice:
     {% do members.append("mem" ~ '%03d' % mem_nm ) %}
 {% endfor %}
 
+{% if DO_OCNICE_COMPRESS %}
+    {% set fileext = ".nc.gz" %}
+{% else %}
+    {% set fileext = ".nc" %}
+{% endif %}
+
 {% for mem in members %}
     {% set tmpl_dict = ({ '${ROTDIR}':ROTDIR,
                           '${RUN}':RUN,
@@ -25,7 +31,7 @@ gefs_ice:
 # Select netcdf files to copy to the atardir
     {% if path_exists(COMIN_ICE_HISTORY) %}
         {% for fhr in range(FHMIN_GFS + FHOUT_ICE_GFS, FHMAX_GFS + FHOUT_ICE_GFS, FHOUT_ICE_GFS) %}
-            {% set file_name = head ~ FHOUT_ICE_GFS ~ "hr_avg" ~ ".f" ~ '%03d'|format(fhr) ~ ".nc" %}
+            {% set file_name = head ~ FHOUT_ICE_GFS ~ "hr_avg" ~ ".f" ~ '%03d'|format(fhr) ~ fileext %}
             {% set file_path = COMIN_ICE_HISTORY ~ "/" ~ file_name %}
             - "{{ file_path | relpath(ROTDIR)}}"
         {% endfor %}

--- a/parm/archive/gefs_extracted_ocean.yaml.j2
+++ b/parm/archive/gefs_extracted_ocean.yaml.j2
@@ -13,6 +13,12 @@ gefs_ocean:
     {% do members.append("mem" ~ '%03d' % mem_nm ) %}
 {% endfor %}
 
+{% if DO_OCNICE_COMPRESS %}
+    {% set fileext = ".nc.gz" %}
+{% else %}
+    {% set fileext = ".nc" %}
+{% endif %}
+
 {% set res = (OCNRES|string())[0] ~ "p" ~ (OCNRES|string())[-2:] %}
 
 {% for mem in members %}
@@ -28,7 +34,7 @@ gefs_ocean:
     {% set netcdf_grid_dir = COMIN_OCEAN_NETCDF ~ "/" ~ res %}
     {% if path_exists(netcdf_grid_dir) %}
         {% for fhr in range(FHMIN_GFS + FHOUT_OCN_GFS, FHMAX_GFS + FHOUT_OCN_GFS, FHOUT_OCN_GFS) %}
-            {% set file_name = head ~ res ~ ".f" ~ '%03d'|format(fhr) ~ ".nc" %}
+            {% set file_name = head ~ res ~ ".f" ~ '%03d'|format(fhr) ~ fileext %}
             {% set file_path = netcdf_grid_dir ~ "/" ~ file_name %}
             - "{{ file_path | relpath(ROTDIR)}}"
         {% endfor %}

--- a/parm/archive/gefs_extracted_wave.yaml.j2
+++ b/parm/archive/gefs_extracted_wave.yaml.j2
@@ -38,14 +38,4 @@ gefs_wave:
         {% endfor %}
     {% endif %}
 
-    {% set COMIN_WAVE_STATION = COM_WAVE_STATION_TMPL | replace_tmpl(tmpl_dict) %}
-    # Select station files to copy to the atardir
-    {% if path_exists(COMIN_WAVE_STATION) %}
-        {% set file_path = COMIN_WAVE_STATION ~ "/" ~ RUN ~ "wave.t" ~ cycle_HH ~ "z.spec_tar.gz" %}
-        - "{{ file_path | relpath(ROTDIR)}}"
-        {% set file_path = COMIN_WAVE_STATION ~ "/" ~ RUN ~ "wave.t" ~ cycle_HH ~ "z.cbull_tar" %}
-        - "{{ file_path | relpath(ROTDIR)}}"
-        {% set file_path = COMIN_WAVE_STATION ~ "/" ~ RUN ~ "wave.t" ~ cycle_HH ~ "z.bull_tar" %}
-        - "{{ file_path | relpath(ROTDIR)}}"
-    {% endif %}
 {% endfor %}

--- a/parm/config/gefs/config.base
+++ b/parm/config/gefs/config.base
@@ -340,6 +340,10 @@ export HPSSICARCH="/NCEPDEV/emc-marine/2year/Neil.Barton/ICS/HR4/C384mx025" # IC
 export DO_DOWNLOAD_ANLY="YES" # Set to YES to download f03 replay analysis from AWS, set to NO to copy f03 analysis locally
 export ANLYDIR="" # f03 replay analysis directory on disk. May be left blank if DO_DOWNLOAD_ANLY is set to YES
 
+export DO_ICE_INTERP="NO" # Set to YES to perform ice post-processing in ice_prod task
+export DO_OCN_INTERP="YES" # Set to YES to perform ocean post-processing in ocean_prod task
+export DO_OCNICE_COMPRESS="YES" # Set to YES to compress ocean and ice products
+
 export DELETE_COM_IN_ARCHIVE_JOB="YES"   # NO=retain ROTDIR.  YES default in arch.sh and earc.sh.
 
 # Number of regional collectives to create soundings for

--- a/parm/config/gefs/config.base
+++ b/parm/config/gefs/config.base
@@ -41,8 +41,16 @@ export COMINsyn="@COMINsyn@"
 
 # USER specific paths
 export HOMEDIR="@HOMEDIR@"
-export STMP="@STMP@"
-export PTMP="@PTMP@"
+
+SUDO_USER=${SUDO_USER:-""}
+if [[ -z ${SUDO_USER} ]]; then
+  export STMP="/lfs/h3/emc/gefstemp/stmp/${USER}/stmp"
+  export PTMP="/lfs/h3/emc/gefstemp/ptmp/${USER}/ptmp"
+else
+  export STMP="/lfs/h3/emc/gefstemp/${SUDO_USER}/${USER}/stmp"
+  export PTMP="/lfs/h2/emc/gefstemp/${SUDO_USER}/${USER}/ptmp"
+fi
+
 export NOSCRUB="@NOSCRUB@"
 
 # Base directories for various builds

--- a/parm/config/gefs/config.base
+++ b/parm/config/gefs/config.base
@@ -47,8 +47,8 @@ if [[ -z ${SUDO_USER} ]]; then
   export STMP="/lfs/h3/emc/gefstemp/stmp/${USER}/stmp"
   export PTMP="/lfs/h3/emc/gefstemp/ptmp/${USER}/ptmp"
 else
-  export STMP="/lfs/h3/emc/gefstemp/${SUDO_USER}/${USER}/stmp"
-  export PTMP="/lfs/h2/emc/gefstemp/${SUDO_USER}/${USER}/ptmp"
+  export STMP="/lfs/h3/emc/gefstemp/${USER}/${SUDO_USER}/stmp"
+  export PTMP="/lfs/h2/emc/gefstemp/${USER}/${SUDO_USER}/ptmp"
 fi
 
 export NOSCRUB="@NOSCRUB@"

--- a/scripts/exglobal_archive.py
+++ b/scripts/exglobal_archive.py
@@ -32,7 +32,7 @@ def main():
             'AERO_ANL_RUN', 'AERO_FCST_RUN', 'DOIBP_WAV', 'DO_JEDIOCNVAR',
             'NMEM_ENS', 'DO_JEDIATMVAR', 'DO_VRFY_OCEANDA', 'FHMAX_FITS', 'waveGRD',
             'IAUFHRS', 'DO_FIT2OBS', 'NET', 'FHOUT_HF_GFS', 'FHMAX_HF_GFS', 'REPLAY_ICS',
-            'OFFSET_START_HOUR']
+            'OFFSET_START_HOUR', 'DO_OCNICE_COMPRESS']
 
     archive_dict = AttrDict()
     for key in keys:

--- a/scripts/exglobal_cleanup.sh
+++ b/scripts/exglobal_cleanup.sh
@@ -103,8 +103,15 @@ RDATE=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} -${FHMAX_GFS} hours")
 if (( GDATE < RDATE )); then
     RDATE=${GDATE}
 fi
-deletion_target="${ROTDIR}/${RUN}.${RDATE:0:8}"
+
+# Delete ROTDIR data from current cycle
+deletion_target="${ROTDIR}/${RUN}.${PDY:0:8}"
 if [[ -d ${deletion_target} ]]; then rm -rf "${deletion_target}"; fi
+
+# Delete ROTDIR data from previous cycle
+PDYprevcyc=$(date --utc +%Y%m%d%H -d "${PDY} 00 -6 hours")
+deletion_target_prevcyc="${ROTDIR}/${RUN}.${PDYprevcyc:0:8}"
+if [[ -d ${deletion_target_prevcyc} ]]; then rm -rf "${deletion_target_prevcyc}"; fi
 
 # sync and wait to avoid filesystem synchronization issues
 sync && sleep 1

--- a/scripts/exglobal_oceanice_products.py
+++ b/scripts/exglobal_oceanice_products.py
@@ -57,5 +57,6 @@ def main():
     if oceanice_dict.DO_OCNICE_COMPRESS:
         oceanice.compress(oceanice_dict)
 
+
 if __name__ == '__main__':
     main()

--- a/scripts/exglobal_oceanice_products.py
+++ b/scripts/exglobal_oceanice_products.py
@@ -26,29 +26,36 @@ def main():
             'component', 'forecast_hour', 'valid_datetime', 'avg_period',
             'model_grid', 'product_grids', 'oceanice_yaml',
             'DO_OCNICE_COMPRESS']
+
     oceanice_dict = AttrDict()
+
     for key in keys:
         oceanice_dict[key] = oceanice.task_config[key]
 
-    # Initialize the DATA/ directory; copy static data
-    oceanice.initialize(oceanice_dict)
+    if oceanice.task_config.do_interp:
 
-    for grid in oceanice_dict.product_grids:
+        # Initialize the DATA/ directory; copy static data
+        oceanice.initialize(oceanice_dict)
 
-        logger.info(f"Processing {grid} grid")
+        for grid in oceanice_dict.product_grids:
 
-        # Configure DATA/ directory for execution; prepare namelist etc.
-        oceanice.configure(oceanice_dict, grid)
+            logger.info(f"Processing {grid} grid")
 
-        # Run the oceanice post executable to interpolate and create grib2 files
-        oceanice.execute(oceanice_dict, grid)
+            # Configure DATA/ directory for execution; prepare namelist etc.
+            oceanice.configure(oceanice_dict, grid)
 
-    # Subset raw model data to create netCDF products
-    oceanice.subset(oceanice_dict)
+            # Run the oceanice post executable to interpolate and create grib2 files
+            oceanice.execute(oceanice_dict, grid)
 
-    # Copy processed output from execute and subset
-    oceanice.finalize(oceanice_dict)
+        # Subset raw model data to create netCDF products
+        oceanice.subset(oceanice_dict)
 
+        # Copy processed output from execute and subset
+        oceanice.finalize(oceanice_dict)
+
+    # Compress ocean and ice data
+    if oceanice_dict.DO_OCNICE_COMPRESS:
+        oceanice.compress(oceanice_dict)
 
 if __name__ == '__main__':
     main()

--- a/scripts/exglobal_oceanice_products.py
+++ b/scripts/exglobal_oceanice_products.py
@@ -21,9 +21,11 @@ def main():
     keys = ['HOMEgfs', 'DATA', 'current_cycle', 'RUN', 'NET',
             f'COM_{oceanice.task_config.component.upper()}_HISTORY',
             f'COM_{oceanice.task_config.component.upper()}_GRIB',
+            f'COM_{oceanice.task_config.component.upper()}_NETCDF',
             'APRUN_OCNICEPOST',
             'component', 'forecast_hour', 'valid_datetime', 'avg_period',
-            'model_grid', 'product_grids', 'oceanice_yaml']
+            'model_grid', 'product_grids', 'oceanice_yaml',
+            'DO_OCNICE_COMPRESS']
     oceanice_dict = AttrDict()
     for key in keys:
         oceanice_dict[key] = oceanice.task_config[key]

--- a/ush/python/pygfs/task/oceanice_products.py
+++ b/ush/python/pygfs/task/oceanice_products.py
@@ -14,7 +14,8 @@ from wxflow import (AttrDict,
                     Task,
                     add_to_datetime, to_timedelta,
                     WorkflowException,
-                    Executable)
+                    Executable,
+                    which)
 
 logger = getLogger(__name__.split('.')[-1])
 
@@ -342,3 +343,14 @@ class OceanIceProducts(Task):
 
         logger.info(f"Copy processed data to COM/ directory")
         FileHandler(data_out).sync()
+
+        # Compress netcdf products
+        if config.DO_OCNICE_COMPRESS:
+            logger.info(f"Compress processed data in COM/ directory")
+            gzip_cmd = which("/usr/bin/gzip")
+            gzip_cmd.add_default_arg("-kf")
+            if config.component == "ocean":
+                interpfile = config.COM_OCEAN_NETCDF + f"/0p25/gefs.{config.component}.t00z.0p25.f{config.forecast_hour:03d}.nc"
+            if config.component == "ice":
+                interpfile = config.COM_ICE_NETCDF + f"/0p25/gefs.{config.component}.t00z.0p25.f{config.forecast_hour:03d}.nc"
+            gzip_cmd(interpfile)

--- a/workflow/applications/gefs.py
+++ b/workflow/applications/gefs.py
@@ -75,6 +75,9 @@ class GEFSAppConfig(AppConfig):
         if self.do_ocean:
             tasks += ['ocean_prod']
 
+        if self.do_ice:
+            tasks += ['ice_prod']
+
         if self.do_wave:
             tasks += ['wavepostsbs']
             if self.do_wave_bnd:

--- a/workflow/applications/gefs.py
+++ b/workflow/applications/gefs.py
@@ -82,7 +82,6 @@ class GEFSAppConfig(AppConfig):
             tasks += ['wavepostsbs']
             if self.do_wave_bnd:
                 tasks += ['wavepostbndpnt', 'wavepostbndpntbll']
-            tasks += ['wavepostpnt']
 
         if self.do_extractvars:
             tasks += ['extractvars', 'arch']

--- a/workflow/hosts/wcoss2.yaml
+++ b/workflow/hosts/wcoss2.yaml
@@ -5,8 +5,8 @@ BASE_IC: '/lfs/h2/emc/global/noscrub/emc.global/data/ICSDIR'
 PACKAGEROOT: '${PACKAGEROOT:-"/lfs/h1/ops/prod/packages"}'
 COMINsyn: '/lfs/h1/ops/prod/com/gfs/v16.3/syndat'
 HOMEDIR: '/lfs/h3/emc/gefstemp/${USER}'
-STMP: '/lfs/h3/emc/gefstemp/stmp/${USER}'
-PTMP: '/lfs/h3/emc/gefstemp/ptmp/${USER}'
+STMP: '/lfs/h2/emc/stmp/${USER}'
+PTMP: '/lfs/h2/emc/ptmp/${USER}'
 NOSCRUB: $HOMEDIR
 ACCOUNT: 'GEFS-DEV'
 SCHEDULER: pbspro

--- a/workflow/hosts/wcoss2.yaml
+++ b/workflow/hosts/wcoss2.yaml
@@ -5,8 +5,8 @@ BASE_IC: '/lfs/h2/emc/global/noscrub/emc.global/data/ICSDIR'
 PACKAGEROOT: '${PACKAGEROOT:-"/lfs/h1/ops/prod/packages"}'
 COMINsyn: '/lfs/h1/ops/prod/com/gfs/v16.3/syndat'
 HOMEDIR: '/lfs/h3/emc/gefstemp/${USER}'
-STMP: '/lfs/h2/emc/stmp/${USER}'
-PTMP: '/lfs/h2/emc/ptmp/${USER}'
+STMP: '/lfs/h3/emc/gefstemp/stmp/${USER}'
+PTMP: '/lfs/h3/emc/gefstemp/ptmp/${USER}'
 NOSCRUB: $HOMEDIR
 ACCOUNT: 'GEFS-DEV'
 SCHEDULER: pbspro

--- a/workflow/rocoto/gefs_tasks.py
+++ b/workflow/rocoto/gefs_tasks.py
@@ -531,6 +531,9 @@ class GEFSTasks(Tasks):
         if self.app_config.do_ocean:
             dep_dict = {'type': 'metatask', 'name': 'gefs_ocean_prod_#member#'}
             deps.append(rocoto.add_dependency(dep_dict))
+        if self.app_config.do_ice:
+            dep_dict = {'type': 'metatask', 'name': 'gefs_ice_prod_#member#'}
+            deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_atm:
             dep_dict = {'type': 'metatask', 'name': 'gefs_atmos_prod_#member#'}
             deps.append(rocoto.add_dependency(dep_dict))
@@ -573,6 +576,9 @@ class GEFSTasks(Tasks):
         deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_ocean:
             dep_dict = {'type': 'metatask', 'name': 'gefs_ocean_prod'}
+            deps.append(rocoto.add_dependency(dep_dict))
+        if self.app_config.do_ice:
+            dep_dict = {'type': 'metatask', 'name': 'gefs_ice_prod'}
             deps.append(rocoto.add_dependency(dep_dict))
         if self.app_config.do_wave:
             dep_dict = {'type': 'metatask', 'name': 'gefs_wave_post_grid'}


### PR DESCRIPTION
<!--
  *** PLEASE READ ***

  Any PRs not following this template will be closed.

  Please delete all these comments before submitting the PR.

  Please use a short (<60 char), descriptive title for the PR title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

  No content should appear above the "Description" header.

  If this PR is not merge-ready (e.g. it depends on other PRs not yet merged), please mark it as draft until it is ready.

  PRs should meet these guidelines:
  - Each PR should address ONE topic and have an associated issue.
  - No hard-coded paths or personal directories.
  - No temporary or backup files should be committed (including logs).
  - Any code that you disabled by being commented out should be removed or reenabled.
-->
# Description
<!-- This description will become the commit message for the PR. -->
<!--
  Solely pointing to an issue is not an adequate description!

  Please use this format for your description:

  Describe your changes. Focus on the *what* and *why*. The *how* will be evident from the changes. In particular, be sure to note any interface changes, such as command line syntax, that will need to be communicated to users.

  At the end of your description, please be sure to add the issue this PR solves using the word "Resolves". If there are any issues that are related but not yet resolved (including in other repos), you may use "Refs".

  Resolves #1234
  Refs #4321
  Refs NOAA-EMC/repo#5678
-->

This PR adds the ability to optionally compress ocean and ice products for the GEFS reforecast. Compression can be set using a new `config.base` variable called `DO_OCNICE_COMPRESS`. For the reforecast, the ice history data and the 0p25 ocean post-processed data are gzipped at the end of the ice and ocean prod tasks, respectively. The archive task was also modified to allow either gzipped or non-gzipped ocean and ice data to be sent to HPSS, which is controlled by `DO_OCNICE_COMPRESS`. 

Furthermore, an option was added to skip the ocean and ice post-processing within the ocean and ice prod jobs, respectively. This can be controlled by `DO_ICE_INTERP` and `DO_OCN_INTERP` in `config.base`. In order to meet the reforecast requirements,  `DO_ICE_INTERP` is set to `NO` and and `DO_OCN_INTERP` is set to `YES` by default. 

This PR also accomplishes the following:

- [x] The default WCOSS2 `STMP` and `PTMP` were modified to `/lfs/h3/emc/gefstemp/` because this is the space where the reforecast will be performed. 
- [x] The wavepostpnt task has been removed. 
- [x] If a group account is used, divide the stmp and ptmp directories by `SUDO_USER`.
- [x] The clean_up job has been modified for the reforecast. 

<!-- For more on writing good commit messages, see https://cbea.ms/git-commit/ -->

# Type of change
- [ ] Bug fix (fixes something broken)
- [x] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->

The GEFS replay configuration was tested on WCOSS2. 

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
