### PR TITLE
Reduce scope to annual CO2 update and PlanetIQ assimilation

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.3.19
+tag = gfsda.v16.3.20
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -26,7 +26,7 @@ The checkout script extracts the following GFS components:
 | --------- | ----------- | ----------------- |
 | MODEL     | GFS.v16.3.1   | Jun.Wang@noaa.gov |
 | GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
-| GSI       | gfsda.v16.3.19 | Andrew.Collard@noaa.gov |
+| GSI       | gfsda.v16.3.20 | Andrew.Collard@noaa.gov |
 | UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
 | POST      | upp_v8.3.0 | Wen.Meng@noaa.gov |
 | WAFS      | gfs_wafs.v6.3.3 | Yali.Mao@noaa.gov |
@@ -124,3 +124,4 @@ DOCUMENTATION
 PREPARED BY
 -----------
 Kate.Friedman@noaa.gov
+Andrew.Collard@noaa.gov

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -91,7 +91,7 @@ CHANGES TO FILE SIZES
 ENVIRONMENT AND RESOURCE CHANGES
 --------------------------------
 
-* No changes from GFS v16.3.19
+* Memory increases to some jobs to resolve Cgroup memory warnings
 
 PRE-IMPLEMENTATION TESTING REQUIREMENTS
 ---------------------------------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -4,7 +4,7 @@ GFS V16.3.20 RELEASE NOTES
 PRELUDE
 -------
 
-Annual CO2 fix file update for 2025. Additionally, the GSI is updated to switch on PlanetIQ GPSRO data.
+Annual CO2 fix file update for 2025. Additionally, the GSI is updated to turn on assimilation of PlanetiQ GPS Radio Occultation (GPS-RO) data.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -1,10 +1,10 @@
-GFS V16.3.19 RELEASE NOTES
+GFS V16.3.20 RELEASE NOTES
 
 -------
 PRELUDE
 -------
 
-PlanetiQ RO data has added noise and is placed into monitor mode until its impact on the cycled analysis forecast system can be assessed.
+Annual CO2 fix file update for 2025. Additionally, the GSI is updated to switch on PlanetIQ GPSRO data.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -13,9 +13,9 @@ The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub are used t
 
 ```bash
 cd $PACKAGEROOT
-mkdir gfs.v16.3.19
-cd gfs.v16.3.19
-git clone -b EMC-v16.3.19 https://github.com/NOAA-EMC/global-workflow.git .
+mkdir gfs.v16.3.20
+cd gfs.v16.3.20
+git clone -b EMC-v16.3.20 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```
@@ -50,47 +50,48 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* `versions/run.ver` - change `version=v16.3.19` and `gfs_ver=v16.3.19`
+* `versions/run.ver` - change `version=v16.3.20` and `gfs_ver=v16.3.20`
 
 SORC CHANGES
 ------------
 
-* No changes from GFS v16.3.18
+* No changes from GFS v16.3.19
 
 JOBS CHANGES
 ------------
 
-* No changes from GFS v16.3.18
+* No changes from GFS v16.3.19
 
 PARM/CONFIG CHANGES
 -------------------
 
-* No changes from GFS v16.3.18
+* No changes from GFS v16.3.19
 
 SCRIPT CHANGES
 --------------
 
-* No changes from GFS v16.3.18
+* No changes from GFS v16.3.19
 
 FIX CHANGES
 -----------
 
+* New 2025 CO2 fix files are added.
 * Updated `global_convinfo.txt` file in GSI package
 
 MODULE CHANGES
 --------------
 
-* No changes from GFS v16.3.18
+* No changes from GFS v16.3.19
 
 CHANGES TO FILE SIZES
 ---------------------
 
-* No changes of existing file sizes from GFS v16.3.18
+* No changes of existing file sizes from GFS v16.3.19
 
 ENVIRONMENT AND RESOURCE CHANGES
 --------------------------------
 
-* No changes from GFS v16.3.18
+* No changes from GFS v16.3.19
 
 PRE-IMPLEMENTATION TESTING REQUIREMENTS
 ---------------------------------------
@@ -103,24 +104,23 @@ PRE-IMPLEMENTATION TESTING REQUIREMENTS
 DISSEMINATION INFORMATION
 -------------------------
 
-* No changes from GFS v16.3.18
+* No changes from GFS v16.3.19
 
 HPSS ARCHIVE
 ------------
 
-* No changes from GFS v16.3.18
+* No changes from GFS v16.3.19
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
 
-* No changes from GFS v16.3.18
+* No changes from GFS v16.3.19
 
 DOCUMENTATION
 -------------
 
-* No changes from GFS v16.3.18
+* No changes from GFS v16.3.19
 
 PREPARED BY
 -----------
 Kate.Friedman@noaa.gov
-Russ.Treadon@noaa.gov

--- a/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_update.ecf
+++ b/ecf/scripts/enkfgdas/analysis/create/jenkfgdas_update.ecf
@@ -3,7 +3,7 @@
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:35:00
+#PBS -l walltime=00:40:00
 #PBS -l select=35:mpiprocs=9:ompthreads=14:ncpus=126
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true

--- a/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
+++ b/ecf/scripts/enkfgdas/analysis/recenter/jenkfgdas_sfc.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:06:00
-#PBS -l select=1:mpiprocs=80:ompthreads=1:ncpus=80:mem=60GB
+#PBS -l select=1:mpiprocs=80:ompthreads=1:ncpus=80:mem=500GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_emcsfc_sfc_prep.ecf
+++ b/ecf/scripts/gdas/atmos/obsproc/prep/jgdas_atmos_emcsfc_sfc_prep.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:08:00
-#PBS -l select=1:ncpus=1:mem=2GB
+#PBS -l select=1:ncpus=1:mem=10GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gdas/wave/post/jgdas_wave_postpnt.ecf
+++ b/ecf/scripts/gdas/wave/post/jgdas_wave_postpnt.ecf
@@ -28,6 +28,8 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 
+module load cmdaccel/${cmdaccel_ver}
+
 module list
 
 ############################################################

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
-#PBS -l select=1:ncpus=28:mpiprocs=28:mem=100GB
+#PBS -l select=1:ncpus=28:mpiprocs=28:mem=150GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
-#PBS -l select=1:ncpus=28:mpiprocs=28:mem=2GB
+#PBS -l select=1:ncpus=28:mpiprocs=28:mem=100GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_meta.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_meta.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
-#PBS -l select=1:ncpus=23:mpiprocs=23:mem=2GB
+#PBS -l select=1:ncpus=23:mpiprocs=23:mem=100GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_ncdc_upapgif.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_gempak_ncdc_upapgif.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
-#PBS -l select=1:ncpus=1:mem=1GB
+#PBS -l select=1:ncpus=1:mem=5GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_npoess_pgrb2_0p5deg.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_npoess_pgrb2_0p5deg.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
-#PBS -l select=1:ncpus=1:mem=1GB
+#PBS -l select=1:ncpus=1:mem=500GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_pgrb2_spec_gempak.ecf
+++ b/ecf/scripts/gfs/atmos/gempak/jgfs_atmos_pgrb2_spec_gempak.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l select=1:ncpus=1:mem=1GB
+#PBS -l select=1:ncpus=1:mem=20GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_emcsfc_sfc_prep.ecf
+++ b/ecf/scripts/gfs/atmos/obsproc/prep/jgfs_atmos_emcsfc_sfc_prep.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:07:00
-#PBS -l select=1:ncpus=1:mem=2GB
+#PBS -l select=1:ncpus=1:mem=10GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_20km_1p0/jgfs_atmos_awips_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l select=1:ncpus=1:mem=3GB
+#PBS -l select=1:ncpus=1:mem=100GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/awips_g2/jgfs_atmos_awips_g2_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l select=1:ncpus=1:mem=3GB
+#PBS -l select=1:ncpus=1:mem=100GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/bulletins/jgfs_atmos_fbwind.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:05:00
-#PBS -l select=1:ncpus=1:mem=4GB
+#PBS -l select=1:ncpus=1:mem=20GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
+++ b/ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf
@@ -3,7 +3,7 @@
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:30:00
+#PBS -l walltime=00:40:00
 #PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=15GB
 #PBS -l place=vscatter
 #PBS -l debug=true

--- a/ecf/scripts/gfs/wave/gempak/jgfs_wave_gempak.ecf
+++ b/ecf/scripts/gfs/wave/gempak/jgfs_wave_gempak.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
-#PBS -l select=1:ncpus=1:mem=1GB
+#PBS -l select=1:ncpus=1:mem=100GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf
@@ -28,6 +28,8 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 
+module load cmdaccel/${cmdaccel_ver}
+
 module list
 
 ############################################################

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpntbll.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpntbll.ecf
@@ -26,6 +26,8 @@ module load intel/${intel_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 
+module load cmdaccel/${cmdaccel_ver}
+
 module list
 
 ############################################################

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf
@@ -28,6 +28,8 @@ module load cray-mpich/${cray_mpich_ver}
 module load cray-pals/${cray_pals_ver}
 module load cfp/${cfp_ver}
 
+module load cmdaccel/${cmdaccel_ver}
+
 module list
 
 ############################################################

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_postsbs.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_postsbs.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=03:00:00
-#PBS -l select=1:mpiprocs=8:ompthreads=1:ncpus=8:mem=10GB
+#PBS -l select=1:mpiprocs=8:ompthreads=1:ncpus=8:mem=100GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_gridded.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_prdgen_gridded.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:00:00
-#PBS -l select=1:ncpus=1:mem=1GB
+#PBS -l select=1:ncpus=1:mem=20GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 

--- a/modulefiles/module_base.wcoss2.lua
+++ b/modulefiles/module_base.wcoss2.lua
@@ -11,6 +11,8 @@ load(pathJoin("esmf", os.getenv("esmf_ver")))
 load(pathJoin("cfp", os.getenv("cfp_ver")))
 setenv("USE_CFP","YES")
 
+load(pathJoin("cmdaccel", os.getenv("cmdaccel_ver")))
+
 load(pathJoin("python", os.getenv("python_ver")))
 load(pathJoin("prod_envir", os.getenv("prod_envir_ver")))
 load(pathJoin("gempak", os.getenv("gempak_ver")))

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -454,7 +454,7 @@ elif [ $step = "gempak" ]; then
     export npe_node_gempak_gfs=28
     export nth_gempak=1
     export memory_gempak="4GB"
-    export memory_gempak_gfs="100GB"
+    export memory_gempak_gfs="150GB"
 
 else
 

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -350,7 +350,7 @@ elif [ $step = "ediag" ]; then
 
 elif [ $step = "eupd" ]; then
 
-    export wtime_eupd="00:35:00"
+    export wtime_eupd="00:40:00"
     if [ $CASE = "C768" ]; then
       export npe_eupd=480
       export nth_eupd=6

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -77,7 +77,7 @@ elif [ $step = "wavepostsbs" ]; then
     export nth_wavepostsbs=1
     export npe_node_wavepostsbs=$npe_wavepostsbs
     export memory_wavepostsbs="10GB"
-    export memory_wavepostsbs_gfs="10GB"
+    export memory_wavepostsbs_gfs="100GB"
     export NTASKS=$npe_wavepostsbs
 
 elif [ $step = "wavepostbndpnt" ]; then
@@ -111,7 +111,7 @@ elif [ $step = "wavegempak" ]; then
     export nth_wavegempak=1
     export npe_node_wavegempak=$npe_wavegempak
     export NTASKS=$npe_wavegempak
-    export memory_wavegempak="1GB"
+    export memory_wavegempak="100GB"
 
 elif [ $step = "waveawipsbulls" ]; then
 
@@ -128,7 +128,7 @@ elif [ $step = "waveawipsgridded" ]; then
     export nth_waveawipsgridded=1
     export npe_node_waveawipsgridded=$(echo "$npe_node_max / $nth_waveawipsgridded" | bc)
     export NTASKS=$npe_waveawipsgridded
-    export memory_waveawipsgridded_gfs="1GB"
+    export memory_waveawipsgridded_gfs="20GB"
 
 elif [ $step = "anal" ]; then
 
@@ -265,7 +265,7 @@ elif [ $step = "wafsgrib20p25" ]; then
 
 elif [ $step = "wafsblending0p25" ]; then
 
-    export wtime_wafsblending0p25="00:30:00"
+    export wtime_wafsblending0p25="00:40:00"
     export npe_wafsblending0p25=1
     export npe_node_wafsblending0p25=$npe_wafsblending0p25
     export nth_wafsblending0p25=1
@@ -399,7 +399,7 @@ elif [ $step = "esfc" ]; then
     export nth_esfc=1
     export nth_cycle=$nth_esfc
     export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
-    export memory_esfc="60GB"
+    export memory_esfc="500GB"
 
 elif [ $step = "efcs" ]; then
 
@@ -438,7 +438,7 @@ elif [ $step = "awips" ]; then
     export npe_awips=1
     export npe_node_awips=1
     export nth_awips=1
-    export memory_awips="3GB"
+    export memory_awips="100GB"
     if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
         export npe_awips=2
         export npe_node_awips=2
@@ -454,7 +454,7 @@ elif [ $step = "gempak" ]; then
     export npe_node_gempak_gfs=28
     export nth_gempak=1
     export memory_gempak="4GB"
-    export memory_gempak_gfs="2GB"
+    export memory_gempak_gfs="100GB"
 
 else
 

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -286,7 +286,7 @@ elif [ $step = "ediag" ]; then
 
 elif [ $step = "eupd" ]; then
 
-    export wtime_eupd="00:35:00"
+    export wtime_eupd="00:40:00"
     export npe_eupd=315
     export nth_eupd=14
     export npe_node_eupd=$(echo "$npe_node_max / $nth_eupd" | bc)

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -350,7 +350,7 @@ elif [ $step = "gempak" ]; then
     export npe_node_gempak_gfs=28
     export nth_gempak=1
     export memory_gempak="4GB"
-    export memory_gempak_gfs="100GB"
+    export memory_gempak_gfs="150GB"
 
 else
 

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -61,7 +61,7 @@ elif [ $step = "wavepostsbs" ]; then
     export nth_wavepostsbs=1
     export npe_node_wavepostsbs=$npe_wavepostsbs
     export memory_wavepostsbs="10GB"
-    export memory_wavepostsbs_gfs="10GB"
+    export memory_wavepostsbs_gfs="100GB"
     export NTASKS=$npe_wavepostsbs
 
 elif [ $step = "wavepostbndpnt" ]; then
@@ -95,7 +95,7 @@ elif [ $step = "wavegempak" ]; then
     export nth_wavegempak=1
     export npe_node_wavegempak=$npe_wavegempak
     export NTASKS=$npe_wavegempak
-    export memory_wavegempak="1GB"
+    export memory_wavegempak="100GB"
 
 elif [ $step = "waveawipsbulls" ]; then
 
@@ -112,7 +112,7 @@ elif [ $step = "waveawipsgridded" ]; then
     export nth_waveawipsgridded=1
     export npe_node_waveawipsgridded=$(echo "$npe_node_max / $nth_waveawipsgridded" | bc)
     export NTASKS=$npe_waveawipsgridded
-    export memory_waveawipsgridded_gfs="1GB"
+    export memory_waveawipsgridded_gfs="20GB"
 
 elif [ $step = "anal" ]; then
 
@@ -225,7 +225,7 @@ elif [ $step = "wafsgrib20p25" ]; then
 
 elif [ $step = "wafsblending0p25" ]; then
 
-    export wtime_wafsblending0p25="00:30:00"
+    export wtime_wafsblending0p25="00:40:00"
     export npe_wafsblending0p25=1
     export npe_node_wafsblending0p25=$npe_wafsblending0p25
     export nth_wafsblending0p25=1
@@ -308,7 +308,7 @@ elif [ $step = "esfc" ]; then
     export nth_esfc=1
     export nth_cycle=$nth_esfc
     export npe_node_cycle=$(echo "$npe_node_max / $nth_cycle" | bc)
-    export memory_esfc="60GB"
+    export memory_esfc="500GB"
 
 elif [ $step = "efcs" ]; then
 
@@ -339,7 +339,7 @@ elif [ $step = "awips" ]; then
     export npe_awips=1
     export npe_node_awips=1
     export nth_awips=1
-    export memory_awips="3GB"
+    export memory_awips="100GB"
 
 elif [ $step = "gempak" ]; then
 
@@ -350,7 +350,7 @@ elif [ $step = "gempak" ]; then
     export npe_node_gempak_gfs=28
     export nth_gempak=1
     export memory_gempak="4GB"
-    export memory_gempak_gfs="2GB"
+    export memory_gempak_gfs="100GB"
 
 else
 

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -35,7 +35,7 @@ fi
 echo gsi checkout ...
 if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
-    git clone --recursive --branch gfsda.v16.3.19 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
+    git clone --recursive --branch gfsda.v16.3.20 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
     git submodule update --init
     cd ${topdir}

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.19
-export gfs_ver=v16.3.19
+export version=v16.3.20
+export gfs_ver=v16.3.20
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2
@@ -47,5 +47,7 @@ export g2_ver=3.4.5
 export zlib_ver=1.2.11
 export sp_ver=2.3.3
 export ip_ver=3.3.3
+
+export cmdaccel_ver=1.1
 
 export NET=gfs


### PR DESCRIPTION
# Description

The `obsproc/v1.3` upgrade is delayed, therefore, the `GFSv16.3.20` will now update the following:

- install 2025 carbon dioxide (CO2) fix file updates before the start of the new year
- updated GSI global_convinfo.txt to turn on assimilation of PlanetiQ GPS Radio Occultation (GPS-RO) data
- memory increases for a number of jobs (provided by NCO)
- load the cmdaccel module at the start of wave point postprocessor jobs to stabilize runtime (provided by NCO)

FYI @DianeStokes-NCO 

Refs #2558

# Type of change

Production update

# How has this been tested?

NCO para testing