### PR TITLE
Update CI build and run directories for GitLab Nightlies on C6 and added GitLab support on Hera

### DIFF
--- a/ci/platforms/config.gaeac6
+++ b/ci/platforms/config.gaeac6
@@ -37,10 +37,11 @@ export JENKINS_WORK_DIR="${GFS_CI_ROOT}/Jenkins/workspace"
 
 # Used in the 'register' step of launch_gitlab_runner.sh for --url parameter
 export GITLAB_URL=https://vlab.noaa.gov/gitlab-licensed
+export GITLAB_RUNNER_NAME="RDHPCS Gaea C6"
 
 # Directory for GitLab builds
 # Used in launch_gitlab_runner.sh for location of builds
-export GITLAB_CI_BUILDS_DIR=/gpfs/f6/drsa-precip3/scratch/role.glopara/GFS_CI_ROOT/GITLAB/CI
+export GITLAB_CI_BUILDS_DIR=/gpfs/f6/drsa-precip3/world-shared/global/CI/GITLAB
 
 # Directory for GitLab runner used by launch_gitlab_runner.sh
 export GITLAB_RUNNER_DIR="${GFS_CI_ROOT}/GitLab/Runner"

--- a/ci/platforms/config.hera
+++ b/ci/platforms/config.hera
@@ -1,25 +1,61 @@
 #!/usr/bin/bash
 
-# Main CI root directory
+#########################################################################
+# config.hera - Platform-specific configuration for Hera
+#
+# This file contains environment variables used by CI/CD scripts,
+# directories, and settings specific to the Gaea C6 platform.
+#########################################################################
+
+# Main CI root directory - Base directory for all CI/CD operations
 export GFS_CI_ROOT=/scratch1/NCEPDEV/global/glopara/GFS_CI_CD
-# ICSDIR root directory used on the create_experment.py command line
+
+# ICSDIR root directory - Contains initial condition data
+# Used by create_experiment.py for setting up test cases
 export ICSDIR_ROOT=/scratch1/NCEPDEV/global/glopara/data/ICSDIR
 
-# JENKINS launch directory for agent
+
+#########################################################################
+# Jenkins configuration settings
+#########################################################################
+
+# JENKINS launch directory for agent - Where Jenkins agents are launched from
 export JENKINS_AGENT_LAUNCH_DIR=${GFS_CI_ROOT}/Jenkins/agent
+
 # JENKINS internal working directories for CI jobs (not for users use)
+# Where Jenkins stores temporary files during CI job execution
 export JENKINS_WORK_DIR=${GFS_CI_ROOT}/Jenkins/workspace
-# JENKINS custom_workspace directory where CI jobs are run
+
+# NOTE: JENKINS custom_workspace directory where CI jobs are run
+# and is defined in $HOMEgfs/ci/Jenkinsfile as custom_workspace
 # /scratch1/NCEPDEV/global/glopara/CI
-# is defined in the Jenkinsfile
+
+
+#########################################################################
+# GitLab CI configuration
+# These variables are referenced directly by launch_gitlab_runner.sh
+#########################################################################
+
+# Used in the 'register' step of launch_gitlab_runner.sh for --url parameter
+export GITLAB_URL=https://vlab.noaa.gov/gitlab-licensed
+export GITLAB_RUNNER_NAME="RDHPCS Hera"
+
+# Directory for GitLab builds
+# Used in launch_gitlab_runner.sh for location of builds
+export GITLAB_CI_BUILDS_DIR=/scratch1/NCEPDEV/global/glopara/GFS_CI_CD/CI_WORKSPACES/CI_GITLAB
+# Directory for GitLab runner used by launch_gitlab_runner.sh
+export GITLAB_RUNNER_DIR="${GFS_CI_ROOT}/GitLab/Runner"
+
 
 # CTest functional test directories for pre stagged input data
 export STAGED_TESTS_DIR=${GFS_CI_ROOT}/STAGED_TESTS_DIR
 
-# CI BASH test directories
+#########################################################################
+# CI CRON system configuration
+#########################################################################
 export GFS_BASH_CI_ROOT=${GFS_CI_ROOT}/GFS_BASH_CI
+export max_concurrent_cases=5
+export max_concurrent_pr=4
 
 # HPC account which overides the default account
 export HPC_ACCOUNT=fv3-cpu
-export max_concurrent_cases=5
-export max_concurrent_pr=4

--- a/ci/scripts/utils/launch_gitlab_runner.sh
+++ b/ci/scripts/utils/launch_gitlab_runner.sh
@@ -27,9 +27,9 @@ source "${HOMEGFS_}/ush/detect_machine.sh"
 # Check the MACHINE_ID and set up the environment accordingly
 case "${MACHINE_ID}" in
   hera | orion | hercules | wcoss2 | gaeac5 | gaeac6 )
-    echo "Launching GitLab Runner on ${MACHINE_ID}";;
+    echo "Running GitLab Runner script on ${MACHINE_ID}";;
   noaacloud )
-    echo "Launching GitLab Runner on ${PW_CSP}";;
+    echo "Running GitLab Runner script on ${PW_CSP}";;
   *)
     echo "Unsupported platform. Exiting with error."
     exit 1;;


### PR DESCRIPTION
# Description

This PR is to:

1. Add GitLab support to Hera
2. Change GitLab  build and run directories on Gaea C6 (as we did for Jenkins) to world-shared projects for Nightly Runs

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO (If YES, please add a link to any PRs that are pending.)
 
# How has this been tested?

Used the GitLab launching script to register and run the self-hosted runner on Hera successfully
