### PR TITLE
Ensure OCNRES and ICERES have 3 digits in the archive script

### DIFF
--- a/scripts/exglobal_archive.py
+++ b/scripts/exglobal_archive.py
@@ -37,9 +37,9 @@ def main():
 
     archive_dict = AttrDict()
     for key in keys:
+        if key in ['OCNRES', 'ICERES']:  # update this key to be 3 digits
+            archive.task_config[key] = f"{archive.task_config.get(key):03d}"
         archive_dict[key] = archive.task_config.get(key)
-        if key in ['OCNRES', 'ICERES']:
-            archive_dict[key] = f"{archive_dict.get(key):03d}"
         if archive_dict[key] is None:
             logger.warning(f"WARNING: key ({key}) not found in task_config!")
 

--- a/scripts/exglobal_archive.py
+++ b/scripts/exglobal_archive.py
@@ -38,15 +38,17 @@ def main():
     archive_dict = AttrDict()
     for key in keys:
         archive_dict[key] = archive.task_config.get(key)
+        if key in ['OCNRES', 'ICERES']:
+            archive_dict[key] = f"{archive_dict.get(key):03d}"
         if archive_dict[key] is None:
-            print(f"Warning: key ({key}) not found in task_config!")
+            logger.warning(f"WARNING: key ({key}) not found in task_config!")
 
     # Also import all COMIN* and COMOUT* directory and template variables
     for key in archive.task_config.keys():
         if key.startswith("COM_") or key.startswith("COMIN_") or key.startswith("COMOUT_"):
             archive_dict[key] = archive.task_config.get(key)
             if archive_dict[key] is None:
-                print(f"Warning: key ({key}) not found in task_config!")
+                logger.warning(f"WARNING: key ({key}) not found in task_config!")
 
     with chdir(config.ROTDIR):
 

--- a/scripts/exglobal_archive.py
+++ b/scripts/exglobal_archive.py
@@ -18,12 +18,11 @@ def main():
     archive = Archive(config)
 
     # update these keys to be 3 digits if they are part of archive.task_config.keys
-    if {'OCNRES', 'ICERES'} <= archive.task_config.keys():
-        for key in ['OCNRES', 'ICERES']:
-            try:
-                archive.task_config[key] = f"{archive.task_config[key]:03d}"
-            except KeyError as ee:
-                logger.info(f"key ({key}) not found in archive.task_config!")
+    for key in ['OCNRES', 'ICERES']:
+        try:
+            archive.task_config[key] = f"{archive.task_config[key]:03d}"
+        except KeyError as ee:
+            logger.info(f"key ({key}) not found in archive.task_config!")
 
     # Pull out all the configuration keys needed to run the rest of archive steps
     keys = ['ATARDIR', 'current_cycle', 'FHMIN', 'FHMAX', 'FHOUT', 'RUN', 'PDY',

--- a/scripts/exglobal_archive.py
+++ b/scripts/exglobal_archive.py
@@ -17,6 +17,14 @@ def main():
     # Instantiate the Archive object
     archive = Archive(config)
 
+    # update these keys to be 3 digits if they are part of archive.task_config.keys
+    if {'OCNRES', 'ICERES'} <= archive.task_config.keys():
+        for key in ['OCNRES', 'ICERES']:
+            try:
+                archive.task_config[key] = f"{archive.task_config[key]:03d}"
+            except KeyError as ee:
+                logger.info(f"key ({key}) not found in archive.task_config!")
+
     # Pull out all the configuration keys needed to run the rest of archive steps
     keys = ['ATARDIR', 'current_cycle', 'FHMIN', 'FHMAX', 'FHOUT', 'RUN', 'PDY',
             'DO_VERFRAD', 'DO_VMINMON', 'DO_VERFOZN', 'DO_ICE', 'DO_PREP_OBS_AERO',
@@ -37,18 +45,15 @@ def main():
 
     archive_dict = AttrDict()
     for key in keys:
-        if key in ['OCNRES', 'ICERES']:  # update this key to be 3 digits
-            archive.task_config[key] = f"{archive.task_config.get(key):03d}"
-        archive_dict[key] = archive.task_config.get(key)
-        if archive_dict[key] is None:
-            logger.warning(f"WARNING: key ({key}) not found in task_config!")
+        try:
+            archive_dict[key] = archive.task_config[key]
+        except KeyError as ee:
+            logger.warning(f"WARNING: key ({key}) not found in archive.task_config!")
 
     # Also import all COMIN* and COMOUT* directory and template variables
     for key in archive.task_config.keys():
-        if key.startswith("COM_") or key.startswith("COMIN_") or key.startswith("COMOUT_"):
+        if key.startswith(("COM_", "COMIN_", "COMOUT_")):
             archive_dict[key] = archive.task_config.get(key)
-            if archive_dict[key] is None:
-                logger.warning(f"WARNING: key ({key}) not found in task_config!")
 
     with chdir(config.ROTDIR):
 


### PR DESCRIPTION
# Description
This PR:
- ensures the `OCNRES` and `ICERES` variables in `task_config` are 3 digits

Resolves #3198 

# Type of change
- [X] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? YES/NO
- Does this change require a documentation update? YES/NO
- Does this change require an update to any of the following submodules? YES/NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
