### PR TITLE
Unexport SHELLOPTS when running htar

### DIFF
--- a/jobs/JGLOBAL_ARCHIVE_TARS
+++ b/jobs/JGLOBAL_ARCHIVE_TARS
@@ -74,6 +74,8 @@ fi
 ###############################################################
 
 set +eu
+# Do not export shell opts to the bash scripts in the htar/hsi wrappers
+export -n SHELLOPTS
 ${GLOBALARCHIVESH:-${SCRgfs}/exglobal_archive_tars.py}
 export err=$?
 set +x

--- a/jobs/JGLOBAL_ENS_ARCHIVE_TARS
+++ b/jobs/JGLOBAL_ENS_ARCHIVE_TARS
@@ -20,6 +20,7 @@ if [[ ! -d ${COMOUT_CONF} ]]; then mkdir -p "${COMOUT_CONF}"; fi
 
 # Calls an external bash command; do not fail on unassigned/error
 set +eu
+export -n SHELLOPTS
 "${SCRgfs}/exgdas_enkf_earc_tars.py"
 export err=$?
 set +x

--- a/jobs/JGLOBAL_ENS_GLOBUS_ARCH
+++ b/jobs/JGLOBAL_ENS_GLOBUS_ARCH
@@ -14,6 +14,7 @@ MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 # Run globus script
 ###############################################################
 
+export -n SHELLOPTS
 ${GLOBALGLOBUSARCHSH:-${SCRgfs}/exglobal_globus_earc.py}
 err=$?
 if [[ ${err} -ne 0 ]]; then

--- a/jobs/JGLOBAL_FETCH
+++ b/jobs/JGLOBAL_FETCH
@@ -3,6 +3,8 @@
 source "${HOMEgfs}/ush/jjob_header.sh" -e "fetch" -c "base fetch"
 
 # Execute fetching
+# Do not export shell opts to the bash scripts in the htar/hsi wrappers
+export -n SHELLOPTS
 "${SCRgfs}/exglobal_fetch.py" 
 err=$?
 

--- a/jobs/JGLOBAL_GLOBUS_ARCH
+++ b/jobs/JGLOBAL_GLOBUS_ARCH
@@ -12,6 +12,7 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 # Run globus script
 ###############################################################
 
+export -n SHELLOPTS
 ${GLOBALGLOBUSARCHSH:-${SCRgfs}/exglobal_globus_arch.py}
 err=$?
 [[ ${err} -ne 0 ]] && exit "${err}"


### PR DESCRIPTION
# Description
This prevents the htar and hsi wrappers from echoing commands (i.e. from `set -x`) so that external commands do not produce extraneous output when output to variables.

Resolves #3581 

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? YES
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
C48_ATM test case on Cactus

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added