### PR TITLE
Add esnowanl to enkfgfs cycle

### DIFF
--- a/jobs/JGLOBAL_SNOWENS_ANALYSIS
+++ b/jobs/JGLOBAL_SNOWENS_ANALYSIS
@@ -23,6 +23,16 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
     COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
     COMOUT_CONF:COM_CONF_TMPL
 
+NMEM_ENS_MAX=${NMEM_ENS:-80}
+if [ "${RUN}" = "enkfgfs" ]; then
+   NMEM_ENS=${NMEM_ENS_GFS:-30}
+   ec_offset=${NMEM_ENS_GFS_OFFSET:-20}
+   mem_offset=$((ec_offset * cyc/6))
+else
+   NMEM_ENS=${NMEM_ENS:-80}
+   mem_offset=0
+fi
+
 for imem in $(seq 1 "${NMEM_ENS}"); do
     memchar="mem$(printf %03i "${imem}")"
     MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl \

--- a/jobs/JGLOBAL_SNOWENS_ANALYSIS
+++ b/jobs/JGLOBAL_SNOWENS_ANALYSIS
@@ -23,16 +23,15 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
     COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
     COMOUT_CONF:COM_CONF_TMPL
 
-NMEM_ENS_MAX=${NMEM_ENS:-80}
+export NMEM_ENS_MAX=${NMEM_ENS:-80}
 if [ "${RUN}" = "enkfgfs" ]; then
    NMEM_ENS=${NMEM_ENS_GFS:-30}
    ec_offset=${NMEM_ENS_GFS_OFFSET:-20}
-   mem_offset=$((ec_offset * cyc/6))
+   export mem_offset=$((ec_offset * cyc/6))
 else
    NMEM_ENS=${NMEM_ENS:-80}
-   mem_offset=0
+   export mem_offset=0
 fi
-
 for imem in $(seq 1 "${NMEM_ENS}"); do
     memchar="mem$(printf %03i "${imem}")"
     MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl \

--- a/jobs/JGLOBAL_SNOWENS_ANALYSIS
+++ b/jobs/JGLOBAL_SNOWENS_ANALYSIS
@@ -13,6 +13,15 @@ export GDUMP
 CDUMP=${RUN/enkf}
 export CDUMP
 
+export NMEM_ENS_MAX=${NMEM_ENS:-80}
+if [ "${RUN}" = "enkfgfs" ]; then
+   NMEM_ENS=${NMEM_ENS_GFS:-30}
+   ec_offset=${NMEM_ENS_GFS_OFFSET:-20}
+   export mem_offset=$((ec_offset * cyc/6))
+else
+   NMEM_ENS=${NMEM_ENS:-80}
+   export mem_offset=0
+fi
 ##############################################
 # Begin JOB SPECIFIC work
 ##############################################
@@ -23,15 +32,6 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
     COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
     COMOUT_CONF:COM_CONF_TMPL
 
-export NMEM_ENS_MAX=${NMEM_ENS:-80}
-if [ "${RUN}" = "enkfgfs" ]; then
-   NMEM_ENS=${NMEM_ENS_GFS:-30}
-   ec_offset=${NMEM_ENS_GFS_OFFSET:-20}
-   export mem_offset=$((ec_offset * cyc/6))
-else
-   NMEM_ENS=${NMEM_ENS:-80}
-   export mem_offset=0
-fi
 for imem in $(seq 1 "${NMEM_ENS}"); do
     memchar="mem$(printf %03i "${imem}")"
     MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl \

--- a/jobs/JGLOBAL_SNOWENS_ANALYSIS
+++ b/jobs/JGLOBAL_SNOWENS_ANALYSIS
@@ -13,13 +13,11 @@ export GDUMP
 CDUMP=${RUN/enkf}
 export CDUMP
 
-export NMEM_ENS_MAX=${NMEM_ENS:-80}
-if [ "${RUN}" = "enkfgfs" ]; then
-   NMEM_ENS=${NMEM_ENS_GFS:-30}
-   ec_offset=${NMEM_ENS_GFS_OFFSET:-20}
-   export mem_offset=$((ec_offset * cyc/6))
+export NMEM_ENS_MAX=${NMEM_ENS}
+if [[ "${RUN}" == "enkfgfs" ]]; then
+   NMEM_ENS=${NMEM_ENS_GFS}
+   export mem_offset=$((NMEM_ENS_GFS_OFFSET * cyc/6))
 else
-   NMEM_ENS=${NMEM_ENS:-80}
    export mem_offset=0
 fi
 ##############################################

--- a/parm/gdas/snow_stage_ens_update.yaml.j2
+++ b/parm/gdas/snow_stage_ens_update.yaml.j2
@@ -22,17 +22,17 @@ copy:
 # copy ensemble background files
 ######################################
 {% for mem in range(1, NMEM_ENS + 1) %}
-    #apply offset for rotating member if needed
-    smem=$((imem + mem_offset))
-    if (( smem > NMEM_ENS_MAX ))
-        smem=$((smem - NMEM_ENS_MAX))
+    {% set gmem = mem+mem_offset %}
+    {% if gmem > NMEM_ENS_MAX %}
+        {% set gmem = gmem-NMEM_ENS_MAX %}
+    {% endif %}
     # define variables
     # Declare a dict of search and replace terms to run on each template
     {% set tmpl_dict = {'${ROTDIR}':ROTDIR,
                         '${RUN}':"enkfgdas",
                         '${YMD}':previous_cycle | to_YMD,
                         '${HH}':previous_cycle | strftime("%H"),
-                        '${MEMDIR}':"mem" + '%03d' % smem} %}
+                        '${MEMDIR}':"mem" + '%03d' % gmem} %}
 
     # copy coupler file
 - ["{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.coupler.res", "{{ DATA }}/bkg/mem{{ '%03d' % mem }}/{{ current_cycle | to_fv3time }}.coupler.res"]

--- a/parm/gdas/snow_stage_ens_update.yaml.j2
+++ b/parm/gdas/snow_stage_ens_update.yaml.j2
@@ -22,13 +22,17 @@ copy:
 # copy ensemble background files
 ######################################
 {% for mem in range(1, NMEM_ENS + 1) %}
+    #apply offset for rotating member if needed
+    smem=$((imem + mem_offset))
+    if (( smem > NMEM_ENS_MAX ))
+        smem=$((smem - NMEM_ENS_MAX))
     # define variables
     # Declare a dict of search and replace terms to run on each template
     {% set tmpl_dict = {'${ROTDIR}':ROTDIR,
-                        '${RUN}':RUN,
+                        '${RUN}':"enkfgdas",
                         '${YMD}':previous_cycle | to_YMD,
                         '${HH}':previous_cycle | strftime("%H"),
-                        '${MEMDIR}':"mem" + '%03d' % mem} %}
+                        '${MEMDIR}':"mem" + '%03d' % smem} %}
 
     # copy coupler file
 - ["{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.coupler.res", "{{ DATA }}/bkg/mem{{ '%03d' % mem }}/{{ current_cycle | to_fv3time }}.coupler.res"]

--- a/workflow/applications/gfs_cycled.py
+++ b/workflow/applications/gfs_cycled.py
@@ -313,8 +313,8 @@ class GFSCycledAppConfig(AppConfig):
                     task_names[run] += ['eobs', 'eupd']
                     task_names[run].append('echgres') if 'gdas' in run else 0
                     task_names[run] += ['ediag'] if options['lobsdiag_forenkf'] else ['eomg']
-                    task_names[run].append('esnowanl') if options['do_jedisnowda'] and 'gdas' in run else 0
 
+                task_names[run].append('esnowanl') if options['do_jedisnowda'] else 0
                 task_names[run].append('efcs') if 'gdas' in run else 0
                 task_names[run].append('epos') if 'gdas' in run else 0
                 task_names[run] += ['stage_ic', 'ecen', 'esfc', 'earc', 'cleanup']

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -619,7 +619,7 @@ class GFSTasks(Tasks):
     def esnowanl(self):
 
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}_epmn', 'offset': f"-{timedelta_to_HMS(self._base['interval_gdas'])}"}
+        dep_dict = {'type': 'metatask', 'name': 'enkfgdas_epmn', 'offset': f"-{timedelta_to_HMS(self._base['interval_gdas'])}"}
         deps.append(rocoto.add_dependency(dep_dict))
         dep_dict = {'type': 'task', 'name': f"{self.run.replace('enkf', '')}_prep"}
         deps.append(rocoto.add_dependency(dep_dict))


### PR DESCRIPTION

# Description

Previously the esnowanl task was setup to run only for the enkfgdas cycle. This PR adds the capability for this task to run for the enkfgfs cycle, incorporating the rotating background directory structure used by other enkfgfs tasks. 

  Resolves #3276 


# Type of change
- [ ] New feature (adds functionality)


# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
3-4 cycles of an ATM with JEDI snow da experiment on Hera. 
COMROOT:  /scratch2/NCEPDEV/stmp3/Travis.J.Elless/comrot/test_snow_ec
EXPDIR:  /scratch1/NCEPDEV/da/Travis.J.Elless/exp/test_snow_ec

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
