### PR TITLE
Update `FIX_DIR` to new GFSv16.4.0 fix set

### DIFF
--- a/parm/parm_wave/bull_awips_gfswave
+++ b/parm/parm_wave/bull_awips_gfswave
@@ -181,7 +181,7 @@ export b55020=AGPS40_KWBJ_OSBM01
 export b55033=AGPS40_KWBJ_OSBM02
 export b55035=AGPS40_KWBJ_OSBM03
 export b55039=AGPS40_KWBJ_OSBM04
-# Gulf of Mexico (GX) spectra (4) south from NC and Puerto Rico (2)
+# Gulf of America (GX) spectra (4) south from NC and Puerto Rico (2)
 export b42001=AGGX42_KWBJ_OSBM01
 export b42002=AGGX42_KWBJ_OSBM02
 export b42003=AGGX42_KWBJ_OSBM03

--- a/sorc/link_fv3gfs.sh
+++ b/sorc/link_fv3gfs.sh
@@ -35,7 +35,7 @@ if [ $machine == "cray" ]; then
 elif [ $machine = "dell" ]; then
     FIX_DIR="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix_nco_gfsv16.3.0"
 elif [ $machine = "wcoss2" ]; then
-    FIX_DIR="/lfs/h2/emc/global/save/emc.global/FIX/fix_nco_gfsv16.3.0"
+    FIX_DIR="/lfs/h2/emc/global/noscrub/emc.global/FIX/fix_nco_gfsv16.4.0"
 elif [ $machine = "hera" ]; then
     FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix_nco_gfsv16.3.0"
 elif [ $machine = "orion" ]; then

--- a/sorc/link_fv3gfs.sh
+++ b/sorc/link_fv3gfs.sh
@@ -37,9 +37,9 @@ elif [ $machine = "dell" ]; then
 elif [ $machine = "wcoss2" ]; then
     FIX_DIR="/lfs/h2/emc/global/noscrub/emc.global/FIX/fix_nco_gfsv16.4.0"
 elif [ $machine = "hera" ]; then
-    FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix_nco_gfsv16.3.0"
+    FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix_nco_gfsv16.4.0"
 elif [ $machine = "orion" ]; then
-    FIX_DIR="/work/noaa/global/glopara/fix_nco_gfsv16.3.0"
+    FIX_DIR="/work/noaa/global/glopara/fix_nco_gfsv16.4.0"
 fi
 cd ${pwd}/../fix                ||exit 8
 for dir in fix_am fix_fv3_gmted2010 fix_gldas fix_orog fix_verif fix_wave_gfs ; do


### PR DESCRIPTION
# Description

This PR updates the `FIX_DIR` for WCOSS2 to use the new `fix_nco_gfsv16.4.0` set. For completeness, also update the Hera and Orion `FIX_DIR` path, in case we also push that fix set to those platforms (note however, we are no longer supporting non-WCOSS2 platforms for GFSv16). The new set includes updated wave buoy fix files for Gulf Of Mexico name change.

Additionally, update "Mexico" to "America" in the `parm/parm_wave/bull_awips_gfswave` wave parm file.

Refs #3326
Refs #2987