### PR TITLE
Hotfix: Point Jenkinsfile back to CI/

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -5,7 +5,7 @@ def cases = ''
 def GH = 'none'
 // Location of the custom workspaces for each machine in the CI system.  They are persitent for each iteration of the PR.
 def NodeName = [hera: 'Hera-EMC', orion: 'Orion-EMC', hercules: 'Hercules-EMC', gaea: 'Gaea']
-def custom_workspace = [hera: '/scratch1/NCEPDEV/global/CI_dh', orion: '/work2/noaa/stmp/CI/ORION', hercules: '/work2/noaa/global/CI/HERCULES', gaea: '/gpfs/f5/epic/proj-shared/global/CI']
+def custom_workspace = [hera: '/scratch1/NCEPDEV/global/CI', orion: '/work2/noaa/stmp/CI/ORION', hercules: '/work2/noaa/global/CI/HERCULES', gaea: '/gpfs/f5/epic/proj-shared/global/CI']
 def repo_url = 'git@github.com:NOAA-EMC/global-workflow.git'
 def STATUS = 'Passed'
 


### PR DESCRIPTION
# Description
This reverts a temporary change to the Jenkinsfile so the global workflow CI will run in /scratch1/NCEPDEV/global/CI again.

# Type of change
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)