### PR TITLE
Change GOA FV3-GSDCHEM-WW3 check out tag

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -30,7 +30,7 @@ if [[ ! -d fv3gfs.fd ]] ; then
     rc=$?
     ((err+=$rc))
     cd fv3gfs.fd
-    git checkout gefs_v12.3.14-0
+    git checkout gefs_v12.3.13-0
     git submodule update --init --recursive
     rc=$?
     ((err+=$rc))


### PR DESCRIPTION
Since the Gulf of America changes are being combined with another planned NCO change, the FV3-GSDCHEM-WW3 tag needs to be updated from gefs_v12.3.14-0 to gefs_v12.3.13-0. 
