### PR TITLE
fix intel stack version number on c5

### DIFF
--- a/versions/build.gaeac5.ver
+++ b/versions/build.gaeac5.ver
@@ -1,5 +1,5 @@
-export stack_intel_ver=2023.1.0
-export stack_cray_mpich_ver=8.1.25
+export stack_intel_ver=2023.2.0
+export stack_cray_mpich_ver=8.1.28
 export spack_env=gsi-addon-dev
 source "${HOMEgfs:-}/versions/spack.ver"
 export spack_mod_path="/ncrc/proj/epic/spack-stack/spack-stack-${spack_stack_ver}/envs/${spack_env}/install/modulefiles/Core"

--- a/versions/run.gaeac5.ver
+++ b/versions/run.gaeac5.ver
@@ -1,5 +1,5 @@
-export stack_intel_ver=2023.1.0
-export stack_cray_mpich_ver=8.1.25
+export stack_intel_ver=2023.2.0
+export stack_cray_mpich_ver=8.1.28
 export spack_env=gsi-addon-dev
 
 export perl_ver=5.38.2


### PR DESCRIPTION
these were inadvertently messed up in the previous PR (PR #3255).  Tested by running a single coupled 3dvar cycle on c5.