### PR TITLE
Hotfix increasing the delay in repeatedly calling Rocoto in rocotostat.py

### DIFF
--- a/dev/ci/scripts/utils/rocotostat.py
+++ b/dev/ci/scripts/utils/rocotostat.py
@@ -102,7 +102,7 @@ def rocotostat_summary(rocotostat):
     """
     rocotostat = copy.deepcopy(rocotostat)
     rocotostat.add_default_arg('--summary')
-    rocotostat_output = attempt_multiple_times(lambda: rocotostat(output=str), 3, 90, ProcessError)
+    rocotostat_output = attempt_multiple_times(lambda: rocotostat(output=str), 3, 120, ProcessError)
     rocotostat_output = rocotostat_output.splitlines()[1:]
     rocotostat_output = [line.split()[0:2] for line in rocotostat_output]
 


### PR DESCRIPTION
# Description
This quick hotfix reduces the delay between recalling rocoto utilities in rocotocheck.py
We have been experiencing limited resources available when spawning process from running Rocoto utilities on Hera.

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO