### PR TITLE
Capture build fail in Jenkins pipeline when no error logs are produced

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -153,6 +153,8 @@ pipeline {
                                         STATUS = 'Failed'
                                         error("Failed to build global-workflow on ${Machine}")
                                     }
+                                    STATUS = 'Failed'
+                                        error("Failed to build global-workflow on ${Machine} and no error.logs file found")
                                 }
                                 sh(script: './link_workflow.sh')
                             }


### PR DESCRIPTION
# Description

The catch block for a build fail in the Jenkins pipeline did not capture the case when there are no error logs produced.
This is has been rectified with this update.  The compute build shell script still could be enhanced by creating a `error.log` file in the log directory.

Resolves #3296 

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)
