### PR TITLE
Update operational GFS version to v16.3.24 in index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Status
 ======
 
 * State of develop (HEAD) branch: GFSv17+ development
-* State of operations (dev/gfs.v16 branch): GFS v16.3.13 `tag: [gfs.v16.3.13] <https://github.com/NOAA-EMC/global-workflow/releases/tag/gfs.v16.3.13>`_
+* State of operations (dev/gfs.v16 branch): GFS v16.3.24 `tag: [gfs.v16.3.24] <https://github.com/NOAA-EMC/global-workflow/releases/tag/gfs.v16.3.24>`_
 
 =============
 Code managers


### PR DESCRIPTION
# Description

This PR updates the operational GFS version noted within the Read-The-Docs front page. The version is now v16.3.24.

Resolves #3590

# Type of change

Documentation update

# Change characteristics

- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? YES
- Does this change require an update to any of the following submodules? NO

# How has this been tested?

N/A