### PR TITLE
Use err_chk in GDAS j-jobs

### DIFF
--- a/jobs/JGDAS_AERO_ANALYSIS_GENERATE_BMATRIX
+++ b/jobs/JGDAS_AERO_ANALYSIS_GENERATE_BMATRIX
@@ -21,11 +21,9 @@ mkdir -p "${COMOUT_CHEM_BMAT}"
 # Run relevant script
 
 EXSCRIPT=${GDASAEROBMATPY:-${SCRgfs}/exgdas_aero_analysis_generate_bmatrix.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work
@@ -41,7 +39,9 @@ fi
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd "${DATAROOT}" || exit 1
+cd "${DATAROOT}" && true
+export err=$?
+err_chk
 if [[ "${KEEPDATA}" == "NO" ]]; then
     rm -rf "${DATA}"
 fi

--- a/jobs/JGDAS_ENKF_ECEN_FV3JEDI
+++ b/jobs/JGDAS_ENKF_ECEN_FV3JEDI
@@ -36,11 +36,9 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 ##############################################
 
 EXSCRIPT=${GDASATMRUNPY:-${SCRgfs}/exgdas_enkf_ecen_fv3jedi.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-  exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work
@@ -58,8 +56,12 @@ fi
 # Remove the Temporary working directory
 ##############################################
 
-cd "${DATAROOT}" || ( echo "FATAL ERROR: ${DATAROOT} does not exist, ABORT!"; exit 1 )
-if [[ ${KEEPDATA} = "NO" ]]; then
+cd "${DATAROOT}" && true
+export err=$?
+set +x
+err_chk "FATAL ERROR: ${DATAROOT} does not exist, ABORT!"
+set_trace
+if [[ "${KEEPDATA}" == "NO" ]]; then
     rm -rf "${DATA}"
 fi
 

--- a/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_ECEN
+++ b/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_ECEN
@@ -38,11 +38,9 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 # Run relevant script
 
 EXSCRIPT=${GDASOCNCENPY:-${HOMEgfs}/scripts/exgdas_global_marine_analysis_ecen.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work
@@ -58,7 +56,10 @@ fi
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd "${DATAROOT}" || exit 1
+cd "${DATAROOT}" && true
+export err=$?
+err_chk
+
 if [[ "${KEEPDATA}" == "NO" ]]; then
     rm -rf "${DATA}"
 fi

--- a/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
+++ b/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
@@ -22,11 +22,9 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 # Run relevant script
 
 EXSCRIPT=${GDASAEROFINALPY:-${SCRgfs}/exglobal_aero_analysis_finalize.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work
@@ -42,7 +40,9 @@ fi
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd "${DATAROOT}" || exit 1
+cd "${DATAROOT}" && true
+export err=$?
+err_chk
 if [[ "${KEEPDATA}" == "NO" ]]; then
     rm -rf "${DATA}"
 fi

--- a/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
+++ b/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
@@ -30,11 +30,9 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 # Run relevant script
 
 EXSCRIPT=${GDASAEROINITPY:-${SCRgfs}/exglobal_aero_analysis_initialize.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_AERO_ANALYSIS_VARIATIONAL
+++ b/jobs/JGLOBAL_AERO_ANALYSIS_VARIATIONAL
@@ -16,11 +16,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "aeroanlvar" -c "base aeroanl aeroanlv
 # Run relevant script
 
 EXSCRIPT=${GDASAEROVARSH:-${SCRgfs}/exglobal_aero_analysis_variational.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
+++ b/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
@@ -23,11 +23,9 @@ mkdir -m 755 -p "${COM_ATMOS_ANALYSIS_ENS}"
 # Run relevant script
 
 EXSCRIPT=${GDASATMENSFINALPY:-${SCRgfs}/exglobal_atmens_analysis_finalize.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work
@@ -43,7 +41,11 @@ fi
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd "${DATAROOT}" || ( echo "FATAL ERROR: ${DATAROOT} does not exist, ABORT!"; exit 1 )
+cd "${DATAROOT}" && true
+export err=$?
+set +e
+err_chk "FATAL ERROR: ${DATAROOT} does not exist, ABORT!"
+set_trace
 if [[ "${KEEPDATA}" == "NO" ]]; then
     rm -rf "${DATA}"
 fi

--- a/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
+++ b/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
@@ -16,11 +16,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlfv3inc" -c "base atmensanl a
 # Run relevant script
 
 EXSCRIPT=${GDASATMENSRUNSH:-${SCRgfs}/exglobal_atmens_analysis_fv3_increment.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
+++ b/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
@@ -25,11 +25,9 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 # Run relevant script
 
 EXSCRIPT=${GDASATMENSINITPY:-${SCRgfs}/exglobal_atmens_analysis_initialize.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
+++ b/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
@@ -16,11 +16,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlletkf" -c "base atmensanl at
 # Run relevant script
 
 EXSCRIPT=${GDASATMENSRUNSH:-${SCRgfs}/exglobal_atmens_analysis_letkf.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
+++ b/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
@@ -16,11 +16,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlobs" -c "base atmensanl atme
 # Run relevant script
 
 EXSCRIPT=${GDASATMENSOBSSH:-${SCRgfs}/exglobal_atmens_analysis_obs.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
+++ b/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
@@ -16,11 +16,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlsol" -c "base atmensanl atme
 # Run relevant script
 
 EXSCRIPT=${GDASATMENSSOLSH:-${SCRgfs}/exglobal_atmens_analysis_sol.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC_FV3JEDI
+++ b/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC_FV3JEDI
@@ -33,11 +33,9 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 ##############################################
 
 EXSCRIPT=${GDASATMRUNPY:-${SCRgfs}/exglobal_atmos_analysis_calc_fv3jedi.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-  exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 # Write analysis log file
 echo "${rCDUMP} ${PDY}${cyc} atmanl and sfcanl done at $(date)" > "${COMOUT_ATMOS_ANALYSIS}/${RUN}.t${cyc}z.loganl.txt"
@@ -58,7 +56,11 @@ fi
 # Remove the Temporary working directory
 ##############################################
 
-cd "${DATAROOT}" || ( echo "FATAL ERROR: ${DATAROOT} does not exist, ABORT!"; exit 1 )
+cd "${DATAROOT}" && true
+export err=$?
+set +x
+err_chk "FATAL ERROR: ${DATAROOT} does not exist, ABORT!"
+set_trace
 if [[ ${KEEPDATA} = "NO" ]]; then
     rm -rf "${DATA}"
 fi

--- a/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
+++ b/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
@@ -33,11 +33,9 @@ mkdir -m 775 -p "${COM_ATMOS_ANALYSIS}"
 # Run relevant script
 
 EXSCRIPT=${GDASATMFINALPY:-${SCRgfs}/exglobal_atm_analysis_finalize.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work
@@ -53,7 +51,11 @@ fi
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd "${DATAROOT}" || ( echo "FATAL ERROR: ${DATAROOT} does not exist, ABORT!"; exit 1 )
+cd "${DATAROOT}" && true
+export err=$?
+set +x
+err_chk "FATAL ERROR: ${DATAROOT} does not exist, ABORT!"
+set_trace
 if [[ "${KEEPDATA}" == "NO" ]]; then
     rm -rf "${DATA}"
 fi

--- a/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
+++ b/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
@@ -18,11 +18,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmanlfv3inc" -c "base atmanl atmanlf
 # Run relevant script
 
 EXSCRIPT=${GDASATMRUNSH:-${SCRgfs}/exglobal_atm_analysis_fv3_increment.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
+++ b/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
@@ -36,11 +36,9 @@ mkdir -m 775 -p "${COM_ATMOS_ANALYSIS}"
 # Run relevant script
 
 EXSCRIPT=${GDASATMINITPY:-${SCRgfs}/exglobal_atm_analysis_initialize.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
+++ b/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
@@ -18,11 +18,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmanlvar" -c "base atmanl atmanlvar"
 # Run relevant script
 
 EXSCRIPT=${GDASATMRUNSH:-${SCRgfs}/exglobal_atm_analysis_variational.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_ATM_PREP_IODA_OBS
+++ b/jobs/JGLOBAL_ATM_PREP_IODA_OBS
@@ -17,12 +17,11 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS
 ###############################################################
 # Run relevant script
 EXSCRIPT=${BUFR2IODASH:-${USHgfs}/run_bufr2ioda.py}
-${EXSCRIPT} "${PDY}${cyc}" "${RUN}" "${DMPDIR}" "${PARMgfs}/gdas/ioda/bufr2ioda" "${COM_OBS}/"
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    echo "FATAL ERROR: Error executing ${EXSCRIPT}"
-    exit "${err}"
-fi
+${EXSCRIPT} "${PDY}${cyc}" "${RUN}" "${DMPDIR}" "${PARMgfs}/gdas/ioda/bufr2ioda" "${COM_OBS}/" && true
+export err=$?
+set +x
+err_chk "FATAL ERROR: Error executing ${EXSCRIPT}"
+set_trace
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_MARINE_ANALYSIS_CHECKPOINT
+++ b/jobs/JGLOBAL_MARINE_ANALYSIS_CHECKPOINT
@@ -18,11 +18,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlchkpt" -c "base marineanl ma
 # Run relevant script
 
 EXSCRIPT=${GDASMARINEANALYSIS:-${SCRgfs}/exglobal_marine_analysis_checkpoint.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_MARINE_ANALYSIS_FINALIZE
+++ b/jobs/JGLOBAL_MARINE_ANALYSIS_FINALIZE
@@ -30,16 +30,17 @@ mkdir -p "${COMOUT_ICE_RESTART}"
 ###############################################################
 
 EXSCRIPT=${GDASMARINEANALYSIS:-${SCRgfs}/exglobal_marine_analysis_finalize.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd "${DATAROOT}" || exit 1
+cd "${DATAROOT}" && true
+export err=$?
+err_chk
+
 if [[ "${KEEPDATA}" == "NO" ]]; then
     rm -rf "${DATA}"
 fi

--- a/jobs/JGLOBAL_MARINE_ANALYSIS_INITIALIZE
+++ b/jobs/JGLOBAL_MARINE_ANALYSIS_INITIALIZE
@@ -36,11 +36,9 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 # Run relevant script
 
 EXSCRIPT=${GDASMARINEANALYSIS:-${SCRgfs}/exglobal_marine_analysis_initialize.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_MARINE_ANALYSIS_LETKF
+++ b/jobs/JGLOBAL_MARINE_ANALYSIS_LETKF
@@ -38,11 +38,9 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 # Run relevant script
 
 EXSCRIPT=${GDASOCNLETKFPY:-${HOMEgfs}/scripts/exglobal_marine_analysis_letkf.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work
@@ -58,7 +56,9 @@ fi
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd "${DATAROOT}" || exit 1
+cd "${DATAROOT}" && true
+export err=$?
+err_chk
 if [[ "${KEEPDATA}" == "NO" ]]; then
     rm -rf "${DATA}"
 fi

--- a/jobs/JGLOBAL_MARINE_ANALYSIS_VARIATIONAL
+++ b/jobs/JGLOBAL_MARINE_ANALYSIS_VARIATIONAL
@@ -20,11 +20,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlvar" -c "base marineanl mari
 # Run relevant script
 
 EXSCRIPT=${GDASMARINERUNSH:-${SCRgfs}/exglobal_marine_analysis_variational.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_MARINE_BMAT
+++ b/jobs/JGLOBAL_MARINE_BMAT
@@ -47,11 +47,9 @@ mkdir -p "${COMOUT_ICE_BMATRIX}"
 # Run relevant script
 
 EXSCRIPT=${GDASMARINEBMATRUNPY:-${SCRgfs}/exglobal_marinebmat.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work

--- a/jobs/JGLOBAL_SNOWENS_ANALYSIS
+++ b/jobs/JGLOBAL_SNOWENS_ANALYSIS
@@ -45,11 +45,9 @@ mkdir -p "${COMOUT_SNOW_ANALYSIS}" "${COMOUT_CONF}"
 # Run relevant script
 
 EXSCRIPT=${SNOWANLPY:-${SCRgfs}/exglobal_snowens_analysis.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work
@@ -65,7 +63,9 @@ fi
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd "${DATAROOT}" || exit 1
+cd "${DATAROOT}" && true
+export err=$?
+err_chk
 if [[ "${KEEPDATA}" == "NO" ]]; then
     rm -rf "${DATA}"
 fi

--- a/jobs/JGLOBAL_SNOW_ANALYSIS
+++ b/jobs/JGLOBAL_SNOW_ANALYSIS
@@ -30,11 +30,9 @@ mkdir -m 775 -p "${COMOUT_SNOW_ANALYSIS}" "${COMOUT_CONF}"
 # Run relevant script
 
 EXSCRIPT=${SNOWANLPY:-${SCRgfs}/exglobal_snow_analysis.py}
-${EXSCRIPT}
-err=$?
-if [[ ${err} -ne 0 ]]; then
-    exit "${err}"
-fi
+${EXSCRIPT} && true
+export err=$?
+err_chk
 
 ##############################################
 # End JOB SPECIFIC work
@@ -50,7 +48,9 @@ fi
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd "${DATAROOT}" || exit 1
+cd "${DATAROOT}" && true
+export err=$?
+err_chk
 if [[ "${KEEPDATA}" == "NO" ]]; then
     rm -rf "${DATA}"
 fi

--- a/jobs/rocoto/esnowanl.sh
+++ b/jobs/rocoto/esnowanl.sh
@@ -1,7 +1,5 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/preamble.sh"
-
 ###############################################################
 # Source UFSDA workflow modules
 . "${HOMEgfs}/ush/load_ufsda_modules.sh"
@@ -16,7 +14,7 @@ export jobid="${job}.$$"
 ###############################################################
 # setup python path for ioda utilities
 # shellcheck disable=SC2311
-pyiodaPATH="${HOMEgfs}/sorc/gdas.cd/build/lib/python$(detect_py_ver)/"
+pyiodaPATH="${HOMEgfs}/sorc/gdas.cd/build/lib/python${PYTHON_VERSION}/"
 gdasappPATH="${HOMEgfs}/sorc/gdas.cd/sorc/iodaconv/src:${pyiodaPATH}"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}:${gdasappPATH}"
 export PYTHONPATH

--- a/jobs/rocoto/prepatmiodaobs.sh
+++ b/jobs/rocoto/prepatmiodaobs.sh
@@ -1,7 +1,5 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/preamble.sh"
-
 ###############################################################
 # Source UFSDA workflow modules
 . "${HOMEgfs}/ush/load_ufsda_modules.sh"
@@ -16,7 +14,7 @@ export jobid="${job}.$$"
 ###############################################################
 # setup python path for ioda utilities
 # shellcheck disable=SC2311
-pyiodaPATH="${HOMEgfs}/sorc/gdas.cd/build/lib/python$(detect_py_ver)/"
+pyiodaPATH="${HOMEgfs}/sorc/gdas.cd/build/lib/python${PYTHON_VERSION}/"
 PYTHONPATH="${pyiodaPATH}:${PYTHONPATH}"
 export PYTHONPATH
 

--- a/jobs/rocoto/prepoceanobs.sh
+++ b/jobs/rocoto/prepoceanobs.sh
@@ -1,7 +1,6 @@
 #! /usr/bin/env bash
 
 export STRICT="NO"
-source "${HOMEgfs}/ush/preamble.sh"
 
 ###############################################################
 # Source UFSDA workflow modules
@@ -17,7 +16,7 @@ export jobid="${job}.$$"
 ###############################################################
 # setup python path for class defs and utils
 # shellcheck disable=SC2311
-pyiodaPATH="${HOMEgfs}/sorc/gdas.cd/build/lib/python$(detect_py_ver)/"
+pyiodaPATH="${HOMEgfs}/sorc/gdas.cd/build/lib/python${PYTHON_VERSION}/"
 PYTHONPATH="${pyiodaPATH}:${PYTHONPATH}"
 export PYTHONPATH
 

--- a/jobs/rocoto/snowanl.sh
+++ b/jobs/rocoto/snowanl.sh
@@ -1,7 +1,5 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/preamble.sh"
-
 ###############################################################
 # Source UFSDA workflow modules
 . "${HOMEgfs}/ush/load_ufsda_modules.sh"
@@ -16,7 +14,7 @@ export jobid="${job}.$$"
 ###############################################################
 # setup python path for ioda utilities
 # shellcheck disable=SC2311
-pyiodaPATH="${HOMEgfs}/sorc/gdas.cd/build/lib/python$(detect_py_ver)/"
+pyiodaPATH="${HOMEgfs}/sorc/gdas.cd/build/lib/python${PYTHON_VERSION}/"
 gdasappPATH="${HOMEgfs}/sorc/gdas.cd/sorc/iodaconv/src:${pyiodaPATH}"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}:${gdasappPATH}"
 export PYTHONPATH

--- a/ush/bash_utils.sh
+++ b/ush/bash_utils.sh
@@ -106,21 +106,7 @@ function wait_for_file() {
     return 1
 }
 
-function detect_py_ver() {
-    # 
-    # Returns the major.minor version of the currently active python executable
-    #
-    regex="[0-9]+\.[0-9]+"
-    # shellcheck disable=SC2312
-    if [[ $(python --version) =~ ${regex} ]]; then
-	    echo "${BASH_REMATCH[0]}"
-    else
-	    echo "FATAL ERROR: Could not detect the python version"
-	    exit 1
-    fi
-}
 # shellcheck disable=
 
 declare -xf declare_from_tmpl
 declare -xf wait_for_file
-declare -xf detect_py_ver

--- a/ush/load_ufsda_modules.sh
+++ b/ush/load_ufsda_modules.sh
@@ -78,6 +78,16 @@ wxflowPATH="${HOMEgfs}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/ush:${wxflowPATH}"
 export PYTHONPATH
 
+# Detect the Python major.minor version
+_regex="[0-9]+\.[0-9]+"
+# shellcheck disable=SC2312
+if [[ $(python --version) =~ ${_regex} ]]; then
+    export PYTHON_VERSION="${BASH_REMATCH[0]}"
+else
+    echo "FATAL ERROR: Could not detect the python version"
+    exit 1
+fi
+
 # Restore stack soft limit:
 ulimit -S -s "${ulimit_s}"
 unset ulimit_s


### PR DESCRIPTION
# Description
This PR replaces `exit` calls with `err_chk` calls in the GDASApp J-Jobs.

Resolves https://github.com/NOAA-EMC/global-workflow/issues/3510
Refs https://github.com/NOAA-EMC/global-workflow/issues/294

# Type of change
- [x] NCO Bug fix (fixes something broken)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
C48mx500_hybAOWCDA test on Hercules

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added