### PR TITLE
Replace "status" (or comparable) with "err" in preparation for moving to err_chk/err_exit

### DIFF
--- a/jobs/JGDAS_AERO_ANALYSIS_GENERATE_BMATRIX
+++ b/jobs/JGDAS_AERO_ANALYSIS_GENERATE_BMATRIX
@@ -23,9 +23,9 @@ mkdir -p "${COMOUT_CHEM_BMAT}"
 
 EXSCRIPT=${GDASAEROBMATPY:-${SCRgfs}/exgdas_aero_analysis_generate_bmatrix.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGDAS_ATMOS_ANALYSIS_DIAG
+++ b/jobs/JGDAS_ATMOS_ANALYSIS_DIAG
@@ -34,9 +34,9 @@ mkdir -m 775 -p "${COMOUT_ATMOS_ANALYSIS}"
 ###############################################################
 # Run relevant script
 ${ANALDIAGSH:-${SCRgfs}/exglobal_diag.sh}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 

--- a/jobs/JGDAS_ATMOS_CHGRES_FORENKF
+++ b/jobs/JGDAS_ATMOS_CHGRES_FORENKF
@@ -23,9 +23,9 @@ MEMDIR="mem001" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_HISTORY_MEM
 ###############################################################
 # Run relevant script
 ${CHGRESFCSTSH:-${SCRgfs}/exgdas_atmos_chgres_forenkf.sh}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 

--- a/jobs/JGDAS_ENKF_DIAG
+++ b/jobs/JGDAS_ENKF_DIAG
@@ -101,9 +101,9 @@ done
 # Run relevant script
 
 ${ANALDIAGSH:-${SCRgfs}/exglobal_diag.sh}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 

--- a/jobs/JGDAS_ENKF_ECEN
+++ b/jobs/JGDAS_ENKF_ECEN
@@ -42,9 +42,9 @@ MEMDIR="ensstat" RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 # Run relevant script
 
 ${ENKFRECENSH:-${SCRgfs}/exgdas_enkf_ecen.sh}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 

--- a/jobs/JGDAS_ENKF_ECEN_FV3JEDI
+++ b/jobs/JGDAS_ENKF_ECEN_FV3JEDI
@@ -38,9 +38,9 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 
 EXSCRIPT=${GDASATMRUNPY:-${SCRgfs}/exgdas_enkf_ecen_fv3jedi.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-  exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+  exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGDAS_ENKF_POST
+++ b/jobs/JGDAS_ENKF_POST
@@ -23,9 +23,9 @@ export LEVS=$((LEVS-1))
 # Run relevant script
 
 ${ENKFPOSTSH:-${SCRgfs}/exgdas_enkf_post.sh}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 

--- a/jobs/JGDAS_ENKF_SELECT_OBS
+++ b/jobs/JGDAS_ENKF_SELECT_OBS
@@ -60,9 +60,9 @@ fi
 # shellcheck disable=SC2153,SC2312
 LEVS=$(${NCDUMP} -h "${ATMGES_ENSMEAN}" | grep -i "pfull" | head -1 | awk -F" = " '{print $2}' | awk -F" " '{print $1}') # get LEVS
 # shellcheck disable=
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 export LEVS
 
@@ -123,9 +123,9 @@ done
 # Run relevant script
 
 ${INVOBSSH:-${SCRgfs}/exgdas_enkf_select_obs.sh}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 

--- a/jobs/JGDAS_ENKF_SFC
+++ b/jobs/JGDAS_ENKF_SFC
@@ -44,9 +44,9 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 # Run relevant script
 
 ${ENKFRESFCSH:-${SCRgfs}/exgdas_enkf_sfc.sh}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 

--- a/jobs/JGDAS_ENKF_UPDATE
+++ b/jobs/JGDAS_ENKF_UPDATE
@@ -38,9 +38,9 @@ MEMDIR="ensstat" RUN="enkfgdas" YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 # Run relevant script
 
 ${ENKFUPDSH:-${SCRgfs}/exgdas_enkf_update.sh}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 

--- a/jobs/JGDAS_FIT2OBS
+++ b/jobs/JGDAS_FIT2OBS
@@ -67,9 +67,9 @@ if [[ ${CDATE} -gt ${SDATE} ]]; then
   ##############################################
 
   "${SCRIPTSfit2obs}/excfs_gdas_vrfyfits.sh"
-  status=$?
-  if [[ ${status} -ne 0 ]]; then
-      exit "${status}"
+  err=$?
+  if [[ ${err} -ne 0 ]]; then
+      exit "${err}"
   fi
 
   ##############################################

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_ECEN
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_ECEN
@@ -40,9 +40,9 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 
 EXSCRIPT=${GDASOCNCENPY:-${HOMEgfs}/scripts/exgdas_global_marine_analysis_ecen.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGFS_ATMOS_POSTSND
+++ b/jobs/JGFS_ATMOS_POSTSND
@@ -38,9 +38,9 @@ fi
 ########################################################
 # Execute the script.
 ${SCRgfs}/exgfs_atmos_postsnd.sh
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 

--- a/jobs/JGFS_ATMOS_VERIFICATION
+++ b/jobs/JGFS_ATMOS_VERIFICATION
@@ -29,8 +29,8 @@ done
 # TODO: If none of these are on, why are we running this job?
 if [[ "${RUN_GRID2GRID_STEP1}" == "YES" || "${RUN_GRID2OBS_STEP1}" == "YES" || "${RUN_PRECIP_STEP1}" == "YES" ]]; then
     ${VERIF_GLOBALSH}
-    status=$?
-	if (( status != 0 )); then exit "${status}"; fi
+    err=$?
+	if (( err != 0 )); then exit "${err}"; fi
 fi
 
 if [[ ${KEEPDATA:-"NO"} = "NO" ]] ; then rm -rf "${DATAROOT}" ; fi  # TODO: This should be $DATA

--- a/jobs/JGFS_ATMOS_VERIFICATION
+++ b/jobs/JGFS_ATMOS_VERIFICATION
@@ -30,7 +30,9 @@ done
 if [[ "${RUN_GRID2GRID_STEP1}" == "YES" || "${RUN_GRID2OBS_STEP1}" == "YES" || "${RUN_PRECIP_STEP1}" == "YES" ]]; then
     ${VERIF_GLOBALSH}
     err=$?
-	if (( err != 0 )); then exit "${err}"; fi
+    if [[ ${err} -ne 0 ]]; 
+        then exit "${err}"
+    fi
 fi
 
 if [[ ${KEEPDATA:-"NO"} = "NO" ]] ; then rm -rf "${DATAROOT}" ; fi  # TODO: This should be $DATA

--- a/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
+++ b/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
@@ -23,9 +23,9 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 
 EXSCRIPT=${GDASAEROFINALPY:-${SCRgfs}/exglobal_aero_analysis_finalize.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
+++ b/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
@@ -32,9 +32,9 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 
 EXSCRIPT=${GDASAEROINITPY:-${SCRgfs}/exglobal_aero_analysis_initialize.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_AERO_ANALYSIS_VARIATIONAL
+++ b/jobs/JGLOBAL_AERO_ANALYSIS_VARIATIONAL
@@ -18,9 +18,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "aeroanlvar" -c "base aeroanl aeroanlv
 
 EXSCRIPT=${GDASAEROVARSH:-${SCRgfs}/exglobal_aero_analysis_variational.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_ARCHIVE_TARS
+++ b/jobs/JGLOBAL_ARCHIVE_TARS
@@ -75,9 +75,9 @@ fi
 ###############################################################
 
 ${GLOBALARCHIVESH:-${SCRgfs}/exglobal_archive_tars.py}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_ARCHIVE_VRFY
+++ b/jobs/JGLOBAL_ARCHIVE_VRFY
@@ -27,9 +27,9 @@ done
 ###############################################################
 
 ${GLOBALARCHIVESH:-${SCRgfs}/exglobal_archive_vrfy.py}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
+++ b/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
@@ -25,9 +25,9 @@ mkdir -m 755 -p "${COM_ATMOS_ANALYSIS_ENS}"
 
 EXSCRIPT=${GDASATMENSFINALPY:-${SCRgfs}/exglobal_atmens_analysis_finalize.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
+++ b/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
@@ -18,9 +18,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlfv3inc" -c "base atmensanl a
 
 EXSCRIPT=${GDASATMENSRUNSH:-${SCRgfs}/exglobal_atmens_analysis_fv3_increment.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
+++ b/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
@@ -27,9 +27,9 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 
 EXSCRIPT=${GDASATMENSINITPY:-${SCRgfs}/exglobal_atmens_analysis_initialize.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
+++ b/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
@@ -18,9 +18,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlletkf" -c "base atmensanl at
 
 EXSCRIPT=${GDASATMENSRUNSH:-${SCRgfs}/exglobal_atmens_analysis_letkf.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
+++ b/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
@@ -18,9 +18,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlobs" -c "base atmensanl atme
 
 EXSCRIPT=${GDASATMENSOBSSH:-${SCRgfs}/exglobal_atmens_analysis_obs.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
+++ b/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
@@ -18,9 +18,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlsol" -c "base atmensanl atme
 
 EXSCRIPT=${GDASATMENSSOLSH:-${SCRgfs}/exglobal_atmens_analysis_sol.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_ATMOS_ANALYSIS
+++ b/jobs/JGLOBAL_ATMOS_ANALYSIS
@@ -52,9 +52,9 @@ fi
 
 # Get LEVS
 export LEVS=$(${NCLEN} ${ATMGES} pfull)
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 
@@ -91,9 +91,9 @@ fi
 # Run relevant script
 
 ${ANALYSISSH:-${SCRgfs}/exglobal_atmos_analysis.sh}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 

--- a/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
+++ b/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
@@ -48,9 +48,9 @@ fi
 
 # Get LEVS
 export LEVS=$(${NCLEN} ${ATMGES} pfull)
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 
@@ -62,9 +62,9 @@ export DOGAUSFCANL=${DOGAUSFCANL:-"YES"}
 # Run relevant script
 
 ${ANALCALCSH:-${SCRgfs}/exglobal_atmos_analysis_calc.sh}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 

--- a/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC_FV3JEDI
+++ b/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC_FV3JEDI
@@ -35,9 +35,9 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 
 EXSCRIPT=${GDASATMRUNPY:-${SCRgfs}/exglobal_atmos_analysis_calc_fv3jedi.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-  exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+  exit "${err}"
 fi
 
 # Write analysis log file

--- a/jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP
+++ b/jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP
@@ -35,9 +35,9 @@ export BLENDED_ICE_FILE_m6hrs=${BLENDED_ICE_FILE_m6hrs:-${COMIN_m6hrs}/${RUN}.${
 ###############################################################
 
 ${EMCSFCPREPSH:-${SCRgfs}/exemcsfc_global_sfc_prep.sh}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_ATMOS_ENSSTAT
+++ b/jobs/JGLOBAL_ATMOS_ENSSTAT
@@ -25,7 +25,9 @@ done
 # Run exglobal script
 "${SCRgfs}/exglobal_atmos_ensstat.sh"
 err=$?
-(( err != 0 )) && exit "${err}"
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
+fi
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATMOS_ENSSTAT
+++ b/jobs/JGLOBAL_ATMOS_ENSSTAT
@@ -24,8 +24,8 @@ done
 ###############################################################
 # Run exglobal script
 "${SCRgfs}/exglobal_atmos_ensstat.sh"
-status=$?
-(( status != 0 )) && exit "${status}"
+err=$?
+(( err != 0 )) && exit "${err}"
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATMOS_PRODUCTS
+++ b/jobs/JGLOBAL_ATMOS_PRODUCTS
@@ -23,8 +23,8 @@ export PREFIX="${RUN}.t${cyc}z."
 ###############################################################
 # Run exglobal script
 "${SCRgfs}/exglobal_atmos_products.sh"
-status=$?
-(( status != 0 )) && exit "${status}"
+err=$?
+(( err != 0 )) && exit "${err}"
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATMOS_PRODUCTS
+++ b/jobs/JGLOBAL_ATMOS_PRODUCTS
@@ -24,7 +24,9 @@ export PREFIX="${RUN}.t${cyc}z."
 # Run exglobal script
 "${SCRgfs}/exglobal_atmos_products.sh"
 err=$?
-(( err != 0 )) && exit "${err}"
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
+fi
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATMOS_SFCANL
+++ b/jobs/JGLOBAL_ATMOS_SFCANL
@@ -35,7 +35,9 @@ mkdir -p "${COMOUT_ATMOS_RESTART}"
 
 ${SFCANALSH:-${SCRgfs}/exglobal_atmos_sfcanl.sh}
 err=$?
-(( err != 0 )) && exit "${err}"
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
+fi
 
 
 ##############################################

--- a/jobs/JGLOBAL_ATMOS_SFCANL
+++ b/jobs/JGLOBAL_ATMOS_SFCANL
@@ -34,8 +34,8 @@ mkdir -p "${COMOUT_ATMOS_RESTART}"
 # Run relevant script
 
 ${SFCANALSH:-${SCRgfs}/exglobal_atmos_sfcanl.sh}
-status=$?
-(( status != 0 )) && exit "${status}"
+err=$?
+(( err != 0 )) && exit "${err}"
 
 
 ##############################################

--- a/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
+++ b/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
@@ -42,9 +42,9 @@ export BKGFREQ=1                                # for hourly relocation
 ##############################################
 
 ${TROPCYQCRELOSH:-${SCRgfs}/exglobal_atmos_tropcy_qc_reloc.sh}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 

--- a/jobs/JGLOBAL_ATMOS_UPP
+++ b/jobs/JGLOBAL_ATMOS_UPP
@@ -24,7 +24,9 @@ if [[ ! -d ${COMOUT_ATMOS_MASTER} ]]; then mkdir -p "${COMOUT_ATMOS_MASTER}"; fi
 
 "${SCRgfs}/exglobal_atmos_upp.py"
 err=$?
-(( err != 0 )) && exit "${err}"
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
+fi
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATMOS_UPP
+++ b/jobs/JGLOBAL_ATMOS_UPP
@@ -23,8 +23,8 @@ if [[ ! -d ${COMOUT_ATMOS_MASTER} ]]; then mkdir -p "${COMOUT_ATMOS_MASTER}"; fi
 # Run relevant exglobal script
 
 "${SCRgfs}/exglobal_atmos_upp.py"
-status=$?
-(( status != 0 )) && exit "${status}"
+err=$?
+(( err != 0 )) && exit "${err}"
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
+++ b/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
@@ -35,9 +35,9 @@ mkdir -m 775 -p "${COM_ATMOS_ANALYSIS}"
 
 EXSCRIPT=${GDASATMFINALPY:-${SCRgfs}/exglobal_atm_analysis_finalize.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
+++ b/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
@@ -20,9 +20,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmanlfv3inc" -c "base atmanl atmanlf
 
 EXSCRIPT=${GDASATMRUNSH:-${SCRgfs}/exglobal_atm_analysis_fv3_increment.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
+++ b/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
@@ -38,9 +38,9 @@ mkdir -m 775 -p "${COM_ATMOS_ANALYSIS}"
 
 EXSCRIPT=${GDASATMINITPY:-${SCRgfs}/exglobal_atm_analysis_initialize.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
+++ b/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
@@ -20,9 +20,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmanlvar" -c "base atmanl atmanlvar"
 
 EXSCRIPT=${GDASATMRUNSH:-${SCRgfs}/exglobal_atm_analysis_variational.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_ATM_PREP_IODA_OBS
+++ b/jobs/JGLOBAL_ATM_PREP_IODA_OBS
@@ -19,10 +19,10 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS
 # Run relevant script
 EXSCRIPT=${BUFR2IODASH:-${USHgfs}/run_bufr2ioda.py}
 ${EXSCRIPT} "${PDY}${cyc}" "${RUN}" "${DMPDIR}" "${PARMgfs}/gdas/ioda/bufr2ioda" "${COM_OBS}/"
-status=$?
-if [[ ${status} -ne 0 ]]; then
+err=$?
+if [[ ${err} -ne 0 ]]; then
     echo "FATAL ERROR: Error executing ${EXSCRIPT}"
-    exit "${status}"
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_CLEANUP
+++ b/jobs/JGLOBAL_CLEANUP
@@ -5,7 +5,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "cleanup" -c "base cleanup"
 
 "${SCRgfs}/exglobal_cleanup.sh"
 err=$?
-(( err != 0 )) && exit "${err}"
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
+fi
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGLOBAL_CLEANUP
+++ b/jobs/JGLOBAL_CLEANUP
@@ -4,8 +4,8 @@ source "${HOMEgfs}/ush/preamble.sh"
 source "${HOMEgfs}/ush/jjob_header.sh" -e "cleanup" -c "base cleanup"
 
 "${SCRgfs}/exglobal_cleanup.sh"
-status=$?
-(( status != 0 )) && exit "${status}"
+err=$?
+(( err != 0 )) && exit "${err}"
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGLOBAL_ENS_ARCHIVE_TARS
+++ b/jobs/JGLOBAL_ENS_ARCHIVE_TARS
@@ -20,9 +20,9 @@ if [[ ! -d ${COMOUT_CONF} ]]; then mkdir -p "${COMOUT_CONF}"; fi
 ###############################################################
 
 "${SCRgfs}/exgdas_enkf_earc_tars.py"
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ###############################################################

--- a/jobs/JGLOBAL_ENS_ARCHIVE_VRFY
+++ b/jobs/JGLOBAL_ENS_ARCHIVE_VRFY
@@ -17,9 +17,9 @@ MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 ###############################################################
 
 "${SCRgfs}/exgdas_enkf_earc_vrfy.py"
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ###############################################################

--- a/jobs/JGLOBAL_ENS_GLOBUS_ARCH
+++ b/jobs/JGLOBAL_ENS_GLOBUS_ARCH
@@ -17,7 +17,9 @@ MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 
 ${GLOBALGLOBUSARCHSH:-${SCRgfs}/exglobal_globus_earc.py}
 err=$?
-[[ ${err} -ne 0 ]] && exit "${err}"
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
+fi
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ENS_GLOBUS_ARCH
+++ b/jobs/JGLOBAL_ENS_GLOBUS_ARCH
@@ -16,8 +16,8 @@ MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 ###############################################################
 
 ${GLOBALGLOBUSARCHSH:-${SCRgfs}/exglobal_globus_earc.py}
-status=$?
-[[ ${status} -ne 0 ]] && exit "${status}"
+err=$?
+[[ ${err} -ne 0 ]] && exit "${err}"
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_EXTRACTVARS
+++ b/jobs/JGLOBAL_EXTRACTVARS
@@ -41,7 +41,9 @@ fi
 # Execute the Script
 "${SCRgfs}/exglobal_extractvars.sh"
 err=$?
-(( err != 0 )) && exit "${err}"
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
+fi
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGLOBAL_EXTRACTVARS
+++ b/jobs/JGLOBAL_EXTRACTVARS
@@ -40,8 +40,8 @@ fi
 
 # Execute the Script
 "${SCRgfs}/exglobal_extractvars.sh"
-status=$?
-(( status != 0 )) && exit "${status}"
+err=$?
+(( err != 0 )) && exit "${err}"
 
 ##########################################
 # Remove the Temporary working directory

--- a/jobs/JGLOBAL_FORECAST
+++ b/jobs/JGLOBAL_FORECAST
@@ -88,7 +88,9 @@ fi
 ###############################################################
 "${FORECASTSH:-${SCRgfs}/exglobal_forecast.sh}"
 err=$?
-(( err != 0 )) && exit "${err}"
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
+fi
 
 # Send DBN alerts for EnKF
 # TODO: Should these be in post manager instead?

--- a/jobs/JGLOBAL_FORECAST
+++ b/jobs/JGLOBAL_FORECAST
@@ -87,8 +87,8 @@ fi
 # Run relevant exglobal script
 ###############################################################
 "${FORECASTSH:-${SCRgfs}/exglobal_forecast.sh}"
-status=$?
-(( status != 0 )) && exit "${status}"
+err=$?
+(( err != 0 )) && exit "${err}"
 
 # Send DBN alerts for EnKF
 # TODO: Should these be in post manager instead?

--- a/jobs/JGLOBAL_GLOBUS_ARCH
+++ b/jobs/JGLOBAL_GLOBUS_ARCH
@@ -14,8 +14,8 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 ###############################################################
 
 ${GLOBALGLOBUSARCHSH:-${SCRgfs}/exglobal_globus_arch.py}
-status=$?
-[[ ${status} -ne 0 ]] && exit "${status}"
+err=$?
+[[ ${err} -ne 0 ]] && exit "${err}"
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_MARINE_ANALYSIS_CHECKPOINT
+++ b/jobs/JGLOBAL_MARINE_ANALYSIS_CHECKPOINT
@@ -20,9 +20,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlchkpt" -c "base marineanl ma
 
 EXSCRIPT=${GDASMARINEANALYSIS:-${SCRgfs}/exglobal_marine_analysis_checkpoint.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_MARINE_ANALYSIS_FINALIZE
+++ b/jobs/JGLOBAL_MARINE_ANALYSIS_FINALIZE
@@ -32,9 +32,9 @@ mkdir -p "${COMOUT_ICE_RESTART}"
 
 EXSCRIPT=${GDASMARINEANALYSIS:-${SCRgfs}/exglobal_marine_analysis_finalize.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##########################################

--- a/jobs/JGLOBAL_MARINE_ANALYSIS_INITIALIZE
+++ b/jobs/JGLOBAL_MARINE_ANALYSIS_INITIALIZE
@@ -38,9 +38,9 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 
 EXSCRIPT=${GDASMARINEANALYSIS:-${SCRgfs}/exglobal_marine_analysis_initialize.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_MARINE_ANALYSIS_LETKF
+++ b/jobs/JGLOBAL_MARINE_ANALYSIS_LETKF
@@ -40,9 +40,9 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 
 EXSCRIPT=${GDASOCNLETKFPY:-${HOMEgfs}/scripts/exglobal_marine_analysis_letkf.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_MARINE_ANALYSIS_VARIATIONAL
+++ b/jobs/JGLOBAL_MARINE_ANALYSIS_VARIATIONAL
@@ -22,9 +22,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlvar" -c "base marineanl mari
 
 EXSCRIPT=${GDASMARINERUNSH:-${SCRgfs}/exglobal_marine_analysis_variational.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_MARINE_BMAT
+++ b/jobs/JGLOBAL_MARINE_BMAT
@@ -49,9 +49,9 @@ mkdir -p "${COMOUT_ICE_BMATRIX}"
 
 EXSCRIPT=${GDASMARINEBMATRUNPY:-${SCRgfs}/exglobal_marinebmat.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_OCEANICE_PRODUCTS
+++ b/jobs/JGLOBAL_OCEANICE_PRODUCTS
@@ -16,8 +16,8 @@ YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx "COM_${COMPONENT^^}_NETCDF"
 ###############################################################
 # Run exglobal script
 "${SCRgfs}/exglobal_oceanice_products.py"
-status=$?
-(( status != 0 )) && exit "${status}"
+err=$?
+(( err != 0 )) && exit "${err}"
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_OCEANICE_PRODUCTS
+++ b/jobs/JGLOBAL_OCEANICE_PRODUCTS
@@ -17,7 +17,9 @@ YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx "COM_${COMPONENT^^}_NETCDF"
 # Run exglobal script
 "${SCRgfs}/exglobal_oceanice_products.py"
 err=$?
-(( err != 0 )) && exit "${err}"
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
+fi
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_PREP_EMISSIONS
+++ b/jobs/JGLOBAL_PREP_EMISSIONS
@@ -18,8 +18,11 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "prep_emissions" -c "base prep_emissio
 # Run relevant script
 EXSCRIPT=${PREP_EMISSIONS_PY:-${SCRgfs}/exglobal_prep_emissions.py}
 ${EXSCRIPT}
-status=$?
-(( status != 0 )) && ( echo "FATAL ERROR: Error executing ${EXSCRIPT}, ABORT!"; exit "${status}" )
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    echo "FATAL ERROR: Error executing ${EXSCRIPT}, ABORT!"
+    exit "${err}"
+fi
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_PREP_OBS_AERO
+++ b/jobs/JGLOBAL_PREP_OBS_AERO
@@ -19,9 +19,9 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMOUT_OBS:COM_OBS_TMPL
 
 EXSCRIPT=${GDASPREPAEROOBSPY:-${SCRgfs}/exglobal_prep_obs_aero.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 

--- a/jobs/JGLOBAL_PREP_OBS_AERO
+++ b/jobs/JGLOBAL_PREP_OBS_AERO
@@ -39,7 +39,7 @@ fi
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd "${DATAROOT}" || exit
+cd "${DATAROOT}" || true
 if [[ "${KEEPDATA}" == "NO" ]]; then
     rm -rf "${DATA}"
 fi

--- a/jobs/JGLOBAL_PREP_OCEAN_OBS
+++ b/jobs/JGLOBAL_PREP_OCEAN_OBS
@@ -19,9 +19,9 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMOUT_OBS:COM_OBS_TMPL
 
 EXSCRIPT=${GDASPREPOCNOBSPY:-${SCRgfs}/exglobal_prep_ocean_obs.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 

--- a/jobs/JGLOBAL_SNOWENS_ANALYSIS
+++ b/jobs/JGLOBAL_SNOWENS_ANALYSIS
@@ -48,7 +48,7 @@ mkdir -p "${COMOUT_SNOW_ANALYSIS}" "${COMOUT_CONF}"
 EXSCRIPT=${SNOWANLPY:-${SCRgfs}/exglobal_snowens_analysis.py}
 ${EXSCRIPT}
 err=$?
-(( err != 0 )) && exit "${err}"
+if [[ ${err} -ne 0 ]]; then exit "${err}"; fi
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_SNOWENS_ANALYSIS
+++ b/jobs/JGLOBAL_SNOWENS_ANALYSIS
@@ -48,7 +48,9 @@ mkdir -p "${COMOUT_SNOW_ANALYSIS}" "${COMOUT_CONF}"
 EXSCRIPT=${SNOWANLPY:-${SCRgfs}/exglobal_snowens_analysis.py}
 ${EXSCRIPT}
 err=$?
-if [[ ${err} -ne 0 ]]; then exit "${err}"; fi
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
+fi
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_SNOWENS_ANALYSIS
+++ b/jobs/JGLOBAL_SNOWENS_ANALYSIS
@@ -47,8 +47,8 @@ mkdir -p "${COMOUT_SNOW_ANALYSIS}" "${COMOUT_CONF}"
 
 EXSCRIPT=${SNOWANLPY:-${SCRgfs}/exglobal_snowens_analysis.py}
 ${EXSCRIPT}
-status=$?
-(( status != 0 )) && exit "${status}"
+err=$?
+(( err != 0 )) && exit "${err}"
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_SNOW_ANALYSIS
+++ b/jobs/JGLOBAL_SNOW_ANALYSIS
@@ -32,9 +32,9 @@ mkdir -m 775 -p "${COMOUT_SNOW_ANALYSIS}" "${COMOUT_CONF}"
 
 EXSCRIPT=${SNOWANLPY:-${SCRgfs}/exglobal_snow_analysis.py}
 ${EXSCRIPT}
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ##############################################

--- a/jobs/JGLOBAL_WAVE_GEMPAK
+++ b/jobs/JGLOBAL_WAVE_GEMPAK
@@ -32,9 +32,9 @@ if [[ ! -d ${COMOUT_WAVE_GEMPAK} ]]; then mkdir -p "${COMOUT_WAVE_GEMPAK}"; fi
 ########################################################
 # Execute the script.
 ${SCRgfs}/exgfs_wave_nawips.sh
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 ###################################
 

--- a/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
+++ b/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
@@ -23,9 +23,9 @@ if [[ ! -d ${COMOUT_WAVE_WMO} ]]; then mkdir -p "${COMOUT_WAVE_WMO}"; fi
 # Execute the Script
 
 ${SCRgfs}/exgfs_wave_prdgen_bulls.sh
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ###################################

--- a/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
+++ b/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
@@ -34,9 +34,9 @@ fi
 # Execute the Script
 ###################################
 ${SCRgfs}/exgfs_wave_prdgen_gridded.sh
-status=$?
-if [[ ${status} -ne 0 ]]; then
-    exit "${status}"
+err=$?
+if [[ ${err} -ne 0 ]]; then
+    exit "${err}"
 fi
 
 ###################################

--- a/ush/run_mpmd.sh
+++ b/ush/run_mpmd.sh
@@ -27,7 +27,7 @@ if [[ "${launcher:-}" =~ ^srun.* ]]; then  #  srun-based system e.g. Hera, Orion
   ${launcher:-} ${mpmd_opt:-} -n ${nprocs} "${mpmd_cmdfile}"
   err=$?
   set_strict
-  if [[ ${err} =-eq 0 ]]; then
+  if [[ ${err} -eq 0 ]]; then
     out_files=$(find . -name 'mpmd.*.*.out')
   fi
 

--- a/ush/run_mpmd.sh
+++ b/ush/run_mpmd.sh
@@ -25,9 +25,9 @@ if [[ "${launcher:-}" =~ ^srun.* ]]; then  #  srun-based system e.g. Hera, Orion
   set +e
   # shellcheck disable=SC2086
   ${launcher:-} ${mpmd_opt:-} -n ${nprocs} "${mpmd_cmdfile}"
-  rc=$?
+  err=$?
   set_strict
-  if (( rc == 0 )); then
+  if [[ ${err} =-eq 0 ]]; then
     out_files=$(find . -name 'mpmd.*.*.out')
   fi
 
@@ -46,20 +46,20 @@ elif [[ "${launcher:-}" =~ ^mpiexec.* ]]; then  # mpiexec
   chmod 755 "${mpmd_cmdfile}"
   # shellcheck disable=SC2086
   ${launcher:-} -np ${nprocs} ${mpmd_opt:-} "${mpmd_cmdfile}"
-  rc=$?
-  if (( rc == 0 )); then
+  err=$?
+  if [[ ${err} -eq 0 ]]; then
     out_files=$(find . -name 'mpmd.*.out')
   fi
 
 else
 
   echo "FATAL ERROR: CFP is not usable with launcher: '${launcher:-}'"
-  rc=1
+  err=1
 
 fi
 
 # On success concatenate processor specific output into a single mpmd.out
-if (( rc == 0 )); then
+if [[ ${err} -eq 0 ]]; then
   rm -f "${mpmd_cmdfile}"
   for file in ${out_files}; do
     cat "${file}" >> mpmd.out
@@ -67,4 +67,4 @@ if (( rc == 0 )); then
   done
 fi
 
-exit "${rc}"
+exit "${err}"


### PR DESCRIPTION
# Description
In preparation for resolving bugzilla 1198 (#294), all fatal `exit` calls based on a status variable are standardized to use the `err` variable.

Resolves https://github.com/NOAA-EMC/global-workflow/issues/3367
# Type of change
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
- [x] CI tests on Hercules
- [ ] CI tests on WCOSS2

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added