### PR TITLE
Rename wave output and refactor some wave scripts

### DIFF
--- a/env/AWSPW.env
+++ b/env/AWSPW.env
@@ -50,7 +50,7 @@ elif [[ "${step}" = "prep_emissions" ]]; then
 
 elif [[ "${step}" = "waveinit" ]] || [[ "${step}" = "waveprep" ]] || [[ "${step}" = "wavepostsbs" ]] || [[ "${step}" = "wavepostbndpnt" ]] || [[ "${step}" = "wavepostbndpntbll" ]] || [[ "${step}" = "wavepostpnt" ]]; then
 
-    export CFP_MP="YES"
+    export USE_CFP="YES"
     if [[ "${step}" = "waveprep" ]]; then export MP_PULSE=0 ; fi
     export wavempexec=${launcher}
     export wave_mpmd=${mpmd_opt}

--- a/env/AZUREPW.env
+++ b/env/AZUREPW.env
@@ -46,7 +46,7 @@ if [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
 
 elif [[ "${step}" = "waveinit" ]] || [[ "${step}" = "waveprep" ]] || [[ "${step}" = "wavepostsbs" ]] || [[ "${step}" = "wavepostbndpnt" ]] || [[ "${step}" = "wavepostbndpntbll" ]] || [[ "${step}" = "wavepostpnt" ]]; then
 
-    export CFP_MP="YES"
+    export USE_CFP="YES"
     if [[ "${step}" = "waveprep" ]]; then export MP_PULSE=0 ; fi
     export wavempexec=${launcher}
     export wave_mpmd=${mpmd_opt}

--- a/env/GAEAC5.env
+++ b/env/GAEAC5.env
@@ -48,7 +48,7 @@ case ${step} in
  ;;
  "waveinit" | "waveprep" | "wavepostsbs" | "wavepostbndpnt" | "wavepostpnt" | "wavepostbndpntbll")
 
-    export CFP_MP="YES"
+    export USE_CFP="YES"
     [[ "${step}" = "waveprep" ]] && export MP_PULSE=0
     export wavempexec=${launcher}
     export wave_mpmd=${mpmd_opt}

--- a/env/GAEAC6.env
+++ b/env/GAEAC6.env
@@ -48,7 +48,7 @@ case ${step} in
  ;;
  "waveinit" | "waveprep" | "wavepostsbs" | "wavepostbndpnt" | "wavepostpnt" | "wavepostbndpntbll")
 
-    export CFP_MP="YES"
+    export USE_CFP="YES"
     [[ "${step}" = "waveprep" ]] && export MP_PULSE=0
     export wavempexec=${launcher}
     export wave_mpmd=${mpmd_opt}

--- a/env/GOOGLEPW.env
+++ b/env/GOOGLEPW.env
@@ -49,7 +49,7 @@ elif [[ "${step}" = "prep_emissions" ]]; then
 
 elif [[ "${step}" = "waveinit" ]] || [[ "${step}" = "waveprep" ]] || [[ "${step}" = "wavepostsbs" ]] || [[ "${step}" = "wavepostbndpnt" ]] || [[ "${step}" = "wavepostbndpntbll" ]] || [[ "${step}" = "wavepostpnt" ]]; then
 
-    export CFP_MP="YES"
+    export USE_CFP="YES"
     if [[ "${step}" = "waveprep" ]]; then export MP_PULSE=0 ; fi
     export wavempexec=${launcher}
     export wave_mpmd=${mpmd_opt}

--- a/env/HERA.env
+++ b/env/HERA.env
@@ -58,7 +58,7 @@ elif [[ "${step}" = "prep_emissions" ]]; then
 
 elif [[ "${step}" = "waveinit" ]] || [[ "${step}" = "waveprep" ]] || [[ "${step}" = "wavepostsbs" ]] || [[ "${step}" = "wavepostbndpnt" ]] || [[ "${step}" = "wavepostbndpntbll" ]] || [[ "${step}" = "wavepostpnt" ]]; then
 
-    export CFP_MP="YES"
+    export USE_CFP="YES"
     if [[ "${step}" = "waveprep" ]]; then export MP_PULSE=0 ; fi
     export wavempexec=${launcher}
     export wave_mpmd=${mpmd_opt}

--- a/env/HERCULES.env
+++ b/env/HERCULES.env
@@ -56,7 +56,7 @@ case ${step} in
  ;;
  "waveinit" | "waveprep" | "wavepostsbs" | "wavepostbndpnt" | "wavepostpnt" | "wavepostbndpntbll")
 
-    export CFP_MP="YES"
+    export USE_CFP="YES"
     [[ "${step}" = "waveprep" ]] && export MP_PULSE=0
     export wavempexec=${launcher}
     export wave_mpmd=${mpmd_opt}

--- a/env/JET.env
+++ b/env/JET.env
@@ -46,7 +46,7 @@ elif [[ "${step}" = "prep_emissions" ]]; then
 
 elif [[ "${step}" = "waveinit" ]] || [[ "${step}" = "waveprep" ]] || [[ "${step}" = "wavepostsbs" ]] || [[ "${step}" = "wavepostbndpnt" ]] || [[ "${step}" = "wavepostbndpntbll" ]] || [[ "${step}" = "wavepostpnt" ]]; then
 
-    export CFP_MP="YES"
+    export USE_CFP="YES"
     if [[ "${step}" = "waveprep" ]]; then export MP_PULSE=0 ; fi
     export wavempexec=${launcher}
     export wave_mpmd=${mpmd_opt}

--- a/env/ORION.env
+++ b/env/ORION.env
@@ -54,7 +54,7 @@ elif [[ "${step}" = "prep_emissions" ]]; then
 elif [[ "${step}" = "waveinit" ]] || [[ "${step}" = "waveprep" ]] || [[ "${step}" = "wavepostsbs" ]] || \
     [[ "${step}" = "wavepostbndpnt" ]] || [[ "${step}" = "wavepostpnt" ]] || [[ "${step}" == "wavepostbndpntbll" ]]; then
 
-    export CFP_MP="YES"
+    export USE_CFP="YES"
     if [[ "${step}" = "waveprep" ]]; then export MP_PULSE=0 ; fi
     export wavempexec=${launcher}
     export wave_mpmd=${mpmd_opt}

--- a/env/S4.env
+++ b/env/S4.env
@@ -46,7 +46,7 @@ elif [[ "${step}" = "prep_emissions" ]]; then
 
 elif [[ "${step}" = "waveinit" ]] || [[ "${step}" = "waveprep" ]] || [[ "${step}" = "wavepostsbs" ]] || [[ "${step}" = "wavepostbndpnt" ]] || [[ "${step}" = "wavepostbndpntbll" ]] || [[ "${step}" = "wavepostpnt" ]]; then
 
-    export CFP_MP="YES"
+    export USE_CFP="YES"
     if [[ "${step}" = "waveprep" ]]; then export MP_PULSE=0 ; fi
     export wavempexec=${launcher}
     export wave_mpmd=${mpmd_opt}

--- a/jobs/JGLOBAL_WAVE_GEMPAK
+++ b/jobs/JGLOBAL_WAVE_GEMPAK
@@ -2,6 +2,7 @@
 
 source "${HOMEgfs}/ush/preamble.sh"
 source "${HOMEgfs}/ush/jjob_header.sh" -e "wavegempak" -c "base wave wavegempak"
+source "${USHgfs}/wave_domain_grid.sh"
 
 # Add default errchk = err_chk
 export errchk=${errchk:-err_chk}
@@ -14,7 +15,6 @@ export SENDDBN=${SENDDBN:-YES}
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
 
 YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-   COMIN_WAVE_GRID:COM_WAVE_GRID_TMPL \
    COMOUT_WAVE_GEMPAK:COM_WAVE_GEMPAK_TMPL
 
 if [[ -n "${GEMPAK_GRIDS}" ]]; then
@@ -31,15 +31,13 @@ if [[ ! -d ${COMOUT_WAVE_GEMPAK} ]]; then mkdir -p "${COMOUT_WAVE_GEMPAK}"; fi
 
 ########################################################
 # Execute the script.
-${SCRgfs}/exgfs_wave_nawips.sh
-status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+"${SCRgfs}/exgfs_wave_nawips.sh"
+err=$?
+if [[ "${err}" -ne 0 ]]; then exit "${err}"; fi
 ###################################
 
 # Remove temp directories
-cd ${DATAROOT}
-if [ "${KEEPDATA}" != "YES" ]; then
-  rm -rf ${DATA}
+cd "${DATAROOT}" || true
+if [[ "${KEEPDATA}" != "YES" ]]; then
+  rm -rf "${DATA}"
 fi
-
-exit 0

--- a/jobs/JGLOBAL_WAVE_INIT
+++ b/jobs/JGLOBAL_WAVE_INIT
@@ -20,13 +20,12 @@ export wavempexec=${wavempexec:-"mpirun -n"}
 export wave_mpmd=${wave_mpmd:-"cfp"}
 
 # Execute the Script
-${SCRgfs}/exgfs_wave_init.sh
+"${SCRgfs}/exgfs_wave_init.sh"
 
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd ${DATAROOT}
-[[ ${KEEPDATA} = "NO" ]] && rm -rf ${DATA}
-
+cd "${DATAROOT}" || true
+if [[ ${KEEPDATA} = "NO" ]]; then rm -rf "${DATA}"; fi
 
 exit 0

--- a/jobs/JGLOBAL_WAVE_POST_BNDPNT
+++ b/jobs/JGLOBAL_WAVE_POST_BNDPNT
@@ -16,13 +16,6 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 
 if [[ ! -d "${COMOUT_WAVE_STATION}" ]]; then mkdir -p "${COMOUT_WAVE_STATION}"; fi
 
-# Set wave model ID tag to include member number
-# if ensemble; waveMEMB var empty in deterministic
-membTAG='p'
-if [ "${waveMEMB}" == "00" ]; then membTAG='c'; fi
-export membTAG
-export WAV_MOD_TAG=${RUN}wave${waveMEMB}
-
 export CFP_VERBOSE=1
 
 export FHMAX_WAV_PNT=${FHMAX_WAV_IBP}

--- a/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
+++ b/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
@@ -14,32 +14,27 @@ export MP_PULSE=0
 
 # Set COM Paths and GETGES environment
 YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-   COMIN_WAVE_PREP:COM_WAVE_PREP_TMPL \
-   COMIN_WAVE_HISTORY:COM_WAVE_HISTORY_TMPL \
-   COMOUT_WAVE_STATION:COM_WAVE_STATION_TMPL
+	COMIN_WAVE_PREP:COM_WAVE_PREP_TMPL \
+	COMIN_WAVE_HISTORY:COM_WAVE_HISTORY_TMPL \
+	COMOUT_WAVE_STATION:COM_WAVE_STATION_TMPL
 
 if [[ ! -d "${COMOUT_WAVE_STATION}" ]]; then mkdir -p "${COMOUT_WAVE_STATION}"; fi
 
-# Set wave model ID tag to include member number
-# if ensemble; waveMEMB var empty in deterministic
-membTAG='p'
-if [ "${waveMEMB}" == "00" ]; then membTAG='c'; fi
-export membTAG
-export WAV_MOD_TAG=${RUN}wave${waveMEMB}
+export WAV_MOD_TAG=${RUN}.wave
 
 export CFP_VERBOSE=1
 
 export FHMAX_WAV_PNT=${FHMAX_WAV_IBP}
-export DOSPC_WAV='NO' # Spectral post
-export DOBLL_WAV='YES' # Bulletin post
-export DOBNDPNT_WAV='YES'  #boundary points
+export DOSPC_WAV='NO'     # Spectral post
+export DOBLL_WAV='YES'    # Bulletin post
+export DOBNDPNT_WAV='YES' #boundary points
 
 # Execute the Script
 ${SCRgfs}/exgfs_wave_post_pnt.sh
 err=$?
 if [ ${err} -ne 0 ]; then
-  echo "FATAL ERROR: ex-script of GFS_WAVE_POST_PNT failed!"
-  exit ${err}
+	echo "FATAL ERROR: ex-script of GFS_WAVE_POST_PNT failed!"
+	exit ${err}
 fi
 
 ##########################################
@@ -47,6 +42,5 @@ fi
 ##########################################
 cd ${DATAROOT}
 [[ ${KEEPDATA} = "NO" ]] && rm -rf ${DATA}
-
 
 exit 0

--- a/jobs/JGLOBAL_WAVE_POST_SBS
+++ b/jobs/JGLOBAL_WAVE_POST_SBS
@@ -32,30 +32,21 @@ if [[ -n "${wavepostGRD}" || -n "${waveinterpGRD}" ]]; then
 else
     echo "Both wavepostGRD and waveinterpGRD are empty. No grids to process."
 fi
-# Set wave model ID tag to include member number
-# if ensemble; waveMEMB var empty in deterministic
-# Set wave model ID tag to include member number
-# if ensemble; waveMEMB var empty in deterministic
-membTAG='p'
-if [ "${waveMEMB}" == "00" ]; then membTAG='c'; fi
-export membTAG
-export WAV_MOD_TAG=${RUN}wave${waveMEMB}
 
 export CFP_VERBOSE=1
 
 # Execute the Script
-${SCRgfs}/exgfs_wave_post_gridded_sbs.sh
+"${SCRgfs}/exgfs_wave_post_gridded_sbs.sh"
 err=$?
-if [ ${err} -ne 0 ]; then
-  echo "FATAL ERROR: ex-script of GWES_POST failed!"
-  exit ${err}
+if [[ ${err} -ne 0 ]]; then
+  echo "FATAL ERROR: ex-script of gridded wave post failed!"
+  exit "${err}"
 fi
 
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd ${DATAROOT}
-[[ ${KEEPDATA} = "NO" ]] && rm -rf ${DATA}
-
+cd "${DATAROOT}" || true
+if [[ ${KEEPDATA} = "NO" ]]; then rm -rf "${DATA}"; fi
 
 exit 0

--- a/jobs/rocoto/wavegempak.sh
+++ b/jobs/rocoto/wavegempak.sh
@@ -1,18 +1,27 @@
 #! /usr/bin/env bash
 
-source "$HOMEgfs/ush/preamble.sh"
+source "${HOMEgfs}/ush/preamble.sh"
 
 ###############################################################
-source $HOMEgfs/ush/load_fv3gfs_modules.sh
-status=$?
-[[ $status -ne 0 ]] && exit $status
+source "${HOMEgfs}/ush/load_fv3gfs_modules.sh"
+err=$?
+if [[ "${err}" -ne 0 ]]; then exit "${err}"; fi
 
-export job="post"
+export job="wavegempak"
 export jobid="${job}.$$"
 
 ###############################################################
-# Execute the JJOB
-$HOMEgfs/jobs/JGLOBAL_WAVE_GEMPAK
-status=$?
+# shellcheck disable=SC2153
+IFS=', ' read -r -a fhr_list <<< "${FHR_LIST}"
 
-exit $status
+export FORECAST_HOUR jobid
+for FORECAST_HOUR in "${fhr_list[@]}"; do
+	fhr3=$(printf '%03d' "${FORECAST_HOUR}")
+	jobid="${job}_f${fhr3}.$$"
+	# Execute the JJOB
+	"${HOMEgfs}/jobs/JGLOBAL_WAVE_GEMPAK"
+	err=$?
+	if [[ "${err}" -ne 0 ]]; then exit "${err}"; fi
+done
+
+exit "${err}"

--- a/jobs/rocoto/wavepostsbs.sh
+++ b/jobs/rocoto/wavepostsbs.sh
@@ -15,10 +15,10 @@ export job="wavepostsbs"
 # shellcheck disable=SC2153
 IFS=', ' read -r -a fhr_list <<< "${FHR_LIST}"
 
-export FHR3 jobid
+export FORECAST_HOUR jobid
 for FORECAST_HOUR in "${fhr_list[@]}"; do
-	FHR3=$(printf '%03d' "${FORECAST_HOUR}")
-	jobid="${job}_f${FHR3}.$$"
+	fhr3=$(printf '%03d' "${FORECAST_HOUR}")
+	jobid="${job}_f${fhr3}.$$"
 	# Execute the JJOB
 	"${HOMEgfs}/jobs/JGLOBAL_WAVE_POST_SBS"
 	status=$?

--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -249,7 +249,7 @@ case ${step} in
     ;;
 
   "wavegempak")
-    walltime="02:00:00"
+    walltime="00:10:00"
     ntasks=1
     threads_per_task=1
     tasks_per_node=$(( max_tasks_per_node / threads_per_task ))

--- a/parm/wave/ak_10m_interp.inp.tmpl
+++ b/parm/wave/ak_10m_interp.inp.tmpl
@@ -1,7 +1,7 @@
 $ Input file for interpolation of GLO30m_ext Grid
 $------------------------------------------------
 $ Start Time DT NSteps
- TIME DT NSTEPS
+ @[time] @[dt] @[nsteps]
 $ Total number of grids 
  2
 $ Grid extensions 

--- a/parm/wave/at_10m_interp.inp.tmpl
+++ b/parm/wave/at_10m_interp.inp.tmpl
@@ -1,7 +1,7 @@
 $ Input file for interpolation of GLO30m_ext Grid
 $------------------------------------------------
 $ Start Time DT NSteps
- TIME DT NSTEPS
+ @[time] @[dt] @[nsteps]
 $ Total number of grids 
  2
 $ Grid extensions 

--- a/parm/wave/ep_10m_interp.inp.tmpl
+++ b/parm/wave/ep_10m_interp.inp.tmpl
@@ -1,7 +1,7 @@
 $ Input file for interpolation of GLO30m_ext Grid
 $------------------------------------------------
 $ Start Time DT NSteps
- TIME DT NSTEPS
+ @[time] @[dt] @[nsteps]
 $ Total number of grids 
  2
 $ Grid extensions 

--- a/parm/wave/glo_15mxt_interp.inp.tmpl
+++ b/parm/wave/glo_15mxt_interp.inp.tmpl
@@ -1,7 +1,7 @@
 $ Input file for interpolation of GLO30m_ext Grid
 $------------------------------------------------
 $ Start Time DT NSteps
- TIME DT NSTEPS
+ @[time] @[dt] @[nsteps]
 $ Total number of grids 
  2
 $ Grid extensions 

--- a/parm/wave/glo_200_interp.inp.tmpl
+++ b/parm/wave/glo_200_interp.inp.tmpl
@@ -1,7 +1,7 @@
 $ Input file for interpolation of GLO30m_ext Grid
 $------------------------------------------------
 $ Start Time DT NSteps
- TIME DT NSTEPS
+ @[time] @[dt] @[nsteps]
 $ Total number of grids 
  2
 $ Grid extensions 

--- a/parm/wave/glo_30m_interp.inp.tmpl
+++ b/parm/wave/glo_30m_interp.inp.tmpl
@@ -1,7 +1,7 @@
 $ Input file for interpolation of GLO30m_ext Grid
 $------------------------------------------------
 $ Start Time DT NSteps
- TIME DT NSTEPS
+ @[time] @[dt] @[nsteps]
 $ Total number of grids 
  2
 $ Grid extensions 

--- a/parm/wave/reg025_interp.inp.tmpl
+++ b/parm/wave/reg025_interp.inp.tmpl
@@ -1,7 +1,7 @@
 $ Input file for interpolation of GLO30m_ext Grid
 $------------------------------------------------
 $ Start Time DT NSteps
- TIME DT NSTEPS
+ @[time] @[dt] @[nsteps]
 $ Total number of grids 
  2
 $ Grid extensions 

--- a/parm/wave/wc_10m_interp.inp.tmpl
+++ b/parm/wave/wc_10m_interp.inp.tmpl
@@ -1,7 +1,7 @@
 $ Input file for interpolation of GLO30m_ext Grid
 $------------------------------------------------
 $ Start Time DT NSteps
- TIME DT NSTEPS
+ @[time] @[dt] @[nsteps]
 $ Total number of grids 
  2
 $ Grid extensions 

--- a/parm/wave/ww3_grib2.ak_10m.inp.tmpl
+++ b/parm/wave/ww3_grib2.ak_10m.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/parm/wave/ww3_grib2.ant_9km.inp.tmpl
+++ b/parm/wave/ww3_grib2.ant_9km.inp.tmpl
@@ -1,10 +1,10 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 20
+@[time]  7 @[modnr] @[gridnr] 0 20
 $
  -60 0 8.64919046313 8.64919046313 64
 $ end of input file

--- a/parm/wave/ww3_grib2.aoc_9km.inp.tmpl
+++ b/parm/wave/ww3_grib2.aoc_9km.inp.tmpl
@@ -1,10 +1,10 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 20
+@[time]  7 @[modnr] @[gridnr] 0 20
 $
  70 0 9.0 9.0 64
 $ 60 0 8.64919046313 8.64919046313 64

--- a/parm/wave/ww3_grib2.at_10m.inp.tmpl
+++ b/parm/wave/ww3_grib2.at_10m.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/parm/wave/ww3_grib2.ep_10m.inp.tmpl
+++ b/parm/wave/ww3_grib2.ep_10m.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/parm/wave/ww3_grib2.glo_025.inp.tmpl
+++ b/parm/wave/ww3_grib2.glo_025.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/parm/wave/ww3_grib2.glo_100.inp.tmpl
+++ b/parm/wave/ww3_grib2.glo_100.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/parm/wave/ww3_grib2.glo_10m.inp.tmpl
+++ b/parm/wave/ww3_grib2.glo_10m.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/parm/wave/ww3_grib2.glo_15mxt.inp.tmpl
+++ b/parm/wave/ww3_grib2.glo_15mxt.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/parm/wave/ww3_grib2.glo_200.inp.tmpl
+++ b/parm/wave/ww3_grib2.glo_200.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/parm/wave/ww3_grib2.glo_30m.inp.tmpl
+++ b/parm/wave/ww3_grib2.glo_30m.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/parm/wave/ww3_grib2.glo_500.inp.tmpl
+++ b/parm/wave/ww3_grib2.glo_500.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/parm/wave/ww3_grib2.gnh_10m.inp.tmpl
+++ b/parm/wave/ww3_grib2.gnh_10m.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/parm/wave/ww3_grib2.gsh_15m.inp.tmpl
+++ b/parm/wave/ww3_grib2.gsh_15m.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/parm/wave/ww3_grib2.gwes_30m.inp.tmpl
+++ b/parm/wave/ww3_grib2.gwes_30m.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/parm/wave/ww3_grib2.reg025.inp.tmpl
+++ b/parm/wave/ww3_grib2.reg025.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/parm/wave/ww3_grib2.wc_10m.inp.tmpl
+++ b/parm/wave/ww3_grib2.wc_10m.inp.tmpl
@@ -1,9 +1,9 @@
 $ WAVEWATCH-III gridded output input file 
 $ ----------------------------------------
-TIME DT NT
+@[time] @[dt] @[nt]
 N
-FLAGS
+@[grib_flags]
 $
-TIME  7 MODNR GRIDNR 0 0
+@[time]  7 @[modnr] @[gridnr] 0 0
 $
 $ end of input file

--- a/scripts/exgfs_wave_init.sh
+++ b/scripts/exgfs_wave_init.sh
@@ -6,15 +6,9 @@
 # Script name:         exwave_init.sh
 # Script description:  Creates model definition files for WW3
 #
-# Author:   Jose-Henrique Alves Org: NCEP/EMC      Date: 2019-04-20
 # Abstract: This script is the init config for the global multi_grid wave model.
 #           It creates model definition files with all configurations of spatial
 #           and spectral grids, as well as physics parameters and time steps.
-#
-# Script history log:
-# 2019-05-06  J-Henrique Alves First Version.
-# 2019-11-02  J-Henrique Alves Ported to global-workflow.
-# 2020-06-10  J-Henrique Alves Ported to R&D machine Hera
 #
 # $Id$
 #
@@ -30,198 +24,87 @@ source "${USHgfs}/preamble.sh"
 
 # 0.a Basic modes of operation
 
-  err=0
-
-  cd $DATA
-
-  set +x
-  echo ' '
-  echo '                      ********************************'
-  echo '                      *** MWW3 INIT CONFIG  SCRIPT ***'
-  echo '                      ********************************'
-  echo '                          Initial configuration script'
-  echo "                       Model identifier : ${RUN}wave"
-  echo ' '
-  echo "Starting at : $(date)"
-  echo ' '
-  set_trace
-
-# Script will run only if pre-defined NTASKS
-#     The actual work is distributed over these tasks.
-  if [ -z ${NTASKS} ]
-  then
-    echo "FATAL ERROR: requires NTASKS to be set "
-    err=1; export err;${errchk}
-  fi
-
-  set +x
-  echo ' '
-  echo " Script set to run with $NTASKS tasks "
-  echo ' '
-  set_trace
-
+cd "${DATA}" || exit 1
 
 # --------------------------------------------------------------------------- #
 # 1.  Get files that are used by most child scripts
 
-  set +x
-  echo 'Preparing input files :'
-  echo '-----------------------'
-  echo ' '
-  set_trace
+cat << EOF
+
+Preparing input files :
+-----------------------
+EOF
 
 # 1.a Model definition files
 
-  nmoddef=0
-
-  rm -f cmdfile
-  touch cmdfile
-  chmod 744 cmdfile
 
 # Eliminate duplicate grids
-  array=($WAVECUR_FID $WAVEICE_FID $WAVEWND_FID $waveuoutpGRD $waveGRD $wavepostGRD $waveinterpGRD)
-  grdALL=$(printf "%s\n" "${array[@]}" | sort -u | tr '\n' ' ')
+# Use an associative array, since they don't allow duplicate keys
+declare -A grdALL
+for grd in ${WAVECUR_FID} ${WAVEICE_FID} ${WAVEWND_FID} ${waveuoutpGRD} ${waveGRD} ${wavepostGRD} ${waveinterpGRD}; do
+  # For ease of access, make the value the same as the key
+  grdALL["${grd}"]="${grd}"
+done
 
-  for grdID in ${grdALL}; do
-    if [[ -f "${COMOUT_WAVE_PREP}/${RUN}wave.mod_def.${grdID}" ]]; then
-      set +x
-      echo " Mod def file for ${grdID} found in ${COMOUT_WAVE_PREP}. copying ...."
-      set_trace
-      cp "${COMOUT_WAVE_PREP}/${RUN}wave.mod_def.${grdID}" "mod_def.${grdID}"
+for grdID in "${grdALL[@]}"; do
+  if [[ -f "${COMOUT_WAVE_PREP}/${RUN}.wave.t${cyc}z.mod_def.${grdID}.bin" ]]; then
+    echo "INFO: Mod def file for ${grdID} found in ${COMOUT_WAVE_PREP}. copying ...."
+    cp "${COMOUT_WAVE_PREP}/${RUN}.wave.t${cyc}z.mod_def.${grdID}.bin" "mod_def.${grdID}"
 
+  else
+    echo "INFO: Mod def file for ${grdID} not found in ${COMOUT_WAVE_PREP}. Setting up to generate ..."
+    if [[ -f "${FIXgfs}/wave/ww3_grid.inp.${grdID}" ]]; then
+      cp "${FIXgfs}/wave/ww3_grid.inp.${grdID}" "ww3_grid.inp.${grdID}"
+    fi
+
+    if [[ -f "ww3_grid.inp.${grdID}" ]]; then
+      echo "INFO: ww3_grid.inp.${grdID} copied (${FIXgfs}/wave/ww3_grid.inp.${grdID})."
     else
-      set +x
-      echo " Mod def file for ${grdID} not found in ${COMOUT_WAVE_PREP}. Setting up to generate ..."
-      echo ' '
-      set_trace
-      if [ -f ${FIXgfs}/wave/ww3_grid.inp.$grdID ]
-      then
-        cp ${FIXgfs}/wave/ww3_grid.inp.$grdID ww3_grid.inp.$grdID
-      fi
-
-      if [ -f ww3_grid.inp.$grdID ]
-      then
-        set +x
-        echo ' '
-        echo "   ww3_grid.inp.$grdID copied (${FIXgfs}/wave/ww3_grid.inp.$grdID)."
-        echo ' '
-        set_trace
-      else
-        set +x
-        echo ' '
-        echo '*********************************************************** '
-        echo '*** FATAL ERROR : NO INP FILE FOR MODEL DEFINITION FILE *** '
-        echo '*********************************************************** '
-        echo "                                grdID = $grdID"
-        echo ' '
-        set_trace
-        err=2;export err;${errchk}
-      fi
-
-
-      if [ -f ${FIXgfs}/wave/${grdID}.msh ]
-      then
-        cp "${FIXgfs}/wave/${grdID}.msh" "${grdID}.msh"
-      fi
-      #TO DO: how do we say "it's unstructured, and therefore need to have error check here" 
-
-      if [ ${CFP_MP:-"NO"} = "YES" ]; then
-        echo "$nmoddef ${USHgfs}/wave_grid_moddef.sh $grdID > $grdID.out 2>&1" >> cmdfile
-      else
-        echo "${USHgfs}/wave_grid_moddef.sh $grdID > $grdID.out 2>&1" >> cmdfile
-      fi
-
-      nmoddef=$(expr $nmoddef + 1)
-
-    fi
-  done
-
-# 1.a.1 Execute parallel or serialpoe
-
-  if [ "$nmoddef" -gt '0' ]
-  then
-
-    set +x
-    echo ' '
-    echo " Generating $nmoddef mod def files"
-    echo ' '
-    set_trace
-
-# Set number of processes for mpmd
-    wavenproc=$(wc -l cmdfile | awk '{print $1}')
-    wavenproc=$(echo $((${wavenproc}<${NTASKS}?${wavenproc}:${NTASKS})))
-
-# 1.a.3 Execute the serial or parallel cmdfile
-
-    set +x
-    echo ' '
-    echo "   Executing the mod_def command file at : $(date)"
-    echo '   ------------------------------------'
-    echo ' '
-    set_trace
-    if [ "$NTASKS" -gt '1' ]
-    then
-      if [ ${CFP_MP:-"NO"} = "YES" ]; then
-        ${wavempexec} -n ${wavenproc} ${wave_mpmd} cmdfile
-      else
-        ${wavempexec} ${wavenproc} ${wave_mpmd} cmdfile
-      fi
-      exit=$?
-    else
-      ./cmdfile
-      exit=$?
+      echo "FATAL ERROR: No inp file for model definition file for grid ${grdID}"
+      err=2; export err; ${errchk}
     fi
 
-    if [[ "$exit" != '0' ]]
-    then
-      set +x
-      echo ' '
-      echo '********************************************************'
-      echo '*** FATAL ERROR: POE FAILURE DURING RAW DATA COPYING ***'
-      echo '********************************************************'
-      echo '     See Details Below '
-      echo ' '
-      set_trace
+    if [[ -f "${FIXgfs}/wave/${grdID}.msh" ]]; then
+      cp "${FIXgfs}/wave/${grdID}.msh" "${grdID}.msh"
     fi
+    #TODO: how do we say "it's unstructured, and therefore need to have error check here" 
 
+    echo "${USHgfs}/wave_grid_moddef.sh ${grdID}" >> mpmd_script
   fi
+done
+
+# 1.a.1 Execute MPMD or process serially
+if [[ "${USE_CFP:-}" == "YES" ]]; then
+  OMP_NUM_THREADS=1 "${USHgfs}/run_mpmd.sh" "${DATA}/mpmd_script"
+  export err=$?
+else
+  chmod 755 "${DATA}/mpmd_script"
+  bash +x "${DATA}/mpmd_script" > mpmd.out 2>&1
+  export err=$?
+fi
+${errchk}
+
+cat mpmd.out
 
 # 1.a.3 File check
-
-  for grdID in ${grdALL}; do
-    if [[ -f "${COMOUT_WAVE_PREP}/${RUN}wave.mod_def.${grdID}" ]]; then
-      set +x
-      echo ' '
-      echo " mod_def.$grdID succesfully created/copied "
-      echo ' '
-      set_trace
-    else
-      set +x
-      echo ' '
-      echo '********************************************** '
-      echo '*** FATAL ERROR : NO MODEL DEFINITION FILE *** '
-      echo '********************************************** '
-      echo "                                grdID = ${grdID}"
-      echo ' '
-      sed "s/^/${grdID}.out : /g"  "${grdID}.out"
-      set_trace
-      err=3;export err;${errchk}
-    fi
-  done
+for grdID in "${grdALL[@]}"; do
+  if [[ -f "${COMOUT_WAVE_PREP}/${RUN}.wave.t${cyc}z.mod_def.${grdID}.bin" ]]; then
+    echo "INFO: mod_def.${grdID} succesfully created/copied"
+  else
+    echo "FATAL ERROR: No model definition file for grid ${grdID}"
+    err=3; export err; ${errchk}
+  fi
+done
 
 # Copy to other members if needed
 if (( NMEM_ENS > 0 )); then
   for mem in $(seq -f "%03g" 1 "${NMEM_ENS}"); do
-    MEMDIR="mem${mem}" YMD=${PDY} HH=${cyc} declare_from_tmpl COMOUT_WAVE_PREP_MEM:COM_WAVE_PREP_TMPL
+    MEMDIR="mem${mem}" YMD="${PDY}" HH="${cyc}" declare_from_tmpl COMOUT_WAVE_PREP_MEM:COM_WAVE_PREP_TMPL
     mkdir -p "${COMOUT_WAVE_PREP_MEM}"
-    for grdID in ${grdALL}; do
-      ${NLN} "${COMOUT_WAVE_PREP}/${RUN}wave.mod_def.${grdID}" "${COMOUT_WAVE_PREP_MEM}/${RUN}wave.mod_def.${grdID}"
+    for grdID in "${grdALL[@]}"; do
+      cpfs "${COMOUT_WAVE_PREP}/${RUN}.wave.t${cyc}z.mod_def.${grdID}.bin" "${COMOUT_WAVE_PREP_MEM}/${RUN}.wave.t${cyc}z.mod_def.${grdID}.bin"
     done
   done
 fi
-
-# --------------------------------------------------------------------------- #
-# 2.  Ending
-
 
 # End of MWW3 init config script ------------------------------------------- #

--- a/scripts/exgfs_wave_nawips.sh
+++ b/scripts/exgfs_wave_nawips.sh
@@ -14,24 +14,8 @@
 source "${USHgfs}/preamble.sh"
 source "${USHgfs}/wave_domain_grid.sh"
 
-#export grids=${GEMPAK_GRIDS:-'glo_30m at_10m ep_10m wc_10m ao_9km'} #Interpolated grids
-export grids=${GEMPAK_GRIDS:-${waveinterpGRD:-'glo_30m'}}  #Native grids
-export RUNwave=${RUNwave:-${RUN}wave}
-export fstart=${fstart:-0}
-export FHMAX_WAV=${FHMAX_WAV:-180}  #180 Total of hours to process
-export FHMAX_HF_WAV=${FHMAX_HF_WAV:-72}
-export FHOUT_WAV=${FHOUT_WAV:-6}
-export FHOUT_HF_WAV=${FHOUT_HF_WAV:-3}
-export maxtries=${maxtries:-720}
-export cycle=${cycle:-t${cyc}z}
-export GEMwave=${GEMwave:-${HOMEgfs}/gempak}
-export DATA=${DATA:-${DATAROOT:?}/${jobid}}
-if [ ! -d ${DATA} ];then
-  mkdir -p ${DATA}
-fi
-
-cd ${DATA}
-cp ${GEMwave}/fix/g2varswmo2.tbl .
+cd "${DATA}" || exit 1
+cp "${HOMEgfs}/gempak/fix/g2varswmo2.tbl" .
 
 cpyfil=gds
 garea=dset
@@ -45,121 +29,106 @@ pdsext=no
 g2tbls=g2varswmo2.tbl
 NAGRIB=nagrib2
 
-sleep_interval=20
-maxtries=15
-fhcnt=${fstart}
-while [ ${fhcnt} -le ${FHMAX_WAV} ]; do
-  fhr=$(printf "%03d" ${fhcnt})
-  for grid in ${grids};do
-    case ${grid} in
-      ao_9km)  grdIDin='arctic.9km'
-               #grdIDout='gfswaveao9km' ;;
-               grdIDout='gfswavearc' ;;
-      at_10m)  grdIDin='atlocn.0p16'
-               grdIDout='gfswaveat10m' ;;
-      ep_10m)  grdIDin='epacif.0p16'
-               grdIDout='gfswaveep10m' ;;
-      wc_10m)  grdIDin='wcoast.0p16'
-               grdIDout='gfswavewc10m' ;;
-      glo_30m) grdIDin='global.0p25'
-               grdIDout='gfswavegl30m' ;;
-      glo_10m) grdIDin='global.0p16'   
-               #grdIDout='gfswaveg16k' ;;
-               grdIDout='gfswavenh' ;;
-      gso_15m) grdIDin='gsouth.0p25' 
-               #grdIDout='gfswaves25k' ;;
-               grdIDout='gfswavesh' ;;
-      glo_200) grdIDin='global.2p00'
-               grdIDout='gfswaves200k' ;;
-      *)       grdIDin= 
-               grdIDout= ;;
+fhr3=$(printf "%03d" "${FORECAST_HOUR}")
+for grid in ${GEMPAK_GRIDS};do
+    case "${grid}" in
+      ao_9km)
+        #grdIDout='gfswaveao9km' ;;
+        grdIDout='gfswavearc'
+        ;;
+      at_10m)
+        grdIDout='gfswaveat10m'
+        ;;
+      ep_10m)
+        grdIDout='gfswaveep10m'
+        ;;
+      wc_10m)
+        grdIDout='gfswavewc10m'
+        ;;
+      glo_30m)
+        grdIDout='gfswavegl30m'
+        ;;
+      glo_10m)
+        #grdIDout='gfswaveg16k' ;;
+        grdIDout='gfswavenh'
+        ;;
+      gso_15m)
+        #grdIDout='gfswaves25k' ;;
+        grdIDout='gfswavesh'
+        ;;
+      glo_200)
+        grdIDout='gfswaves200k'
+        ;;
+      *)
+        echo "FATAL ERROR: Unknown wave grid ${grid}"
+        exit 10
+        ;;
     esac
     process_grdID "${grid}"
     com_varname="COMIN_WAVE_GRID_${GRDREGION}_${GRDRES}"
     com_dir=${!com_varname}
-    GRIBIN="${com_dir}/${RUNwave}.${cycle}.${grdIDin}.f${fhr}.grib2"
-    GRIBIN_chk=${GRIBIN}.idx
-    if ! wait_for_file "${GRIBIN_chk}" "${sleep_interval}" "${maxtries}"; then
-      echo "FATAL ERROR: ${GRIBIN_chk} not found after waiting $((sleep_interval * ( maxtries - 1))) secs"
-      echo "${RUNwave} ${grdID} ${fhr} prdgen ${date} ${cycle} : GRIB file missing." >> "${wavelog}"
-      err=1;export err;"${errchk}" || exit "${err}"
-    fi
+    GRIBIN="${RUN}.wave.${cycle}.${GRDRES}.f${fhr3}.${GRDREGION}.grib2"
+    cp "${com_dir}/${GRIBIN}" "./${GRIBIN}"
 
-    #if [ "$grdIDin" = "global.0p25" && "$grid" = "glo_30m" ]; then
-    if [ "${grdIDin}" = "global.0p25" ]; then
-      ${WGRIB2} -lola 0:720:0.5 -90:361:0.5 gribfile.${grdIDout}.f${fhr}  grib \
-                                          ${GRIBIN} 1> out 2>&1
-      OK=$?
-      if [ "${OK}" != '0' ]; then
-        msg="ABNORMAL EXIT: ERROR IN interpolation the global grid"
-        #set +x
-        echo ' '
-        echo '************************************************************* '
-        echo '*** FATAL ERROR : ERROR IN making  gribfile.$grdID.f${fhr}*** '
-        echo '************************************************************* '
-        echo ' '
-        echo ${msg}
-        #set_trace
-        echo "${RUNwave} ${grdID} prdgen ${date} ${cycle} : error in grbindex." >> ${wavelog}
-        err=2;export err;err_chk
+    if [[ "${GRDREGION}.${GRDRES}" == "global.0p25" ]]; then
+      ${WGRIB2} -lola 0:720:0.5 -90:361:0.5 \
+        "${RUN}.wave.t${cyc}z.f${fhr3}.${grdIDout}.grib2" grib "${GRIBIN}"
+      err=$?
+      if [[ "${err}" -ne 0 ]]; then
+        echo 'FATAL ERROR: Error interolating the global grid'
+        err=2; export err; err_chk
       else
-        #cp $GRIBIN gribfile.$grdID.f${fhr}
-        GRIBIN=gribfile.${grdIDout}.f${fhr}
+        GRIBIN="${RUN}.wave.t${cyc}z.f${fhr3}.${grdIDout}.grib2"
       fi
     fi
-    echo ${GRIBIN}
+    echo "INFO: ${GRIBIN}"
 
-    GEMGRD=${grdIDout}_${PDY}${cyc}f${fhr}
+    GEMGRD="${RUN}.wave.t${cyc}z.gempak.f${fhr3}.${grdIDout}.gem"
 
-    cp ${GRIBIN} grib_${grid}
-
+    pgm=${NAGRIB}
     startmsg
-
-	${NAGRIB} <<-EOF
-	GBFILE   = grib_${grid}
-	INDXFL   = 
-	GDOUTF   = ${GEMGRD}
-	PROJ     = ${proj}
-	GRDAREA  = ${grdarea}
-	KXKY     = ${kxky}
-	MAXGRD   = ${maxgrd}
-	CPYFIL   = ${cpyfil}
-	GAREA    = ${garea}
-	OUTPUT   = ${output}
-	GBTBLS   = ${gbtbls}
-	G2TBLS   = ${g2tbls}
-	GBDIAG   = 
-	PDSEXT   = ${pdsext}
-	l
-	r
-	EOF
-    export err=$?;pgm=${NAGRIB};err_chk
+    cat << EOF > gempak_ctrl
+        GBFILE   = ${GRIBIN}
+        INDXFL   = 
+        GDOUTF   = ${GEMGRD}
+        PROJ     = ${proj}
+        GRDAREA  = ${grdarea}
+        KXKY     = ${kxky}
+        MAXGRD   = ${maxgrd}
+        CPYFIL   = ${cpyfil}
+        GAREA    = ${garea}
+        OUTPUT   = ${output}
+        GBTBLS   = ${gbtbls}
+        G2TBLS   = ${g2tbls}
+        GBDIAG   = 
+        PDSEXT   = ${pdsext}
+        l
+        r
+EOF
+    ${pgm} < gempak_ctrl
+    export err=$?; err_chk
     #####################################################
     # GEMPAK DOES NOT ALWAYS HAVE A NON ZERO RETURN CODE
     # WHEN IT CAN NOT PRODUCE THE DESIRED GRID.  CHECK
     # FOR THIS CASE HERE.
     #####################################################
-    ls -l ${GEMGRD}
-    export err=$?;export pgm="GEMPAK CHECK FILE";err_chk
+    ls -l "${GEMGRD}"
+    export err=$?
+    if [[ "${err}" -ne 0 ]]; then
+        echo "FATAL ERROR: Gempak failed to create gem file"
+        pgm="GEMPAK CHECK FILE" err_chk
+    fi
 
-    if [ "${NAGRIB}" = "nagrib2" ] ; then
+    if [[ "${NAGRIB}" == "nagrib2" ]] ; then
       gpend
     fi
 
     cpfs "${GEMGRD}" "${COMOUT_WAVE_GEMPAK}/${GEMGRD}"
-    if [ ${SENDDBN} = "YES" ] ; then
+    if [[ "${SENDDBN}" == "YES" ]] ; then
         "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" "${COMOUT_WAVE_GEMPAK}/${GEMGRD}"
     else
-        echo "##### DBN_ALERT is: MODEL ${DBN_ALERT_TYPE} ${job} ${COMOUT_WAVE_GEMPAK}/${GEMGRD}#####"
+        echo "INFO: DBN_ALERT is: MODEL ${DBN_ALERT_TYPE} ${job} ${COMOUT_WAVE_GEMPAK}/${GEMGRD}"
     fi
-    rm grib_${grid}
-  done
-  if [ ${fhcnt} -ge ${FHMAX_HF_WAV} ]; then
-    inc=${FHOUT_WAV}
-  else
-    inc=${FHOUT_HF_WAV}
-  fi
-  let fhcnt=fhcnt+inc
 done
 #####################################################################
 

--- a/scripts/exgfs_wave_post_gridded_sbs.sh
+++ b/scripts/exgfs_wave_post_gridded_sbs.sh
@@ -37,177 +37,125 @@ source "${USHgfs}/wave_domain_grid.sh"
 
 # 0.a Basic modes of operation
 
-  # Set wave model ID tag to include member number
-  # if ensemble; waveMEMB var empty in deterministic
-  export WAV_MOD_TAG=${RUN}wave${waveMEMB}
+# Set wave model ID tag to include member number
+export WAV_MOD_TAG="${RUN}.wave"
 
-  cd $DATA
-
-  echo "Starting WAVE POSTPROCESSOR SCRIPT for $WAV_MOD_TAG"
-
-  set +x
-  echo ' '
-  echo '                     *********************************'
-  echo '                     *** WAVE POSTPROCESSOR SCRIPT ***'
-  echo '                     *********************************'
-  echo ' '
-  echo "Starting at : $(date)"
-  echo '-------------'
-  echo ' '
-  set_trace
+cd "${DATA}" || exit 1
 
 # Script will run only if pre-defined NTASKS
 #     The actual work is distributed over these tasks.
-  if [ -z ${NTASKS} ]
-  then
-    echo "FATAL ERROR: requires NTASKS to be set "
-    err=1; export err;${errchk}
-    exit $err
-  fi
+if [[ -z ${NTASKS} ]]; then
+  echo "FATAL ERROR: requires NTASKS to be set"
+  err=1; export err; ${errchk}
+  exit "${err}"
+fi
 
 # 0.c Defining model grids
 
 # 0.c.1 Grids
 
-  export waveGRD=${waveGRD?Var waveGRD Not Set}
+export waveGRD=${waveGRD?Var waveGRD Not Set}
 
 # 0.c.2 extended global grid and rtma transfer grid
-  export waveinterpGRD=${waveinterpGRD?Var wavepostGRD Not Set}
-  export wavepostGRD=${wavepostGRD?Var wavepostGRD Not Set}
+export waveinterpGRD=${waveinterpGRD?Var wavepostGRD Not Set}
+export wavepostGRD=${wavepostGRD?Var wavepostGRD Not Set}
 
+cat << EOF
+Grid information  :
+-------------------
+   Native wave grids  : ${waveGRD}
+   Interpolated grids : ${waveinterpGRD}
+   Post-process grids : ${wavepostGRD}
+EOF
 
-  set +x
-  echo ' '
-  echo 'Grid information  :'
-  echo '-------------------'
-  echo "   Native wave grids  : $waveGRD"
-  echo "   Interpolated grids : $waveinterpGRD"
-  echo "   Post-process grids : $wavepostGRD"
-  echo ' '
-  set_trace
-
-  export FHRUN=0
+export FHRUN=0
 
 # --------------------------------------------------------------------------- #
 # 1.  Get files that are used by most child scripts
 
-  export DOGRB_WAV=${DOGRB_WAV:-'YES'} #Create grib2 files
-  export DOGRI_WAV=${DOGRI_WAV:-'NO'} #Create interpolated grids
+export DOGRB_WAV=${DOGRB_WAV:-'YES'} #Create grib2 files
+export DOGRI_WAV=${DOGRI_WAV:-'NO'} #Create interpolated grids
 
-  exit_code=0
-
-  set +x
-  echo ' '
-  echo 'Preparing input files :'
-  echo '-----------------------'
-  set_trace
+cat << EOF
+Preparing input files :
+-----------------------
+EOF
 
 # 1.a Model definition files and output files (set up using poe)
 
 # 1.a.1 Copy model definition files
-  for grdID in ${waveGRD} ${wavepostGRD} ${waveinterpGRD}; do
-    if [[ -f "${COMIN_WAVE_PREP}/${RUN}wave.mod_def.${grdID}" ]]; then
-      set +x
-      echo " Mod def file for ${grdID} found in ${COMIN_WAVE_PREP}. copying ...."
-      set_trace
+# Eliminate duplicate grids
+declare -A grdALL
+for grd in ${waveGRD} ${wavepostGRD} ${waveinterpGRD}; do
+  # For ease of access, make the value the same as the key
+  grdALL["${grd}"]="${grd}"
+done
 
-      cp -f "${COMIN_WAVE_PREP}/${RUN}wave.mod_def.${grdID}" "mod_def.${grdID}"
-    fi
-  done
+for grdID in "${grdALL[@]}"; do
+  if [[ -f "${COMIN_WAVE_PREP}/${RUN}.wave.t${cyc}z.mod_def.${grdID}.bin" ]]; then
+    echo "INFO: Mod def file for ${grdID} found in ${COMIN_WAVE_PREP}. copying ...."
+    cp -f "${COMIN_WAVE_PREP}/${RUN}.wave.t${cyc}z.mod_def.${grdID}.bin" "mod_def.${grdID}"
+  fi
+done
 
 # 1.a.2 Check that model definition files exist
-  for grdID in ${waveGRD} ${wavepostGRD} ${waveinterpGRD}; do
-    if [[ ! -f "mod_def.${grdID}" ]]; then
-      set +x
-      echo ' '
-      echo '*************************************************** '
-      echo " FATAL ERROR : NO MOD_DEF FILE mod_def.$grdID "
-      echo '*************************************************** '
-      echo ' '
-      set_trace
-      err=2; export err;${errchk}
-      exit $err
-      DOGRB_WAV='NO'
-    else
-      set +x
-      echo "File mod_def.$grdID found. Syncing to all nodes ..."
-      set_trace
-    fi
-  done
-
+for grdID in "${grdALL[@]}"; do
+  if [[ ! -f "mod_def.${grdID}" ]]; then
+    echo "FATAL ERROR : No mod_def file mod_def.${grdID}"
+    err=2; export err;${errchk}
+    exit "${err}"
+  else
+    echo "INFO: File mod_def.${grdID} found. Syncing to all nodes ..."
+  fi
+done
 
 # 1.b Input template files
 
-  if [ "$DOGRI_WAV" = 'YES' ]
-  then
-    for intGRD in $waveinterpGRD
-    do
-      if [ -f ${PARMgfs}/wave/${intGRD}_interp.inp.tmpl ]
-      then
-        cp -f ${PARMgfs}/wave/${intGRD}_interp.inp.tmpl ${intGRD}_interp.inp.tmpl
-      fi
+if [[ "${DOGRI_WAV}" == 'YES' ]]; then
+  for intGRD in ${waveinterpGRD}; do
+    if [[ -f "${PARMgfs}/wave/${intGRD}_interp.inp.tmpl" ]]; then
+      cp -f "${PARMgfs}/wave/${intGRD}_interp.inp.tmpl" "${intGRD}_interp.inp.tmpl"
+    fi
 
-      if [ -f ${intGRD}_interp.inp.tmpl ]
-      then
-        set +x
-        echo "   ${intGRD}_interp.inp.tmpl copied. Syncing to all nodes ..."
-        set_trace
-      else
-        set +x
-        echo ' '
-        echo '*********************************************** '
-        echo '*** ERROR : NO TEMPLATE FOR GRINT INPUT FILE *** '
-        echo '*********************************************** '
-        echo ' '
-        set_trace
-        echo "${WAV_MOD_TAG} post ${PDY} ${cycle} : GRINT template file missing."
-        exit_code=1
-        DOGRI_WAV='NO'
-      fi
-    done
-  fi
+    if [[ -f "${intGRD}_interp.inp.tmpl" ]]; then
+      echo "${intGRD}_interp.inp.tmpl copied. Syncing to all nodes ..."
+    else
+      echo "FATAL ERROR: No template for ${intGRD} input file"
+      err=1
+      DOGRI_WAV='NO'
+    fi
+  done
+fi
 
-  if [ "$DOGRB_WAV" = 'YES' ]
-  then
-    for grbGRD in $waveinterpGRD $wavepostGRD
-    do
-      if [ -f ${PARMgfs}/wave/ww3_grib2.${grbGRD}.inp.tmpl ]
-      then
-        cp -f ${PARMgfs}/wave/ww3_grib2.${grbGRD}.inp.tmpl ww3_grib2.${grbGRD}.inp.tmpl
-      fi
+if [[ "${DOGRB_WAV}" == 'YES' ]]; then
+  for grbGRD in ${waveinterpGRD} ${wavepostGRD}; do
+    if [[ -f "${PARMgfs}/wave/ww3_grib2.${grbGRD}.inp.tmpl" ]]; then
+      cp -f "${PARMgfs}/wave/ww3_grib2.${grbGRD}.inp.tmpl" "ww3_grib2.${grbGRD}.inp.tmpl"
+    fi
 
-      if [ -f ww3_grib2.${grbGRD}.inp.tmpl ]
-      then
-        set +x
-        echo "   ww3_grib2.${grbGRD}.inp.tmpl copied. Syncing to all nodes ..."
-        set_trace
-      else
-        set +x
-        echo ' '
-        echo '*********************************************** '
-        echo "*** ERROR : NO TEMPLATE FOR ${grbGRD} GRIB INPUT FILE *** "
-        echo '*********************************************** '
-        echo ' '
-        set_trace
-        exit_code=2
-        DOGRB_WAV='NO'
-      fi
-    done
-  fi
+    if [[ -f "ww3_grib2.${grbGRD}.inp.tmpl" ]]; then
+      echo "INFO: ww3_grib2.${grbGRD}.inp.tmpl copied."
+    else
+      echo "FATAL ERROR: No template for ${grbGRD} grib input file"
+      err=2
+      DOGRB_WAV='NO'
+    fi
+  done
+fi
 
 
 # 1.c Data summary
+#shellcheck disable=SC2312
+cat << EOF
 
-  set +x
-  echo ' '
-  echo "   Input files read and processed at : $(date)"
-  echo ' '
-  echo '   Data summary : '
-  echo '   ---------------------------------------------'
-  echo "      Sufficient data for GRID interpolation    : $DOGRI_WAV"
-  echo "      Sufficient data for GRIB files            : $DOGRB_WAV"
-  echo ' '
-  set_trace
+Input files read and processed at : $(date)
+
+Data summary:
+---------------------------------------------
+  Sufficient data for GRID interpolation    : ${DOGRI_WAV}
+  Sufficient data for GRIB files            : ${DOGRB_WAV}
+
+EOF
 
 # --------------------------------------------------------------------------- #
 # 2.  Make consolidated grib2 file for side-by-side grids and interpolate
@@ -215,157 +163,60 @@ source "${USHgfs}/wave_domain_grid.sh"
 #
 # 2.a Command file set-up
 
-  set +x
-  echo '   Making command file for sbs grib2 and GRID Interpolation '
-  set_trace
-  fhr=$(( 10#${FHR3} ))
-  ymdh=$($NDATE $fhr ${PDY}${cyc})
-  YMD=$(echo $ymdh | cut -c1-8)
-  HMS="$(echo $ymdh | cut -c9-10)0000"
-  YMDHMS=${YMD}${HMS}
-  FH3=$(printf %03i $fhr)
+echo 'INFO: Making command file for grib2 and grid interpolation'
+valid_time=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} +${FORECAST_HOUR} hours")
+fhr3=$(printf '%03i' "${FORECAST_HOUR}")
 
-  fcmdnow=cmdfile.${FH3}
-  fcmdigrd=icmdfile.${FH3}
-  mkdir output_$YMDHMS
-  cd output_$YMDHMS
-  rm -f ${fcmdnow} ${fcmdigrd}
-  touch ${fcmdnow} ${fcmdigrd}
+rm -f "mpmd_script"
+touch "mpmd_script"
 
+# Input model data
+gfile="${RUN}.wave.t${cyc}z.${waveGRD}.f${fhr3}.bin"
+if [[ ! -s "${COMIN_WAVE_HISTORY}/${gfile}" ]]; then
+  echo "FATAL ERROR: No raw field output file ${COMIN_WAVE_HISTORY}/${gfile}"
+  err=3; export err; "${errchk}"
+  exit "${err}"
+fi
+cp "${COMIN_WAVE_HISTORY}/${gfile}" "./out_grd.${waveGRD}"
 
-# Create instances of directories for gridded output
-  export GRIBDATA=${DATA}/output_$YMDHMS
-  export GRDIDATA=${DATA}/output_$YMDHMS
-
-# Gridded data (main part, need to be run side-by-side with forecast
-  gfile="${COMIN_WAVE_HISTORY}/${WAV_MOD_TAG}.out_grd.${waveGRD}.${YMD}.${HMS}"
-  if [[ ! -s "${gfile}" ]]; then
-    echo " FATAL ERROR : NO RAW FIELD OUTPUT FILE ${gfile}"
-    err=3; export err; "${errchk}"
-    exit "${err}"
-  fi
-  ${NLN} "${gfile}" "./out_grd.${waveGRD}"
-
-  if [ "$DOGRI_WAV" = 'YES' ]
-  then
-    nigrd=1
-    for grdID in $waveinterpGRD
-    do
-      ymdh_int=$($NDATE -${WAVHINDH} $ymdh); dt_int=3600.; n_int=9999 ;
-      echo "${USHgfs}/wave_grid_interp_sbs.sh $grdID $ymdh_int $dt_int $n_int > grint_$grdID.out 2>&1" >> ${fcmdigrd}.${nigrd}
-      if [ "$DOGRB_WAV" = 'YES' ]
-      then
-        gribFL=\'$(echo ${OUTPARS_WAV})\'
-        process_grdID "${grdID}"
-        echo "${USHgfs}/wave_grib2_sbs.sh $grdID $GRIDNR $MODNR $ymdh $fhr $GRDREGION $GRDRES $gribFL > grib_$grdID.out 2>&1" >> ${fcmdigrd}.${nigrd}
-      fi
-      echo "${GRIBDATA}/${fcmdigrd}.${nigrd}" >> ${fcmdnow}
-      chmod 744 ${fcmdigrd}.${nigrd}
-      nigrd=$((nigrd+1))
-    done
-  fi
-
-  if [ "$DOGRB_WAV" = 'YES' ]
-  then
-    for grdID in ${wavepostGRD} # First concatenate grib files for sbs grids
-    do
-      gribFL=\'$(echo ${OUTPARS_WAV})\'
+if [[ "${DOGRI_WAV}" == 'YES' ]]; then
+  for grdID in ${waveinterpGRD}; do
+    interp_time=$(date --utc +%Y%m%d%H -d "${valid_time:0:8} ${valid_time:8:2} -${WAVHINDH} hours")
+    dt_int=3600.
+    n_int=9999
+    echo "#! /usr/bin/env bash" > "${grdID}.sh"
+    echo "${USHgfs}/wave_grid_interp_sbs.sh ${grdID} ${interp_time} ${dt_int} ${n_int} ${FORECAST_HOUR}" >> "${grdID}.sh"
+    if [[ "${DOGRB_WAV}" == 'YES' ]]; then
+      gribFL="${OUTPARS_WAV}"
       process_grdID "${grdID}"
-      echo "${USHgfs}/wave_grib2_sbs.sh $grdID $GRIDNR $MODNR $ymdh $fhr $GRDREGION $GRDRES $gribFL > grib_$grdID.out 2>&1" >> ${fcmdnow}
-    done
-  fi
-
-  if [ ${CFP_MP:-"NO"} = "YES" ]; then
-    nfile=0
-    ifile=0
-    iline=1
-    ifirst='yes'
-    nlines=$( wc -l ${fcmdnow} | awk '{print $1}' )
-    while [ $iline -le $nlines ]; do
-      line=$( sed -n ''$iline'p' ${fcmdnow} )
-      if [ -z "$line" ]; then
-        break
-      else
-        if [ "$ifirst" = 'yes' ]; then
-          echo "#!/bin/sh" > cmdmfile.$nfile
-          echo "$nfile cmdmfile.$nfile" >> cmdmprog
-          chmod 744 "cmdmfile.$nfile"
-        fi
-        echo $line >> "cmdmfile.$nfile"
-        nfile=$(( nfile + 1 ))
-        if [ "$nfile" -eq "$NTASKS" ]; then
-          nfile=0
-          ifirst='no'
-        fi
-        iline=$(( iline + 1 ))
-      fi
-    done
-  fi
-
-  wavenproc=$(wc -l ${fcmdnow} | awk '{print $1}')
-  wavenproc=$(echo $((${wavenproc}<${NTASKS}?${wavenproc}:${NTASKS})))
-
-  set +x
-  echo ' '
-  echo "   Executing the grib2_sbs scripts at : $(date)"
-  echo '   ------------------------------------'
-  echo ' '
-  set_trace
-
-  if [ "$wavenproc" -gt '1' ]
-  then
-    if [ ${CFP_MP:-"NO"} = "YES" ]; then
-      ${wavempexec} -n ${wavenproc} ${wave_mpmd} cmdmprog
-    else
-      ${wavempexec} ${wavenproc} ${wave_mpmd} ${fcmdnow}
+      echo "${USHgfs}/wave_grib2_sbs.sh ${grdID} ${GRIDNR} ${MODNR} ${valid_time} ${FORECAST_HOUR} ${GRDREGION} ${GRDRES} '${gribFL}'" >> "${grdID}.sh"
     fi
-    exit=$?
-  else
-    chmod 744 ${fcmdnow}
-    ./${fcmdnow}
-    exit=$?
-  fi
+    echo "${DATA}/${grdID}.sh" >> "mpmd_script"
+    chmod 744 "${grdID}.sh"
+  done
+fi
 
-  if [ "$exit" != '0' ]
-  then
-    set +x
-    echo ' '
-    echo '*************************************'
-    echo '*** FATAL ERROR: CMDFILE FAILED   ***'
-    echo '*************************************'
-    echo '     See Details Below '
-    echo ' '
-    set_trace
-    err=4; export err;${errchk}
-    exit "$err"
-  fi
+if [[ "${DOGRB_WAV}" == 'YES' ]]; then
+  # First concatenate grib files for sbs grids
+  for grdID in ${wavepostGRD}; do
+    gribFL="${OUTPARS_WAV}"
+    process_grdID "${grdID}"
+    echo "${USHgfs}/wave_grib2_sbs.sh ${grdID} ${GRIDNR} ${MODNR} ${valid_time} ${FORECAST_HOUR} ${GRDREGION} ${GRDRES} '${gribFL}'" >> "mpmd_script"
+  done
+fi
 
-  rm -f out_grd.* # Remove large binary grid output files
+# Run with MPMD or serial
+echo ""
+if [[ "${USE_CFP:-}" == "YES" ]]; then
+  OMP_NUM_THREADS=1 "${USHgfs}/run_mpmd.sh" "${DATA}/mpmd_script"
+  export err=$?
+else
+  chmod 755 "${DATA}/mpmd_script"
+  bash +x "${DATA}/mpmd_script" > mpmd.out 2>&1
+  export err=$?
+fi
+err_chk
 
-  cd $DATA
- 
-# Check if grib2 file created
-    ENSTAG=""
-    com_varname="COMOUT_WAVE_GRID_${GRDREGION}_${GRDRES}"
-    com_dir=${!com_varname}
-    if [ ${waveMEMB} ]; then ENSTAG=".${membTAG}${waveMEMB}" ; fi
-    gribchk="${RUN}wave.${cycle}${ENSTAG}.${GRDREGION}.${GRDRES}.f${FH3}.grib2"
-    if [ ! -s ${com_dir}/${gribchk} ]; then
-      set +x
-      echo ' '
-      echo '********************************************'
-      echo "*** FATAL ERROR: $gribchk not generated "
-      echo '********************************************'
-      echo '     See Details Below '
-      echo ' '
-      set_trace
-      err=5; export err;${errchk}
-      exit "$err"
-    fi
-
-# --------------------------------------------------------------------------- #
-# 7.  Ending output
-
-echo "$exit_code"
+cat mpmd.out
 
 # End of MWW3 prostprocessor script ---------------------------------------- #

--- a/scripts/exgfs_wave_post_pnt.sh
+++ b/scripts/exgfs_wave_post_pnt.sh
@@ -44,7 +44,7 @@ source "${USHgfs}/preamble.sh"
 
   # Set wave model ID tag to include member number
   # if ensemble; waveMEMB var empty in deterministic
-  export WAV_MOD_TAG=${RUN}wave${waveMEMB}
+  export WAV_MOD_TAG=${RUN}.wave.t${cyc}z
 
   echo "HAS BEGUN on $(hostname)"
   echo "Starting WAVE PNT POSTPROCESSOR SCRIPT for $WAV_MOD_TAG"
@@ -121,12 +121,12 @@ source "${USHgfs}/preamble.sh"
 # Copy model definition files
   iloop=0
   for grdID in ${waveuoutpGRD}; do
-    if [[ -f "${COMIN_WAVE_PREP}/${RUN}wave.mod_def.${grdID}" ]]; then
+    if [[ -f "${COMIN_WAVE_PREP}/${RUN}.wave.t${cyc}z.mod_def.${grdID}.bin" ]]; then
       set +x
       echo " Mod def file for ${grdID} found in ${COMIN_WAVE_PREP}. copying ...."
       set_trace
 
-      cp -f "${COMIN_WAVE_PREP}/${RUN}wave.mod_def.${grdID}" "mod_def.${grdID}"
+      cp -f "${COMIN_WAVE_PREP}/${RUN}.wave.t${cyc}z.mod_def.${grdID}.bin" "mod_def.${grdID}"
       iloop=$((iloop + 1))
     fi
   done
@@ -252,15 +252,12 @@ source "${USHgfs}/preamble.sh"
                                ww3_outp_spec.inp.tmpl > ww3_outp.inp
 
     ${NLN} mod_def.$waveuoutpGRD mod_def.ww3
-    #export OFFSET_START_HOUR=$( printf "%02d" ${half_assim} )
-    hh=$( printf "%02d" $(( cyc + OFFSET_START_HOUR )) )
-    HMS="${hh}0000"
-    if [[ -f "${COMIN_WAVE_HISTORY}/${WAV_MOD_TAG}.out_pnt.${waveuoutpGRD}.${PDY}.${HMS}" ]]; then
-      ${NLN} "${COMIN_WAVE_HISTORY}/${WAV_MOD_TAG}.out_pnt.${waveuoutpGRD}.${PDY}.${HMS}" \
+    if [[ -f "${COMIN_WAVE_HISTORY}/${WAV_MOD_TAG}.points.f000.bin" ]]; then
+      ${NLN} "${COMIN_WAVE_HISTORY}/${WAV_MOD_TAG}.points.f000.bin" \
         "./out_pnt.${waveuoutpGRD}"
     else
       echo '*************************************************** '
-      echo " FATAL ERROR : NO RAW POINT OUTPUT FILE out_pnt.${waveuoutpGRD}.${PDY}.${HMS} "
+      echo " FATAL ERROR : NO RAW POINT OUTPUT FILE ${COMIN_WAVE_HISTORY}/${WAV_MOD_TAG}.points.f000.bin"
       echo '*************************************************** '
       echo ' '
       set_trace
@@ -377,12 +374,12 @@ source "${USHgfs}/preamble.sh"
     export BULLDATA=${DATA}/output_$YMDHMS
     cp $DATA/mod_def.${waveuoutpGRD} mod_def.${waveuoutpGRD}
 
-    pfile="${COMIN_WAVE_HISTORY}/${WAV_MOD_TAG}.out_pnt.${waveuoutpGRD}.${YMD}.${HMS}"
+    pfile="${COMIN_WAVE_HISTORY}/${WAV_MOD_TAG}.points.f${FH3}.bin"
     if [ -f  ${pfile} ]
     then
       ${NLN} ${pfile} ./out_pnt.${waveuoutpGRD}
     else
-      echo " FATAL ERROR : NO RAW POINT OUTPUT FILE out_pnt.$waveuoutpGRD.${YMD}.${HMS} "
+      echo " FATAL ERROR : NO RAW POINT OUTPUT FILE ${WAV_MOD_TAG}.points.f${FH3}.bin"
       echo ' '
       set_trace
       err=7; export err;${errchk}
@@ -439,7 +436,7 @@ source "${USHgfs}/preamble.sh"
   done
 
 
-  if [ ${CFP_MP:-"NO"} = "YES" ]; then
+  if [ ${USE_CFP:-"NO"} = "YES" ]; then
     nfile=0
     ifile=0
     iline=1
@@ -478,7 +475,7 @@ source "${USHgfs}/preamble.sh"
 
   if [ "$wavenproc" -gt '1' ]
   then
-    if [ ${CFP_MP:-"NO"} = "YES" ]; then
+    if [ ${USE_CFP:-"NO"} = "YES" ]; then
       ${wavempexec} -n ${wavenproc} ${wave_mpmd} cmdmprog
     else
       ${wavempexec} ${wavenproc} ${wave_mpmd} cmdfile
@@ -528,7 +525,7 @@ source "${USHgfs}/preamble.sh"
     sed "s/^\(.*\)$/${escaped_USHgfs}\/wave_outp_cat.sh \1 ${FHMAX_WAV_PNT} bull > ${escaped_CATOUTDIR}\/bull_cat_\1.out 2>\&1/" buoy_lst.txt >> cmdfile.buoy
   fi
 
-  if [ ${CFP_MP:-"NO"} = "YES" ]; then
+  if [ ${USE_CFP:-"NO"} = "YES" ]; then
     nfile=0
     ifile=0
     iline=1
@@ -567,7 +564,7 @@ source "${USHgfs}/preamble.sh"
 
   if [ "$wavenproc" -gt '1' ]
   then
-    if [ ${CFP_MP:-"NO"} = "YES" ]; then
+    if [ ${USE_CFP:-"NO"} = "YES" ]; then
       # shellcheck disable=SC2086
       ${wavempexec} -n "${wavenproc}" ${wave_mpmd} cmdmprogbuoy
     else
@@ -613,9 +610,9 @@ source "${USHgfs}/preamble.sh"
 
 # 6.b Spectral data files
 
-  if [ ${CFP_MP:-"NO"} = "YES" ]; then nm=0; fi
+  if [ ${USE_CFP:-"NO"} = "YES" ]; then nm=0; fi
 
-  if [ ${CFP_MP:-"NO"} = "YES" ] && [ "$DOBLL_WAV" = "YES" ]; then
+  if [ ${USE_CFP:-"NO"} = "YES" ] && [ "$DOBLL_WAV" = "YES" ]; then
     if [ "$DOBNDPNT_WAV" = YES ]; then
       if [ "$DOSPC_WAV" = YES ]; then
         echo "$nm ${USHgfs}/wave_tar.sh $WAV_MOD_TAG ibp $Nb > ${WAV_MOD_TAG}_spec_tar.out 2>&1 "   >> cmdtarfile
@@ -671,7 +668,7 @@ source "${USHgfs}/preamble.sh"
 
   if [ "$wavenproc" -gt '1' ]
   then
-    if [ ${CFP_MP:-"NO"} = "YES" ]; then
+    if [ ${USE_CFP:-"NO"} = "YES" ]; then
       ${wavempexec} -n ${wavenproc} ${wave_mpmd} cmdtarfile
     else
       ${wavempexec} ${wavenproc} ${wave_mpmd} cmdtarfile

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -412,16 +412,17 @@ WW3_postdet() {
   #fi	  
       
   # Link output files
-  local wavprfx="${RUN}wave${WAV_MEMBER:-}"
+  local wavprfx="${RUN}.wave.t${cyc}z"
   ${NLN} "${COMOUT_WAVE_HISTORY}/${wavprfx}.log.${waveGRD}.${PDY}${cyc}" "log.ww3"
 
   # Loop for gridded output (uses FHINC)
-  local fhr vdate FHINC ww3_grid
+  local fhr fhr3 vdate FHINC ww3_grid
   fhr=${FHMIN_WAV}
   fhinc=${FHOUT_WAV}
   while (( fhr <= FHMAX_WAV )); do
+    fhr3=$(printf '%03d' "${fhr}")
     vdate=$(date --utc -d "${current_cycle:0:8} ${current_cycle:8:2} + ${fhr} hours" +%Y%m%d.%H0000)
-    ${NLN} "${COMOUT_WAVE_HISTORY}/${wavprfx}.out_grd.${waveGRD}.${vdate}" "${DATA}/${vdate}.out_grd.ww3"
+    ${NLN} "${COMOUT_WAVE_HISTORY}/${wavprfx}.${waveGRD}.f${fhr3}.bin" "${DATA}/${vdate}.out_grd.ww3"
 
     if (( FHMAX_HF_WAV > 0 && FHOUT_HF_WAV > 0 && fhr < FHMAX_HF_WAV )); then
       fhinc=${FHOUT_HF_WAV}
@@ -433,8 +434,9 @@ WW3_postdet() {
   fhr=${FHMIN_WAV}
   fhinc=${FHINCP_WAV}
   while (( fhr <= FHMAX_WAV )); do
+    fhr3=$(printf '%03d' "${fhr}")
     vdate=$(date --utc -d "${current_cycle:0:8} ${current_cycle:8:2} + ${fhr} hours" +%Y%m%d.%H0000)
-    ${NLN} "${COMOUT_WAVE_HISTORY}/${wavprfx}.out_pnt.${waveuoutpGRD}.${vdate}" "${DATA}/${vdate}.out_pnt.ww3"
+    ${NLN} "${COMOUT_WAVE_HISTORY}/${wavprfx}.points.f${fhr3}.bin" "${DATA}/${vdate}.out_pnt.ww3"
 
     fhr=$((fhr + fhinc))
   done

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -604,8 +604,8 @@ WW3_predet(){
   # Copy mod_def files for wave grids
   local ww3_grid
   #if shel, only 1 waveGRD which is linked to mod_def.ww3
-  ${NCP} "${COMIN_WAVE_PREP}/${RUN}wave.mod_def.${waveGRD}" "${DATA}/mod_def.ww3" \
-  || ( echo "FATAL ERROR: Failed to copy '${RUN}wave.mod_def.${waveGRD}' from '${COMIN_WAVE_PREP}'"; exit 1 )
+  ${NCP} "${COMIN_WAVE_PREP}/${RUN}.wave.t${cyc}z.mod_def.${waveGRD}.bin" "${DATA}/mod_def.ww3" \
+  || ( echo "FATAL ERROR: Failed to copy '${RUN}.wave.t${cyc}z.mod_def.${waveGRD}.bin' from '${COMIN_WAVE_PREP}'"; exit 1 )
 
   if [[ "${WW3ICEINP}" == "YES" ]]; then
     local wavicefile="${COMIN_WAVE_PREP}/${RUN}wave.${WAVEICE_FID}.t${current_cycle:8:2}z.ice"
@@ -636,7 +636,7 @@ WW3_predet(){
     ${NCP} "${FIXgfs}/wave/${MESH_WAV}" "${DATA}/"
   fi
 
-  WAV_MOD_TAG="${RUN}wave${waveMEMB}"
+  WAV_MOD_TAG="${RUN}.wave"
 }
 
 # shellcheck disable=SC2034

--- a/ush/run_mpmd.sh
+++ b/ush/run_mpmd.sh
@@ -11,6 +11,11 @@ nprocs=$(wc -l < "${cmdfile}")
 mpmd_cmdfile="${DATA:-}/mpmd_cmdfile"
 if [[ -s "${mpmd_cmdfile}" ]]; then rm -f "${mpmd_cmdfile}"; fi
 
+cat << EOF
+  INFO: Executing MPMD job, STDOUT redirected for each process separately
+  INFO: On failure, logs for each job will be available in ${DATA}/mpmd.proc_num.out
+  INFO: The proc_num corresponds to the line in ${mpmd_cmdfile}
+EOF
 if [[ "${launcher:-}" =~ ^srun.* ]]; then  #  srun-based system e.g. Hera, Orion, etc.
 
   # Slurm requires a counter in front of each line in the script

--- a/ush/wave_grib2_sbs.sh
+++ b/ush/wave_grib2_sbs.sh
@@ -179,7 +179,7 @@ else
 fi
 
 # Verify grib2 file created
-if [[ ! -s ${comout}/${outfile} ]]; then
+if [[ ! -s "${comout}/${outfile}" ]]; then
   echo "FATAL ERROR: ${comout}/${outfile} not generated"
   err=5; export err; ${errchk}
   exit "${err}"

--- a/ush/wave_grib2_sbs.sh
+++ b/ush/wave_grib2_sbs.sh
@@ -26,241 +26,161 @@
 # 0.  Preparations
 
 source "${USHgfs}/preamble.sh"
+source "${USHgfs}/atparse.bash"
 
-# 0.a Basic modes of operation
+# 0.a Define directories and the search path.
+#     The tested variables should be exported by the postprocessor script.
 
-cd "${GRIBDATA}" || exit 2
+# shellcheck disable=SC2034
+{
+  grdID=$1
+  gridnr=$2
+  modnr=$3
+  valid_time=$4
+  fhr=$5
+  grid_region=$6
+  grid_res=$7
+  grib_flags=$8
+}
 
-alertName=${RUN^^}
+# 0.b Basic modes of operation
 
-grdID=$1
-gribDIR="${grdID}_grib"
-rm -rfd "${gribDIR}"
-mkdir "${gribDIR}"
+cd "${DATA}" || exit 2
+
+grib_data="grib_${grdID}"
+rm -rf "${grib_data}"
+mkdir "${grib_data}"
 err=$?
 if [[ ${err} != 0 ]]; then
-  set +x
-  echo ' '
-  echo '******************************************************************************* '
-  echo '*** FATAL ERROR : ERROR IN ww3_grib2 (COULD NOT CREATE TEMP DIRECTORY) *** '
-  echo '******************************************************************************* '
-  echo ' '
-  set_trace
+  echo "FATAL ERROR: Could not create temp directory ${grib_data}"
   exit 1
 fi
 
-cd "${gribDIR}" || exit 2
+cd "${grib_data}" || exit 2
 
-# 0.b Define directories and the search path.
-#     The tested variables should be exported by the postprocessor script.
-
-GRIDNR=$2
-MODNR=$3
-ymdh=$4
-fhr=$5
-grdnam=$6
-grdres=$7
-gribflags=$8
-ngrib=1 # only one time slice
-dtgrib=3600 # only one time slice
 # SBS one time slice per file
-FH3=$(printf %03i "${fhr}")
-
-# Verify if grib2 file exists from interrupted run
-ENSTAG=""
-if [[ -n ${waveMEMB} ]]; then ENSTAG=".${membTAG}${waveMEMB}" ; fi
-outfile="${WAV_MOD_TAG}.${cycle}${ENSTAG}.${grdnam}.${grdres}.f${FH3}.grib2"
+fhr3=$(printf %03i "${fhr}")
 
 #create the COM directory var
-com_varname="COMOUT_WAVE_GRID_${grdnam}_${grdres}"
-com_dir="${!com_varname}"
+com_varname="COMOUT_WAVE_GRID_${grid_region}_${grid_res}"
+comout="${!com_varname}"
 
-# Check if the COM directory exists, create it if necessary
-if [[ ! -d "${com_dir}" ]]; then
-    mkdir -p -m "${com_dir}"
-    echo "Directory ${com_dir} created."
-else
-    echo "Directory ${com_dir} already exists."
-fi
+# Verify if grib2 file exists from interrupted run
+outfile="${RUN}.wave.${cycle}.${grid_res}.f${fhr3}.${grid_region}.grib2"
+
 # Only create file if not present in COM
-if [[ ! -s "${com_dir}/${outfile}.idx" ]]; then
-
-  set +x
-  echo ' '
-  echo '+--------------------------------+'
-  echo '!         Make GRIB files        |'
-  echo '+--------------------------------+'
-  echo "   Model ID         : $WAV_MOD_TAG"
-  set_trace
-
-  if [[ -z "${PDY}" ]] || [[ -z ${cyc} ]] || [[ -z "${cycle}" ]] || [[ -z "${EXECgfs}" ]] || \
-	 [[ -z "${com_dir}" ]] || [[ -z "${WAV_MOD_TAG}" ]] || [[ -z "${gribflags}" ]] || \
-	 [[ -z "${GRIDNR}" ]] || [[ -z "${MODNR}" ]] || \
-     [[ -z "${SENDDBN}" ]]; then
-    set +x
-    echo ' '
-    echo '***************************************************'
-    echo '*** EXPORTED VARIABLES IN postprocessor NOT SET ***'
-    echo '***************************************************'
-    echo ' '
-    set_trace
-    exit 1
-  fi
+if [[ ! -s "${comout}/${outfile}.idx" ]]; then
 
   # 0.c Starting time for output
 
-  tstart="${ymdh:0:8} ${ymdh:8:2}0000"
+  time="${valid_time:0:8} ${valid_time:8:2}0000"
 
-  set +x
-  echo "   Starting time    : ${tstart}"
-  echo "   Time step        : Single SBS"
-  echo "   Number of times  : Single SBS"
-  echo "   GRIB field flags : ${gribflags}"
-  echo ' '
-  set_trace
+  cat << EOF
+    Starting time    : ${time}
+    GRIB field flags : ${grib_flags}
+EOF
 
   # 0.e Links to working directory
 
-  ${NLN} "${DATA}/mod_def.${grdID}" "mod_def.ww3"
-  ${NLN} "${DATA}/output_${ymdh}0000/out_grd.${grdID}" "out_grd.ww3"
+  ${NLN} "../mod_def.${grdID}" "mod_def.ww3"
+  ${NLN} "../out_grd.${grdID}" "out_grd.ww3"
 
   # --------------------------------------------------------------------------- #
   # 1.  Generate GRIB file with all data
   # 1.a Generate input file for ww3_grib2
   #     Template copied in mother script ...
 
-  set +x
-  echo "   Generate input file for ww3_grib2"
-  set_trace
+  echo "INFO: Generate input file for ww3_grib2"
 
-  sed -e "s/TIME/${tstart}/g" \
-      -e "s/DT/${dtgrib}/g" \
-      -e "s/NT/${ngrib}/g" \
-      -e "s/GRIDNR/${GRIDNR}/g" \
-      -e "s/MODNR/${MODNR}/g" \
-      -e "s/FLAGS/${gribflags}/g" \
-      "${DATA}/ww3_grib2.${grdID}.inp.tmpl" > ww3_grib.inp
-
+  # shellcheck disable=SC2034
+  {
+    nt=1 # only one time slice
+    dt=3600 # only one time slice
+  }
+  atparse < "${DATA}/ww3_grib2.${grdID}.inp.tmpl" > ww3_grib.inp
 
   echo "ww3_grib.inp"
   cat ww3_grib.inp
 
   # 1.b Run GRIB packing program
 
-
   export pgm="${NET,,}_ww3_grib.x"
-  . prep_step
+  source prep_step
 
-  set +x
-  echo "   Executing ${EXECgfs}/${pgm}"
-  set_trace
+  echo "INFO: Executing ${EXECgfs}/${pgm}"
 
-  "${EXECgfs}/${pgm}" > "grib2_${grdnam}_${FH3}.out" 2>&1
-  export err=$?;err_chk
-  if [ ! -s gribfile ]; then
-    set +x
-    echo ' '
-    echo '************************************************ '
-    echo "*** FATAL ERROR : ERROR IN ${pgm} encoding *** "
-    echo '************************************************ '
-    echo ' '
-    set_trace
+  "${EXECgfs}/${pgm}"
+  export err=$?; err_chk
+  if [[ ! -s gribfile ]]; then
+    echo "FATAL ERROR: Error in ${pgm} encoding"
     exit 3
   fi
 
   if (( fhr > 0 )); then
-    ${WGRIB2} gribfile -set_date "${PDY}${cyc}" -set_ftime "${fhr} hour fcst" -grib "${com_dir}/${outfile}"
+    ${WGRIB2} gribfile -set_date "${PDY}${cyc}" -set_ftime "${fhr} hour fcst" -grib "${outfile}"
     err=$?
   else
     ${WGRIB2} gribfile -set_date "${PDY}${cyc}" -set_ftime "${fhr} hour fcst" \
-      -set table_1.4 1 -set table_1.2 1 -grib "${com_dir}/${outfile}"
+      -set 'table_1.4' '1' -set 'table_1.2' '1' -grib "${outfile}"
     err=$?
   fi
 
   if [[ ${err} != 0 ]]; then
-    set +x
-    echo ' '
-    echo '********************************************* '
-    echo "*** FATAL ERROR : ERROR IN ${pgm} *** "  # FIXME: This is not an error in $pgm, but in WGRIB2
-    echo '********************************************* '
-    echo ' '
-    set_trace
+    echo "FATAL ERROR: Error setting grib2 parameters with wgrib2"
     exit 3
   fi
 
   # Create index
-  ${WGRIB2} -s "${com_dir}/${outfile}" > "${com_dir}/${outfile}.idx"
+  ${WGRIB2} -s "${outfile}" > "${outfile}.idx"
 
   # Create grib2 subgrid is this is the source grid
-  if [[ "${grdID}" = "${WAV_SUBGRBSRC}" ]]; then
-    for subgrb in ${WAV_SUBGRB}; do
-      subgrbref=$(echo ${!subgrb} | cut -d " " -f 1-20)
-      subgrbnam=$(echo ${!subgrb} | cut -d " " -f 21)
-      subgrbres=$(echo ${!subgrb} | cut -d " " -f 22)
-      subfnam="${WAV_MOD_TAG}.${cycle}${ENSTAG}.${subgrbnam}.${subgrbres}.f${FH3}.grib2"
-      ${COPYGB2} -g "${subgrbref}" -i0 -x "${com_dir}/${outfile}" "${com_dir}/${subfnam}"
-      ${WGRIB2} -s "${com_dir}/${subfnam}" > "${com_dir}/${subfnam}.idx"
+  if [[ "${grdID}" == "${WAV_SUBGRBSRC}" ]]; then
+    subgrid_filenames=()
+    for subgrib_varname in ${WAV_SUBGRB}; do
+      subgrib=${!subgrib_varname}
+      subgrib_ref=$(cut -d " " -f 1-20 <<< "${subgrib}")
+      subgrib_name=$(cut -d " " -f 21 <<< "${subgrib}")
+      subgrib_res=$(cut -d " " -f 22 <<< "${subgrib}")
+      subgrib_filename="${RUN}.wave.${cycle}.${subgrib_name}.${subgrib_res}.f${fhr3}.grib2"
+      ${COPYGB2} -g "${subgrib_ref}" -i0 -x "${outfile}" "${subgrib_filename}"
+      ${WGRIB2} -s "${subgrib_filename}" > "${subgrib_filename}.idx"
+      # Save filenames to copy to COM later
+      subgrib_filenames+=("${subgrib_filename}")
    done
   fi
 
   # 1.e Save in /com
 
-  if [[ ! -s "${com_dir}/${outfile}" ]]; then
-    set +x
-    echo ' '
-    echo '********************************************* '
-    echo "*** FATAL ERROR : ERROR IN ${pgm} *** "
-    echo '********************************************* '
-    echo ' '
-    echo " Error in moving grib file ${outfile} to com"
-    echo ' '
-    set_trace
-    exit 4
+  # Check if the COM directory exists, create it if necessary
+  if [[ ! -d "${comout}" ]]; then
+      mkdir -p -m "${comout}"
+      echo "INFO: Directory ${comout} created."
   fi
-  if [[ ! -s "${com_dir}/${outfile}.idx" ]]; then
-    set +x
-    echo ' '
-    echo '*************************************************** '
-    echo "*** FATAL ERROR : ERROR IN ${pgm} INDEX FILE *** "
-    echo '*************************************************** '
-    echo ' '
-    echo " Error in moving grib file ${outfile}.idx to com"
-    echo ' '
-    set_trace
-    exit 4
-  fi
+
+  # Copy main grib files
+  cpfs "${outfile}" "${comout}/${outfile}"
+  cpfs "${outfile}.idx" "${comout}/${outfile}.idx"
+
+  # Copy subgrid files
+  for subgrid_filename in "${subgrid_filenames[@]}"; do
+    cpfs "${subgrid_filename}" "${comout}/${subgrid_filename}"
+    cpfs "${subgrid_filename}.idx" "${comout}/${subgrid_filename}.idx"
+  done
 
   if [[ "${SENDDBN}" = 'YES' ]] && [[ ${outfile} != *global.0p50* ]]; then
-    set +x
-    echo "   Alerting GRIB file as ${com_dir}/${outfile}"
-    echo "   Alerting GRIB index file as ${com_dir}/${outfile}.idx"
-    set_trace
-    "${DBNROOT}/bin/dbn_alert" MODEL "${alertName}_WAVE_GB2" "${job}" "${com_dir}/${outfile}"
-    "${DBNROOT}/bin/dbn_alert" MODEL "${alertName}_WAVE_GB2_WIDX" "${job}" "${com_dir}/${outfile}.idx"
+    "${DBNROOT}/bin/dbn_alert" MODEL "${RUN^^}_WAVE_GB2" "${job}" "${comout}/${outfile}"
+    "${DBNROOT}/bin/dbn_alert" MODEL "${RUN^^}_WAVE_GB2_WIDX" "${job}" "${comout}/${outfile}.idx"
   else
-    echo "${outfile} is global.0p50 or SENDDBN is NO, no alert sent"
+    echo "INFO: ${outfile} is global.0p50 or SENDDBN is NO, no alert sent"
   fi
 
-
-  # --------------------------------------------------------------------------- #
-  # 3.  Clean up the directory
-
-  rm -f gribfile
-
-  set +x
-  echo "   Removing work directory after success."
-  set_trace
-
-  cd ../
-  mv -f "${gribDIR}" "done.${gribDIR}"
-
 else
-  set +x
-  echo ' '
-  echo " File ${com_dir}/${outfile} found, skipping generation process"
-  echo ' '
-  set_trace
+  echo "INFO: File ${comout}/${outfile} already exists, skipping generation"
 fi
 
-
-# End of ww3_grib2.sh -------------------------------------------------- #
+# Verify grib2 file created
+if [[ ! -s ${comout}/${outfile} ]]; then
+  echo "FATAL ERROR: ${comout}/${outfile} not generated"
+  err=5; export err; ${errchk}
+  exit "${err}"
+fi

--- a/ush/wave_grid_interp_sbs.sh
+++ b/ush/wave_grid_interp_sbs.sh
@@ -26,171 +26,108 @@
 # 0.  Preparations
 
 source "${USHgfs}/preamble.sh"
+source "${USHgfs}/atparse.bash"
 
 # 0.a Basic modes of operation
 
-  cd $GRDIDATA
+cd "${DATA}" || exit 2
 
+# shellcheck disable=SC2034
+{
   grdID=$1
-  ymdh=$2
+  verif_date=$2
   dt=$3
-  nst=$4
-  echo "Making GRID Interpolation Files for $grdID."
-  rm -rf grint_${grdID}_${ymdh}
-  mkdir grint_${grdID}_${ymdh}
-  err=$?
+  nsteps=$4
+  fhr=$5
+}
 
-  if [ "$err" != '0' ]
-  then
-    set +x
-    echo ' '
-    echo '************************************************************************************* '
-    echo '*** FATAL ERROR : ERROR IN ww3_grid_interp (COULD NOT CREATE TEMP DIRECTORY) *** '
-    echo '************************************************************************************* '
-    echo ' '
-    set_trace
-    exit 1
-  fi
+echo "INFO: Making GRID Interpolation Files for ${grdID}"
+interp_data="grid_interp_${grdID}"
+rm -rf "${interp_data}"
+mkdir "${interp_data}"
+err=$?
+if [[ "${err}" != '0' ]]; then
+  echo 'FATAL ERROR: Could not create temp directory'
+  exit 1
+fi
 
-  cd grint_${grdID}_${ymdh}
+cd "${interp_data}" || exit 2
 
 # 0.b Define directories and the search path.
 #     The tested variables should be exported by the postprocessor script.
 
-  set +x
-  echo ' '
-  echo '+--------------------------------+'
-  echo '!         Make GRID files        |'
-  echo '+--------------------------------+'
-  echo "   Model ID         : $WAV_MOD_TAG"
-  set_trace
-
-  if [[ -z "${PDY}" ]] || [[ -z "${cyc}" ]] || [[ -z "${cycle}" ]] || [[ -z "${EXECgfs}" ]] || \
-	 [[ -z "${COMOUT_WAVE_PREP}" ]] || [[ -z "${WAV_MOD_TAG}" ]] || [[ -z "${SENDDBN}" ]] || \
-	 [ -z "${waveGRD}" ]
-  then
-    set +x
-    echo ' '
-    echo '***************************************************'
-    echo '*** EXPORTED VARIABLES IN postprocessor NOT SET ***'
-    echo '***************************************************'
-    echo ' '
-    echo "${PDY}${cyc} ${cycle} ${EXECgfs} ${COMOUT_WAVE_PREP} ${WAV_MOD_TAG} ${SENDDBN} ${waveGRD}"
-    set_trace
-    exit 1
-  fi
+echo 'INFO: Make interpolated grid files'
 
 # 0.c Links to files
 
-  rm -f ${DATA}/output_${ymdh}0000/out_grd.$grdID
+if [[ ! -f "${DATA}/${grdID}_interp.inp.tmpl" ]]; then
+  cp "${PARMgfs}/wave/${grdID}_interp.inp.tmpl" "${DATA}/${grdID}_interp.inp.tmpl"
+fi
+${NLN} "../${grdID}_interp.inp.tmpl" "${grdID}_interp.inp.tmpl"
 
-  if [ ! -f ${DATA}/${grdID}_interp.inp.tmpl ]; then
-    cp "${PARMgfs}/wave/${grdID}_interp.inp.tmpl" "${DATA}/${grdID}_interp.inp.tmpl"
-  fi
-  ${NLN} "${DATA}/${grdID}_interp.inp.tmpl" "${grdID}_interp.inp.tmpl"
+# Link input file within DATA
+${NLN} "../out_grd.${waveGRD}" "out_grd.${waveGRD}"
 
-  ${NLN} "${DATA}/output_${ymdh}0000/out_grd.${waveGRD}" "out_grd.${waveGRD}"
+# Link output file within DATA
+${NLN} "../out_grd.${grdID}" "out_grd.${grdID}"
 
-  for ID in ${waveGRD} ${grdID}; do
-    ${NLN} "${DATA}/mod_def.${ID}" "mod_def.${ID}"
-  done
-  
+for id in ${waveGRD} ${grdID}; do
+  ${NLN} "../mod_def.${id}" "mod_def.${id}"
+done
+
 
 # --------------------------------------------------------------------------- #
 # 1.  Generate GRID file with all data
 # 1.a Generate Input file
 
-  time="${ymdh:0:8} ${ymdh:8:2}0000"
-
-  sed -e "s/TIME/$time/g" \
-      -e "s/DT/$dt/g" \
-      -e "s/NSTEPS/$nst/g" ${grdID}_interp.inp.tmpl > ww3_gint.inp
+# shellcheck disable=SC2034
+time="${verif_date:0:8} ${verif_date:8:2}0000"
+atparse < "${grdID}_interp.inp.tmpl" > ww3_gint.inp
 
 # Check if there is an interpolation weights file available
 
-  wht_OK='no'
-  if [ ! -f ${DATA}/ww3_gint.WHTGRIDINT.bin.${grdID} ]; then
-    if [ -f ${FIXgfs}/wave/ww3_gint.WHTGRIDINT.bin.${grdID} ]
-    then
-      set +x
-      echo ' '
-      echo " Copying ${FIXgfs}/wave/ww3_gint.WHTGRIDINT.bin.${grdID} "
-      set_trace
-      cp ${FIXgfs}/wave/ww3_gint.WHTGRIDINT.bin.${grdID} ${DATA}
-      wht_OK='yes'
-    else
-      set +x
-      echo ' '
-      echo " Not found: ${FIXgfs}/wave/ww3_gint.WHTGRIDINT.bin.${grdID} "
-    fi
+weights_exist='no'
+if [[ ! -f "${DATA}/ww3_gint.WHTGRIDINT.bin.${grdID}" ]]; then
+  if [[ -f "${FIXgfs}/wave/ww3_gint.WHTGRIDINT.bin.${grdID}" ]]; then
+    echo "INFO: Copying ${FIXgfs}/wave/ww3_gint.WHTGRIDINT.bin.${grdID}"
+    cp "${FIXgfs}/wave/ww3_gint.WHTGRIDINT.bin.${grdID}" "${DATA}/ww3_gint.WHTGRIDINT.bin.${grdID}"
+    weights_exist='yes'
+  else
+    echo "INFO: Not found: ${FIXgfs}/wave/ww3_gint.WHTGRIDINT.bin.${grdID}"
   fi
+fi
 # Check and link weights file
-  if [ -f ${DATA}/ww3_gint.WHTGRIDINT.bin.${grdID} ]
-  then
-    ${NLN} ${DATA}/ww3_gint.WHTGRIDINT.bin.${grdID} ./WHTGRIDINT.bin
-  fi
+if [[ -f "${DATA}/ww3_gint.WHTGRIDINT.bin.${grdID}" ]]; then
+  ${NLN} "../ww3_gint.WHTGRIDINT.bin.${grdID}" "./WHTGRIDINT.bin"
+fi
 
 # 1.b Run interpolation code
 
-  export pgm="${NET,,}_ww3_gint.x"
-  source prep_step
+export pgm="${NET,,}_ww3_gint.x"
+source prep_step
 
-  set +x
-  echo "   Executing ${pgm}"
-  set_trace
+echo "INFO: Executing ${pgm}"
 
-  "${EXECgfs}/${pgm}" 1> gint.${grdID}.out 2>&1
-  export err=$?;err_chk
+"${EXECgfs}/${pgm}" 1> "gint.${grdID}.out" 2>&1
+export err=$?; err_chk
 
 # Write interpolation file to main TEMP dir area if not there yet
-  if [ "wht_OK" = 'no' ]  # FIXME: This is never going to evaluate to true, wht_OK is a string and needs to be ${wht_OK}.  With ${wht_OK}, the next line is trying to copy into ${FIXgfs} space.  This leads to a Permission denied error. The logic here needs to be evaluated and recoded.  #TODO
-  then
-    cp -f ./WHTGRIDINT.bin ${DATA}/ww3_gint.WHTGRIDINT.bin.${grdID}
-    cp -f ./WHTGRIDINT.bin ${FIXgfs}/wave/ww3_gint.WHTGRIDINT.bin.${grdID}
-  fi
+if [[ "${weights_exist}" == 'no' ]]; then
+  cp -f "./WHTGRIDINT.bin" "../ww3_gint.WHTGRIDINT.bin.${grdID}"
+fi
 
+if [[ "${err}" != '0' ]]; then
+  echo "FATAL ERROR: Error in ${pgm} interpolation"
+  exit 3
+fi
 
-  if [ "$err" != '0' ]
-  then
-    set +x
-    echo ' '
-    echo '*************************************************** '
-    echo "*** FATAL ERROR : ERROR IN ${pgm} interpolation * "
-    echo '*************************************************** '
-    echo ' '
-    set_trace
-    exit 3
-  fi
+# 1.b Save in /com
 
-# 1.b Clean up
+# WCK - I don't think these actually need to be sent to COM
+#  Check with Jessica
 
-  rm -f grid_interp.inp
-  rm -f mod_def.*
-  mv out_grd.$grdID ${DATA}/output_${ymdh}0000/out_grd.$grdID
-
-# 1.c Save in /com
-
-  set +x
-  echo "   Saving GRID file as ${COMOUT_WAVE_PREP}/${WAV_MOD_TAG}.out_grd.${grdID}.${PDY}${cyc}"
-  set_trace
-  cp "${DATA}/output_${ymdh}0000/out_grd.${grdID}" "${COMOUT_WAVE_PREP}/${WAV_MOD_TAG}.out_grd.${grdID}.${PDY}${cyc}"
-
-#    if [ "$SENDDBN" = 'YES' ]
-#    then
-#      set +x
-#      echo "   Alerting GRID file as $COMOUT/rundata/$WAV_MOD_TAG.out_grd.$grdID.${PDY}${cyc}
-#      set_trace
-
-#
-# PUT DBNET ALERT HERE ....
-#
-
-#    fi
-
-# --------------------------------------------------------------------------- #
-# 2.  Clean up the directory
-
-  cd ../
-  mv -f grint_${grdID}_${ymdh} done.grint_${grdID}_${ymdh}
+# outfile="${RUN}.wave.${grdID}.f${fhr3}.bin"
+# echo "INFO: Saving GRID file as ${COMOUT_WAVE_PREP}/${outfile}"
+# cpfs "out_grd.${grdID}" "${COMOUT_WAVE_PREP}/${outfile}"
 
 # End of ww3_grid_interp.sh -------------------------------------------- #

--- a/ush/wave_grid_moddef.sh
+++ b/ush/wave_grid_moddef.sh
@@ -23,103 +23,42 @@
 source "${USHgfs}/preamble.sh"
 
 # 0.a Basic modes of operation
+  grdID=${1?Must provide grdID}
 
-  echo "Generating mod_def file"
+  echo "INFO: Generating mod_def file for ${grdID}"
 
-  mkdir -p moddef_${1}
-  cd moddef_${1}
-
-  grdID=$1
-
-  set +x
-  echo ' '
-  echo '+--------------------------------+'
-  echo '!     Generate moddef file       |'
-  echo '+--------------------------------+'
-  echo "   Grid            : $1"
-  echo ' '
-  set_trace
-
-# 0.b Check if grid set
-
-  if [ "$#" -lt '1' ]
-  then
-    set +x
-    echo ' '
-    echo '**************************************************'
-    echo '*** Grid not identifife in ww3_mod_def.sh ***'
-    echo '**************************************************'
-    echo ' '
-    set_trace
-    exit 1
-  else
-    grdID=$1
-  fi
-
-# 0.c Define directories and the search path.
-#     The tested variables should be exported by the postprocessor script.
-
-  if [ -z "$grdID" ] || [ -z "${EXECgfs}" ]
-  then
-    set +x
-    echo ' '
-    echo '*********************************************************'
-    echo '*** EXPORTED VARIABLES IN ww3_mod_def.sh NOT SET ***'
-    echo '*********************************************************'
-    echo ' '
-    set_trace
-    exit 2
-  fi
+  mkdir -p "moddef_${grdID}"
+  cd "moddef_${grdID}" || exit 2
 
 # --------------------------------------------------------------------------- #
 # 2.  Create mod_def file
 
-  set +x
-  echo ' '
-  echo '   Creating mod_def file ...'
-  echo "   Executing ${EXECgfs}/${NET,,}_ww3_grid.x"
-  echo ' '
-  set_trace
 
-  rm -f ww3_grid.inp
-  ${NLN} ../ww3_grid.inp.$grdID ww3_grid.inp
+  rm -f "ww3_grid.inp"
+  ${NLN} "../ww3_grid.inp.${grdID}" "ww3_grid.inp"
 
-  if [ -f ../${grdID}.msh ]
-  then
-     rm -f ${grdID}.msh
-     ${NLN} ../${grdID}.msh ${grdID}.msh
+  if [[ -f "../${grdID}.msh" ]]; then
+     rm -f "${grdID}.msh"
+     ${NLN} "../${grdID}.msh" "${grdID}.msh"
   fi
-
 
   export pgm="${NET,,}_ww3_grid.x"
 
-  "${EXECgfs}/${pgm}" 1> "grid_${grdID}.out" 2>&1
-  err=$?
+  echo "INFO: Executing ${EXECgfs}/${NET,,}_ww3_grid.x"
 
-  if [ "$err" != '0' ]
-  then
-    set +x
-    echo ' '
-    echo '******************************************** '
-    echo "*** FATAL ERROR : ERROR IN ${pgm} *** "
-    echo '******************************************** '
-    echo ' '
-    set_trace
-    exit 3
+  "${EXECgfs}/${pgm}"
+  export err=$?
+
+  if [[ "${err}" != '0' ]]; then
+    echo "FATAL ERROR: Error in ${pgm}"
+    exit "${err}"
   fi
 
-  if [[ -f mod_def.ww3 ]]
-  then
-    cp mod_def.ww3 "${COMOUT_WAVE_PREP}/${RUN}wave.mod_def.${grdID}"
-    mv mod_def.ww3 "../mod_def.${grdID}"
+  if [[ -f mod_def.ww3 ]];then
+    cpfs "mod_def.ww3" "${COMOUT_WAVE_PREP}/${RUN}.wave.t${cyc}z.mod_def.${grdID}.bin"
+    mv "mod_def.ww3" "../mod_def.${grdID}"
   else
-    set +x
-    echo ' '
-    echo '******************************************** '
-    echo '*** FATAL ERROR : MOD DEF FILE NOT FOUND *** '
-    echo '******************************************** '
-    echo ' '
-    set_trace
+    echo "FATAL ERROR: Mod def file not created for ${grdID}"
     exit 4
   fi
 

--- a/ush/wave_tar.sh
+++ b/ush/wave_tar.sh
@@ -69,7 +69,7 @@ source "${USHgfs}/preamble.sh"
   if [[ "$type" = "ibpcbull" ]]; then filext='cbull'; fi
 
 
-  rm -rf TAR_${filext}_$ID 
+  rm -rf TAR_${filext}_$ID
   mkdir  TAR_${filext}_$ID
 # this directory is used only for error capturing
 
@@ -110,9 +110,9 @@ source "${USHgfs}/preamble.sh"
     if [[ "${nf}" -ge "${nbm2}" ]]
     then
 
-      tar -cf "${ID}.${cycle}.${type}_tar" ./${ID}.*.${filext}
+      tar -cf "${ID}.${type}.tar" ./${ID}.*.${filext}
       exit=$?
-      filename="${ID}.${cycle}.${type}_tar" 
+      filename="${ID}.${type}.tar" 
       if ! wait_for_file "${filename}" "${sleep_interval}" "${countMAX}" ; then
         echo "FATAL ERROR: File ${filename} not found after waiting $(( sleep_interval * (countMAX + 1) )) secs"
         exit 3
@@ -130,7 +130,7 @@ source "${USHgfs}/preamble.sh"
         exit 3
       fi
       
-      if [[ -f "${ID}.${cycle}.${type}_tar" ]]
+      if [[ -f "${ID}.${type}.tar" ]]
       then
         tardone='yes'
       fi
@@ -152,10 +152,10 @@ source "${USHgfs}/preamble.sh"
 
   if [[ "${type}" = 'spec' ]]
   then
-    if [[ -s "${ID}.${cycle}.${type}_tar" ]]
+    if [[ -s "${ID}.${type}.tar" ]]
     then
-      file_name="${ID}.${cycle}.${type}_tar.gz"
-      /usr/bin/gzip -c "${ID}.${cycle}.${type}_tar" > "${file_name}"
+      file_name="${ID}.${type}.tar.gz"
+      /usr/bin/gzip -c "${ID}.${type}.tar" > "${file_name}"
       exit=$?
 
       if  [[ "${exit}" != '0' ]]
@@ -171,7 +171,7 @@ source "${USHgfs}/preamble.sh"
       fi
     fi
   else
-    file_name="${ID}.${cycle}.${type}_tar"
+    file_name="${ID}.${type}.tar"
   fi
 
 # --------------------------------------------------------------------------- #

--- a/workflow/rocoto/gefs_tasks.py
+++ b/workflow/rocoto/gefs_tasks.py
@@ -318,10 +318,10 @@ class GEFSTasks(Tasks):
 
         wave_grid = self._configs['base']['waveGRD']
         history_path = self._template_to_rocoto_cycstring(self._base['COM_WAVE_HISTORY_TMPL'], {'MEMDIR': 'mem#member#'})
-        history_file = f'/{self.run}wave.out_grd.{wave_grid}.@Y@m@d.@H@M@S'
+        history_file = f'/{self.run}.wave.t@Hz.{wave_grid}.f#fhr3_next#.bin'
 
         deps = []
-        dep_dict = {'type': 'data', 'data': [history_path, history_file], 'offset': [None, '#fhr3_next#:00:00']}
+        dep_dict = {'type': 'data', 'data': f'{history_path}/{history_file}'}
         deps.append(rocoto.add_dependency(dep_dict))
         dep_dict = {'type': 'task', 'name': f'{self.run}_fcst_mem#member#_#seg_dep#'}
         deps.append(rocoto.add_dependency(dep_dict))

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -1269,7 +1269,7 @@ class GFSTasks(Tasks):
     def wavepostbndpntbll(self):
 
         # The wavepostbndpntbll job runs on forecast hours up to FHMAX_WAV_IBP
-        last_fhr = self._configs['wave']['FHMAX_WAV_IBP']
+        last_fhr = self._configs['wavepostbndpntbll']['FHMAX_WAV_IBP']
 
         deps = []
         atmos_hist_path = self._template_to_rocoto_cycstring(self._base["COM_ATMOS_HISTORY_TMPL"])

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -1339,7 +1339,6 @@ class GFSTasks(Tasks):
         # Adjust walltime based on the largest group
         largest_group = max([len(grp.split(',')) for grp in fhr_var_dict['fhr_list'].split(' ')])
         resources['walltime'] = Tasks.multiply_HMS(resources['walltime'], largest_group)
-        print(resources['walltime'])
 
         task_name = f'{self.run}_wavegempak_#fhr_label#'
         task_dict = {'task_name': task_name,

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -1200,10 +1200,10 @@ class GFSTasks(Tasks):
 
         wave_grid = self._configs['base']['waveGRD']
         history_path = self._template_to_rocoto_cycstring(self._base['COM_WAVE_HISTORY_TMPL'])
-        history_file = f'/{self.run}wave.out_grd.{wave_grid}.@Y@m@d.@H@M@S'
+        history_file = f'/{self.run}.wave.t@Hz.{wave_grid}.f#fhr3_next#.bin'
 
         deps = []
-        dep_dict = {'type': 'data', 'data': [history_path, history_file], 'offset': [None, '#fhr3_next#:00:00']}
+        dep_dict = {'type': 'data', 'data': f'{history_path}/{history_file}'}
         deps.append(rocoto.add_dependency(dep_dict))
         dep_dict = {'type': 'task', 'name': f'{self.run}_fcst_#seg_dep#'}
         deps.append(rocoto.add_dependency(dep_dict))

--- a/workflow/rocoto/gfs_tasks.py
+++ b/workflow/rocoto/gfs_tasks.py
@@ -1272,9 +1272,7 @@ class GFSTasks(Tasks):
         last_fhr = self._configs['wavepostbndpntbll']['FHMAX_WAV_IBP']
 
         deps = []
-        atmos_hist_path = self._template_to_rocoto_cycstring(self._base["COM_ATMOS_HISTORY_TMPL"])
-        data = f'{atmos_hist_path}/{self.run}.t@Hz.atm.logf{last_fhr:03d}.txt'
-        dep_dict = {'type': 'data', 'data': data}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_wavepostbndpnt'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
@@ -1323,16 +1321,31 @@ class GFSTasks(Tasks):
 
     def wavegempak(self):
         deps = []
-        dep_dict = {'type': 'metatask', 'name': f'{self.run}_wavepostsbs'}
+        dep_dict = {'type': 'task', 'name': f'{self.run}_wavepostsbs_#fhr_label#'}
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
+        # Hour groupings need to match gridded post for dependencies to be correct
+        fhrs = self._get_forecast_hours(self.run, self._configs['wavepostsbs'], 'wave')
+        max_tasks = self._configs['wavepostsbs']['MAX_TASKS']
+        fhr_var_dict = self.get_grouped_fhr_dict(fhrs=fhrs, ngroups=max_tasks)
+
+        wave_post_envars = self.envars.copy()
+        postenvar_dict = {'FHR_LIST': '#fhr_list#'}
+        for key, value in postenvar_dict.items():
+            wave_post_envars.append(rocoto.create_envar(name=key, value=str(value)))
+
         resources = self.get_resource('wavegempak')
-        task_name = f'{self.run}_wavegempak'
+        # Adjust walltime based on the largest group
+        largest_group = max([len(grp.split(',')) for grp in fhr_var_dict['fhr_list'].split(' ')])
+        resources['walltime'] = Tasks.multiply_HMS(resources['walltime'], largest_group)
+        print(resources['walltime'])
+
+        task_name = f'{self.run}_wavegempak_#fhr_label#'
         task_dict = {'task_name': task_name,
                      'resources': resources,
                      'dependency': dependencies,
-                     'envars': self.envars,
+                     'envars': wave_post_envars,
                      'cycledef': self.run.replace('enkf', ''),
                      'command': f'{self.HOMEgfs}/jobs/rocoto/wavegempak.sh',
                      'job_name': f'{self.pslot}_{task_name}_@H',
@@ -1340,7 +1353,11 @@ class GFSTasks(Tasks):
                      'maxtries': '&MAXTRIES;'
                      }
 
-        task = rocoto.create_task(task_dict)
+        metatask_dict = {'task_name': f'{self.run}_wavegempak',
+                         'task_dict': task_dict,
+                         'var_dict': fhr_var_dict}
+
+        task = rocoto.create_task(metatask_dict)
 
         return task
 
@@ -2532,6 +2549,9 @@ class GFSTasks(Tasks):
                             deps.append(rocoto.add_dependency(dep_dict))
                             dep_dict = {'type': 'metatask', 'name': f'{self.run}_gempakgrb2spec'}
                             deps.append(rocoto.add_dependency(dep_dict))
+                    if self.options['do_wave']:
+                        dep_dict = {'type': 'metatask', 'name': f'{self.run}_wavegempak'}
+                        deps.append(rocoto.add_dependency(dep_dict))
 
             if self.options['do_metp'] and self.run in ['gfs']:
                 deps2 = []


### PR DESCRIPTION
# Description
Wave products are renamed to be uniform with other components and follow NCO implementation standards. This means all output is in the format `${RUN}.wave.tCCz.product[.fHHH][.domain].suffix`.

Some wave scripts are refactored to make them consistent with other parts of the workflow. All scripts for those jobs now pass `shellcheck` without warnings. Point job scripts were only updated for the file rename, as those scripts will be redone in the near future anyway.

The biggest changes in the refactor include beyond those necessary for the file rename include:
- Using the `run_mpmd.sh` script
- Updated templates to use atparse instead of `sed`
- Removed redirection of output to logs that get deleted (#296)
- The wave gempak job now only operates on one forecast hour at a time. The corresponding rocoto task has been made into a metatask, using the same grouping as wave gridded post. The gempak job must use the same fhr and max tasks settings to ensure the dependencies line up.

One functional change is raw interpolated grids are no longer copied to COM, only the resulting grib files. Need to confirm with Jessica this is okay.

Resolves #296
Resolves #3270

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
- Forecast-only test on Hercules
- Forecast-only test on Hera with boundary points and gempak turned on

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
