### PR TITLE
Add missing file safeguard for IMS prep in snow analysis tasks

### DIFF
--- a/ush/python/pygfs/task/snow_analysis.py
+++ b/ush/python/pygfs/task/snow_analysis.py
@@ -176,6 +176,11 @@ class SnowAnalysis(Task):
         prep_ims_config = parse_j2yaml(self.task_config.IMS_OBS_LIST, localconf)
         logger.debug(f"{self.task_config.IMS_OBS_LIST}:\n{pformat(prep_ims_config)}")
 
+        asc_file = os.path.join(localconf.COMIN_OBS,f"{self.task_config.OPREFIX}imssnow96.asc")
+        if not os.path.isfile(asc_file):
+            logger.exception(f"Obs files are missing. Will not execute CALCFIMSEXE")
+            return
+
         # copy the IMS obs files from COMIN_OBS to DATA/obs
         logger.info("Copying IMS obs for CALCFIMSEXE")
         FileHandler(prep_ims_config.calcfims).sync()

--- a/ush/python/pygfs/task/snow_analysis.py
+++ b/ush/python/pygfs/task/snow_analysis.py
@@ -176,7 +176,7 @@ class SnowAnalysis(Task):
         prep_ims_config = parse_j2yaml(self.task_config.IMS_OBS_LIST, localconf)
         logger.debug(f"{self.task_config.IMS_OBS_LIST}:\n{pformat(prep_ims_config)}")
 
-        asc_file = os.path.join(localconf.COMIN_OBS, f"{self.task_config.OPREFIX}imssnow96.asc")
+        asc_file = os.path.join(localconf.COMIN_OBS, f"{localconf.OPREFIX}imssnow96.asc")
         if not os.path.isfile(asc_file):
             logger.exception(f"Obs files are missing. Will not execute CALCFIMSEXE")
             return

--- a/ush/python/pygfs/task/snow_analysis.py
+++ b/ush/python/pygfs/task/snow_analysis.py
@@ -176,7 +176,7 @@ class SnowAnalysis(Task):
         prep_ims_config = parse_j2yaml(self.task_config.IMS_OBS_LIST, localconf)
         logger.debug(f"{self.task_config.IMS_OBS_LIST}:\n{pformat(prep_ims_config)}")
 
-        asc_file = os.path.join(localconf.COMIN_OBS,f"{self.task_config.OPREFIX}imssnow96.asc")
+        asc_file = os.path.join(localconf.COMIN_OBS, f"{self.task_config.OPREFIX}imssnow96.asc")
         if not os.path.isfile(asc_file):
             logger.exception(f"Obs files are missing. Will not execute CALCFIMSEXE")
             return

--- a/ush/python/pygfs/task/snow_analysis.py
+++ b/ush/python/pygfs/task/snow_analysis.py
@@ -178,7 +178,7 @@ class SnowAnalysis(Task):
 
         asc_file = os.path.join(localconf.COMIN_OBS, f"{localconf.OPREFIX}imssnow96.asc")
         if not os.path.isfile(asc_file):
-            logger.warn(f"WARNING: Obs files are missing. Will not execute CALCFIMSEXE")
+            logger.warning(f"WARNING: Obs files are missing. Will not execute CALCFIMSEXE")
             return
 
         # copy the IMS obs files from COMIN_OBS to DATA/obs

--- a/ush/python/pygfs/task/snow_analysis.py
+++ b/ush/python/pygfs/task/snow_analysis.py
@@ -178,7 +178,7 @@ class SnowAnalysis(Task):
 
         asc_file = os.path.join(localconf.COMIN_OBS, f"{localconf.OPREFIX}imssnow96.asc")
         if not os.path.isfile(asc_file):
-            logger.exception(f"Obs files are missing. Will not execute CALCFIMSEXE")
+            logger.warn(f"WARNING: Obs files are missing. Will not execute CALCFIMSEXE")
             return
 
         # copy the IMS obs files from COMIN_OBS to DATA/obs

--- a/ush/python/pygfs/task/snowens_analysis.py
+++ b/ush/python/pygfs/task/snowens_analysis.py
@@ -199,7 +199,7 @@ class SnowEnsAnalysis(Task):
 
         asc_file = os.path.join(localconf.COMIN_OBS, f"{localconf.OPREFIX}imssnow96.asc")
         if not os.path.isfile(asc_file):
-            logger.exception(f"Obs files are missing. Will not execute CALCFIMSEXE")
+            logger.warn(f"WARNING: Obs files are missing. Will not execute CALCFIMSEXE")
             return
 
         # copy the IMS obs files from COMIN_OBS to DATA/obs

--- a/ush/python/pygfs/task/snowens_analysis.py
+++ b/ush/python/pygfs/task/snowens_analysis.py
@@ -197,7 +197,7 @@ class SnowEnsAnalysis(Task):
         prep_ims_config = parse_j2yaml(self.task_config.IMS_OBS_LIST, localconf)
         logger.debug(f"{self.task_config.IMS_OBS_LIST}:\n{pformat(prep_ims_config)}")
 
-        asc_file = os.path.join(localconf.COMIN_OBS, f"{self.task_config.OPREFIX}imssnow96.asc")
+        asc_file = os.path.join(localconf.COMIN_OBS, f"{localconf.OPREFIX}imssnow96.asc")
         if not os.path.isfile(asc_file):
             logger.exception(f"Obs files are missing. Will not execute CALCFIMSEXE")
             return

--- a/ush/python/pygfs/task/snowens_analysis.py
+++ b/ush/python/pygfs/task/snowens_analysis.py
@@ -197,6 +197,11 @@ class SnowEnsAnalysis(Task):
         prep_ims_config = parse_j2yaml(self.task_config.IMS_OBS_LIST, localconf)
         logger.debug(f"{self.task_config.IMS_OBS_LIST}:\n{pformat(prep_ims_config)}")
 
+        asc_file = os.path.join(localconf.COMIN_OBS,f"{self.task_config.OPREFIX}imssnow96.asc")
+        if not os.path.isfile(asc_file):
+            logger.exception(f"Obs files are missing. Will not execute CALCFIMSEXE")
+            return
+
         # copy the IMS obs files from COMIN_OBS to DATA/obs
         logger.info("Copying IMS obs for CALCFIMSEXE")
         FileHandler(prep_ims_config.calcfims).sync()

--- a/ush/python/pygfs/task/snowens_analysis.py
+++ b/ush/python/pygfs/task/snowens_analysis.py
@@ -197,7 +197,7 @@ class SnowEnsAnalysis(Task):
         prep_ims_config = parse_j2yaml(self.task_config.IMS_OBS_LIST, localconf)
         logger.debug(f"{self.task_config.IMS_OBS_LIST}:\n{pformat(prep_ims_config)}")
 
-        asc_file = os.path.join(localconf.COMIN_OBS,f"{self.task_config.OPREFIX}imssnow96.asc")
+        asc_file = os.path.join(localconf.COMIN_OBS, f"{self.task_config.OPREFIX}imssnow96.asc")
         if not os.path.isfile(asc_file):
             logger.exception(f"Obs files are missing. Will not execute CALCFIMSEXE")
             return

--- a/ush/python/pygfs/task/snowens_analysis.py
+++ b/ush/python/pygfs/task/snowens_analysis.py
@@ -199,7 +199,7 @@ class SnowEnsAnalysis(Task):
 
         asc_file = os.path.join(localconf.COMIN_OBS, f"{localconf.OPREFIX}imssnow96.asc")
         if not os.path.isfile(asc_file):
-            logger.warn(f"WARNING: Obs files are missing. Will not execute CALCFIMSEXE")
+            logger.warning(f"WARNING: Obs files are missing. Will not execute CALCFIMSEXE")
             return
 
         # copy the IMS obs files from COMIN_OBS to DATA/obs


### PR DESCRIPTION
# Description
This PR adds a safeguard to only continue running the IMS prep step in the snow analysis tasks if the necessary obs file is present. 
Resolves #3328 

# Type of change
- [ ] New feature (adds functionality)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
2.5 cycle experiment on Hera

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes

