### PR TITLE
Update issue templates to use new issue type field

### DIFF
--- a/.github/ISSUE_TEMPLATE/NCO_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/NCO_bug_report.yml
@@ -1,7 +1,7 @@
 name: NCO Bug Report
 description: Report something that is incorrect or broken
 labels: ["nco-bug", "triage"]
-type: ["bug"]
+type: bug
 assignees:
   - aerorahul
 

--- a/.github/ISSUE_TEMPLATE/NCO_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/NCO_bug_report.yml
@@ -2,7 +2,7 @@ name: NCO Bug Report
 description: Report something that is incorrect or broken
 labels: ["nco-bug", "triage"]
 type: "bug"
-projects: ["global-workflow development"]
+projects: ["NOAA-EMC/41"]
 assignees:
   - aerorahul
 

--- a/.github/ISSUE_TEMPLATE/NCO_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/NCO_bug_report.yml
@@ -1,7 +1,8 @@
 name: NCO Bug Report
 description: Report something that is incorrect or broken
 labels: ["nco-bug", "triage"]
-type: bug
+type: "bug"
+projects: ["global-workflow development"]
 assignees:
   - aerorahul
 

--- a/.github/ISSUE_TEMPLATE/NCO_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/NCO_bug_report.yml
@@ -1,6 +1,7 @@
 name: NCO Bug Report
 description: Report something that is incorrect or broken
 labels: ["nco-bug", "triage"]
+type: ["bug"]
 assignees:
   - aerorahul
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: Report something that is incorrect or broken
-labels: ["bug", "triage"]
+labels: ["triage"]
+type: ["bug"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,8 @@
 name: Bug Report
 description: Report something that is incorrect or broken
 labels: ["triage"]
-type: bug
+type: "bug"
+projects: ["global-workflow development"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,7 +2,7 @@ name: Bug Report
 description: Report something that is incorrect or broken
 labels: ["triage"]
 type: "bug"
-projects: ["global-workflow development"]
+projects: ["NOAA-EMC/41"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report something that is incorrect or broken
 labels: ["triage"]
-type: ["bug"]
+type: bug
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/dump_request.yml
+++ b/.github/ISSUE_TEMPLATE/dump_request.yml
@@ -1,7 +1,7 @@
 name: Global Observation Dump Request
 description: Request additional dates be added to a machine's global dump archive (GDA) or introduce experimental dump data to the GDA
 labels: ["Static Data Mgmt"]
-type: ["task"]
+type: task
 assignees:
   - KateFriedman-NOAA
   - WalterKolczynski-NOAA

--- a/.github/ISSUE_TEMPLATE/dump_request.yml
+++ b/.github/ISSUE_TEMPLATE/dump_request.yml
@@ -2,7 +2,7 @@ name: Global Observation Dump Request
 description: Request additional dates be added to a machine's global dump archive (GDA) or introduce experimental dump data to the GDA
 labels: ["Static Data Mgmt"]
 type: "task"
-projects: ["global-workflow development"]
+projects: ["NOAA-EMC/41"]
 assignees:
   - KateFriedman-NOAA
   - WalterKolczynski-NOAA

--- a/.github/ISSUE_TEMPLATE/dump_request.yml
+++ b/.github/ISSUE_TEMPLATE/dump_request.yml
@@ -1,7 +1,8 @@
 name: Global Observation Dump Request
 description: Request additional dates be added to a machine's global dump archive (GDA) or introduce experimental dump data to the GDA
 labels: ["Static Data Mgmt"]
-type: task
+type: "task"
+projects: ["global-workflow development"]
 assignees:
   - KateFriedman-NOAA
   - WalterKolczynski-NOAA

--- a/.github/ISSUE_TEMPLATE/dump_request.yml
+++ b/.github/ISSUE_TEMPLATE/dump_request.yml
@@ -1,6 +1,7 @@
 name: Global Observation Dump Request
 description: Request additional dates be added to a machine's global dump archive (GDA) or introduce experimental dump data to the GDA
 labels: ["Static Data Mgmt"]
+type: ["task"]
 assignees:
   - KateFriedman-NOAA
   - WalterKolczynski-NOAA

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Request new capability
 labels: ["triage"]
-type: ["feature"]
+type: feature
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,8 @@
 name: Feature Request
 description: Request new capability
 labels: ["triage"]
-type: feature
+type: "feature"
+projects: ["global-workflow development"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature Request
 description: Request new capability
-labels: ["feature", "triage"]
+labels: ["triage"]
+type: ["feature"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,7 @@ name: Feature Request
 description: Request new capability
 labels: ["triage"]
 type: "feature"
-projects: ["global-workflow development"]
+projects: ["NOAA-EMC/41"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/production_update.yml
+++ b/.github/ISSUE_TEMPLATE/production_update.yml
@@ -2,7 +2,7 @@ name: Production Update
 description: Begin the process of an operational production update
 labels: ["production update", "triage"]
 type: "feature"
-projects: ["global-workflow development"]
+projects: ["NOAA-EMC/41"]
 assignees:
   - WalterKolczynski-NOAA
   - KateFriedman-NOAA

--- a/.github/ISSUE_TEMPLATE/production_update.yml
+++ b/.github/ISSUE_TEMPLATE/production_update.yml
@@ -1,6 +1,7 @@
 name: Production Update
 description: Begin the process of an operational production update
 labels: ["production update", "triage"]
+type: ["feature"]
 assignees:
   - WalterKolczynski-NOAA
   - KateFriedman-NOAA

--- a/.github/ISSUE_TEMPLATE/production_update.yml
+++ b/.github/ISSUE_TEMPLATE/production_update.yml
@@ -1,7 +1,8 @@
 name: Production Update
 description: Begin the process of an operational production update
 labels: ["production update", "triage"]
-type: feature
+type: "feature"
+projects: ["global-workflow development"]
 assignees:
   - WalterKolczynski-NOAA
   - KateFriedman-NOAA

--- a/.github/ISSUE_TEMPLATE/production_update.yml
+++ b/.github/ISSUE_TEMPLATE/production_update.yml
@@ -1,7 +1,7 @@
 name: Production Update
 description: Begin the process of an operational production update
 labels: ["production update", "triage"]
-type: ["feature"]
+type: feature
 assignees:
   - WalterKolczynski-NOAA
   - KateFriedman-NOAA

--- a/.github/ISSUE_TEMPLATE/static_data.yml
+++ b/.github/ISSUE_TEMPLATE/static_data.yml
@@ -1,7 +1,7 @@
 name: Static Data Update
 description: Request static data be added or updated
 labels: ["Static Data Mgmt"]
-type: ["task"]
+type: task
 assignees:
   - KateFriedman-NOAA
   - WalterKolczynski-NOAA

--- a/.github/ISSUE_TEMPLATE/static_data.yml
+++ b/.github/ISSUE_TEMPLATE/static_data.yml
@@ -2,7 +2,7 @@ name: Static Data Update
 description: Request static data be added or updated
 labels: ["Static Data Mgmt"]
 type: "task"
-projects: ["global-workflow development"]
+projects: ["NOAA-EMC/41"]
 assignees:
   - KateFriedman-NOAA
   - WalterKolczynski-NOAA

--- a/.github/ISSUE_TEMPLATE/static_data.yml
+++ b/.github/ISSUE_TEMPLATE/static_data.yml
@@ -1,7 +1,8 @@
 name: Static Data Update
 description: Request static data be added or updated
 labels: ["Static Data Mgmt"]
-type: task
+type: "task"
+projects: ["global-workflow development"]
 assignees:
   - KateFriedman-NOAA
   - WalterKolczynski-NOAA

--- a/.github/ISSUE_TEMPLATE/static_data.yml
+++ b/.github/ISSUE_TEMPLATE/static_data.yml
@@ -1,6 +1,7 @@
 name: Static Data Update
 description: Request static data be added or updated
 labels: ["Static Data Mgmt"]
+type: ["task"]
 assignees:
   - KateFriedman-NOAA
   - WalterKolczynski-NOAA


### PR DESCRIPTION
# Description
GitHub added a new issue type field to indicate whether an issue is a bug, feature, or task. This switches issue templates to use this new field instead of labels. Also adds issue to "global-workflow development" project.

Resolves #3368

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
N/A, GitHub template only

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
