### PR TITLE
Release v16.3.22 optimized point output

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,7 @@
 # External sub-modules of global-workflow
 
 [FV3GFS]
-tag = GFS.v16.3.1
+tag = GFS.v16.3.22
 local_path = sorc/fv3gfs.fd
 repo_url = https://github.com/ufs-community/ufs-weather-model.git
 protocol = git

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -112,6 +112,8 @@ PRE-IMPLEMENTATION TESTING REQUIREMENTS
 * Which production jobs should be tested as part of this implementation?
   * emcsfc_sfc_prep and analysis
   * wave_post_pnt
+  * wave_post_bndpnt
+  * wave_post_bndpntbll
 * Does this change require a 30-day evaluation?
   * No
 

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -51,7 +51,7 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* * `versions/run.ver` - change `version=v16.3.22`, `gfs_ver=v16.3.22`, and `obsproc_ver=v1.3`
+* `versions/run.ver` - change `version=v16.3.22`, `gfs_ver=v16.3.22`, and `obsproc_ver=v1.3`
 
 SORC CHANGES
 ------------
@@ -68,17 +68,20 @@ JOBS CHANGES
 PARM/CONFIG CHANGES
 -------------------
 
-* `config.resources.emc.dyn` and `config.resources.nco.static` are changed to reduce the resources accordingly.
+In `config.resources.emc.dyn` and `config.resources.nco.static` following resources are changed:
+* for wavepostbndpnt: npe from 240 to 1; wtime from 1hr to 30min
+* for wavepostbndpntbll: npe from 448 to 2; wtime from 1hr to 10min
+* for wavepostpnt: npe from 200 to 3; wtime from 1.5hr to 35min
 
 SCRIPT CHANGES
 --------------
 
-* `scripts/exgfs_wave_post_pnt.sh` is changed to create be compatible with the new `ww3_outp`.
+* `scripts/exgfs_wave_post_pnt.sh` is changed to be compatible with the  new `ww3_outp`.
 
 FIX CHANGES
 -----------
 
-* GSI `global_convinfo.txt` fix update for saildrone```
+* GSI `global_convinfo.txt` fix update for saildrone
 
 MODULE CHANGES
 --------------
@@ -89,14 +92,11 @@ CHANGES TO FILE AND FILE SIZES
 ------------------------------
 
 No longer ingest:
-* `${RUN}.${cycle}.NPR.SNWN.SP.S1200.MESH16.grb` (`AFWA_NH_FILE`)	
+* `${RUN}.${cycle}.NPR.SNWN.SP.S1200.MESH16.grb` (`AFWA_NH_FILE`)
 * `${RUN}.${cycle}.NPR.SNWS.SP.S1200.MESH16.grb` (`AFWA_SH_FILE`)
 
-Now ingest:	
+Now ingest:
 * `${RUN}.${cycle}.snow.usaf.grib2` (`AFWA_GLOBAL_FILE`)
-
-No longer uses the parallel command file `cmdfile` for the `scripts/exgfs_wave_post_pnt.sh`.
-
 
 ENVIRONMENT AND RESOURCE CHANGES
 --------------------------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -49,7 +49,7 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* No changes from GFS v16.3.22
+* No changes from GFS v16.3.21
 
 SORC CHANGES
 ------------
@@ -59,7 +59,7 @@ SORC CHANGES
 JOBS CHANGES
 ------------
 
-* No changes from GFS v16.3.22
+* No changes from GFS v16.3.21
 
 PARM/CONFIG CHANGES
 -------------------
@@ -74,12 +74,12 @@ SCRIPT CHANGES
 FIX CHANGES
 -----------
 
-* No changes from GFS v16.3.22
+* No changes from GFS v16.3.21
 
 MODULE CHANGES
 --------------
 
-* No changes from GFS v16.3.22
+* No changes from GFS v16.3.21
 
 CHANGES TO FILE AND FILE SIZES
 ------------------------------
@@ -106,24 +106,27 @@ PRE-IMPLEMENTATION TESTING REQUIREMENTS
 DISSEMINATION INFORMATION
 -------------------------
 
-* No changes from GFS v16.3.22
+* No changes from GFS v16.3.21
 
 HPSS ARCHIVE
 ------------
 
-* No changes from GFS v16.3.22
+* No changes from GFS v16.3.21
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
 
-* No changes from GFS v16.3.22
+* No changes from GFS v16.3.21
 
 DOCUMENTATION
 -------------
 
-* No changes from GFS v16.3.22
+* No changes from GFS v16.3.21
 
 PREPARED BY
 -----------
-Ali Salimi Tarazouj
-Jessica Meixner
+Kate.Friedman@noaa.gov
+George.Gayno@noaa.gov
+Andrew.Collard@noaa.gov
+Ali.Salmi@noaa.gov
+Jessica.Meixner@noaa.gov

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -63,7 +63,7 @@ SORC CHANGES
 JOBS CHANGES
 ------------
 
-* No changes from GFS v16.3.21
+* `jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP` - new AFWA filename
 
 PARM/CONFIG CHANGES
 -------------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -86,6 +86,13 @@ MODULE CHANGES
 CHANGES TO FILE AND FILE SIZES
 ------------------------------
 
+No longer ingest:
+* `${RUN}.${cycle}.NPR.SNWN.SP.S1200.MESH16.grb` (`AFWA_NH_FILE`)	
+* `${RUN}.${cycle}.NPR.SNWS.SP.S1200.MESH16.grb` (`AFWA_SH_FILE`)
+
+Now ingest:	
+* `${RUN}.${cycle}.snow.usaf.grib2` (`AFWA_GLOBAL_FILE`)
+
 No longer uses the parallel command file `cmdfile` for the `scripts/exgfs_wave_post_pnt.sh`.
 
 

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -3,8 +3,10 @@ GFS V16.3.22 RELEASE NOTES
 -------
 PRELUDE
 -------
-
-The WW3 point output program (ww3_outp) is improved to process per-time-step point output to reduce the resources for the wave_post_pnt jobs.
+The upstream OBSPROC package is updated to v1.3. Along with this are the following companion updates:
+* workflow and UFS_UTILS package updates to use the new AFWA global snow file due to the hemispheric snow files being phased out
+* updated GSI code and convinfo file for saildrone observations
+* ww3_outp is improved for th wave point output
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -128,5 +130,5 @@ PREPARED BY
 Kate.Friedman@noaa.gov
 George.Gayno@noaa.gov
 Andrew.Collard@noaa.gov
-Ali.Salmi@noaa.gov
 Jessica.Meixner@noaa.gov
+Ali.Salimi@noaa.gov

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -56,7 +56,9 @@ VERSION FILE CHANGES
 SORC CHANGES
 ------------
 
-* `ww3_outp` program and associated scripts are improved to process the per-time-step point outputs more efficiently.
+* New UFS_UTILS tag - `emcsfc_snow2mdl` program and associated scripts are updated to process global AFWA snow data
+* New GSI tag - `src/gsi/read_prepbufr.f90` code update for new saildrone subtype
+* New MODEL tag - WW3 program `ww3_outp` and associated scripts are improved to process the per-time-step point outputs more efficiently.
 
 JOBS CHANGES
 ------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -101,6 +101,7 @@ PRE-IMPLEMENTATION TESTING REQUIREMENTS
 ---------------------------------------
 
 * Which production jobs should be tested as part of this implementation?
+  * emcsfc_sfc_prep and analysis
   * wave_post_pnt
 * Does this change require a 30-day evaluation?
   * No

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -6,7 +6,7 @@ PRELUDE
 The upstream OBSPROC package is updated to v1.3. Along with this are the following companion updates:
 * workflow and UFS_UTILS package updates to use the new AFWA global snow file due to the hemispheric snow files being phased out
 * updated GSI code and convinfo file for saildrone observations
-* ww3_outp is improved for th wave point output
+* ww3_outp is improved for the wave point output
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -51,7 +51,7 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* No changes from GFS v16.3.21
+* * `versions/run.ver` - change `version=v16.3.22`, `gfs_ver=v16.3.22`, and `obsproc_ver=v1.3`
 
 SORC CHANGES
 ------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -4,9 +4,7 @@ GFS V16.3.22 RELEASE NOTES
 PRELUDE
 -------
 
-The upstream OBSPROC package is updated to v1.3. Along with this are the following companion updates:
-* workflow and UFS_UTILS package updates to use the new AFWA global snow file due to the hemispheric snow files being phased out
-* updated GSI code and convinfo file for saildrone observations
+The WW3 point output program (ww3_outp) is improved to process per-time-step point output to reduce the resources for the wave_post_pnt jobs.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -26,7 +24,7 @@ The checkout script extracts the following GFS components:
 
 | Component | Tag         | POC               |
 | --------- | ----------- | ----------------- |
-| MODEL     | GFS.v16.3.1   | Jun.Wang@noaa.gov |
+| MODEL     | GFS.v16.3.22   | Jun.Wang@noaa.gov |
 | GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
 | GSI       | gfsda.v16.3.22 | Andrew.Collard@noaa.gov |
 | UFS_UTILS | ops-gfsv16.3.20 | George.Gayno@noaa.gov |
@@ -51,85 +49,81 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* `versions/run.ver` - change `version=v16.3.22`, `gfs_ver=v16.3.22`, and `obsproc_ver=v1.3`
+* No changes from GFS v16.3.22
 
 SORC CHANGES
 ------------
 
-* New UFS_UTILS tag - `emcsfc_snow2mdl` program and associated scripts are updated to process global AFWA snow data
-* New GSI tag - `src/gsi/read_prepbufr.f90` code update for new saildrone subtype
+* `ww3_outp` program and associated scripts are improved to process the per-time-step point outputs more efficiently.
 
 JOBS CHANGES
 ------------
 
-* `jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP` - new AFWA filename
+* No changes from GFS v16.3.22
 
 PARM/CONFIG CHANGES
 -------------------
 
-* No changes from GFS v16.3.21
+* `config.resources.emc.dyn` and `config.resources.nco.static` are changed to reduce the resources accordingly.
 
 SCRIPT CHANGES
 --------------
 
-* No changes from GFS v16.3.21
+* `scripts/exgfs_wave_post_pnt.sh` is changed to create be compatible with the new `ww3_outp`.
 
 FIX CHANGES
 -----------
 
-* GSI `global_convinfo.txt` fix update for saildrone
+* No changes from GFS v16.3.22
 
 MODULE CHANGES
 --------------
 
-* No changes from GFS v16.3.21
+* No changes from GFS v16.3.22
 
 CHANGES TO FILE AND FILE SIZES
 ------------------------------
 
-No longer ingest:
-* `${RUN}.${cycle}.NPR.SNWN.SP.S1200.MESH16.grb` (`AFWA_NH_FILE`)
-* `${RUN}.${cycle}.NPR.SNWS.SP.S1200.MESH16.grb` (`AFWA_SH_FILE`)
+No longer uses the parallel command file `cmdfile` for the `scripts/exgfs_wave_post_pnt.sh`.
 
-Now ingest:
-* `${RUN}.${cycle}.snow.usaf.grib2` (`AFWA_GLOBAL_FILE`)
 
 ENVIRONMENT AND RESOURCE CHANGES
 --------------------------------
 
-* Increase ncpus from 50 to 60 for gfs_wave_postpnt job.
-  NCO provided change to avoid ncpu burst warnings.
+Reduce the ncpu and wtime as follow:
+* for jobs/JGLOBAL_WAVE_POST_BNDPNT; ncpu from 240 to 1; wtime from 1hr to 30min
+* for jobs/JGLOBAL_WAVE_POST_BNDPNTBLL; ncpu from 448 to 2; wtime from 1hr to 10min
+* for jobs/JGLOBAL_WAVE_POST_PNT; ncpu from 200 to 3; wtime from 1.5hr to 35min
 
 PRE-IMPLEMENTATION TESTING REQUIREMENTS
 ---------------------------------------
 
 * Which production jobs should be tested as part of this implementation?
-  * emcsfc_sfc_prep and analysis
+  * wave_post_pnt
 * Does this change require a 30-day evaluation?
   * No
 
 DISSEMINATION INFORMATION
 -------------------------
 
-* No changes from GFS v16.3.21
+* No changes from GFS v16.3.22
 
 HPSS ARCHIVE
 ------------
 
-* No changes from GFS v16.3.21
+* No changes from GFS v16.3.22
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
 
-* No changes from GFS v16.3.21
+* No changes from GFS v16.3.22
 
 DOCUMENTATION
 -------------
 
-* No changes from GFS v16.3.21
+* No changes from GFS v16.3.22
 
 PREPARED BY
 -----------
-Kate.Friedman@noaa.gov
-George.Gayno@noaa.gov
-Andrew.Collard@noaa.gov
+Ali Salimi Tarazouj
+Jessica Meixner

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -76,7 +76,7 @@ SCRIPT CHANGES
 FIX CHANGES
 -----------
 
-* No changes from GFS v16.3.21
+* GSI `global_convinfo.txt` fix update for saildrone```
 
 MODULE CHANGES
 --------------

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpnt.ecf
@@ -3,8 +3,8 @@
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:00:00
-#PBS -l select=3:ncpus=80:ompthreads=1
+#PBS -l walltime=00:30:00
+#PBS -l select=1:ncpus=1:ompthreads=1
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpntbll.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_post_bndpntbll.ecf
@@ -3,8 +3,8 @@
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:00:00
-#PBS -l select=4:ncpus=112:ompthreads=1
+#PBS -l walltime=00:10:00
+#PBS -l select=1:ncpus=2:ompthreads=1
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 

--- a/ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf
+++ b/ecf/scripts/gfs/wave/post/jgfs_wave_postpnt.ecf
@@ -3,8 +3,8 @@
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:30:00
-#PBS -l select=4:ncpus=50:ompthreads=1
+#PBS -l walltime=00:35:00
+#PBS -l select=1:ncpus=3:ompthreads=1
 #PBS -l place=vscatter:exclhost
 #PBS -l debug=true
 

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -82,26 +82,26 @@ elif [ $step = "wavepostsbs" ]; then
 
 elif [ $step = "wavepostbndpnt" ]; then
 
-    export wtime_wavepostbndpnt="01:00:00"
-    export npe_wavepostbndpnt=240
+    export wtime_wavepostbndpnt="00:30:00"
+    export npe_wavepostbndpnt=1
     export nth_wavepostbndpnt=1
-    export npe_node_wavepostbndpnt=80
+    export npe_node_wavepostbndpnt=1
     export NTASKS=$npe_wavepostbndpnt
 
 elif [ $step = "wavepostbndpntbll" ]; then
 
-    export wtime_wavepostbndpntbll="01:00:00"
-    export npe_wavepostbndpntbll=448
+    export wtime_wavepostbndpntbll="00:10:00"
+    export npe_wavepostbndpntbll=2
     export nth_wavepostbndpntbll=1
-    export npe_node_wavepostbndpntbll=112
+    export npe_node_wavepostbndpntbll=2
     export NTASKS=$npe_wavepostbndpntbll
 
 elif [ $step = "wavepostpnt" ]; then
 
-    export wtime_wavepostpnt="01:30:00"
-    export npe_wavepostpnt=200
+    export wtime_wavepostpnt="00:35:00"
+    export npe_wavepostpnt=3
     export nth_wavepostpnt=1
-    export npe_node_wavepostpnt=50
+    export npe_node_wavepostpnt=3
     export NTASKS=$npe_wavepostpnt
 
 elif [ $step = "wavegempak" ]; then

--- a/parm/config/config.resources.emc.dyn
+++ b/parm/config/config.resources.emc.dyn
@@ -85,7 +85,7 @@ elif [ $step = "wavepostbndpnt" ]; then
     export wtime_wavepostbndpnt="00:30:00"
     export npe_wavepostbndpnt=1
     export nth_wavepostbndpnt=1
-    export npe_node_wavepostbndpnt=1
+    export npe_node_wavepostbndpnt=${npe_wavepostbndpnt}
     export NTASKS=$npe_wavepostbndpnt
 
 elif [ $step = "wavepostbndpntbll" ]; then
@@ -93,7 +93,7 @@ elif [ $step = "wavepostbndpntbll" ]; then
     export wtime_wavepostbndpntbll="00:10:00"
     export npe_wavepostbndpntbll=2
     export nth_wavepostbndpntbll=1
-    export npe_node_wavepostbndpntbll=2
+    export npe_node_wavepostbndpntbll=${npe_wavepostbndpntbll}
     export NTASKS=$npe_wavepostbndpntbll
 
 elif [ $step = "wavepostpnt" ]; then
@@ -101,7 +101,7 @@ elif [ $step = "wavepostpnt" ]; then
     export wtime_wavepostpnt="00:35:00"
     export npe_wavepostpnt=3
     export nth_wavepostpnt=1
-    export npe_node_wavepostpnt=3
+    export npe_node_wavepostpnt=${npe_wavepostpnt}
     export NTASKS=$npe_wavepostpnt
 
 elif [ $step = "wavegempak" ]; then

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -66,26 +66,26 @@ elif [ $step = "wavepostsbs" ]; then
 
 elif [ $step = "wavepostbndpnt" ]; then
 
-    export wtime_wavepostbndpnt="01:00:00"
-    export npe_wavepostbndpnt=240
+    export wtime_wavepostbndpnt="00:30:00"
+    export npe_wavepostbndpnt=1
     export nth_wavepostbndpnt=1
-    export npe_node_wavepostbndpnt=80
+    export npe_node_wavepostbndpnt=1
     export NTASKS=$npe_wavepostbndpnt
 
 elif [ $step = "wavepostbndpntbll" ]; then
 
-    export wtime_wavepostbndpntbll="01:00:00"
-    export npe_wavepostbndpntbll=448
+    export wtime_wavepostbndpntbll="00:10:00"
+    export npe_wavepostbndpntbll=2
     export nth_wavepostbndpntbll=1
-    export npe_node_wavepostbndpntbll=112
+    export npe_node_wavepostbndpntbll=2
     export NTASKS=$npe_wavepostbndpntbll
 
 elif [ $step = "wavepostpnt" ]; then
 
-    export wtime_wavepostpnt="01:30:00"
-    export npe_wavepostpnt=200
+    export wtime_wavepostpnt="00:35:00"
+    export npe_wavepostpnt=3
     export nth_wavepostpnt=1
-    export npe_node_wavepostpnt=50
+    export npe_node_wavepostpnt=3
     export NTASKS=$npe_wavepostpnt
 
 elif [ $step = "wavegempak" ]; then

--- a/parm/config/config.resources.nco.static
+++ b/parm/config/config.resources.nco.static
@@ -69,7 +69,7 @@ elif [ $step = "wavepostbndpnt" ]; then
     export wtime_wavepostbndpnt="00:30:00"
     export npe_wavepostbndpnt=1
     export nth_wavepostbndpnt=1
-    export npe_node_wavepostbndpnt=1
+    export npe_node_wavepostbndpnt=${npe_wavepostbndpnt}
     export NTASKS=$npe_wavepostbndpnt
 
 elif [ $step = "wavepostbndpntbll" ]; then
@@ -77,7 +77,7 @@ elif [ $step = "wavepostbndpntbll" ]; then
     export wtime_wavepostbndpntbll="00:10:00"
     export npe_wavepostbndpntbll=2
     export nth_wavepostbndpntbll=1
-    export npe_node_wavepostbndpntbll=2
+    export npe_node_wavepostbndpntbll=${npe_wavepostbndpntbll}
     export NTASKS=$npe_wavepostbndpntbll
 
 elif [ $step = "wavepostpnt" ]; then
@@ -85,7 +85,7 @@ elif [ $step = "wavepostpnt" ]; then
     export wtime_wavepostpnt="00:35:00"
     export npe_wavepostpnt=3
     export nth_wavepostpnt=1
-    export npe_node_wavepostpnt=3
+    export npe_node_wavepostpnt=${npe_wavepostpnt}
     export NTASKS=$npe_wavepostpnt
 
 elif [ $step = "wavegempak" ]; then

--- a/scripts/exgfs_wave_post_pnt.sh
+++ b/scripts/exgfs_wave_post_pnt.sh
@@ -364,7 +364,7 @@
     fhr=$fhrp # no gridded output, loop with out_pnt stride
   done
 
-  if [ "$DOSPC_WAV" = 'YES' ] && [ "$DOBLL_WAV" = "NO" ]; then
+  if [ "$DOSPC_WAV" = 'YES' ]; then
     sed -e "s/TIME/$tstart/g" \
         -e "s/DT/$dtspec/g" \
 	-e "s/999/$N/g" \
@@ -372,10 +372,12 @@
         -e "s/ITYPE/1/g" \
         -e "s/FORMAT/F/g" \
                                ww3_outp_spec.inp.tmpl > ww3_outp.inp
-  
+   
     $EXECwave/ww3_outp ${WAV_MOD_TAG} 1> ww3_outp_spec.log 2>&1
 
-  elif [ "$DOSPC_WAV" = 'NO' ] && [ "$DOBLL_WAV" = "YES" ]; then
+  fi
+
+  if [ "$DOBLL_WAV" = "YES" ]; then
     sed -e "s/TIME/$tstart/g" \
         -e "s/DT/$dtspec/g" \
         -e "s/999/$N/g" \
@@ -384,27 +386,6 @@
 	                       ww3_outp_bull.inp.tmpl > ww3_outp.inp
     
     $EXECwave/ww3_outp ${WAV_MOD_TAG} 1> ww3_outp_bull.log 2>&1
-
-  elif [[ "$DOSPC_WAV" == "YES" && "$DOBLL_WAV" == "YES" ]]; then
-    sed -e "s/TIME/$tstart/g" \
-        -e "s/DT/$dtspec/g" \
-        -e "s/999/$N/g" \
-        -e "s|POINT|$points|g" \
-        -e "s/ITYPE/1/g" \
-        -e "s/FORMAT/F/g" \
-                               ww3_outp_spec.inp.tmpl > ww3_outp.inp
-
-    $EXECwave/ww3_outp ${WAV_MOD_TAG} 1> ww3_outp_spec.log 2>&1
-
-    sed -e "s/TIME/$tstart/g" \
-        -e "s/DT/$dtspec/g" \
-        -e "s/999/$N/g" \
-        -e "s|POINT|$points|g" \
-        -e "s/REFT/$truntime/g" \
-                               ww3_outp_bull.inp.tmpl > ww3_outp.inp
-
-    $EXECwave/ww3_outp ${WAV_MOD_TAG} 1> ww3_outp_bull.log 2>&1
-
   fi
 
 # --------------------------------------------------------------------------- #

--- a/scripts/exgfs_wave_post_pnt.sh
+++ b/scripts/exgfs_wave_post_pnt.sh
@@ -240,7 +240,7 @@
     HMS="$(echo $CDATE | cut -c9-10)0000"
     if [ -f $COMIN/rundata/${WAV_MOD_TAG}.out_pnt.${waveuoutpGRD}.${YMD}.${HMS} ]
     then
-      ln -s $COMIN/rundata/${WAV_MOD_TAG}.out_pnt.${waveuoutpGRD}.${YMD}.${HMS}
+      ln -s $COMIN/rundata/${WAV_MOD_TAG}.out_pnt.${waveuoutpGRD}.${YMD}.${HMS} ./${WAV_MOD_TAG}.out_pnt.${waveuoutpGRD}.${YMD}.${HMS}
     else
       echo '*************************************************** '
       echo " FATAL ERROR : NO RAW POINT OUTPUT FILE out_pnt.${waveuoutpGRD}.${YMD}.${HMS} "
@@ -351,7 +351,7 @@
     pfile=$COMIN/rundata/${WAV_MOD_TAG}.out_pnt.${waveuoutpGRD}.${YMD}.${HMS}
     if [ -f  ${pfile} ]
     then
-      ln -fs ${pfile}
+      ln -fs ${pfile} ./${WAV_MOD_TAG}.out_pnt.${waveuoutpGRD}.${YMD}.${HMS}
     else
       echo " FATAL ERROR : NO RAW POINT OUTPUT FILE out_pnt.$waveuoutpGRD.${YMD}.${HMS} "
       echo ' '

--- a/scripts/exgfs_wave_post_pnt.sh
+++ b/scripts/exgfs_wave_post_pnt.sh
@@ -410,13 +410,13 @@
   if [ ${CFP_MP:-"NO"} = "YES" ]; then
     if [ "$DOBNDPNT_WAV" = YES ]; then
       if [ "$DOSPC_WAV" = YES ]; then 
-        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG ibp $Nb > ${WAV_MOD_TAG}_spec_tar.out 2>&1 "   >> cmdtarfile
+        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG ibp $Nb > ${WAV_MOD_TAG}_ibp_tar.out 2>&1 "   >> cmdtarfile
         nm=$(( nm + 1 ))
       fi 
       if [ "$DOBLL_WAV" = YES ]; then
-        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG ibpbull $Nb > ${WAV_MOD_TAG}_spec_tar.out 2>&1 "   >> cmdtarfile
+        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG ibpbull $Nb > ${WAV_MOD_TAG}_ibpbull_tar.out 2>&1 "   >> cmdtarfile
         nm=$(( nm + 1 ))
-        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG ibpcbull $Nb > ${WAV_MOD_TAG}_spec_tar.out 2>&1 "   >> cmdtarfile
+        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG ibpcbull $Nb > ${WAV_MOD_TAG}_ibpcbull_tar.out 2>&1 "   >> cmdtarfile
         nm=$(( nm + 1 ))
       fi 
     else 
@@ -425,28 +425,28 @@
         nm=$(( nm + 1 ))
       fi
       if [ "$DOBLL_WAV" = YES ]; then
-        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG bull $Nb > ${WAV_MOD_TAG}_spec_tar.out 2>&1 "   >> cmdtarfile
+        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG bull $Nb > ${WAV_MOD_TAG}_bull_tar.out 2>&1 "   >> cmdtarfile
         nm=$(( nm + 1 ))
-        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG cbull $Nb > ${WAV_MOD_TAG}_spec_tar.out 2>&1 "   >> cmdtarfile
+        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG cbull $Nb > ${WAV_MOD_TAG}_cbull_tar.out 2>&1 "   >> cmdtarfile
         nm=$(( nm + 1 ))
       fi 
     fi
   else
     if [ "$DOBNDPNT_WAV" = YES ]; then
       if [ "$DOSPC_WAV" = YES ]; then
-        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG ibp $Nb > ${WAV_MOD_TAG}_spec_tar.out 2>&1 "   >> cmdtarfile
+        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG ibp $Nb > ${WAV_MOD_TAG}_ibp_tar.out 2>&1 "   >> cmdtarfile
       fi
       if [ "$DOBLL_WAV" = YES ]; then
-        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG ibpbull $Nb > ${WAV_MOD_TAG}_spec_tar.out 2>&1 "   >> cmdtarfile
-        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG ibpcbull $Nb > ${WAV_MOD_TAG}_spec_tar.out 2>&1 "   >> cmdtarfile
+        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG ibpbull $Nb > ${WAV_MOD_TAG}_ibpbull_tar.out 2>&1 "   >> cmdtarfile
+        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG ibpcbull $Nb > ${WAV_MOD_TAG}_ibpcbull_tar.out 2>&1 "   >> cmdtarfile
       fi
     else 
       if [ "$DOSPC_WAV" = YES ]; then
         echo "$USHwave/wave_tar.sh $WAV_MOD_TAG spec $Nb > ${WAV_MOD_TAG}_spec_tar.out 2>&1 "   >> cmdtarfile
       fi
       if [ "$DOBLL_WAV" = YES ]; then
-        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG bull $Nb > ${WAV_MOD_TAG}_spec_tar.out 2>&1 "   >> cmdtarfile
-        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG cbull $Nb > ${WAV_MOD_TAG}_spec_tar.out 2>&1 "   >> cmdtarfile
+        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG bull $Nb > ${WAV_MOD_TAG}_bull_tar.out 2>&1 "   >> cmdtarfile
+        echo "$USHwave/wave_tar.sh $WAV_MOD_TAG cbull $Nb > ${WAV_MOD_TAG}_cbull_tar.out 2>&1 "   >> cmdtarfile
       fi
     fi
   fi

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -23,8 +23,7 @@ echo $topdir
 echo fv3gfs checkout ...
 if [[ ! -d fv3gfs.fd ]] ; then
     rm -f ${topdir}/checkout-fv3gfs.log
-    git clone --recursive --branch prodpoint https://github.com/AliS-Noaa/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
-    #git clone --recursive --branch GFS.v16.3.1 https://github.com/ufs-community/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
+    git clone --recursive --branch GFS.v16.3.22 https://github.com/ufs-community/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory fv3gfs.fd already exists.'

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -23,7 +23,8 @@ echo $topdir
 echo fv3gfs checkout ...
 if [[ ! -d fv3gfs.fd ]] ; then
     rm -f ${topdir}/checkout-fv3gfs.log
-    git clone --recursive --branch GFS.v16.3.1 https://github.com/ufs-community/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
+    git clone --recursive --branch prodpoint https://github.com/AliS-Noaa/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
+    #git clone --recursive --branch GFS.v16.3.1 https://github.com/ufs-community/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory fv3gfs.fd already exists.'

--- a/ush/wave_tar.sh
+++ b/ush/wave_tar.sh
@@ -107,7 +107,7 @@
   while [ "$count" -lt "$countMAX" ] && [ "$tardone" = 'no' ]
   do
     
-    nf=`ls -1 $ID.*.$filext | awk 'END{print NR}'`
+    nf=$(ls | awk '/'$ID.*.$filext'/ {a++} END {print a}')
     nbm2=$(( $nb - 2 ))
     if [ $nf -ge $nbm2 ]
     then 

--- a/ush/wave_tar.sh
+++ b/ush/wave_tar.sh
@@ -92,8 +92,6 @@
     exit 2
   fi
 
-  cd ${STA_DIR}/${filext}
-
 # --------------------------------------------------------------------------- #
 # 2.  Generate tar file (spectral files are compressed)
 
@@ -109,7 +107,7 @@
   while [ "$count" -lt "$countMAX" ] && [ "$tardone" = 'no' ]
   do
     
-    nf=`ls | awk '/'$ID.*.$filext'/ {a++} END {print a}'`
+    nf=`ls -1 $ID.*.$filext | awk 'END{print NR}'`
     nbm2=$(( $nb - 2 ))
     if [ $nf -ge $nbm2 ]
     then 
@@ -202,7 +200,6 @@
     exit 4
   fi
 
-  # if [ "$SENDDBN" = 'YES' -a  $type != "ibp" ]
   if [ "$SENDDBN" = 'YES' ]
   then
     set +x


### PR DESCRIPTION
# Description
following @dkokron work on the per time step output reading the ww3_outp is optimized to read per time step binary output and create per point spectral and bull/cbull output. 
Addressing https://github.com/NOAA-EMC/global-workflow/issues/2913

# Type of change
- [ ] Bug fix (fixes something broken)
- [x] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? YES
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? YES (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [x] UFS-weather-model https://github.com/NOAA-EMC/WW3/pull/1355#issue-2810360566
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
This one was for operational branch and we ran similar runs as ops and got identical point outputs with less resources. Testing is conducted on WCOSS2 (Cactus). This will be incorporated into the dev branch soon.


# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
