### PR TITLE
Disable METplus jobs on Hera

### DIFF
--- a/workflow/hosts/hera.yaml
+++ b/workflow/hosts/hera.yaml
@@ -30,3 +30,5 @@ COMINecmwf: /scratch1/NCEPDEV/global/glopara/data/external_gempak/ecmwf
 COMINnam: /scratch1/NCEPDEV/global/glopara/data/external_gempak/nam
 COMINukmet: /scratch1/NCEPDEV/global/glopara/data/external_gempak/ukmet
 AERO_INPUTS_DIR: /scratch1/NCEPDEV/global/glopara/data/gocart_emissions
+# TODO Reenable when RDHPCS#2025022654000078 is resolved
+DO_METP: 'NO'


### PR DESCRIPTION
# Description
This fix disables the METplus jobs on Hera while permissions issues are investigated by RDHPCS.

Resolves #3401

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? YES
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Generated all CI tests and verified that they did not include METplus jobs.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added