### PR TITLE
make sure cold starts are handled correctly when DOIAU=YES (issue #3516)

### DIFF
--- a/ci/platforms/config.gaeac6
+++ b/ci/platforms/config.gaeac6
@@ -3,7 +3,7 @@
 # Main CI root directory
 export GFS_CI_ROOT=/ncrc/proj/nggps_emc/${USER}/GFS_CI_CD
 # ICSDIR root directory used on the create_experment.py command line
-export ICSDIR_ROOT=/gpfs/f6/bil-fire8/world-shared/global/glopara/data/ICSDIR
+export ICSDIR_ROOT=/gpfs/f6/drsa-precip3/world-shared/role.glopara/data/ICSDIR
 
 # JENKINS launch directory for agent
 export JENKINS_AGENT_LAUNCH_DIR=${GFS_CI_ROOT}/Jenkins/agent

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -746,9 +746,14 @@ CMEPS_predet(){
       CMEPS_RESTART_FH=("${FHMAX}")
     fi
   else
-    if [[ "${DOIAU:-NO}" == "YES" ]] && [[ "${warm_start}" == ".true." ]] ; then
-      local restart_interval_start=$(( cmeps_restart_interval + half_window ))
-      local restart_interval_end=$(( FHMAX + half_window ))
+    if [[ "${DOIAU:-NO}" == "YES" ]]; then
+      if [[ "${MODE}" = "cycled" && "${SDATE}" = "${PDY}${cyc}" && ${EXP_WARM_START} = ".false." ]]; then
+         local restart_interval_start=${cmeps_restart_interval}
+         local restart_interval_end=${FHMAX}
+      else
+         local restart_interval_start=$(( cmeps_restart_interval + half_window ))
+         local restart_interval_end=$(( FHMAX + half_window ))
+      fi
     else
       local restart_interval_start=${cmeps_restart_interval}
       local restart_interval_end=${FHMAX}

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -95,6 +95,7 @@ common_predet(){
   rCDUMP=${rCDUMP:-${RUN}}
 
   CDATE=${CDATE:-"${PDY}${cyc}"}
+  SDATE=${SDATE:-"${PDY}${cyc}"}
   ENSMEM=${ENSMEM:-000}
   MEMBER=$(( 10#${ENSMEM:-"-1"} )) # -1: control, 0: ensemble mean, >0: ensemble member $MEMBER
 


### PR DESCRIPTION

changes to ush/forecast_predet.sh to fix the problem identified in issue #3516 (the previous logic was relying on the warm_start variable which is always false in forecast_predet.sh).

  Resolves #3156


# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
ran a cycled 3dvar test on gaeac6 with DOIAU=YES and cold start initial conditions and verfied that the restart parameters are set correclty.


# Checklist
- [x ] Any dependent changes have been merged and published
- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have documented my code, including function, input, and output descriptions
- [x ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [x ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ x] I have made corresponding changes to the system documentation if necessary
