### PR TITLE
Enable global-workflow to run C768C384 GSI on Gaea-C6

### DIFF
--- a/parm/config/gfs/config.resources.GAEAC6
+++ b/parm/config/gfs/config.resources.GAEAC6
@@ -4,6 +4,7 @@
 
 unset memory
 unset "memory_${RUN}"
+export FI_CXI_RX_MATCH_MODE=hybrid
 
 case ${step} in
   "fcst" | "efcs")
@@ -19,6 +20,18 @@ case ${step} in
         true
         ;;
     esac
+  ;;
+  "eupd")
+    # update ntasks to 80 and threads_per_task to 20
+    case ${CASE} in
+      "C768")
+        export ntasks=80
+        export threads_per_task=20
+        ;;
+      *)
+        ;;
+    esac
+  export tasks_per_node=$(( max_tasks_per_node / threads_per_task ))
   ;;
   *)
   ;;

--- a/workflow/hosts/gaeac6.yaml
+++ b/workflow/hosts/gaeac6.yaml
@@ -32,6 +32,6 @@ MAKE_ACFTBUFR: 'NO'
 DO_TRACKER: 'YES'
 DO_GENESIS: 'YES'
 DO_METP: 'NO'
-SUPPORTED_RESOLUTIONS: ['C384', 'C192', 'C96', 'C48']
+SUPPORTED_RESOLUTIONS: ['C768', 'C384', 'C192', 'C96', 'C48']
 AERO_INPUTS_DIR: '/gpfs/f6/drsa-precip3/world-shared/role.glopara/data/gocart_emissions'
 USE_SCRONTAB: 'YES'


### PR DESCRIPTION
# Description
What: update resources to run global-workflow global-ensemble forecasts at C768C384 with GSI on Gaea-C6.
Why: requested new feature from GSL
Resolves #2983 

# Type of change
- [ ] New feature (adds functionality)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO (If YES, please add a link to any PRs that are pending.)
 
# How has this been tested?
Clone, build, and run global-ensemble 48-hour forecasts at C768C384 with GSI conducted on Gaea-C6 with DO_TRACKER, DO_GENESIS, DO_METP=YES.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
