### PR TITLE
Update MSU FIX_DIR paths

### DIFF
--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -72,8 +72,8 @@ ${LINK_OR_COPY} "${HOMEgfs}/versions/run.${machine}.ver" "${HOMEgfs}/versions/ru
 case "${machine}" in
 "wcoss2") FIX_DIR="/lfs/h2/emc/global/noscrub/emc.global/FIX/fix" ;;
 "hera") FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix" ;;
-"orion") FIX_DIR="/work/noaa/global/glopara/fix" ;;
-"hercules") FIX_DIR="/work/noaa/global/glopara/fix" ;;
+"orion") FIX_DIR="/work2/noaa/global/role-global//fix" ;;
+"hercules") FIX_DIR="/work2/noaa/global/role-global/fix" ;;
 "jet") FIX_DIR="/lfs5/HFIP/hfv3gfs/glopara/FIX/fix" ;;
 "s4") FIX_DIR="/data/prod/glopara/fix" ;;
 "gaeac5") FIX_DIR="/gpfs/f5/ufs-ard/world-shared/global/glopara/data/fix" ;;

--- a/sorc/link_workflow.sh
+++ b/sorc/link_workflow.sh
@@ -72,7 +72,7 @@ ${LINK_OR_COPY} "${HOMEgfs}/versions/run.${machine}.ver" "${HOMEgfs}/versions/ru
 case "${machine}" in
 "wcoss2") FIX_DIR="/lfs/h2/emc/global/noscrub/emc.global/FIX/fix" ;;
 "hera") FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix" ;;
-"orion") FIX_DIR="/work2/noaa/global/role-global//fix" ;;
+"orion") FIX_DIR="/work2/noaa/global/role-global/fix" ;;
 "hercules") FIX_DIR="/work2/noaa/global/role-global/fix" ;;
 "jet") FIX_DIR="/lfs5/HFIP/hfv3gfs/glopara/FIX/fix" ;;
 "s4") FIX_DIR="/data/prod/glopara/fix" ;;


### PR DESCRIPTION
# Description

This updates the FIX_DIRs paths for Orion and Hercules after establishment of role.global on MSU. This was left out of PR #3443.

Refs #3203

# Type of change

Bug fix, change left out of prior PR

# Change characteristics

Path updates in workflow link script

# How has this been tested?

Ran link_workflow.sh on Hercules and confirmed fix folder paths are correct now