### PR TITLE
Standardize ocean and ice filenames

### DIFF
--- a/ush/python/pygfs/task/marine_bmat.py
+++ b/ush/python/pygfs/task/marine_bmat.py
@@ -216,6 +216,7 @@ class MarineBMat(Task):
         """
 
         APREFIX = self.task_config.APREFIX
+
         window_begin_iso = self.task_config.MARINE_WINDOW_BEGIN.strftime('%Y-%m-%dT%H:%M:%SZ')
         window_middle_iso = self.task_config.MARINE_WINDOW_MIDDLE.strftime('%Y-%m-%dT%H:%M:%SZ')
         window_end_iso = self.task_config.MARINE_WINDOW_END.strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -234,6 +235,8 @@ class MarineBMat(Task):
             src = os.path.join(self.task_config.DATAstaticb, f"{diff_type}_ocean.nc")
             dest = os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX,
                                 f"{APREFIX}{diff_type}_ocean.nc")
+            dest = rename_file( dest )  # correct the file name
+            
             diffusion_coeff_list.append([src, dest])
 
         FileHandler({'copy': diffusion_coeff_list}).sync()
@@ -243,29 +246,37 @@ class MarineBMat(Task):
         diagb_list = []
 
         # TODO(AFE) the two renames are to accomodate yaml settings in var task, which should changed
-        # ocean diag B
         os.rename(os.path.join(self.task_config.DATAstaticb, f"ocn.bkgerr_stddev.incr.{window_end_iso}.nc"),
                   os.path.join(self.task_config.DATAstaticb, f"ocn.bkgerr_stddev.nc"))
         src = os.path.join(self.task_config.DATAstaticb, f"ocn.bkgerr_stddev.nc")
-        dst = os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX, f"{APREFIX}ocean.bkgerr_ens_stddev.nc")
+        
+        dst = os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX, f"{APREFIX}ocean.bkgerr_ens_stddev.nc")  
+        dst = rename_file( dst )  # correct the file name
+        
         diagb_list.append([src, dst])
 
-        # ice diag B
         os.rename(os.path.join(self.task_config.DATAstaticb, f"ice.bkgerr_stddev.incr.{window_end_iso}.nc"),
                   os.path.join(self.task_config.DATAstaticb, f"ice.bkgerr_stddev.nc"))
+                               
         src = os.path.join(self.task_config.DATAstaticb, f"ice.bkgerr_stddev.nc")
         dst = os.path.join(self.task_config.COMOUT_ICE_BMATRIX, f"{APREFIX}ice.bkgerr_ens_stddev.nc")
+        dst = rename_file( dst ) # correct the file name
+
         diagb_list.append([src, dst])
 
         if self.task_config.DOHYBVAR_OCN == "YES" or self.task_config.NMEM_ENS >= 2:
-            src = os.path.join(self.task_config.DATAstaticb, f"ocn.ssh_recentering_error.incr.{window_begin_iso}.nc")
+            src = os.path.join(self.task_config.DATAstaticb, f"ocn.ssh_recentering_error.incr.{window_begin_iso}.nc") 
             dst = os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX, f"{APREFIX}ocean.recentering_error.nc")
-            diagb_list.append([src, dst])
+            dst = rename_file( dst )  # correct the file name
 
+            diagb_list.append([src, dst])
+            
             src = os.path.join(self.task_config.DATAstaticb, f"ice.ssh_recentering_error.incr.{window_begin_iso}.nc")
             dst = os.path.join(self.task_config.COMOUT_ICE_BMATRIX, f"{APREFIX}ice.recentering_error.nc")
+            dst = rename_file( dst )  # correct the file name
+            
             diagb_list.append([src, dst])
-
+            
         FileHandler({'copy': diagb_list}).sync()
 
         # Copy the ensemble perturbation diagnostics to the ROTDIR
@@ -274,15 +285,18 @@ class MarineBMat(Task):
             src = os.path.join(self.task_config.DATA, f"ocn.ens_weights.incr.{window_middle_iso}.nc")
             dst = os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX,
                                f"{APREFIX}ocean.ens_weights.nc")
+            dst = rename_file( dst )  # correct the file name
+
             weight_list.append([src, dst])
 
-            src = os.path.join(self.task_config.DATA, f"ice.ens_weights.incr.{window_middle_iso}.nc")
+            src = os.path.join(self.task_config.DATA, f"ice.ens_weights.incr.{window_middle_iso}.nc") 
             dst = os.path.join(self.task_config.COMOUT_ICE_BMATRIX,
                                f"{APREFIX}ice.ens_weights.nc")
+
             weight_list.append([src, dst])
 
             # Copy the ssh diagnostics
-            for string in ['ssh_steric_stddev', 'ssh_unbal_stddev', 'ssh_total_stddev', 'steric_explained_variance']:
+            for string in ['ssh_steric_stddev', 'ssh_unbal_stddev', 'ssh_total_stddev', 'steric_explained_variance']: 
                 weight_list.append([os.path.join(self.task_config.DATA, 'staticb', f'ocn.{string}.incr.{window_begin_iso}.nc'),
                                     os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX, f'{APREFIX}ocean.{string}.nc')])
 
@@ -296,3 +310,23 @@ class MarineBMat(Task):
                                 f"{APREFIX}{os.path.basename(yaml_file)}")
             yaml_list.append([yaml_file, dest])
         FileHandler({'copy': yaml_list}).sync()
+
+
+def rename_file(dst):
+    # Correct the name of the output file 
+
+    dst_path_file = dst.rpartition("/")  # gives path+file    
+    fname = dst_path_file[-1]
+    the_path = dst_path_file[0]
+    
+    delimiter = "."  # fix quotes
+    parts = fname.split(delimiter)
+
+    if 1 < len(parts) and 0 <= 2 < len(parts):
+        parts[1], parts[2] = parts[2], parts[1]
+        new_fname = delimiter.join(parts)
+        new_dst = the_path + "/" + new_fname
+
+        return new_dst
+    else:
+        return "Incorrect file name specification"

--- a/ush/python/pygfs/task/marine_bmat.py
+++ b/ush/python/pygfs/task/marine_bmat.py
@@ -64,7 +64,6 @@ class MarineBMat(Task):
                 'MARINE_WINDOW_LENGTH': f"PT{self.task_config['assim_freq']}H",
                 'ENSPERT_RELPATH': _enspert_relpath,
                 'CALC_SCALE_EXEC': _calc_scale_exec,
-                'APREFIX': f"{self.task_config.RUN}.t{self.task_config.cyc:02d}z.",
                 'APREFIX_OCEAN': f"{self.task_config.RUN}.ocean.t{self.task_config.cyc:02d}z.",
                 'APREFIX_ICE': f"{self.task_config.RUN}.ice.t{self.task_config.cyc:02d}z.",
                 'MOM6_LEVS': mdau.get_mom6_levels(str(self.task_config.OCNRES))
@@ -217,7 +216,6 @@ class MarineBMat(Task):
         None
         """
 
-        APREFIX = self.task_config.APREFIX
         APREFIX_OCEAN = self.task_config.APREFIX_OCEAN
         APREFIX_ICE = self.task_config.APREFIX_ICE
 
@@ -298,7 +296,7 @@ class MarineBMat(Task):
             # Copy the ssh diagnostics
             for string in ['ssh_steric_stddev', 'ssh_unbal_stddev', 'ssh_total_stddev', 'steric_explained_variance']:
                 weight_list.append([os.path.join(self.task_config.DATA, 'staticb', f'ocn.{string}.incr.{window_begin_iso}.nc'),
-                                    os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX, f'{APREFIX}ocean.{string}.nc')])
+                                    os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX, f'{APREFIX_OCEAN}{string}.nc')])
 
             FileHandler({'copy': weight_list}).sync()
 
@@ -307,6 +305,6 @@ class MarineBMat(Task):
         yaml_list = []
         for yaml_file in yamls:
             dest = os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX,
-                                f"{APREFIX}{os.path.basename(yaml_file)}")
+                                f"{APREFIX_OCEAN}{os.path.basename(yaml_file)}")
             yaml_list.append([yaml_file, dest])
         FileHandler({'copy': yaml_list}).sync()

--- a/ush/python/pygfs/task/marine_bmat.py
+++ b/ush/python/pygfs/task/marine_bmat.py
@@ -65,6 +65,8 @@ class MarineBMat(Task):
                 'ENSPERT_RELPATH': _enspert_relpath,
                 'CALC_SCALE_EXEC': _calc_scale_exec,
                 'APREFIX': f"{self.task_config.RUN}.t{self.task_config.cyc:02d}z.",
+                'APREFIX_OCEAN': f"{self.task_config.RUN}.ocean.t{self.task_config.cyc:02d}z.",
+                'APREFIX_ICE': f"{self.task_config.RUN}.ice.t{self.task_config.cyc:02d}z.",
                 'MOM6_LEVS': mdau.get_mom6_levels(str(self.task_config.OCNRES))
             }
         )
@@ -216,6 +218,8 @@ class MarineBMat(Task):
         """
 
         APREFIX = self.task_config.APREFIX
+        APREFIX_OCEAN = self.task_config.APREFIX_OCEAN
+        APREFIX_ICE = self.task_config.APREFIX_ICE
 
         window_begin_iso = self.task_config.MARINE_WINDOW_BEGIN.strftime('%Y-%m-%dT%H:%M:%SZ')
         window_middle_iso = self.task_config.MARINE_WINDOW_MIDDLE.strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -234,9 +238,8 @@ class MarineBMat(Task):
         for diff_type in ['hz', 'vt']:
             src = os.path.join(self.task_config.DATAstaticb, f"{diff_type}_ocean.nc")
             dest = os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX,
-                                f"{APREFIX}{diff_type}_ocean.nc")
-            dest = rename_file( dest )  # correct the file name
-            
+                                f"{APREFIX_OCEAN}{diff_type}.nc")
+
             diffusion_coeff_list.append([src, dest])
 
         FileHandler({'copy': diffusion_coeff_list}).sync()
@@ -246,37 +249,35 @@ class MarineBMat(Task):
         diagb_list = []
 
         # TODO(AFE) the two renames are to accomodate yaml settings in var task, which should changed
+        # ocean diag B
         os.rename(os.path.join(self.task_config.DATAstaticb, f"ocn.bkgerr_stddev.incr.{window_end_iso}.nc"),
                   os.path.join(self.task_config.DATAstaticb, f"ocn.bkgerr_stddev.nc"))
+
         src = os.path.join(self.task_config.DATAstaticb, f"ocn.bkgerr_stddev.nc")
-        
-        dst = os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX, f"{APREFIX}ocean.bkgerr_ens_stddev.nc")  
-        dst = rename_file( dst )  # correct the file name
-        
+        dst = os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX, f"{APREFIX_OCEAN}bkgerr_ens_stddev.nc")
+
         diagb_list.append([src, dst])
+        # ice diag B
 
         os.rename(os.path.join(self.task_config.DATAstaticb, f"ice.bkgerr_stddev.incr.{window_end_iso}.nc"),
                   os.path.join(self.task_config.DATAstaticb, f"ice.bkgerr_stddev.nc"))
-                               
+
         src = os.path.join(self.task_config.DATAstaticb, f"ice.bkgerr_stddev.nc")
-        dst = os.path.join(self.task_config.COMOUT_ICE_BMATRIX, f"{APREFIX}ice.bkgerr_ens_stddev.nc")
-        dst = rename_file( dst ) # correct the file name
+        dst = os.path.join(self.task_config.COMOUT_ICE_BMATRIX, f"{APREFIX_ICE}bkgerr_ens_stddev.nc")
 
         diagb_list.append([src, dst])
 
         if self.task_config.DOHYBVAR_OCN == "YES" or self.task_config.NMEM_ENS >= 2:
-            src = os.path.join(self.task_config.DATAstaticb, f"ocn.ssh_recentering_error.incr.{window_begin_iso}.nc") 
-            dst = os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX, f"{APREFIX}ocean.recentering_error.nc")
-            dst = rename_file( dst )  # correct the file name
+            src = os.path.join(self.task_config.DATAstaticb, f"ocn.ssh_recentering_error.incr.{window_begin_iso}.nc")
+            dst = os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX, f"{APREFIX_OCEAN}recentering_error.nc")
 
             diagb_list.append([src, dst])
-            
+
             src = os.path.join(self.task_config.DATAstaticb, f"ice.ssh_recentering_error.incr.{window_begin_iso}.nc")
-            dst = os.path.join(self.task_config.COMOUT_ICE_BMATRIX, f"{APREFIX}ice.recentering_error.nc")
-            dst = rename_file( dst )  # correct the file name
-            
+            dst = os.path.join(self.task_config.COMOUT_ICE_BMATRIX, f"{APREFIX_ICE}recentering_error.nc")
+
             diagb_list.append([src, dst])
-            
+
         FileHandler({'copy': diagb_list}).sync()
 
         # Copy the ensemble perturbation diagnostics to the ROTDIR
@@ -284,19 +285,18 @@ class MarineBMat(Task):
             weight_list = []
             src = os.path.join(self.task_config.DATA, f"ocn.ens_weights.incr.{window_middle_iso}.nc")
             dst = os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX,
-                               f"{APREFIX}ocean.ens_weights.nc")
-            dst = rename_file( dst )  # correct the file name
+                               f"{APREFIX_OCEAN}ens_weights.nc")
 
             weight_list.append([src, dst])
 
-            src = os.path.join(self.task_config.DATA, f"ice.ens_weights.incr.{window_middle_iso}.nc") 
+            src = os.path.join(self.task_config.DATA, f"ice.ens_weights.incr.{window_middle_iso}.nc")
             dst = os.path.join(self.task_config.COMOUT_ICE_BMATRIX,
-                               f"{APREFIX}ice.ens_weights.nc")
+                               f"{APREFIX_ICE}ens_weights.nc")
 
             weight_list.append([src, dst])
 
             # Copy the ssh diagnostics
-            for string in ['ssh_steric_stddev', 'ssh_unbal_stddev', 'ssh_total_stddev', 'steric_explained_variance']: 
+            for string in ['ssh_steric_stddev', 'ssh_unbal_stddev', 'ssh_total_stddev', 'steric_explained_variance']:
                 weight_list.append([os.path.join(self.task_config.DATA, 'staticb', f'ocn.{string}.incr.{window_begin_iso}.nc'),
                                     os.path.join(self.task_config.COMOUT_OCEAN_BMATRIX, f'{APREFIX}ocean.{string}.nc')])
 
@@ -310,23 +310,3 @@ class MarineBMat(Task):
                                 f"{APREFIX}{os.path.basename(yaml_file)}")
             yaml_list.append([yaml_file, dest])
         FileHandler({'copy': yaml_list}).sync()
-
-
-def rename_file(dst):
-    # Correct the name of the output file 
-
-    dst_path_file = dst.rpartition("/")  # gives path+file    
-    fname = dst_path_file[-1]
-    the_path = dst_path_file[0]
-    
-    delimiter = "."  # fix quotes
-    parts = fname.split(delimiter)
-
-    if 1 < len(parts) and 0 <= 2 < len(parts):
-        parts[1], parts[2] = parts[2], parts[1]
-        new_fname = delimiter.join(parts)
-        new_dst = the_path + "/" + new_fname
-
-        return new_dst
-    else:
-        return "Incorrect file name specification"


### PR DESCRIPTION
# Description

All ocean and ice output file names should be standardized as per the COM inventory spreadsheet, in accordance with NCO guidelines #1522.  Other than filenames, the marine output will be identical to before.
 
 Resolves #3272

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [X] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics

- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? YES
- Does this change require an update to any of the following submodules? NO 
  
# How has this been tested?
In process of being tested on Hera


# Checklist
- [ ] Any dependent changes have been merged and published
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
