### PR TITLE
Chang permission modes of HOMEDIR STMP PTMP as writable at setup time

### DIFF
--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -29,6 +29,8 @@ def makedirs_if_missing(dirname):
     if not os.path.exists(dirname):
         os.makedirs(dirname)
 
+    return
+
 def chmod_dir_permission(dirname):
     """
     change the permission mode of a directory as writable
@@ -44,6 +46,7 @@ def chmod_dir_permission(dirname):
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
 
+    return
 
 def fill_expdir(inputs):
     """

--- a/workflow/setup_expt.py
+++ b/workflow/setup_expt.py
@@ -5,6 +5,7 @@ Entry point for setting up an experiment in the global-workflow
 """
 
 import os
+import stat
 import glob
 import shutil
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, SUPPRESS, ArgumentTypeError
@@ -14,6 +15,7 @@ from hosts import Host
 from wxflow import parse_j2yaml
 from wxflow import AttrDict
 from wxflow import to_datetime, to_timedelta, datetime_to_YMDH
+
 
 
 _here = os.path.dirname(__file__)
@@ -26,6 +28,21 @@ def makedirs_if_missing(dirname):
     """
     if not os.path.exists(dirname):
         os.makedirs(dirname)
+
+def chmod_dir_permission(dirname):
+    """
+    change the permission mode of a directory as writable
+    """
+    permission_mode = stat.S_IRWXU
+    try:
+        os.chmod(dirname, permission_mode)
+        print(f"Permissions for '{dirname}' changed successfully to {oct(permission_mode)}.")
+    except FileNotFoundError:
+        print(f"Error: Directory '{dirname}' not found.")
+    except PermissionError:
+        print(f"Error: You do not have permission to change permissions for '{dirname}'.")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
 
 
 def fill_expdir(inputs):
@@ -424,6 +441,11 @@ def main(*argv):
     # Update the default host account if the user supplied one
     if user_inputs.account is not None:
         host.info.ACCOUNT = user_inputs.account
+
+    # chmod directories (HOMEDIR, STMP, PTMP) as writable
+    chmod_dir_permission(host.info.HOMEDIR)
+    chmod_dir_permission(host.info.STMP)
+    chmod_dir_permission(host.info.PTMP)
 
     # Determine ocean resolution if not provided
     if user_inputs.resdetocean <= 0:


### PR DESCRIPTION
# Description
When setting up an experiment, in particular at setup_xml.py/setup_expt.py time, a check should be added to verify that the user running the experiment is able to write to those directories. This will save debugging time if a user forgets/doesn't know to change these directories.
Refs https://github.com/NOAA-EMC/global-workflow/issues/3318

# Type of change
- [x] New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
 
- Clone and build on RDHPCS
- Cycled tests on Hercules
- Forecast-only tests on Hercules
 
# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] I have made corresponding changes to the documentation if necessary