### PR TITLE
Fix for syndat_getjtbul code parsing 3-character storm names (GFSv16.3.21)

### DIFF
--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -4,7 +4,7 @@ GFS V16.3.21 RELEASE NOTES
 PRELUDE
 -------
 
-The WAFS is separated from the GFS and is now its own package in production as WAFS.v7.0.1.
+The WAFS is separated from the GFS and is now its own package in production as WAFS.v7.0.1. A code update for syndat_getjtbul is also included.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -59,6 +59,9 @@ The `sorc/checkout.sh` and `Externals.cfg` checkout script no longer clone WAFS.
 The `sorc/build_all.sh` script no longer builds the WAFS code.
 The `sorc/build_gfs_wafs.sh` build script is deleted.
 The `sorc/link_fv3gfs.sh` script no longer links/copies WAFS files/execs.
+
+Also included in this package is a fix to the syndat_getjtbul code to resolve a
+parsing problem with 3-character storm names.
 
 JOBS CHANGES
 ------------
@@ -190,3 +193,4 @@ PREPARED BY
 Kate.Friedman@noaa.gov
 Yali.Mao@noaa.gov
 Rahul.Mahajan@noaa.gov
+Qingfu.Liu@noaa.gov

--- a/sorc/syndat_getjtbul.fd/getjtbul.f
+++ b/sorc/syndat_getjtbul.fd/getjtbul.f
@@ -104,13 +104,21 @@ c  Check TABs and replaced it with ' '  (added by Qingfu Liu)
            END IF
          END DO
 
-         IF(INL1(26).EQ.' '.or.INL1(27).EQ.' ') THEN
+         IF(INL1(25).EQ.' '.or.INL1(26).EQ.' '.or.INL1(27).EQ.' ') THEN
 
 c ... THIS RECORD STILL CONTAINS THE OLD 2-DIGIT FORM OF THE YEAR -
 c ... THIS PROGRAM WILL NOW CONVERT THE RECORD TO A 4-DIGIT YEAR USING
 c      THE "WINDOWING" TECHNIQUE SINCE SUBSEQUENT LOGIC EXPECTS THIS
 
-          IF(INL(18:19).EQ.'20') THEN
+          IF(INL(17:18).EQ.'20') THEN
+            DUMY2K(1:16) = INL(1:16)
+            DUMY2K(17:19) = '   '
+            DUMY2K(20:80) = INL(17:77)
+            INL= DUMY2K
+            PRINT *, ' '
+            PRINT *, '==> This is an new-format record with a 4-digit '
+            PRINT *, ' '
+          ELSE IF(INL(18:19).EQ.'20') THEN
             DUMY2K(1:17) = INL(1:17)
             DUMY2K(18:19) = '  '
             DUMY2K(20:80) = INL(18:78)

--- a/sorc/syndat_getjtbul.fd/getjtbul.f
+++ b/sorc/syndat_getjtbul.fd/getjtbul.f
@@ -116,7 +116,7 @@ c      THE "WINDOWING" TECHNIQUE SINCE SUBSEQUENT LOGIC EXPECTS THIS
             DUMY2K(20:80) = INL(17:77)
             INL= DUMY2K
             PRINT *, ' '
-            PRINT *, '==> This is an new-format record with a 4-digit '
+            PRINT *, '==> This is a record with a 4-digit year'
             PRINT *, ' '
           ELSE IF(INL(18:19).EQ.'20') THEN
             DUMY2K(1:17) = INL(1:17)
@@ -124,7 +124,7 @@ c      THE "WINDOWING" TECHNIQUE SINCE SUBSEQUENT LOGIC EXPECTS THIS
             DUMY2K(20:80) = INL(18:78)
             INL= DUMY2K
             PRINT *, ' '
-            PRINT *, '==> This is an new-format record with a 4-digit '
+            PRINT *, '==> This is a record with a 4-digit year'
             PRINT *, ' '
           ELSE IF(INL(19:20).EQ.'20') THEN
             DUMY2K(1:18) = INL(1:18)
@@ -132,7 +132,7 @@ c      THE "WINDOWING" TECHNIQUE SINCE SUBSEQUENT LOGIC EXPECTS THIS
             DUMY2K(20:80) = INL(19:79)
             INL= DUMY2K
             PRINT *, ' '
-            PRINT *, '==> This is an new-format record with a 4-digit '
+            PRINT *, '==> This is a record with a 4-digit year'
             PRINT *, ' '
           ELSE
             PRINT *, ' '


### PR DESCRIPTION
# Description

This PR introduces an update to the `sorc/syndat_getjtbul.fd/getjtbul.f` code to resolve a problem parsing 3-character storm names. This update is being included in the GFSv16.3.21 package (with approval by NCO). 

From the developer @Qingfu-Liu:

> The `gfs_atmos_tropcy_qc_reloc` job did not properly parse the vitals info from a raw bulletin with a tab in the storm name field for storm "SIX". The code sorc/syndat_getjtbul.fd/getjtbul.f converting a tab to a space worked well for storms that have at least 4 characters in their names, but does not work as well for storms with 3-character names. This code change will fix the parsing problem for 3-character storms.

Refs #2591

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics

Update to code that lives within global-workflow branch.

# How has this been tested?

Tested by NCO and developer