### PR TITLE
Update HPC_ACCOUNT on Hercules to fv3-cpu

### DIFF
--- a/ci/platforms/config.gaea
+++ b/ci/platforms/config.gaea
@@ -3,6 +3,6 @@
 export GFS_CI_ROOT=/gpfs/f5/epic/proj-shared/global/GFS_CI_ROOT
 export ICSDIR_ROOT=/gpfs/f5/epic/proj-shared/global/glopara/data/ICSDIR
 export STMP="/gpfs/f5/epic/scratch/${USER}"
-export SLURM_ACCOUNT=ufs-ard
+export HPC_ACCOUNT=ufs-ard
 export max_concurrent_cases=5
 export max_concurrent_pr=4

--- a/ci/platforms/config.hercules
+++ b/ci/platforms/config.hercules
@@ -2,7 +2,7 @@
 
 export GFS_CI_ROOT=/work2/noaa/stmp/GFS_CI_ROOT/HERCULES
 export ICSDIR_ROOT=/work/noaa/global/glopara/data/ICSDIR
-export HPC_ACCOUNT=nems
+export HPC_ACCOUNT=fv3-cpu
 export max_concurrent_cases=5
 export max_concurrent_pr=4
 


### PR DESCRIPTION
# Description

Hotfix to update CI allocation to run on **fv3-cpu** for Hercules
Also updated variable name to HPC_ACCOUNT for Gaea as it was set to SLURM_ACCOUNT

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

