### PR TITLE
Copy marine ensemble output observation diags and spread

### DIFF
--- a/ush/python/pygfs/task/marine_letkf.py
+++ b/ush/python/pygfs/task/marine_letkf.py
@@ -183,8 +183,26 @@ class MarineLETKF(Analysis):
         logger.info("finalize")
 
         letkfsaveconf = AttrDict()
+
+        # get the list of obs output files
+        obs_list = parse_j2yaml(self.task_config.MARINE_OBS_LIST_YAML, self.task_config)
+        obs_files = []
+        for ob in obs_list['observers']:
+            obs_files.append(ob['obs space']['obsdataout']['engine']['obsfile'])
+        obs_files_to_copy = []
+        # copy obs from diags to COMOUT
+        for obs_src in obs_files:
+            obs_dst = os.path.join(self.task_config.COMOUT_OCEAN_LETKF, 'diags',
+                                   os.path.basename(obs_src))
+            if os.path.exists(obs_src):
+                obs_files_to_copy.append([obs_src, obs_dst])
+        # stage the desired diag files
+        FileHandler({'mkdir': [os.path.join(self.task_config.COMOUT_OCEAN_LETKF, 'diags')]}).sync()
+        FileHandler({'copy': obs_files_to_copy}).sync()
+
         keys = ['current_cycle', 'DATA', 'NMEM_ENS', 'WINDOW_BEGIN', 'GDUMP_ENS',
-                'PARMgfs', 'ROTDIR', 'COM_OCEAN_LETKF_TMPL', 'COM_ICE_LETKF_TMPL']
+                'PARMgfs', 'ROTDIR', 'COM_OCEAN_LETKF_TMPL', 'COM_ICE_LETKF_TMPL',
+                'COMOUT_OCEAN_LETKF', 'COMOUT_ICE_LETKF', 'WINDOW_MIDDLE']
         for key in keys:
             letkfsaveconf[key] = self.task_config[key]
         letkf_save_list = parse_j2yaml(self.task_config.MARINE_LETKF_SAVE_YAML_TMPL, letkfsaveconf)


### PR DESCRIPTION
# Description

Saves to COMROOT marine LETKF obs diagnostics files (for ensemble spread diagnostics in the observation space) and sets up additional keys to pass to the gdasapp jinja template for copying model space files (for ensemble mean and spread diagnostics in the model space).

Resolves #3363 

# Type of change
- [ ] Bug fix (fixes something broken)
- [x] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?

Tested with low-res and high-res marine hybrid DA experiments; the output obs files from LETKF are copied in the expected directory.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
