### PR TITLE
Fix marine LETKF archiving

### DIFF
--- a/parm/archive/enkf_marine_grp.yaml.j2
+++ b/parm/archive/enkf_marine_grp.yaml.j2
@@ -28,7 +28,9 @@ enkf_marine_grp:
         {% set anl_delta = "-3H" | to_timedelta %}
         {% set anl_time = current_cycle | add_to_datetime(anl_delta) %}
         - "{{ COMIN_OCEAN_ANALYSIS_MEM | relpath(ROTDIR) }}/{{ head }}ocninc.nc"
-        - "{{ COMIN_OCEAN_LETKF_MEM | relpath(ROTDIR) }}/{{ head_ocean }}analysis.nc"
         - "{{ COMIN_ICE_ANALYSIS_MEM | relpath(ROTDIR) }}/{{ anl_time | to_YMD }}.{{ anl_time | strftime("%H") }}0000.cice_model_anl.res.nc"
+        {% if DOLETKF_OCN %}
+        - "{{ COMIN_OCEAN_LETKF_MEM | relpath(ROTDIR) }}/{{ head_ocean }}analysis.nc"
         - "{{ COMIN_ICE_LETKF_MEM | relpath(ROTDIR) }}/{{ head_ice }}analysis.nc"
+        {% endif %}
         {% endfor %}  # first_group_mem to last_group_mem

--- a/scripts/exgdas_enkf_earc_tars.py
+++ b/scripts/exgdas_enkf_earc_tars.py
@@ -28,7 +28,7 @@ def main():
             'DOHYBVAR', 'DOIAU_ENKF', 'IAU_OFFSET', 'DOIAU', 'DO_CA',
             'DO_CALC_INCREMENT', 'assim_freq', 'ARCH_CYC', 'DO_JEDISNOWDA',
             'ARCH_WARMICFREQ', 'ARCH_FCSTICFREQ', 'DOHYBVAR_OCN',
-            'IAUFHRS_ENKF', 'NET', 'NMEM_ENS_GFS']
+            'DOLETKF_OCN', 'IAUFHRS_ENKF', 'NET', 'NMEM_ENS_GFS']
 
     archive_dict = AttrDict()
     for key in keys:


### PR DESCRIPTION
# Description
This wraps files generated by the marine LETKF job in `DOLETKF_OCN` during archiving to prevent attempting to grab files that do not exist.

Resolves https://github.com/NOAA-EMC/global-workflow/issues/3627

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Tested on Hercules with local archiving for a C96C48mx500_S2SW_cyc_gfs case with DOLETKF_OCN=NO and DOLETKF_OCN=YES.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [X] This change is covered by an existing CI test or a new one has been added