### PR TITLE
When sourcing for RUN=enkf*, use CASE_ENS

### DIFF
--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -959,7 +959,7 @@ case ${step} in
           declare -x "walltime"="01:20:00"
           ;;
         *)
-          echo "FATAL ERROR: Resources not defined for job ${step} at resolution ${CASE}"
+          echo "FATAL ERROR: Resources not defined for job ${step} at resolution ${CASE} for ${RUN}"
           exit 4
           ;;
       esac
@@ -972,7 +972,7 @@ case ${step} in
           declare -x "walltime"="00:30:00"
           ;;
         *)
-          echo "FATAL ERROR: Resources not defined for job ${step} at resolution ${CASE}"
+          echo "FATAL ERROR: Resources not defined for job ${step} at resolution ${CASE_ENS} for ${RUN}"
           exit 4
           ;;
       esac
@@ -985,7 +985,7 @@ case ${step} in
           declare -x "walltime"="06:00:00"
           ;;
         *)
-          echo "FATAL ERROR: Resources not defined for job ${step} at resolution ${CASE}"
+          echo "FATAL ERROR: Resources not defined for job ${step} at resolution ${CASE} for ${RUN}"
           exit 4
           ;;
       esac

--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -964,7 +964,7 @@ case ${step} in
           ;;
       esac
     elif [[ "${RUN}" =~ enkfg(das|fs) ]]; then
-      case "${CASE}" in
+      case "${CASE_ENS}" in
         "C48" | "C96" | "C192")
           declare -x "walltime"="00:20:00"
           ;;
@@ -1242,10 +1242,10 @@ case ${step} in
     tasks_per_node=$(( max_tasks_per_node / threads_per_task ))
     export is_exclusive=True
     ;;
-    
+
   "eobs")
     walltime="00:15:00"
-    
+
     case ${CASE} in
       "C1152" | "C768")       ntasks=200;;
       "C384")                 ntasks=100;;


### PR DESCRIPTION
# Description
This PR:
- is a hotfix for issue #3474 
Resolves #3474 

# Type of change
- [X] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? YES/NO
- Does this change require a documentation update? YES/NO
- Does this change require an update to any of the following submodules? YES/NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
Tested by creating an experiment on Hera following the comments in #3474 

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
