### PR TITLE
Rename Gulf of Mexico to Gulf of America

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,7 @@
 # External sub-modules of global-workflow
 
 [FV3GFS]
-tag = GFS.v16.3.1
+tag = GFS.v16.3.22
 local_path = sorc/fv3gfs.fd
 repo_url = https://github.com/ufs-community/ufs-weather-model.git
 protocol = git

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -24,7 +24,7 @@ The checkout script extracts the following GFS components:
 
 | Component | Tag         | POC               |
 | --------- | ----------- | ----------------- |
-| MODEL     | GFS.v16.3.22   | Jun.Wang@noaa.gov |
+| MODEL     | GFS.v16.3.22 | Jun.Wang@noaa.gov |
 | GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
 | GSI       | gfsda.v16.3.20 | Andrew.Collard@noaa.gov |
 | UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
@@ -54,7 +54,7 @@ VERSION FILE CHANGES
 SORC CHANGES
 ------------
 
-* New MODEL tag - includes WW3 updates for name change
+* New MODEL tag `GFS.v16.3.22` - includes WW3 updates for name change
 
 JOBS CHANGES
 ------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -1,10 +1,10 @@
-GFS V16.3.21 RELEASE NOTES
+GFS V16.3.22 RELEASE NOTES
 
 -------
 PRELUDE
 -------
 
-The WAFS is separated from the GFS and is now its own package in production as WAFS.v7.0.1. A code update for syndat_getjtbul is also included.
+The Gulf of Mexico is renamed to the Gulf of America.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -13,9 +13,9 @@ The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub are used t
 
 ```bash
 cd $PACKAGEROOT
-mkdir gfs.v16.3.21
-cd gfs.v16.3.21
-git clone -b EMC-v16.3.21 https://github.com/NOAA-EMC/global-workflow.git .
+mkdir gfs.v16.3.22
+cd gfs.v16.3.22
+git clone -b EMC-v16.3.22 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```
@@ -24,7 +24,7 @@ The checkout script extracts the following GFS components:
 
 | Component | Tag         | POC               |
 | --------- | ----------- | ----------------- |
-| MODEL     | GFS.v16.3.1   | Jun.Wang@noaa.gov |
+| MODEL     | GFS.v16.3.22   | Jun.Wang@noaa.gov |
 | GLDAS     | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov |
 | GSI       | gfsda.v16.3.20 | Andrew.Collard@noaa.gov |
 | UFS_UTILS | ops-gfsv16.3.0 | George.Gayno@noaa.gov |
@@ -49,116 +49,50 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* `versions/run.ver` - change `version=v16.3.21` and `gfs_ver=v16.3.21`
+* `versions/run.ver` - change `version=v16.3.22` and `gfs_ver=v16.3.22`
 
 SORC CHANGES
 ------------
 
-The WAFS is no longer a submodule that is checked out within the GFS package.
-The `sorc/checkout.sh` and `Externals.cfg` checkout script no longer clone WAFS.
-The `sorc/build_all.sh` script no longer builds the WAFS code.
-The `sorc/build_gfs_wafs.sh` build script is deleted.
-The `sorc/link_fv3gfs.sh` script no longer links/copies WAFS files/execs.
-
-Also included in this package is a fix to the syndat_getjtbul code to resolve a
-parsing problem with 3-character storm names.
+* New MODEL tag - includes WW3 updates for name change
 
 JOBS CHANGES
 ------------
 
-All WAFS jobs are removed from the GFS ecFlow definition file, rocoto mesh, and `ush/ecflow/prod.yml`.
-Jobs removed:
-* `jgfs_atmos_wafs_gcip`
-* `jgfs_atmos_wafs_fFFF`
-* `jgfs_atmos_wafs_grib2`
-* `jgfs_atmos_wafs_grib2_0p25`
-* `jgfs_atmos_wafs_blending_0p25`
+* No changes from GFS v16.3.21
 
 PARM/CONFIG CHANGES
 -------------------
 
-The following config files are deleted:
-* `parm/config/config.wafs`
-* `parm/config/config.wafsblending`
-* `parm/config/config.wafsblending0p25`
-* `parm/config/config.wafsgcip`
-* `parm/config/config.wafsgrib2`
-* `parm/config/config.wafsgrib20p25`
-
-* The `WAFSF` flag is removed from `parm/config/config.base.emc.dyn` and `parm/config/config.base.nco.static`.
-* All WAFS jobs are removed from platform env files, `parm/config/config.resources.emc.dyn`, and `parm/config/config.resources.nco.static`.
-* The WAFS jobs are removed from experiment setup.
-
-WAFS output is removed from the following transfer list files:
-* `parm/product/transfer_gfs_1.list`
-* `parm/product/transfer_gfs_7.list`
+* `parm/parm_wave/bull_awips_gfswave` - internal name change
 
 SCRIPT CHANGES
 --------------
 
-The following WAFS rocoto scripts are removed:
-* `jobs/rocoto/wafs.sh`
-* `jobs/rocoto/wafsblending.sh`
-* `jobs/rocoto/wafsblending0p25.sh`
-* `jobs/rocoto/wafsgcip.sh`
-* `jobs/rocoto/wafsgrib2.sh`
-* `jobs/rocoto/wafsgrib20p25.sh`
-
-The following ecf scripts are removed from the GFS:
-* `ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending.ecf`
-* `ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_blending_0p25.ecf`
-* `ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2.ecf`
-* `ecf/scripts/gfs/atmos/post_processing/grib2_wafs/jgfs_atmos_wafs_grib2_0p25.ecf`
-* `ecf/scripts/gfs/atmos/post_processing/grib_wafs/jgfs_atmos_wafs_master.ecf`
-* `ecf/scripts/gfs/atmos/post_processing/jgfs_atmos_wafs_gcip.ecf`
-
-The WAFS is removed from `ecf/setup_ecf_links.sh`.
-
-The WAFS output is removed from archival (`ush/hpssarch_gen.sh`).
+* No changes from GFS v16.3.21
 
 FIX CHANGES
 -----------
 
-* `fix/product/wafs_admin_msg` - removed
+Internal name change updates:
+* `wave_gfs.buoys`
+* `wave_gfs.buoys.full`
+* `wave_gfs.buoys.dat`
 
 MODULE CHANGES
 --------------
 
-Modules needed by WAFS are removed from `modulefiles/module_base.wcoss_dell_p3`.
+* No changes from GFS v16.3.21
 
 CHANGES TO FILE AND FILE SIZES
 ------------------------------
 
-The following files will no longer be produced within the GFS COM:
-* `gfs.tCCz.awf_0p25.fFFF.grib2`  - renamed to `wafs.tCCz.awf.0p25.fFFF.grib2` in WAFSv7. Filesize is changed from 55M to 56M with 7 extra levels of aviation fields.
-* `gfs.tCCz.awf_grb45fFF.grib2` - renamed to `wafs.tCCz.awf_grid45.fFFF.grib2` in WAFSv7
-* `wmo/grib2.tCCz.awf_grbfFF.45` - renamed to `wmo/grib2.wafs.tCCz.awf_grid45.fFFF` in WAFSv7
-* `gfs.tCCz.wafs.0p25.anl` - renamed to `wafs.tCCz.0p25.anl.grib2` in WAFSv7
-* `gfs.tCCz.wafs.0p25.anl.idx`
-* `gfs.tCCz.wafs_0p25_unblended.fFFF.grib2` - renamed to `WAFS_0p25_unblended_YYYYMMDDHHfFFF.grib2` in WAFSv7
-* `gfs.tCCz.wafs_0p25_unblended.fFFF.grib2.idx`
-* `gfs.tCCz.wafs.grb2fFFF` - renamed to `wafs.tCCz.master.fFFF.grib2` in WAFSv7. Between forecast hours [006-048], filesize is changed from 929M to 936M with 7 extra levels of aviation fields; for f000, filesize increases from 949M to 956M with 7 extra levels of aviation fields. No size change for other forecast hours
-* `gfs.tCCz.wafs.grb2fFFF.idx`
-* `gfs.tCCz.wafs_grb45fFF.grib2` - renamed to `gfs.tCCz.wafs_grb45fFFF.grib2` in WAFSv7
-* `gfs.tCCz.wafs_grb45fFF.grib2.idx`
-* `wmo/grib2.tCCz.wafs_grbfFF.45` - renamed to `wmo/grib2.wafs.tCCz.awf_grid45.fFFF` in WAFSv7
-* `wmo/xtrn.wfsgfsCCFF[a/b].gfs_atmos_wafs_fFF_CC` - renamed to `wmo/xtrn.wfsgfsCCFF[a/b]` in WAFSv7
-* `gfs.tCCz.gcip.f00.grib2` - renamed to `wafs.tCCz.gcip.f000.grib2` in WAFSv7
-* `WAFS_0p25_blended_YYYYMMDDHHf[06-48].grib2` - renamed to `WAFS_0p25_blended_ YYYYMMDDHHfFFF.grib2` in WAFSv7
-
-The following files will no longer be produced within the GFS COM
-and are being retired from the WAFS package, which will free 20G:
-* `gfs.tCCz.wafs_icao.grb2fFFF`
-* `gfs.tCCz.wafs_icao.grb2fFFF.idx`
-* `wafs.tCCz.master.fFFF.grib2` where FFF is from 001 to 005
-* `gfs.tCCz.control.wafsblending_0p25`
+* No changes from GFS v16.3.21
 
 ENVIRONMENT AND RESOURCE CHANGES
 --------------------------------
 
-* Updates to improve the enkfgdas_update job runtime stability.
-  * Run with `--cpu-bind core` instead of `--cpu-bind depth`
-  * Change tasks to 280 and threads to 16
+* No changes from GFS v16.3.21
 
 PRE-IMPLEMENTATION TESTING REQUIREMENTS
 ---------------------------------------
@@ -171,26 +105,25 @@ PRE-IMPLEMENTATION TESTING REQUIREMENTS
 DISSEMINATION INFORMATION
 -------------------------
 
-* No changes from GFS v16.3.20
+* No changes from GFS v16.3.21
 
 HPSS ARCHIVE
 ------------
 
-* No changes from GFS v16.3.20
+* No changes from GFS v16.3.21
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
 
-* Removal of WAFS jobs.
+* No changes from GFS v16.3.21
 
 DOCUMENTATION
 -------------
 
-* No changes from GFS v16.3.20
+* No changes from GFS v16.3.21
 
 PREPARED BY
 -----------
 Kate.Friedman@noaa.gov
-Yali.Mao@noaa.gov
-Rahul.Mahajan@noaa.gov
-Qingfu.Liu@noaa.gov
+Jessica.Meixner@noaa.gov
+Brian.Curtis@noaa.gov

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -4,7 +4,7 @@ GFS V16.3.22 RELEASE NOTES
 PRELUDE
 -------
 
-The Gulf of Mexico is renamed to the Gulf of America.
+The Gulf of Mexico is renamed to the Gulf of America. This is a non-science change and does not impact model output.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -54,7 +54,7 @@ VERSION FILE CHANGES
 SORC CHANGES
 ------------
 
-* New MODEL tag `GFS.v16.3.22` - includes WW3 updates for name change
+* New MODEL tag `GFS.v16.3.22` - includes WW3 updates for name change, results do not change
 
 JOBS CHANGES
 ------------

--- a/parm/parm_wave/bull_awips_gfswave
+++ b/parm/parm_wave/bull_awips_gfswave
@@ -181,7 +181,7 @@ export b55020=AGPS40_KWBJ_OSBM01
 export b55033=AGPS40_KWBJ_OSBM02
 export b55035=AGPS40_KWBJ_OSBM03
 export b55039=AGPS40_KWBJ_OSBM04
-# Gulf of Mexico (GX) spectra (4) south from NC and Puerto Rico (2)
+# Gulf of America (GX) spectra (4) south from NC and Puerto Rico (2)
 export b42001=AGGX42_KWBJ_OSBM01
 export b42002=AGGX42_KWBJ_OSBM02
 export b42003=AGGX42_KWBJ_OSBM03

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -23,7 +23,7 @@ echo $topdir
 echo fv3gfs checkout ...
 if [[ ! -d fv3gfs.fd ]] ; then
     rm -f ${topdir}/checkout-fv3gfs.log
-    git clone --recursive --branch GFS.v16.3.1 https://github.com/ufs-community/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
+    git clone --recursive --branch GFS.v16.3.22 https://github.com/ufs-community/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory fv3gfs.fd already exists.'

--- a/sorc/link_fv3gfs.sh
+++ b/sorc/link_fv3gfs.sh
@@ -35,11 +35,11 @@ if [ $machine == "cray" ]; then
 elif [ $machine = "dell" ]; then
     FIX_DIR="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix_nco_gfsv16.3.0"
 elif [ $machine = "wcoss2" ]; then
-    FIX_DIR="/lfs/h2/emc/global/save/emc.global/FIX/fix_nco_gfsv16.3.0"
+    FIX_DIR="/lfs/h2/emc/global/noscrub/emc.global/FIX/fix_nco_gfsv16.3.22"
 elif [ $machine = "hera" ]; then
-    FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix_nco_gfsv16.3.0"
+    FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix_nco_gfsv16.3.22"
 elif [ $machine = "orion" ]; then
-    FIX_DIR="/work/noaa/global/glopara/fix_nco_gfsv16.3.0"
+    FIX_DIR="/work/noaa/global/glopara/fix_nco_gfsv16.3.22"
 fi
 cd ${pwd}/../fix                ||exit 8
 for dir in fix_am fix_fv3_gmted2010 fix_gldas fix_orog fix_verif fix_wave_gfs ; do

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.21
-export gfs_ver=v16.3.21
+export version=v16.3.22
+export gfs_ver=v16.3.22
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2


### PR DESCRIPTION
# Description

This PR updates the name of the "Gulf of _Mexico_" to the "Gulf of _America_". This includes fix/parm file updates and a new UWM tag for WW3 rename updates.

Refs #3326

# Type of change

Production update

# Change characteristics

- Fix and parm file updates
- UWM tag update