### PR TITLE
Updates for AOWCDA and hybatmaerosnowDA cases on Gaea C6

### DIFF
--- a/ci/cases/pr/C48mx500_3DVarAOWCDA.yaml
+++ b/ci/cases/pr/C48mx500_3DVarAOWCDA.yaml
@@ -18,7 +18,6 @@ arguments:
   yaml: {{ HOMEgfs }}/ci/cases/yamls/soca_gfs_defaults_ci.yaml
 
 skip_ci_on_hosts:
-  - gaeac6
   - gaeac5
   - orion
   - awsepicglobalworkflow

--- a/ci/cases/pr/C48mx500_hybAOWCDA.yaml
+++ b/ci/cases/pr/C48mx500_hybAOWCDA.yaml
@@ -20,6 +20,5 @@ arguments:
 
 skip_ci_on_hosts:
   - gaeac5
-  - gaeac6
   - orion
   - awsepicglobalworkflow

--- a/ci/cases/pr/C96C48_hybatmaerosnowDA.yaml
+++ b/ci/cases/pr/C96C48_hybatmaerosnowDA.yaml
@@ -20,6 +20,5 @@ arguments:
 skip_ci_on_hosts:
   - orion
   - gaeac5
-  - gaeac6
   - hercules
   - awsepicglobalworkflow

--- a/env/GAEAC5.env
+++ b/env/GAEAC5.env
@@ -97,7 +97,7 @@ case ${step} in
     export NTHREADS_AEROANL=${NTHREADSmax}
     export APRUN_AEROANL="${APRUN_default} --cpus-per-task=${NTHREADS_AEROANL}"
  ;;
-  "aeroanlgenb")
+ "aeroanlgenb")
 
     export NTHREADS_AEROANLGENB=${NTHREADSmax}
     export APRUN_AEROANLGENB="${APRUN_default} --cpus-per-task=${NTHREADS_AEROANLGENB}"
@@ -106,7 +106,7 @@ case ${step} in
 
     export NTHREADS_PREPOBSAERO=${NTHREADS1}
     export APRUN_PREPOBSAERO="${APRUN_default} --cpus-per-task=${NTHREADS_PREPOBSAERO}"
-;;
+ ;;
  "snowanl")
 
     export APRUN_CALCFIMS="${launcher} -n 1"
@@ -116,14 +116,15 @@ case ${step} in
 
     export APRUN_APPLY_INCR="${launcher} -n 6"
  ;;
- "esnowrecen")
+ "esnowanl")
 
-    export NTHREADS_ESNOWRECEN=${NTHREADSmax}
-    export APRUN_ESNOWRECEN="${APRUN_default} --cpus-per-task=${NTHREADS_ESNOWRECEN}"
+    export APRUN_CALCFIMS="${launcher} -n 1"
+
+    export NTHREADS_ESNOWANL=${NTHREADSmax}
+    export APRUN_ESNOWANL="${APRUN_default} --cpus-per-task=${NTHREADS_ESNOWANL}"
 
     export APRUN_APPLY_INCR="${launcher} -n 6"
  ;;
-
  "marinebmat")
 
     export APRUNCFP="${launcher} -n \$ncmd ${mpmd_opt}"
@@ -134,24 +135,32 @@ case ${step} in
     export APRUNCFP="${launcher} -n \$ncmd ${mpmd_opt}"
     export APRUN_MARINEANLVAR="${APRUN_default}"
  ;;
-"ocnanalecen")
+ "ocnanalecen")
 
-    export APRUNCFP="${launcher} -n \$ncmd ${mpmd_opt}"
-
-    max_threads_per_task=$((max_tasks_per_node / tasks_per_node_ocnanalecen))
-
-    export NTHREADS_OCNANALECEN=${threads_per_task_ocnanalecen:-${max_threads_per_task}}
-    if [[ ${NTHREADS_OCNANALECEN} -gt ${max_threads_per_task} ]]; then
-        export NTHREADS_OCNANALECEN=${max_threads_per_task}
-    fi
-    export APRUN_OCNANALECEN="${launcher} -n ${ntasks_ocnanalecen} --cpus-per-task=${NTHREADS_OCNANALECEN}"
-;;
+    export APRUN_OCNANALECEN="${APRUN_default}"
+ ;;
  "marineanlchkpt")
 
     export APRUNCFP="${launcher} -n \$ncmd ${mpmd_opt}"
 
     export NTHREADS_OCNANAL=${NTHREADSmax}
     export APRUN_MARINEANLCHKPT="${APRUN_default} --cpus-per-task=${NTHREADS_OCNANAL}"
+ ;;
+ "marineanlletkf")
+
+    export NTHREADS_MARINEANLLETKF=${NTHREADSmax}
+    export APRUN_MARINEANLLETKF="${APRUN_default}"
+ ;;
+ "ecen_fv3jedi")
+
+    export NTHREADS_ECEN_FV3JEDI=${NTHREADSmax}
+    export APRUN_CORRECTION_INCREMENT="${launcher} -n ${ntasks_correction_increment} --cpus-per-task=${NTHREADS_ECEN_FV3JEDI}"
+    export APRUN_ENSEMBLE_RECENTER="${launcher} -n ${ntasks_ensemble_recenter} --cpus-per-task=${NTHREADS_ECEN_FV3JEDI}"
+ ;;
+ "analcalc_fv3jedi")
+
+    export NTHREADS_ANALCALC_FV3JEDI=${NTHREADSmax}
+    export APRUN_ANALCALC_FV3JEDI="${APRUN_default} --cpus-per-task=${NTHREADS_ANALCALC_FV3JEDI}"
  ;;
  "anal" | "analcalc")
 
@@ -235,24 +244,20 @@ case ${step} in
     export APRUN_UFS="${launcher} -n ${ufs_ntasks}"
     unset nnodes ufs_ntasks
  ;;
-
  "upp")
 
     export NTHREADS_UPP=${NTHREADS1}
     export APRUN_UPP="${APRUN_default} --cpus-per-task=${NTHREADS_UPP}"
  ;;
-
  "atmos_products")
 
     export USE_CFP="YES"  # Use MPMD for downstream product generation
  ;;
-
-"oceanice_products")
+ "oceanice_products")
 
     export NTHREADS_OCNICEPOST=${NTHREADS1}
     export APRUN_OCNICEPOST="${launcher} -n 1 --cpus-per-task=${NTHREADS_OCNICEPOST}"
-;;
-
+ ;;
  "ecen")
 
     export NTHREADS_ECEN=${NTHREADSmax}

--- a/env/GAEAC6.env
+++ b/env/GAEAC6.env
@@ -97,7 +97,7 @@ case ${step} in
     export NTHREADS_AEROANL=${NTHREADSmax}
     export APRUN_AEROANL="${APRUN_default} --cpus-per-task=${NTHREADS_AEROANL}"
  ;;
-  "aeroanlgenb")
+ "aeroanlgenb")
 
     export NTHREADS_AEROANLGENB=${NTHREADSmax}
     export APRUN_AEROANLGENB="${APRUN_default} --cpus-per-task=${NTHREADS_AEROANLGENB}"
@@ -106,7 +106,7 @@ case ${step} in
 
     export NTHREADS_PREPOBSAERO=${NTHREADS1}
     export APRUN_PREPOBSAERO="${APRUN_default} --cpus-per-task=${NTHREADS_PREPOBSAERO}"
-;;
+ ;;
  "snowanl")
 
     export APRUN_CALCFIMS="${launcher} -n 1"
@@ -116,14 +116,15 @@ case ${step} in
 
     export APRUN_APPLY_INCR="${launcher} -n 6"
  ;;
- "esnowrecen")
+ "esnowanl")
 
-    export NTHREADS_ESNOWRECEN=${NTHREADSmax}
-    export APRUN_ESNOWRECEN="${APRUN_default} --cpus-per-task=${NTHREADS_ESNOWRECEN}"
+    export APRUN_CALCFIMS="${launcher} -n 1"
+
+    export NTHREADS_ESNOWANL=${NTHREADSmax}
+    export APRUN_ESNOWANL="${APRUN_default} --cpus-per-task=${NTHREADS_ESNOWANL}"
 
     export APRUN_APPLY_INCR="${launcher} -n 6"
  ;;
-
  "marinebmat")
 
     export APRUNCFP="${launcher} -n \$ncmd ${mpmd_opt}"
@@ -134,24 +135,32 @@ case ${step} in
     export APRUNCFP="${launcher} -n \$ncmd ${mpmd_opt}"
     export APRUN_MARINEANLVAR="${APRUN_default}"
  ;;
-"ocnanalecen")
+ "ocnanalecen")
 
-    export APRUNCFP="${launcher} -n \$ncmd ${mpmd_opt}"
-
-    max_threads_per_task=$((max_tasks_per_node / tasks_per_node_ocnanalecen))
-
-    export NTHREADS_OCNANALECEN=${threads_per_task_ocnanalecen:-${max_threads_per_task}}
-    if [[ ${NTHREADS_OCNANALECEN} -gt ${max_threads_per_task} ]]; then
-        export NTHREADS_OCNANALECEN=${max_threads_per_task}
-    fi
-    export APRUN_OCNANALECEN="${launcher} -n ${ntasks_ocnanalecen} --cpus-per-task=${NTHREADS_OCNANALECEN}"
-;;
+    export APRUN_OCNANALECEN="${APRUN_default}"
+ ;;
  "marineanlchkpt")
 
     export APRUNCFP="${launcher} -n \$ncmd ${mpmd_opt}"
 
     export NTHREADS_OCNANAL=${NTHREADSmax}
     export APRUN_MARINEANLCHKPT="${APRUN_default} --cpus-per-task=${NTHREADS_OCNANAL}"
+ ;;
+ "marineanlletkf")
+
+    export NTHREADS_MARINEANLLETKF=${NTHREADSmax}
+    export APRUN_MARINEANLLETKF="${APRUN_default}"
+ ;;
+ "ecen_fv3jedi")
+
+    export NTHREADS_ECEN_FV3JEDI=${NTHREADSmax}
+    export APRUN_CORRECTION_INCREMENT="${launcher} -n ${ntasks_correction_increment} --cpus-per-task=${NTHREADS_ECEN_FV3JEDI}"
+    export APRUN_ENSEMBLE_RECENTER="${launcher} -n ${ntasks_ensemble_recenter} --cpus-per-task=${NTHREADS_ECEN_FV3JEDI}"
+ ;;
+ "analcalc_fv3jedi")
+
+    export NTHREADS_ANALCALC_FV3JEDI=${NTHREADSmax}
+    export APRUN_ANALCALC_FV3JEDI="${APRUN_default} --cpus-per-task=${NTHREADS_ANALCALC_FV3JEDI}"
  ;;
  "anal" | "analcalc")
 
@@ -242,24 +251,20 @@ case ${step} in
     export APRUN_UFS="${launcher} -n ${ufs_ntasks}"
     unset nnodes ufs_ntasks
  ;;
-
  "upp")
 
     export NTHREADS_UPP=${NTHREADS1}
     export APRUN_UPP="${APRUN_default} --cpus-per-task=${NTHREADS_UPP}"
  ;;
-
  "atmos_products")
 
     export USE_CFP="YES"  # Use MPMD for downstream product generation
  ;;
-
-"oceanice_products")
+ "oceanice_products")
 
     export NTHREADS_OCNICEPOST=${NTHREADS1}
     export APRUN_OCNICEPOST="${launcher} -n 1 --cpus-per-task=${NTHREADS_OCNICEPOST}"
-;;
-
+ ;;
  "ecen")
 
     export NTHREADS_ECEN=${NTHREADSmax}

--- a/env/HERCULES.env
+++ b/env/HERCULES.env
@@ -114,7 +114,7 @@ case ${step} in
 
     export NTHREADS_PREPOBSAERO=${NTHREADS1}
     export APRUN_PREPOBSAERO="${APRUN_default} --cpus-per-task=${NTHREADS_PREPOBSAERO}"
-;;
+ ;;
  "snowanl")
 
     export APRUN_CALCFIMS="${launcher} -n 1"
@@ -133,7 +133,6 @@ case ${step} in
 
     export APRUN_APPLY_INCR="${launcher} -n 6"
  ;;
-
  "marinebmat")
 
     export APRUNCFP="${launcher} -n \$ncmd ${mpmd_opt}"
@@ -144,11 +143,10 @@ case ${step} in
     export APRUNCFP="${launcher} -n \$ncmd ${mpmd_opt}"
     export APRUN_MARINEANLVAR="${APRUN_default}"
  ;;
-"ocnanalecen")
+ "ocnanalecen")
 
    export APRUN_OCNANALECEN="${APRUN_default}"
-;;
-
+ ;;
  "marineanlchkpt")
 
     export APRUNCFP="${launcher} -n \$ncmd ${mpmd_opt}"


### PR DESCRIPTION
# Description

This PR makes updates to turn on several CI tests and related case functionality on Gaea C6. Some updates are also made for Gaea C5 but the CI tests are not turned on there yet. Some alignment fixes are also made to several env files.

Resolves #3261

# Type of change

Increase case availability on C6

# Change characteristics

Workflow environment settings and CI availability

# How has this been tested?

Ran the C48mx500_hybAOWCDA and C96C48_hybatmaerosnowDA CI tests on Gaea C6.
@JessicaMeixner-NOAA also ran the C48mx500_3DVarAOWCDA test on Gaea C6.