### PR TITLE
Fix memory unsetting on Gaea

### DIFF
--- a/parm/config/gfs/config.resources.GAEAC5
+++ b/parm/config/gfs/config.resources.GAEAC5
@@ -5,7 +5,4 @@
 export FI_VERBS_PREFER_XRC=0
 
 unset memory
-# shellcheck disable=SC2312
-for mem_var in $(env | grep '^memory_' | cut -d= -f1); do
-  unset "${mem_var}"
-done
+unset "memory_${RUN}"

--- a/parm/config/gfs/config.resources.GAEAC6
+++ b/parm/config/gfs/config.resources.GAEAC6
@@ -3,7 +3,4 @@
 # GaeaC6-specific job resources
 
 unset memory
-# shellcheck disable=SC2312
-for mem_var in $(env | grep '^memory_' | cut -d= -f1); do
-  unset "${mem_var}"
-done
+unset "memory_${RUN}"


### PR DESCRIPTION
# Description
Memory requests are not valid on Gaea, so the variable must be unset when running the setup scripts there.  This fixes memory unsetting when variables like `memory_gdas` are set in config.resources.

Resolves #3322 

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
C48_S2SW on Gaea C6

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added