### PR TITLE
Add ecen dependency for enkfgfs when running ocean variational DA

### DIFF
--- a/dev/workflow/rocoto/gfs_tasks.py
+++ b/dev/workflow/rocoto/gfs_tasks.py
@@ -2918,6 +2918,8 @@ class GFSTasks(Tasks):
             dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
         else:  # early cycle enkf run (enkfgfs)
             dep_dict = {'type': 'task', 'name': f'{self.run}_esfc'}
+            if self.options['do_jediocnvar']:
+                dep_dict = {'type': 'metatask', 'name': f'{self.run}_ecmn'}
             deps.append(rocoto.add_dependency(dep_dict))
             dependencies = rocoto.create_dependency(dep=deps)
 


### PR DESCRIPTION
# Description
This adds a dependency for the ecen metatask on enkfgfs archiving when running ocean variational DA to prevent a race condition.

Resolves https://github.com/NOAA-EMC/global-workflow/issues/3627

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
It has not yet been tested.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added