### PR TITLE
Update release notes and `gfs_ver` for GFSv16.3.24

### DIFF
--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -1,16 +1,10 @@
-GFS V16.3.23 RELEASE NOTES
+GFS V16.3.24 RELEASE NOTES
 
 -------
 PRELUDE
 -------
 
-The GFS is updated for the following:
-
-* workflow and UFS_UTILS package updates to use the new AFWA global snow file due to the hemispheric snow files being phased out
-* updated GSI code and convinfo file for saildrone observations and to allow assimilation of GOES-19 AMVs
-* ww3_outp is improved for the wave point output
-* bufr station updates to three stations and the addition of 121 new stations
-* obsproc/v1.2.4
+Tropical storm name updates for the 2025-2026 hurricane seasons are made in the GFS syndat_stmnames fix file.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -19,9 +13,9 @@ The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub are used t
 
 ```bash
 cd $PACKAGEROOT
-mkdir gfs.v16.3.23
-cd gfs.v16.3.23
-git clone -b EMC-v16.3.23 https://github.com/NOAA-EMC/global-workflow.git .
+mkdir gfs.v16.3.24
+cd gfs.v16.3.24
+git clone -b EMC-v16.3.24 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```
@@ -55,102 +49,77 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* `versions/run.ver` - change `version=v16.3.23` and `gfs_ver=v16.3.23`
-* `versions/MACHINE.ver` - update `obsproc_run_ver=1.2.4`
+* `versions/run.ver` - change `version=v16.3.24` and `gfs_ver=v16.3.24`
 
 SORC CHANGES
 ------------
 
-* New UFS_UTILS tag - `emcsfc_snow2mdl` program and associated scripts are updated to process global AFWA snow data
-* New GSI tag - `src/gsi/read_prepbufr.f90` code update for new saildrone subtype
-* New MODEL tag - WW3 program `ww3_outp` and associated scripts are improved to process the per-time-step point outputs more efficiently.
+* No changes from GFS v16.3.24
 
 JOBS CHANGES
 ------------
 
-* `jobs/JGLOBAL_ATMOS_EMCSFC_SFC_PREP` - new AFWA filename
+* No changes from GFS v16.3.24
 
 PARM/CONFIG CHANGES
 -------------------
 
-In `config.resources.emc.dyn` and `config.resources.nco.static` following resources are changed:
-* for wavepostbndpnt: npe from 240 to 1; wtime from 1hr to 30min
-* for wavepostbndpntbll: npe from 448 to 2; wtime from 1hr to 10min
-* for wavepostpnt: npe from 200 to 3; wtime from 1.5hr to 35min
-
-Bufr station updates:
-* `parm/parm_wave/bull_awips_gfswave`
-* `parm/product/bufr_ij13km.txt`
-* `parm/product/bufr_stalist.meteo.gfs`
+* No changes from GFS v16.3.24
 
 SCRIPT CHANGES
 --------------
 
-* `scripts/exgfs_wave_post_pnt.sh` is changed to be compatible with the  new `ww3_outp`.
+* No changes from GFS v16.3.24
 
 FIX CHANGES
 -----------
 
-* GSI `global_convinfo.txt` fix update for saildrone and GOES-19
+The `fix_am/syndat_stmnames` file is updated to adjust some hurricane names for 2025/2026 seasons.
 
 MODULE CHANGES
 --------------
 
-* No changes from GFS v16.3.22
+* No changes from GFS v16.3.24
 
 CHANGES TO FILE AND FILE SIZES
 ------------------------------
 
-No longer ingest:
-* `${RUN}.${cycle}.NPR.SNWN.SP.S1200.MESH16.grb` (`AFWA_NH_FILE`)
-* `${RUN}.${cycle}.NPR.SNWS.SP.S1200.MESH16.grb` (`AFWA_SH_FILE`)
-
-Now ingest:
-* `${RUN}.${cycle}.snow.usaf.grib2` (`AFWA_GLOBAL_FILE`)
+* No changes from GFS v16.3.24
 
 ENVIRONMENT AND RESOURCE CHANGES
 --------------------------------
 
-Reduce the ncpu and wtime as follow:
-* for jobs/JGLOBAL_WAVE_POST_BNDPNT; ncpu from 240 to 1; wtime from 1hr to 30min
-* for jobs/JGLOBAL_WAVE_POST_BNDPNTBLL; ncpu from 448 to 2; wtime from 1hr to 10min
-* for jobs/JGLOBAL_WAVE_POST_PNT; ncpu from 200 to 3; wtime from 1.5hr to 35min
+* No changes from GFS v16.3.24
 
 PRE-IMPLEMENTATION TESTING REQUIREMENTS
 ---------------------------------------
 
 * Which production jobs should be tested as part of this implementation?
-  * emcsfc_sfc_prep and analysis
-  * wave_post_pnt
-  * wave_post_bndpnt
-  * wave_post_bndpntbll
+  * All
 * Does this change require a 30-day evaluation?
   * No
 
 DISSEMINATION INFORMATION
 -------------------------
 
-* No changes from GFS v16.3.22
+* No changes from GFS v16.3.24
 
 HPSS ARCHIVE
 ------------
 
-* No changes from GFS v16.3.22
+* No changes from GFS v16.3.24
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
 
-* No changes from GFS v16.3.22
+* No changes from GFS v16.3.24
 
 DOCUMENTATION
 -------------
 
-* No changes from GFS v16.3.22
+* No changes from GFS v16.3.24
 
 PREPARED BY
 -----------
 Kate.Friedman@noaa.gov
-George.Gayno@noaa.gov
-Andrew.Collard@noaa.gov
-Jessica.Meixner@noaa.gov
-Ali.Salimi@noaa.gov
+Qingfu.Liu@noaa.gov

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.23
-export gfs_ver=v16.3.23
+export version=v16.3.24
+export gfs_ver=v16.3.24
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2


### PR DESCRIPTION
# Description

This PR updates the release notes for GFSv16.3.24 and updates `gfs_ver=v16.3.24`. The updated `syndat_stmnames` has been staged in the `/lfs/h2/emc/global/noscrub/emc.global/FIX/fix_nco_gfsv16.3.22` pickup location on WCOSS2.

Refs #3590

# Type of change

Production update