### PR TITLE
Update the gdas.cd hash and enable GDASApp to run on WCOSS2

### DIFF
--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -13,7 +13,8 @@ step=$1
 export launcher="mpiexec -l"
 export mpmd_opt="--cpu-bind verbose,core cfp"
 
-# Add path to GDASApp libraries
+# TODO: Add path to GDASApp libraries and cray-mpich as temporary patches
+# TODO: Remove LD_LIBRARY_PATH lines as soon as permanent solutions are available
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${HOMEgfs}/sorc/gdas.cd/build/lib"
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/cray/pe/mpich/8.1.19/ofi/intel/19.0/lib"
 

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -13,6 +13,10 @@ step=$1
 export launcher="mpiexec -l"
 export mpmd_opt="--cpu-bind verbose,core cfp"
 
+# Add path to GDASApp libraries
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOMEgfs/sorc/gdas.cd/build/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/cray/pe/mpich/8.1.19/ofi/intel/19.0/lib"
+
 # Calculate common resource variables
 # Check first if the dependent variables are set
 if [[ -n "${ntasks:-}" && -n "${max_tasks_per_node:-}" && -n "${tasks_per_node:-}" ]]; then

--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -14,8 +14,8 @@ export launcher="mpiexec -l"
 export mpmd_opt="--cpu-bind verbose,core cfp"
 
 # Add path to GDASApp libraries
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOMEgfs/sorc/gdas.cd/build/lib"
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/cray/pe/mpich/8.1.19/ofi/intel/19.0/lib"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${HOMEgfs}/sorc/gdas.cd/build/lib"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/cray/pe/mpich/8.1.19/ofi/intel/19.0/lib"
 
 # Calculate common resource variables
 # Check first if the dependent variables are set

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -51,6 +51,8 @@ elif [[ ${MACHINE_ID} = s4* ]] ; then
 
 elif [[ ${MACHINE_ID} = wcoss2 ]]; then
     # We are on WCOSS2
+    # Ignore default modules of the same version lower in the search path (req'd by spack-stack)
+    export LMOD_TMOD_FIND_FIRST=yes
     module reset
 
 elif [[ ${MACHINE_ID} = cheyenne* ]] ; then


### PR DESCRIPTION
# Description
This PR does the following:
1. update the `sorc/gdas.cd` hash to bring new GDASApp functionality into g-w
2. update `env/WCOSS2.env`
3. update the WCOSS2 section of `ush/module-setup.sh`

The change to `WCOSS2.env` is due to changes introduced during the fall 2024 WCOSS2 upgrade. The change to `module-setup.sh` is required when using spack-stack on WCOSS2.

Resolves #3219 
Resolves #3100 

# Type of change
- [x] Maintenance (update `gdas.cd` hash)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? **NO**
- Does this change require a documentation update? **NO**
- Does this change require an update to any of the following submodules? **YES**
  - [x] GDAS - this PR points at the updated `sorc/gdas.cd` hash.  No PRs are pending.
  
# How has this been tested?
- [x] Clone and build on WCOSS2, Hera, Hercules, and Orion
- [x] Run g-w CI on WCOSS2, Hera, Hercules, and Orion


# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass with my changes
