### PR TITLE
Add mpich/8.1.19 to the WCOSS2 LD_LIBRARY_PATH for GDASApp jobs

### DIFF
--- a/ush/load_ufsda_modules.sh
+++ b/ush/load_ufsda_modules.sh
@@ -41,6 +41,7 @@ case "${MACHINE_ID}" in
       # TODO: Add path to GDASApp libraries and cray-mpich as temporary patches
       # TODO: Remove LD_LIBRARY_PATH lines as soon as permanent solutions are available	
       export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${HOMEgfs}/sorc/gdas.cd/build/lib"
+      export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/cray/pe/mpich/8.1.19/ofi/intel/19.0/lib"
     fi
     module load "${MODS}/${MACHINE_ID}"
     ncdump=$( command -v ncdump )


### PR DESCRIPTION
 # Description
This PR allows the snowanl jobs in g-w CI case C96C48_hybatmaerosnowDA to successfully run to completion on Cactus.  Without the changes in this PR the 20211221 00Z gdas and enkfgdas snowanl jobs fail on Cactus

Resolves #3395

# Type of change
- [x] Bug fix (fixes something broken)


# Change characteristics
- Is this a breaking change (a change in existing functionality)? **NO**
- Does this change require a documentation update? **NO**
- Does this change require an update to any of the following submodules? **NO**


# How has this been tested?
Clone, build, and run g-w CI C96C48_hybatmaerosnowDA on Cactus.  See this [comment](https://github.com/NOAA-EMC/global-workflow/pull/3295#issuecomment-2683235333) from PR #3295 for details.


# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] This change is covered by an existing CI test or a new one has been added

