### PR TITLE
Spread epos over more nodes on Hera to increase allocated memory

### DIFF
--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -1331,6 +1331,7 @@ case ${step} in
     ntasks=80
     threads_per_task=1
     tasks_per_node=$(( max_tasks_per_node / threads_per_task ))
+    memory="${mem_node_max}"
     export is_exclusive=True
     ;;
 

--- a/parm/config/gfs/config.resources.HERA
+++ b/parm/config/gfs/config.resources.HERA
@@ -50,6 +50,10 @@ case ${step} in
     fi
     ;;
 
+  "epos")
+    tasks_per_node=20
+    ;;
+
   *)
     ;;
 esac


### PR DESCRIPTION
# Description
This spreads the epos job over 4 nodes to increase the memory request for the jobs.  This job sometimes fails with out of memory errors on Hera and possibly WCOSS2 as well.

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
CI testing on Hera and WCOSS2 is required.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added