### PR TITLE
Remove early-cycle EnKF forecast

### DIFF
--- a/parm/archive/enkf.yaml.j2
+++ b/parm/archive/enkf.yaml.j2
@@ -3,6 +3,7 @@ enkf:
     target: "{{ ATARDIR }}/{{ cycle_YMDH }}/{{ RUN }}.tar"
     required:
         # Logs
+        {% if RUN == 'enkfgdas' %}
         {% for mem in range(1, nmem_ens + 1) %}
         - "logs/{{ cycle_YMDH }}/{{ RUN }}_fcst_mem{{ '%03d' % mem }}.log"
         {% endfor %}
@@ -10,6 +11,7 @@ enkf:
         - "logs/{{ cycle_YMDH }}/{{ RUN }}_epos{{ '%03d' % (fhr - fhmin) }}.log"
         {% endfor %}
         - "logs/{{ cycle_YMDH }}/{{ RUN }}_echgres.log"
+        {% endif %}
         - "logs/{{ cycle_YMDH }}/{{ RUN }}_esfc.log"
         {% for grp in range(IAUFHRS | length) %}
         - "logs/{{ cycle_YMDH }}/{{ RUN }}_ecen{{ '%03d' % grp }}.log"
@@ -37,6 +39,7 @@ enkf:
         {% endfor %}
 
         # Ensemble mean and spread
+        {% if RUN == 'enkfgdas' %}
         {% for fhr in range(3, fhmax + 1, 3) %}
         - "{{ COMIN_ATMOS_HISTORY_ENSSTAT | relpath(ROTDIR) }}/{{ head }}atmf{{ '%03d' % fhr }}.ensmean.nc"
         - "{{ COMIN_ATMOS_HISTORY_ENSSTAT | relpath(ROTDIR) }}/{{ head }}sfcf{{ '%03d' % fhr }}.ensmean.nc"
@@ -44,6 +47,7 @@ enkf:
         - "{{ COMIN_ATMOS_HISTORY_ENSSTAT | relpath(ROTDIR) }}/{{ head }}atmf{{ '%03d' % fhr }}.ensspread.nc"
         {% endif %}
         {% endfor %}
+        {% endif %}
 
         # Ensemble mean state
         {% if not DO_JEDIATMENS %}

--- a/parm/archive/enkf_grp.yaml.j2
+++ b/parm/archive/enkf_grp.yaml.j2
@@ -17,7 +17,7 @@ enkf_grp:
 
         # Only store the 6-hour surface forecast
         - "{{ COMIN_ATMOS_HISTORY_MEM | relpath(ROTDIR) }}/{{ head }}sfcf006.nc"
-        {% end if %}
+        {% endif %}
 
         # Store the individual member analysis data
         {% if not lobsdiag_forenkf %}

--- a/parm/archive/enkf_grp.yaml.j2
+++ b/parm/archive/enkf_grp.yaml.j2
@@ -10,12 +10,14 @@ enkf_grp:
         {% set COMIN_ATMOS_RESTART_MEM = COMIN_ATMOS_RESTART_MEM_list[imem] %}
 
         # Forecast data
+        {% if RUN == 'enkfgdas' %}
         {% for fhr in range(3, 10, 3) %}
         - "{{ COMIN_ATMOS_HISTORY_MEM | relpath(ROTDIR) }}/{{ head }}atmf{{ "%03d" % fhr }}.nc"
         {% endfor %}
 
         # Only store the 6-hour surface forecast
         - "{{ COMIN_ATMOS_HISTORY_MEM | relpath(ROTDIR) }}/{{ head }}sfcf006.nc"
+        {% end if %}
 
         # Store the individual member analysis data
         {% if not lobsdiag_forenkf %}

--- a/parm/archive/enkf_restartb_grp.yaml.j2
+++ b/parm/archive/enkf_restartb_grp.yaml.j2
@@ -22,6 +22,7 @@ enkf_restartb_grp:
         {% endfor %}
 
         # Now get the restart files.
+        {% if RUN == 'enkfgdas' %}
         {% for r_time in range(restart_interval, fhmax + 1, restart_interval) %}
         {% set r_timedelta = (r_time | string + "H") | to_timedelta %}
         {% set r_dt = current_cycle | add_to_datetime(r_timedelta) %}
@@ -38,3 +39,4 @@ enkf_restartb_grp:
         - "{{ COMIN_ATMOS_RESTART_MEM | relpath(ROTDIR) }}/{{ r_prefix }}.fv_core.res.nc"
         {% endfor %}
         {% endfor %}
+        {% endif %}

--- a/scripts/exgdas_enkf_earc.py
+++ b/scripts/exgdas_enkf_earc.py
@@ -28,7 +28,7 @@ def main():
             'DOHYBVAR', 'DOIAU_ENKF', 'IAU_OFFSET', 'DOIAU', 'DO_CA',
             'DO_CALC_INCREMENT', 'assim_freq', 'ARCH_CYC', 'DO_JEDISNOWDA',
             'ARCH_WARMICFREQ', 'ARCH_FCSTICFREQ',
-            'IAUFHRS_ENKF', 'NET']
+            'IAUFHRS_ENKF', 'NET', 'NMEM_ENS_GFS']
 
     archive_dict = AttrDict()
     for key in keys:

--- a/workflow/applications/gfs_cycled.py
+++ b/workflow/applications/gfs_cycled.py
@@ -317,7 +317,9 @@ class GFSCycledAppConfig(AppConfig):
                     task_names[run].append('echgres') if 'gdas' in run else 0
                     task_names[run] += ['ediag'] if options['lobsdiag_forenkf'] else ['eomg']
                     task_names[run].append('esnowanl') if options['do_jedisnowda'] and 'gdas' in run else 0
+                    task_names[run].append('efcs') if 'gdas' in run else 0
+                    task_names[run].append('epos') if 'gdas' in run else 0
 
-                task_names[run] += ['stage_ic', 'ecen', 'esfc', 'efcs', 'epos', 'earc', 'cleanup']
+                task_names[run] += ['stage_ic', 'ecen', 'esfc', 'earc', 'cleanup']
 
         return task_names

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -2896,7 +2896,10 @@ class GFSTasks(Tasks):
     def earc(self):
 
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}_epmn'}
+        if 'enkfgdas' in self.run:
+            dep_dict = {'type': 'metatask', 'name': f'{self.run}_epmn'}
+        else:
+            dep_dict = {'type': 'task', 'name': f'{self.run}_esfc'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 


### PR DESCRIPTION

# Description
Currently GFS experiments with the early-cycle EnKF call identical jobs to the late-cycle. However, since the forecast portion of the early-cycle is handled through the GEFS workflow, the forecast and post jobs are not needed in the GFS early-cycle EnKF. This PR removes calling the early-cycle EnFK forecast and post jobs in GFS experiments, and adds statements to the archive yamls to only search for forecast files during the late-cyle EnKF. 

<!-- For more on writing good commit messages, see https://cbea.ms/git-commit/ -->

# Type of change
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
- Cycled test on Hera


# Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
