### PR TITLE
Remove cpus-per-task from APRUN_OCNANALECEN on WCOSS2

### DIFF
--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -123,7 +123,7 @@ elif [[ "${step}" = "marineanlchkpt" ]]; then
 elif [[ "${step}" = "ocnanalecen" ]]; then
 
     export NTHREADS_OCNANALECEN=${NTHREADSmax}
-    export APRUN_OCNANALECEN="${APRUN_default} --cpus-per-task=${NTHREADS_OCNANALECEN}"
+    export APRUN_OCNANALECEN="${APRUN_default}"
 
 elif [[ "${step}" = "marineanlletkf" ]]; then
 


### PR DESCRIPTION
# Description
Job gdas_ocnanalecen fails on WCOSS2 when running g-w CI C48mx500_hybAOWCDA. The failure is due to an invalid option on the `mpiexec` line.
```
^[[38;5;39m2025-01-07 19:21:20,262 - DEBUG    - marine_recenter: Executing mpiexec -l -n 16 --cpus-per-task=1 /lfs/h2/emc/da/noscrub/russ.treadon/git/global-workflow/test/exec/gdas_soca_gridgen.x /lfs/h2/emc/da/noscrub/russ.treadon/git/global-workflow/test/sorc/gdas.cd/parm/soca/gridgen/gridgen.yaml^[[0m
mpiexec: unrecognized option '--cpus-per-task=1'
```

This PR removes `--cpus-per-task` from `WCOSS2.env`.

Resolves #3158

# Type of change
- [x] Bug fix (fixes something broken)


# Change characteristics
- Is this a breaking change (a change in existing functionality)? **NO**.  This PR restores a broken functionality
- Does this change require a documentation update? **NO**
- Does this change require an update to any of the following submodules? **NO**

# How has this been tested?
- Clone, build, and cycled test on WCOSS2 (Cactus)


# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
