### PR TITLE
Temporarily disable compute builds on C6

### DIFF
--- a/ci/scripts/utils/ci_utils.sh
+++ b/ci/scripts/utils/ci_utils.sh
@@ -190,6 +190,11 @@ function cleanup_experiment() {
 function build_compute () {
 
   source "${HOMEgfs}/ci/platforms/config.${MACHINE_ID}"
-  "${HOMEgfs}/sorc/build_compute.sh" -A "${HPC_ACCOUNT}" -v all
+  # TODO: when it's safe to build on C6 compute nodes again, do so
+  if [[ "${MACHINE_ID}" == "gaeac6" ]]; then
+     "${HOMEgfs}/sorc/build_all.sh" -v -k all
+  else
+     "${HOMEgfs}/sorc/build_compute.sh" -A "${HPC_ACCOUNT}" -v all
+  fi
 
 }


### PR DESCRIPTION
# Description
Compute node builds on C6 are sometimes failing.  This hot fix temporarily moves the builds to the head node.  This will mean that no more than one build can happen at one time on head nodes.

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? YES (disables compute builds in CI)
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
- [ ] CI on C6

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added