### PR TITLE
Check that partition should be set

### DIFF
--- a/workflow/rocoto/tasks.py
+++ b/workflow/rocoto/tasks.py
@@ -410,7 +410,7 @@ class Tasks:
             task_partition = self.partition_batch
             # on CSPs, partition_batch for fcst/efcs/wavepostbndpnt is "compute",
             # others are "process". So need to modify task_partition here.
-            if (task_config['PARTITION_BATCH'] != self.partition_batch):
+            if task_config['PARTITION_BATCH'] != self.partition_batch and task_partition is not None:
                 task_partition = task_config['PARTITION_BATCH']
             task_queue = self.queue_batch
             task_clusters = self.clusters_batch


### PR DESCRIPTION
# Description
This adds a check to see if partition should be set at all before attempting to override the default partition with the task partition.  This resolves a bug discovered on WCOSS2, which does not have a partition, introduced by #3483.

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Generated an XML on WCOSS2 and C6.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added