### PR TITLE
Remake the GFS package for obsproc and AFWA upgrade

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.3.20
+tag = gfsda.v16.3.22
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git
@@ -29,7 +29,7 @@ protocol = git
 required = True
 
 [UFS_UTILS]
-tag = ops-gfsv16.3.0
+tag = ops-gfsv16.3.20
 local_path = sorc/ufs_utils.fd
 repo_url = https://github.com/ufs-community/UFS_UTILS.git
 protocol = git

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -1,10 +1,12 @@
-GFS V16.3.21 RELEASE NOTES
+GFS V16.3.22 RELEASE NOTES
 
 -------
 PRELUDE
 -------
 
-The WAFS is separated from the GFS and is now its own package in production as WAFS.v7.0.1.
+The upstream OBSPROC package is updated to v1.3. Along with this are the following companion updates:
+* workflow and UFS_UTILS package updates to use the new AFWA global snow file due to the hemispheric snow files being phased out
+* updated GSI code and convinfo file for saildrone observations
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -13,9 +15,9 @@ The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub are used t
 
 ```bash
 cd $PACKAGEROOT
-mkdir gfs.v16.3.21
-cd gfs.v16.3.21
-git clone -b EMC-v16.3.21 https://github.com/NOAA-EMC/global-workflow.git .
+mkdir gfs.v16.3.22
+cd gfs.v16.3.22
+git clone -b EMC-v16.3.22 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```
@@ -26,8 +28,8 @@ The checkout script extracts the following GFS components:
 | --------- | ----------- | ----------------- |
 | MODEL     | GFS.v16.3.1   | Jun.Wang@noaa.gov |
 | GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
-| GSI       | gfsda.v16.3.20 | Andrew.Collard@noaa.gov |
-| UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
+| GSI       | gfsda.v16.3.22 | Andrew.Collard@noaa.gov |
+| UFS_UTILS | ops-gfsv16.3.20 | George.Gayno@noaa.gov |
 | POST      | upp_v8.3.0 | Wen.Meng@noaa.gov |
 
 To build all the GFS components, execute:
@@ -49,144 +51,84 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* `versions/run.ver` - change `version=v16.3.21` and `gfs_ver=v16.3.21`
+* `versions/run.ver` - change `version=v16.3.22`, `gfs_ver=v16.3.22`, and `obsproc_ver=v1.3`
 
 SORC CHANGES
 ------------
 
-The WAFS is no longer a submodule that is checked out within the GFS package.
-The `sorc/checkout.sh` and `Externals.cfg` checkout script no longer clone WAFS.
-The `sorc/build_all.sh` script no longer builds the WAFS code.
-The `sorc/build_gfs_wafs.sh` build script is deleted.
-The `sorc/link_fv3gfs.sh` script no longer links/copies WAFS files/execs.
+* New UFS_UTILS tag - `emcsfc_snow2mdl` program and associated scripts are updated to process global AFWA snow data
+* New GSI tag - `src/gsi/read_prepbufr.f90` code update for new saildrone subtype
 
 JOBS CHANGES
 ------------
 
-All WAFS jobs are removed from the GFS ecFlow definition file, rocoto mesh, and `ush/ecflow/prod.yml`.
-Jobs removed:
-* `jgfs_atmos_wafs_gcip`
-* `jgfs_atmos_wafs_fFFF`
-* `jgfs_atmos_wafs_grib2`
-* `jgfs_atmos_wafs_grib2_0p25`
-* `jgfs_atmos_wafs_blending_0p25`
+* `jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP` - new AFWA filename
 
 PARM/CONFIG CHANGES
 -------------------
 
-The following config files are deleted:
-* `parm/config/config.wafs`
-* `parm/config/config.wafsblending`
-* `parm/config/config.wafsblending0p25`
-* `parm/config/config.wafsgcip`
-* `parm/config/config.wafsgrib2`
-* `parm/config/config.wafsgrib20p25`
-
-* The `WAFSF` flag is removed from `parm/config/config.base.emc.dyn` and `parm/config/config.base.nco.static`.
-* All WAFS jobs are removed from platform env files, `parm/config/config.resources.emc.dyn`, and `parm/config/config.resources.nco.static`.
-* The WAFS jobs are removed from experiment setup.
-
-WAFS output is removed from the following transfer list files:
-* `parm/product/transfer_gfs_1.list`
-* `parm/product/transfer_gfs_7.list`
+* No changes from GFS v16.3.21
 
 SCRIPT CHANGES
 --------------
 
-The following WAFS rocoto scripts are removed:
-* `jobs/rocoto/wafs.sh`
-* `jobs/rocoto/wafsblending.sh`
-* `jobs/rocoto/wafsblending0p25.sh`
-* `jobs/rocoto/wafsgcip.sh`
-* `jobs/rocoto/wafsgrib2.sh`
-* `jobs/rocoto/wafsgrib20p25.sh`
-
-The following ecf scripts are removed from the GFS:
-* `ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending.ecf`
-* `ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf`
-* `ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2.ecf`
-* `ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2_0p25.ecf`
-* `ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_master.ecf`
-* `ecf/scripts/gfs/atmos/post_processing/jgfs_atmos_wafs_gcip.ecf`
-
-The WAFS is removed from `ecf/setup_ecf_links.sh`.
-
-The WAFS output is removed from archival (`ush/hpssarch_gen.sh`).
+* No changes from GFS v16.3.21
 
 FIX CHANGES
 -----------
 
-* `fix/product/wafs_admin_msg` - removed
+* GSI `global_convinfo.txt` fix update for saildrone
 
 MODULE CHANGES
 --------------
 
-Modules needed by WAFS are removed from `modulefiles/module_base.wcoss_dell_p3`.
+* No changes from GFS v16.3.21
 
 CHANGES TO FILE AND FILE SIZES
 ------------------------------
 
-The following files will no longer be produced within the GFS COM:
-* `gfs.tCCz.awf_0p25.fFFF.grib2`  - renamed to `wafs.tCCz.awf.0p25.fFFF.grib2` in WAFSv7. Filesize is changed from 55M to 56M with 7 extra levels of aviation fields.
-* `gfs.tCCz.awf_grb45fFF.grib2` - renamed to `wafs.tCCz.awf_grid45.fFFF.grib2` in WAFSv7
-* `wmo/grib2.tCCz.awf_grbfFF.45` - renamed to `wmo/grib2.wafs.tCCz.awf_grid45.fFFF` in WAFSv7
-* `gfs.tCCz.wafs.0p25.anl` - renamed to `wafs.tCCz.0p25.anl.grib2` in WAFSv7
-* `gfs.tCCz.wafs.0p25.anl.idx`
-* `gfs.tCCz.wafs_0p25_unblended.fFFF.grib2` - renamed to `WAFS_0p25_unblended_YYYYMMDDHHfFFF.grib2` in WAFSv7
-* `gfs.tCCz.wafs_0p25_unblended.fFFF.grib2.idx`
-* `gfs.tCCz.wafs.grb2fFFF` - renamed to `wafs.tCCz.master.fFFF.grib2` in WAFSv7. Between forecast hours [006-048], filesize is changed from 929M to 936M with 7 extra levels of aviation fields; for f000, filesize increases from 949M to 956M with 7 extra levels of aviation fields. No size change for other forecast hours
-* `gfs.tCCz.wafs.grb2fFFF.idx`
-* `gfs.tCCz.wafs_grb45fFF.grib2` - renamed to `gfs.tCCz.wafs_grb45fFFF.grib2` in WAFSv7
-* `gfs.tCCz.wafs_grb45fFF.grib2.idx`
-* `wmo/grib2.tCCz.wafs_grbfFF.45` - renamed to `wmo/grib2.wafs.tCCz.awf_grid45.fFFF` in WAFSv7
-* `wmo/xtrn.wfsgfsCCFF[a/b].gfs_atmos_wafs_fFF_CC` - renamed to `wmo/xtrn.wfsgfsCCFF[a/b]` in WAFSv7
-* `gfs.tCCz.gcip.f00.grib2` - renamed to `wafs.tCCz.gcip.f000.grib2` in WAFSv7
-* `WAFS_0p25_blended_YYYYMMDDHHf[06-48].grib2` - renamed to `WAFS_0p25_blended_ YYYYMMDDHHfFFF.grib2` in WAFSv7
+No longer ingest:
+* `${RUN}.${cycle}.NPR.SNWN.SP.S1200.MESH16.grb` (`AFWA_NH_FILE`)
+* `${RUN}.${cycle}.NPR.SNWS.SP.S1200.MESH16.grb` (`AFWA_SH_FILE`)
 
-The following files will no longer be produced within the GFS COM
-and are being retired from the WAFS package, which will free 20G:
-* `gfs.tCCz.wafs_icao.grb2fFFF`
-* `gfs.tCCz.wafs_icao.grb2fFFF.idx`
-* `wafs.tCCz.master.fFFF.grib2` where FFF is from 001 to 005
-* `gfs.tCCz.control.wafsblending_0p25`
+Now ingest:
+* `${RUN}.${cycle}.snow.usaf.grib2` (`AFWA_GLOBAL_FILE`)
 
 ENVIRONMENT AND RESOURCE CHANGES
 --------------------------------
 
-* Updates to improve the enkfgdas_update job runtime stability.
-  * Run with `--cpu-bind core` instead of `--cpu-bind depth`
-  * Change tasks to 280 and threads to 16
+* No changes from GFS v16.3.21
 
 PRE-IMPLEMENTATION TESTING REQUIREMENTS
 ---------------------------------------
 
 * Which production jobs should be tested as part of this implementation?
-  * None
+  * emcsfc_sfc_prep and analysis
 * Does this change require a 30-day evaluation?
   * No
 
 DISSEMINATION INFORMATION
 -------------------------
 
-* No changes from GFS v16.3.20
+* No changes from GFS v16.3.21
 
 HPSS ARCHIVE
 ------------
 
-* No changes from GFS v16.3.20
+* No changes from GFS v16.3.21
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
 
-* Removal of WAFS jobs.
+* No changes from GFS v16.3.21
 
 DOCUMENTATION
 -------------
 
-* No changes from GFS v16.3.20
+* No changes from GFS v16.3.21
 
 PREPARED BY
 -----------
 Kate.Friedman@noaa.gov
-Yali.Mao@noaa.gov
-Rahul.Mahajan@noaa.gov
+George.Gayno@noaa.gov
+Andrew.Collard@noaa.gov

--- a/jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP
+++ b/jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP
@@ -8,7 +8,7 @@ date
 #############################
 # Source relevant config files
 #############################
-configs="base"
+configs="base sfcprep"
 export EXPDIR=${EXPDIR:-$HOMEgfs/parm/config}
 config_path=${EXPDIR:-$NWROOT/gfs.${gfs_ver}/parm/config}
 for config in $configs; do
@@ -16,6 +16,13 @@ for config in $configs; do
     status=$?
     [[ $status -ne 0 ]] && exit $status
 done
+
+##########################################
+# Source machine runtime environment
+##########################################
+. $HOMEgfs/env/${machine}.env sfcprep
+status=$?
+[[ $status -ne 0 ]] && exit $status
 
 
 ##############################################
@@ -64,8 +71,7 @@ export COMIN_m6hrs=${COMIN_m6hrs:-$(compath.py ${envir}/${NET}/${gfs_ver})/${RUN
 
 export IMS_FILE=${COMINobsproc}/${RUN}.${cycle}.imssnow96.grib2
 export FIVE_MIN_ICE_FILE=${COMINobsproc}/${RUN}.${cycle}.seaice.5min.grib2
-export AFWA_NH_FILE=${COMINobsproc}/${RUN}.${cycle}.NPR.SNWN.SP.S1200.MESH16.grb
-export AFWA_SH_FILE=${COMINobsproc}/${RUN}.${cycle}.NPR.SNWS.SP.S1200.MESH16.grb
+export AFWA_GLOBAL_FILE=${COMINobsproc}/${RUN}.${cycle}.snow.usaf.grib2
 
 export BLENDED_ICE_FILE=${BLENDED_ICE_FILE:-${RUN}.${cycle}.seaice.5min.blend.grb}
 export BLENDED_ICE_FILE_m6hrs=${BLENDED_ICE_FILE_m6hrs:-${COMIN_m6hrs}/${RUN}.${cycle_m6hrs}.seaice.5min.blend.grb}

--- a/jobs/rocoto/sfcprep.sh
+++ b/jobs/rocoto/sfcprep.sh
@@ -1,0 +1,13 @@
+#!/bin/ksh -x
+
+###############################################################
+# Source FV3GFS workflow modules
+. $HOMEgfs/ush/load_fv3gfs_modules.sh
+status=$?
+[[ $status -ne 0 ]] && exit $status
+
+###############################################################
+# Execute the JJOB
+$HOMEgfs/jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP
+status=$?
+exit $status

--- a/parm/config/config.base.emc.dyn
+++ b/parm/config/config.base.emc.dyn
@@ -47,6 +47,9 @@ export NOSCRUB="@NOSCRUB@"
 # Base directories for various builds
 export BASE_GIT="@BASE_GIT@"
 
+# Toggle to turn on/off EMCSFC_SFC_PREP job
+export DO_SFCPREP="NO"    # SNOGRB dump file production
+
 # Toggle to turn on/off GFS downstream processing.
 export DO_BUFRSND="YES"    # BUFR sounding products
 export DO_GEMPAK="NO"      # GEMPAK products

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -8,7 +8,7 @@ if [ $# -ne 1 ]; then
 
     echo "Must specify an input task argument to set resource variables!"
     echo "argument can be any one of the following:"
-    echo "anal analcalc analdiag gldas fcst post vrfy metp arch echgres"
+    echo "sfcprep prep anal analcalc analdiag gldas fcst post vrfy metp arch echgres"
     echo "eobs ediag eomg eupd ecen esfc efcs epos earc"
     echo "waveinit waveprep wavepostsbs wavepostbndpnt wavepostbndpntbll wavepostpnt"
     echo "wavegempak waveawipsbulls waveawipsgridded"
@@ -36,7 +36,16 @@ elif [[ "$machine" = "ORION" ]]; then
    export npe_node_max=40
 fi
 
-if [ $step = "prep" -o $step = "prepbufr" ]; then
+if [ $step = "sfcprep" ]; then
+
+    export wtime_sfcprep="00:08:00"
+    export npe_sfcprep=1
+    export nth_sfcprep=1
+    export npe_node_sfcprep=1
+    export NTASKS=$npe_sfcprep
+    export memory_sfcprep="10GB"
+
+elif [ $step = "prep" -o $step = "prepbufr" ]; then
 
     eval "export wtime_$step='00:45:00'"
     eval "export npe_$step=4"

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -8,7 +8,7 @@ if [ $# -ne 1 ]; then
 
     echo "Must specify an input task argument to set resource variables!"
     echo "argument can be any one of the following:"
-    echo "anal analcalc analdiag gldas fcst post vrfy metp arch echgres"
+    echo "sfcprep prep anal analcalc analdiag gldas fcst post vrfy metp arch echgres"
     echo "eobs ediag eomg eupd ecen esfc efcs epos earc"
     echo "waveinit waveprep wavepostsbs wavepostbndpnt wavepostbndpntbll wavepostpnt"
     echo "wavegempak waveawipsbulls waveawipsgridded"
@@ -23,7 +23,16 @@ echo "BEGIN: config.resources"
 
 export npe_node_max=128
 
-if [ $step = "prep" -o $step = "prepbufr" ]; then
+if [ $step = "sfcprep" ]; then
+
+    export wtime_sfcprep="00:08:00"
+    export npe_sfcprep=1
+    export nth_sfcprep=1
+    export npe_node_sfcprep=1
+    export NTASKS=$npe_sfcprep
+    export memory_sfcprep="10GB"
+
+elif [ $step = "prep" -o $step = "prepbufr" ]; then
 
     eval "export wtime_$step='00:45:00'"
     eval "export npe_$step=4"

--- a/parm/config/config.sfcprep
+++ b/parm/config/config.sfcprep
@@ -1,0 +1,20 @@
+#!/bin/ksh -x
+
+########## config.sfcprep ##########
+# Prep step specific
+
+echo "BEGIN: config.sfcprep"
+
+# Get task specific resources
+. $EXPDIR/config.resources sfcprep
+
+if [[ $RUN_ENVIR == "emc" ]]; then
+
+  export SENDCOM="YES"
+  export COMOUT=${COMOUTatmos}
+  export COMINobsproc=${DMPDIR}/${CDUMP}.${PDY}/${cyc}/atmos
+  export COMIN_m6hrs=${DMPDIR}/${GDUMP}.${gPDY}/${gcyc}/atmos
+
+fi
+
+echo "END: config.sfcprep"

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -32,7 +32,7 @@ fi
 echo gsi checkout ...
 if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
-    git clone --recursive --branch gfsda.v16.3.20 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
+    git clone --recursive --branch gfsda.v16.3.22 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
     git submodule update --init
     cd ${topdir}
@@ -52,7 +52,7 @@ fi
 echo ufs_utils checkout ...
 if [[ ! -d ufs_utils.fd ]] ; then
     rm -f ${topdir}/checkout-ufs_utils.log
-    git clone --branch ops-gfsv16.3.0 https://github.com/ufs-community/UFS_UTILS ufs_utils.fd >> ${topdir}/checkout-ufs_utils.fd.log 2>&1
+    git clone --branch ops-gfsv16.3.20 https://github.com/ufs-community/UFS_UTILS ufs_utils.fd >> ${topdir}/checkout-ufs_utils.fd.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory ufs_utils.fd already exists.'

--- a/versions/hera.ver
+++ b/versions/hera.ver
@@ -2,8 +2,8 @@ export hpc_ver=1.2.0
 export hpc_intel_ver=18.0.5.274
 export hpc_impi_ver=2018.0.4
 
-export obsproc_run_ver=1.2.0
-export prepobs_run_ver=1.1.0
+export obsproc_run_ver=1.3.0
+export prepobs_run_ver=1.2.0
 
 export hpss_ver=hpss
 export prod_util_ver=1.2.2

--- a/versions/orion.ver
+++ b/versions/orion.ver
@@ -2,8 +2,8 @@ export hpc_ver=1.2.0
 export hpc_intel_ver=2018.4
 export hpc_impi_ver=2018.4
 
-export obsproc_run_ver=1.2.0
-export prepobs_run_ver=1.1.0
+export obsproc_run_ver=1.3.0
+export prepobs_run_ver=1.2.0
 
 export prod_util_ver=1.2.2
 export cmake_ver=3.22.1

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,11 +1,11 @@
-export version=v16.3.21
-export gfs_ver=v16.3.21
+export version=v16.3.22
+export gfs_ver=v16.3.22
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2
 export rtofs_ver=v2.4
 export radarl2_ver=v1.2
-export obsproc_ver=v1.2
+export obsproc_ver=v1.3
 
 export PrgEnv_intel_ver=8.1.0
 export intel_ver=19.1.3.304

--- a/versions/wcoss2.ver
+++ b/versions/wcoss2.ver
@@ -2,8 +2,8 @@ export envvar_ver=1.0
 export prod_envir_ver=${prod_envir_ver:-2.0.4} # Allow override from ops ecflow
 export prod_util_ver=${prod_util_ver:-2.0.9}   # Allow override from ops ecflow
 
-export obsproc_run_ver=1.2.0
-export prepobs_run_ver=1.1.0
+export obsproc_run_ver=1.3.0
+export prepobs_run_ver=1.2.0
 
 export tracker_ver=v1.1.15.5
 export fit_ver="newm.1.5"


### PR DESCRIPTION
# Description

The order of the upgrade to obsproc/v1.3 and the new AFWA global file was moved back and thus the release branch needed to be remade. This PR includes all updates for the GFS upgrade to obsproc/v1.3 and the new global AFWA data file:

- new UFS_UTILS tag (`ops-gfsv16.3.20`) to support new global AFWA file
- new GSI tag (`gfsda.v16.3.22`) to support obsproc/v1.3 and saildrone
- workflow changes to support obsproc/v1.3 (and prepobs/v1.2 internal to obsproc) and AFWA global file
- also workflow changes to allow developers to run the emcsfc_sfc_prep job within the rocoto mesh via `DO_SFCPREP=YES` in config.base

This PR is a repeat of prior ones to get this package in place.

Refs #2913