### PR TITLE
Update compression options for GEFS history files

### DIFF
--- a/parm/config/gefs/config.ufs
+++ b/parm/config/gefs/config.ufs
@@ -268,7 +268,7 @@ case ${fv3_res} in
   "C384" | "C768" | "C1152" | "C3072")
     zstandard_level=0
     ideflate=1
-    quantize_nsd=5
+    quantize_nsd=14
     OUTPUT_FILETYPE_ATM="netcdf_parallel"
     if [[ "${fv3_res}" == "C384" ]]; then
       OUTPUT_FILETYPE_SFC="netcdf"  # For C384, the write grid component is better off with serial netcdf


### PR DESCRIPTION
# Description
Different compression options are applied for the high resolution history files. The value of quantize_nsd will be different depending on the value of quantize_mode, so a fix is required to obtain the same behavior as the previous compression options. This option needs to be updated for both GFS and GEFS.

Resolves: #3178

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
The change of `quantize_nsd` from 5 to 14 was tested for the GFS at C384.  See #3129 for details.  This change was NOT tested in the GEFS.

# Checklist
- [ ] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
