### PR TITLE
Move WCOSS2 LD_LIBRARY_PATH patches to load_ufsda_modules.sh

### DIFF
--- a/env/WCOSS2.env
+++ b/env/WCOSS2.env
@@ -13,11 +13,6 @@ step=$1
 export launcher="mpiexec -l"
 export mpmd_opt="--cpu-bind verbose,core cfp"
 
-# TODO: Add path to GDASApp libraries and cray-mpich as temporary patches
-# TODO: Remove LD_LIBRARY_PATH lines as soon as permanent solutions are available
-export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${HOMEgfs}/sorc/gdas.cd/build/lib"
-export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/cray/pe/mpich/8.1.19/ofi/intel/19.0/lib"
-
 # Calculate common resource variables
 # Check first if the dependent variables are set
 if [[ -n "${ntasks:-}" && -n "${max_tasks_per_node:-}" && -n "${tasks_per_node:-}" ]]; then

--- a/ush/load_ufsda_modules.sh
+++ b/ush/load_ufsda_modules.sh
@@ -38,6 +38,10 @@ case "${MACHINE_ID}" in
     #TODO: Remove LMOD_TMOD_FIND_FIRST line when spack-stack on WCOSS2
     if [[ "${MACHINE_ID}" == "wcoss2" ]]; then
       export LMOD_TMOD_FIND_FIRST=yes
+      # TODO: Add path to GDASApp libraries and cray-mpich as temporary patches
+      # TODO: Remove LD_LIBRARY_PATH lines as soon as permanent solutions are available	
+      export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${HOMEgfs}/sorc/gdas.cd/build/lib"
+      export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/cray/pe/mpich/8.1.19/ofi/intel/19.0/lib"
     fi
     module load "${MODS}/${MACHINE_ID}"
     ncdump=$( command -v ncdump )


### PR DESCRIPTION
# Description
This PR moves the `LD_LIBRARY_PATH` patches currently needed to run GDASApp on WCOSS2 from `WCOSS2.env` to `load_ufsda_modules.sh`.   With this change, the `LD_LIBRARY_PATH` patch is only applied to WCOSS2 GDASApp jobs. 

This change was suggested by @aerorahul 

Resolves #3232 

# Type of change
- [x] Maintenance (clean up)

# Change characteristics
- Is this a breaking change (a change in existing functionality)?  **NO**
- Does this change require a documentation update? **NO**
- Does this change require an update to any of the following submodules? **NO**

# How has this been tested?
- Clone and build on WCOSS2 (Cactus), Hera, and Orion
- run g-w CI on WCOSS2 (Cactus), Hera, and Orion

All jobs in all CI streams [successfully run to completion](https://github.com/NOAA-EMC/global-workflow/issues/3232#issuecomment-2595231470) on Cactus, Hera, and Orion

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test

