### PR TITLE
Resolve bug with LMOD_TMOD_FIND_FIRST setting affecting build on WCOSS2

### DIFF
--- a/ush/load_ufsda_modules.sh
+++ b/ush/load_ufsda_modules.sh
@@ -35,6 +35,10 @@ module use "${HOMEgfs}/sorc/gdas.cd/modulefiles"
 
 case "${MACHINE_ID}" in
   ("hera" | "orion" | "hercules" | "wcoss2")
+    #TODO: Remove LMOD_TMOD_FIND_FIRST line when spack-stack on WCOSS2
+    if [[ "${MACHINE_ID}" == "wcoss2" ]]; then
+      export LMOD_TMOD_FIND_FIRST=yes
+    fi
     module load "${MODS}/${MACHINE_ID}"
     ncdump=$( command -v ncdump )
     NETCDF=$( echo "${ncdump}" | cut -d " " -f 3 )

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -52,7 +52,7 @@ elif [[ ${MACHINE_ID} = s4* ]] ; then
 elif [[ ${MACHINE_ID} = wcoss2 ]]; then
     # We are on WCOSS2
     # Ignore default modules of the same version lower in the search path (req'd by spack-stack)
-    export LMOD_TMOD_FIND_FIRST=yes
+    #export LMOD_TMOD_FIND_FIRST=yes #TODO: Uncomment this when using spack-stack
     module reset
 
 elif [[ ${MACHINE_ID} = cheyenne* ]] ; then

--- a/workflow/generate_workflows.sh
+++ b/workflow/generate_workflows.sh
@@ -5,7 +5,7 @@ function _usage() {
    cat << EOF
    This script automates the experiment setup process for the global workflow.
    Options are also available to update submodules, build the workflow (with
-   specific build flags), specicy which YAMLs and YAML directory to run, and
+   specific build flags), specify which YAMLs and YAML directory to run, and
    whether to automatically update your crontab.
 
    Usage: generate_workflows.sh [OPTIONS] /path/to/RUNTESTS


### PR DESCRIPTION
# Description

This PR temporarily comments out the `LMOD_TMOD_FIND_FIRST=yes` setting in `ush/module-setup.sh`. Have moved it to `ush/load_ufsda_modules.sh` for runtime usage for now. Left note to undo these changes when WCOSS2 is using spack-stack.

Also found and corrected a spelling mistake.

Resolves #3225

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics

Build and runtime script updates.

# How has this been tested?

Ran CI tests on WCOSS2-Cactus.