### PR TITLE
Fix the empty aerosol DA aerostat tar file issue

### DIFF
--- a/parm/archive/gdas.yaml.j2
+++ b/parm/archive/gdas.yaml.j2
@@ -65,7 +65,7 @@ gdas:
         - "{{ COMIN_ATMOS_ANALYSIS | relpath(ROTDIR) }}/{{ head }}radstat"
             {% endif %}
             {% if DO_AERO_ANL %}
-        - "{{ COMIN_CHEM_ANALYSIS | relpath(ROTDIR) }}/{{ head }}aerostat"
+        - "{{ COMIN_CHEM_ANALYSIS | relpath(ROTDIR) }}/{{ head }}aerostat.tgz"
             {% endif %}
             {% if DO_PREP_OBS_AERO %}
         - "{{ COMIN_OBS | relpath(ROTDIR) }}/{{ head }}aeroobs"

--- a/parm/archive/gfs_arcdir.yaml.j2
+++ b/parm/archive/gfs_arcdir.yaml.j2
@@ -51,8 +51,8 @@
     {% endif %}
 
     {% if DO_AERO_ANL %}
-        {% do det_anl_files.append([COMIN_CHEM_ANALYSIS ~ "/" ~ head ~ "aerostat",
-                                    ARCDIR ~ "/aerostat." ~ RUN ~ "." ~ cycle_YMDH ]) %}
+        {% do det_anl_files.append([COMIN_CHEM_ANALYSIS ~ "/" ~ head ~ "aerostat.tgz",
+                                    ARCDIR ~ "/aerostat." ~ RUN ~ "." ~ cycle_YMDH ~ ".tgz"]) %}
     {% endif %}
 
     {% if DO_PREP_OBS_AERO == True %}

--- a/parm/archive/gfsa.yaml.j2
+++ b/parm/archive/gfsa.yaml.j2
@@ -39,7 +39,7 @@ gfsa:
         - "{{ COMIN_ATMOS_ANALYSIS | relpath(ROTDIR) }}/{{ head }}gsistat"
         {% endif %}
         {% if DO_AERO_ANL %}
-        - "{{ COMIN_CHEM_ANALYSIS | relpath(ROTDIR) }}/{{ head }}aerostat"
+        - "{{ COMIN_CHEM_ANALYSIS | relpath(ROTDIR) }}/{{ head }}aerostat.tgz"
         {% endif %}
         {% if DO_PREP_OBS_AERO %}
         - "{{ COMIN_OBS | relpath(ROTDIR) }}/{{ head }}aeroobs"

--- a/ush/python/pygfs/task/aero_analysis.py
+++ b/ush/python/pygfs/task/aero_analysis.py
@@ -191,7 +191,7 @@ class AerosolAnalysis(Task):
         FileHandler(aero_var_final_list).sync()
 
         # open tar file for writing
-        with tarfile.open(aerostat, "w") as archive:
+        with tarfile.open(aerostat, "w|gz") as archive:
             for diagfile in diags:
                 diaggzip = f"{diagfile}.gz"
                 archive.add(diaggzip, arcname=os.path.basename(diaggzip))

--- a/ush/python/pygfs/task/aero_analysis.py
+++ b/ush/python/pygfs/task/aero_analysis.py
@@ -167,10 +167,10 @@ class AerosolAnalysis(Task):
         # ---- tar up diags
         # path of output tar statfile
         logger.info('Preparing observation space diagnostics for archiving')
-        aerostat = os.path.join(self.task_config.COMOUT_CHEM_ANALYSIS, f"{self.task_config['APREFIX']}aerostat")
+        aerostat = os.path.join(self.task_config.COMOUT_CHEM_ANALYSIS, f"{self.task_config['APREFIX']}aerostat.tgz")
 
         # get list of diag files to put in tarball
-        diags = glob.glob(os.path.join(self.task_config['DATA'], 'diags', 'diag*nc4'))
+        diags = glob.glob(os.path.join(self.task_config['DATA'], 'diags', 'diag*nc'))
 
         # gzip the files first
         for diagfile in diags:


### PR DESCRIPTION
Somewhere along the way, an inconsistency between the aerosol DA diagnostic file output name suffixes and the workflow crept in, where the files were generated, but not found via glob and put in a tarball because of `.nc` vs `.nc4`. This PR resolves this issue plus also renames the file to be more descriptive, e.g.:
`gdas.t00z.aerostat.tgz`
to clarify it is a tar ball with gzip. The PR also makes it a tarball with gzip instead of an uncompressed tar.

  Resolves #3327 

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics

- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 
  - [ ] EMC verif-global 
  - [ ] GDAS 
  - [ ] GFS-utils 
  - [ ] GSI 
  - [ ] GSI-monitor 
  - [ ] GSI-utils 
  - [ ] UFS-utils 
  - [ ] UFS-weather-model 
  - [ ] wxflow 

# How has this been tested?

Example:
- Clone and build on Hera
- Cycled test on Hera

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
