### PR TITLE
Migration to role account for Jenkins on Orion

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -6,7 +6,7 @@ def CI_CASES = ''
 def GH = 'none'
 // Location of the custom workspaces for each machine in the CI system.  They are persistent for each iteration of the PR.
 def NodeName = [hera: 'Hera-EMC', orion: 'Orion-EMC', hercules: 'Hercules-EMC', gaea: 'Gaea', gaeac6: 'Gaeac6-EMC']
-def custom_workspace = [hera: '/scratch1/NCEPDEV/global/glopara/CI', orion: '/work2/noaa/stmp/CI/ORION', hercules: '/work2/noaa/global/CI/HERCULES', gaea: '/gpfs/f5/epic/proj-shared/global/CI', gaeac6: '/gpfs/f6/drsa-precip3/proj-shared/global/CI']
+def custom_workspace = [hera: '/scratch1/NCEPDEV/global/glopara/CI', orion: '/work2/noaa/stmp/CI/ORION', hercules: '/work2/noaa/global/role-global/GFS_CI_CD/HERCULES/CI', gaea: '/gpfs/f5/epic/proj-shared/global/CI', gaeac6: '/gpfs/f6/drsa-precip3/proj-shared/global/CI']
 def repo_url = 'git@github.com:NOAA-EMC/global-workflow.git'
 def STATUS = 'Passed'
 

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -6,7 +6,7 @@ def CI_CASES = ''
 def GH = 'none'
 // Location of the custom workspaces for each machine in the CI system.  They are persistent for each iteration of the PR.
 def NodeName = [hera: 'Hera-EMC', orion: 'Orion-EMC', hercules: 'Hercules-EMC', gaea: 'Gaea', gaeac6: 'Gaeac6-EMC']
-def custom_workspace = [hera: '/scratch1/NCEPDEV/global/glopara/CI', orion: '/work2/noaa/stmp/CI/ORION', hercules: '/work2/noaa/global/role-global/GFS_CI_CD/HERCULES/CI', gaea: '/gpfs/f5/epic/proj-shared/global/CI', gaeac6: '/gpfs/f6/drsa-precip3/proj-shared/global/CI']
+def custom_workspace = [hera: '/scratch1/NCEPDEV/global/glopara/CI', orion: '/work2/noaa/global/role-global/GFS_CI_CD/ORION/CI', hercules: '/work2/noaa/global/role-global/GFS_CI_CD/HERCULES/CI', gaea: '/gpfs/f5/epic/proj-shared/global/CI', gaeac6: '/gpfs/f6/drsa-precip3/proj-shared/global/CI']
 def repo_url = 'git@github.com:NOAA-EMC/global-workflow.git'
 def STATUS = 'Passed'
 

--- a/ci/platforms/config.gaeac6
+++ b/ci/platforms/config.gaeac6
@@ -1,17 +1,23 @@
 #!/usr/bin/bash
 
+# Main CI root directory
 export GFS_CI_ROOT=/ncrc/proj/nggps_emc/${USER}/GFS_CI_CD
+# ICSDIR root directory used on the create_experment.py command line
 export ICSDIR_ROOT=/gpfs/f6/bil-fire8/world-shared/global/glopara/data/ICSDIR
 
-# CI BASH test directories
-export GFS_BASH_CI_ROOT=${GFS_CI_ROOT}/GFS_BASH_CI
-
-# Jenkins directories
+# JENKINS launch directory for agent
 export JENKINS_AGENT_LAUNCH_DIR=${GFS_CI_ROOT}/Jenkins/agent
+# JENKINS internal working directories for CI jobs (not for users use)
 export JENKINS_WORK_DIR=${GFS_CI_ROOT}/Jenkins/workspace
+# NOTE: JENKINS custom_workspace directory where CI jobs are run
+# /gpfs/f6/drsa-precip3/proj-shared/global/CI
+# is defined in the Jenkinsfile
 
 # CTest functional test directories for pre stagged input data
 export STAGED_TESTS_DIR=${GFS_CI_ROOT}/STAGED_TESTS_DIR
+
+# CI BASH test directories
+export GFS_BASH_CI_ROOT=${GFS_CI_ROOT}/GFS_BASH_CI
 
 export HPC_ACCOUNT=drsa-precip3
 export max_concurrent_cases=5

--- a/ci/platforms/config.gaeac6
+++ b/ci/platforms/config.gaeac6
@@ -7,7 +7,7 @@ export ICSDIR_ROOT=/gpfs/f6/bil-fire8/world-shared/global/glopara/data/ICSDIR
 export GFS_BASH_CI_ROOT=${GFS_CI_ROOT}/GFS_BASH_CI
 
 # Jenkins directories
-export JENKINS_AGENT_LANUCH_DIR=${GFS_CI_ROOT}/Jenkins/agent
+export JENKINS_AGENT_LAUNCH_DIR=${GFS_CI_ROOT}/Jenkins/agent
 export JENKINS_WORK_DIR=${GFS_CI_ROOT}/Jenkins/workspace
 
 # CTest functional test directories for pre stagged input data

--- a/ci/platforms/config.hera
+++ b/ci/platforms/config.hera
@@ -1,13 +1,17 @@
 #!/usr/bin/bash
 
+# Main CI root directory
 export GFS_CI_ROOT=/scratch1/NCEPDEV/global/glopara/GFS_CI_CD
+# ICSDIR root directory used on the create_experment.py command line
 export ICSDIR_ROOT=/scratch1/NCEPDEV/global/glopara/data/ICSDIR
 
-# Jenkins directories
+# JENKINS launch directory for agent
 export JENKINS_AGENT_LAUNCH_DIR=${GFS_CI_ROOT}/Jenkins/agent
+# JENKINS internal working directories for CI jobs (not for users use)
 export JENKINS_WORK_DIR=${GFS_CI_ROOT}/Jenkins/workspace
 # JENKINS custom_workspace directory where CI jobs are run
 # /scratch1/NCEPDEV/global/glopara/CI
+# is defined in the Jenkinsfile
 
 # CTest functional test directories for pre stagged input data
 export STAGED_TESTS_DIR=${GFS_CI_ROOT}/STAGED_TESTS_DIR
@@ -15,6 +19,7 @@ export STAGED_TESTS_DIR=${GFS_CI_ROOT}/STAGED_TESTS_DIR
 # CI BASH test directories
 export GFS_BASH_CI_ROOT=${GFS_CI_ROOT}/GFS_BASH_CI
 
+# HPC account which overides the default account
 export HPC_ACCOUNT=fv3-cpu
 export max_concurrent_cases=5
 export max_concurrent_pr=4

--- a/ci/platforms/config.hera
+++ b/ci/platforms/config.hera
@@ -4,7 +4,7 @@ export GFS_CI_ROOT=/scratch1/NCEPDEV/global/glopara/GFS_CI_CD
 export ICSDIR_ROOT=/scratch1/NCEPDEV/global/glopara/data/ICSDIR
 
 # Jenkins directories
-export JENKINS_AGENT_LANUCH_DIR=${GFS_CI_ROOT}/Jenkins/agent
+export JENKINS_AGENT_LAUNCH_DIR=${GFS_CI_ROOT}/Jenkins/agent
 export JENKINS_WORK_DIR=${GFS_CI_ROOT}/Jenkins/workspace
 # JENKINS custom_workspace directory where CI jobs are run
 # /scratch1/NCEPDEV/global/glopara/CI

--- a/ci/platforms/config.hercules
+++ b/ci/platforms/config.hercules
@@ -4,7 +4,7 @@ export GFS_CI_ROOT=/work2/noaa/stmp/GFS_CI_ROOT/HERCULES
 export ICSDIR_ROOT=/work/noaa/global/glopara/data/ICSDIR
 
 # Jenkins directories
-export JENKINS_AGENT_LANUCH_DIR=/home/role-nems/GFS_CI_ROOT_JENKINS/AGENT_mterry
+export JENKINS_AGENT_LAUNCH_DIR=/home/role-nems/GFS_CI_ROOT_JENKINS/AGENT_mterry
 export JENKINS_WORK_DIR=/home/role-nems/GFS_CI_ROOT_JENKINS
 
 # CTest functional test directories for pre stagged input data

--- a/ci/platforms/config.hercules
+++ b/ci/platforms/config.hercules
@@ -1,11 +1,17 @@
 #!/usr/bin/bash
 
-export GFS_CI_ROOT=/work2/noaa/stmp/GFS_CI_ROOT/HERCULES
+# Main CI root directory
+export GFS_CI_ROOT=/work2/noaa/global/${USER}/GFS_CI_CD/HERCULES
+# ICSDIR root directory used on the create_experment.py command line
 export ICSDIR_ROOT=/work/noaa/global/glopara/data/ICSDIR
 
-# Jenkins directories
-export JENKINS_AGENT_LAUNCH_DIR=/home/role-nems/GFS_CI_ROOT_JENKINS/AGENT_mterry
-export JENKINS_WORK_DIR=/home/role-nems/GFS_CI_ROOT_JENKINS
+# JENKINS launch directory for agent
+export JENKINS_AGENT_LAUNCH_DIR=${GFS_CI_ROOT}/Jenkins/agent
+# JENKINS internal working directories for CI jobs (not for users use)
+export JENKINS_WORK_DIR=${GFS_CI_ROOT}/Jenkins/workspace
+# NOTE: JENKINS custom_workspace directory where CI jobs are run
+# /work2/noaa/global/role-global/GFS_CI_CD/HERCULES/CI
+# is defined in the Jenkinsfile
 
 # CTest functional test directories for pre stagged input data
 export STAGED_TESTS_DIR=${GFS_CI_ROOT}/STAGED_TESTS_DIR
@@ -13,6 +19,7 @@ export STAGED_TESTS_DIR=${GFS_CI_ROOT}/STAGED_TESTS_DIR
 # CI BASH test directories
 export GFS_BASH_CI_ROOT=${GFS_CI_ROOT}/GFS_BASH_CI
 
+# HPC account which overides the default account
 export HPC_ACCOUNT=fv3-cpu
 export max_concurrent_cases=5
 export max_concurrent_pr=4

--- a/ci/platforms/config.orion
+++ b/ci/platforms/config.orion
@@ -1,18 +1,25 @@
 #!/usr/bin/bash
 
-export GFS_CI_ROOT=/work2/noaa/stmp/GFS_CI_ROOT/ORION
+# Main CI root directory
+export GFS_CI_ROOT=/work2/noaa/global/${USER}/GFS_CI_CD/ORION
+# ICSDIR root directory used on the create_experment.py command line
 export ICSDIR_ROOT=/work/noaa/global/glopara/data/ICSDIR
 
-# Jenkins directories
-export JENKINS_AGENT_LAUNCH_DIR=/home/role-nems/GFS_CI_ROOT_JENKINS/AGENT_mterry
-export JENKINS_WORK_DIR=/home/role-nems/GFS_CI_ROOT_JENKINS
+# JENKINS launch directory for agent
+export JENKINS_AGENT_LAUNCH_DIR=${GFS_CI_ROOT}/Jenkins/agent
+# JENKINS internal working directories for CI jobs (not for users use)
+export JENKINS_WORK_DIR=${GFS_CI_ROOT}/Jenkins/workspace
+# NOTE: JENKINS custom_workspace directory where CI jobs are run
+# /work2/noaa/global/role-global/GFS_CI_CD/ORION/CI
+# is defined in the Jenkinsfile
+
+# CTest functional test directories for pre stagged input data
+export STAGED_TESTS_DIR=${GFS_CI_ROOT}/STAGED_TESTS_DIR
 
 # CI BASH test directories
 export GFS_BASH_CI_ROOT=${GFS_CI_ROOT}/GFS_BASH_CI
 
-# CTest functional test directories for pre stagged input data
-export STAGED_TESTS_DIR=/work/noaa/stmp/GFS_CI_ROOT/ORION/STAGED_TESTS_DIR
-
-export HPC_ACCOUNT=nems
+# HPC account which overides the default account
+export HPC_ACCOUNT=fv3-cpu
 export max_concurrent_cases=5
 export max_concurrent_pr=4

--- a/ci/platforms/config.orion
+++ b/ci/platforms/config.orion
@@ -4,7 +4,7 @@ export GFS_CI_ROOT=/work2/noaa/stmp/GFS_CI_ROOT/ORION
 export ICSDIR_ROOT=/work/noaa/global/glopara/data/ICSDIR
 
 # Jenkins directories
-export JENKINS_AGENT_LANUCH_DIR=/home/role-nems/GFS_CI_ROOT_JENKINS/AGENT_mterry
+export JENKINS_AGENT_LAUNCH_DIR=/home/role-nems/GFS_CI_ROOT_JENKINS/AGENT_mterry
 export JENKINS_WORK_DIR=/home/role-nems/GFS_CI_ROOT_JENKINS
 
 # CI BASH test directories

--- a/ci/scripts/utils/launch_java_agent.sh
+++ b/ci/scripts/utils/launch_java_agent.sh
@@ -81,7 +81,7 @@ case ${MACHINE_ID} in
     exit 1;;
 esac
 
-LOG=lanuched_agent-$(date +%Y%m%d%M).log
+LOG=launched_agent-$(date +%Y%m%d%M).log
 rm -f "${LOG}"
 
 HOMEgfs="${HOMEGFS_}" source "${HOMEGFS_}/ush/module-setup.sh"
@@ -118,9 +118,9 @@ fi
 echo "gh authenticating with emcbot TOKEN ok"
 
 if [[ -d "${JENKINS_AGENT_LAUNCH_DIR}" ]]; then
-  echo "Jenkins Agent Lanuch Directory: ${JENKINS_AGENT_LAUNCH_DIR}"
+  echo "Jenkins Agent Launch Directory: ${JENKINS_AGENT_LAUNCH_DIR}"
 else
-  echo "ERROR: Jenkins Agent Lanuch Directory not found. Exiting with error."
+  echo "ERROR: Jenkins Agent Launch Directory not found. Exiting with error."
   exit 1
 fi
 cd "${JENKINS_AGENT_LAUNCH_DIR}"

--- a/ci/scripts/utils/launch_java_agent.sh
+++ b/ci/scripts/utils/launch_java_agent.sh
@@ -89,7 +89,7 @@ module use "${HOMEGFS_}/modulefiles"
 module load "module_gwsetup.${MACHINE_ID}"
 source "${HOMEGFS_}/ci/platforms/config.${MACHINE_ID}"
 
-JAVA_HOME="${JENKINS_AGENT_LANUCH_DIR}/JAVA/jdk-17.0.10"
+JAVA_HOME="${JENKINS_AGENT_LAUNCH_DIR}/JAVA/jdk-17.0.10"
 if [[ ! -d "${JAVA_HOME}" ]]; then
   JAVA_HOME=/usr/lib/jvm/jre-17
   if [[ ! -d "${JAVA_HOME}" ]]; then
@@ -117,13 +117,13 @@ if [[ "${check_token}" != *"*****"* ]]; then
 fi
 echo "gh authenticating with emcbot TOKEN ok"
 
-if [[ -d "${JENKINS_AGENT_LANUCH_DIR}" ]]; then
-  echo "Jenkins Agent Lanuch Directory: ${JENKINS_AGENT_LANUCH_DIR}"
+if [[ -d "${JENKINS_AGENT_LAUNCH_DIR}" ]]; then
+  echo "Jenkins Agent Lanuch Directory: ${JENKINS_AGENT_LAUNCH_DIR}"
 else
   echo "ERROR: Jenkins Agent Lanuch Directory not found. Exiting with error."
   exit 1
 fi
-cd "${JENKINS_AGENT_LANUCH_DIR}"
+cd "${JENKINS_AGENT_LAUNCH_DIR}"
 echo "Entered directory ${PWD}"
 
 if ! [[ -f agent.jar ]]; then

--- a/ci/scripts/utils/launch_java_agent.sh
+++ b/ci/scripts/utils/launch_java_agent.sh
@@ -163,7 +163,7 @@ check_node_online() {
 }
 
 lauch_agent () {
-    echo "Launching Jenkins Agent on ${host}"
+    echo "Launching Jenkins Agent on ${host} using internal workspace ${JENKINS_WORK_DIR}"
     command="nohup ${JAVA} -jar agent.jar -jnlpUrl ${controller_url}/computer/${MACHINE_ID^}-EMC/jenkins-agent.jnlp  -secret @jenkins-secret-file -workDir ${JENKINS_WORK_DIR}"
     echo -e "Launching Jenkins Agent on ${host} with the command:\n${command}" >& "${LOG}"
     ${command} >> "${LOG}" 2>&1 &

--- a/workflow/hosts/hercules.yaml
+++ b/workflow/hosts/hercules.yaml
@@ -5,8 +5,8 @@ BASE_IC: '/work/noaa/global/glopara/data/ICSDIR'
 PACKAGEROOT: '/work/noaa/global/glopara/nwpara'
 COMINsyn: '/work/noaa/global/glopara/com/gfs/prod/syndat'
 HOMEDIR: '/work/noaa/global/${USER}'
-STMP: '/work/noaa/stmp/${USER}/HERCULES'
-PTMP: '/work/noaa/stmp/${USER}/HERCULES'
+STMP: '/work2/noaa/global/${USER}/HERCULES'
+PTMP: '/work2/noaa/global/${USER}/HERCULES'
 NOSCRUB: $HOMEDIR
 SCHEDULER: slurm
 ACCOUNT: fv3-cpu


### PR DESCRIPTION
# Description

This PR has the necessary updates to the CI scripts in Jenkins for running on **Orion** with the glopara role account.

[PyGithub](https://github.com/PyGithub/PyGithub) is not in **Spack Stack** yet and is needed in support of the GitHub logging and gist creation python codes.  This python module will be installed in `$HOME/.local` in the role accounts until the module is added to **Spack Stack**.

Same with **GitHub CLI** (which will be supported in Spack Stack 1.9) it will be installed in  `${ROLE_HOME}/utils/bin` which should be in role account's `$PATH `where `ROLE_HOME` is at the same level as `fix` and `data`.

This is setup to run in the role account with the following added directories and utils:

`/work2/noaa/global/role-global/GFS_CI_CD/ORION/CI`

Location on disk where the CI test cases actually build and run specified in [Jenkinsfile](https://github.com/TerrenceMcGuinness-NOAA/global-workflow/blob/8cbb38c059a52342c982a9b8d7baf63c1d30dd1d/ci/Jenkinsfile#L9)

```
└── GFS_CI_CD
    ├── global-workflow
    │   └── workflow
    ├── GFS_BASH_CI
    ├── GitLab
    └── Jenkins
        ├── agent
        └── workspace

```
Top level CI directories (this will file structure be duplicated for each role account)
```
GFS_CI_CD
```
CI system directory for Jenkins launching scripts and in support of BASH CI
```
GFS_CI_CD/global-workflow
```
Directory where the JAVA agent is launched from
```
Jenkins/agent
```
Jenkins work space (system level workspace)
```
Jenkins/workspace
```


  Resolves #3427 

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?

This PR can be tested in place
