### PR TITLE
Disable restart archiving for enkfgfs RUNs

### DIFF
--- a/parm/archive/enkf.yaml.j2
+++ b/parm/archive/enkf.yaml.j2
@@ -3,7 +3,7 @@ enkf:
     target: "{{ ATARDIR }}/{{ cycle_YMDH }}/{{ RUN }}.tar"
     required:
         # Logs
-        {% if RUN == 'enkfgdas' %}
+        {% if is_gdas %}
         {% for mem in range(1, nmem_ens + 1) %}
         - "logs/{{ cycle_YMDH }}/{{ RUN }}_fcst_mem{{ '%03d' % mem }}.log"
         {% endfor %}
@@ -40,7 +40,7 @@ enkf:
         {% endfor %}
 
         # Ensemble mean and spread
-        {% if RUN == 'enkfgdas' %}
+        {% if is_gdas %}
         {% for fhr in range(3, fhmax + 1, 3) %}
         - "{{ COMIN_ATMOS_HISTORY_ENSSTAT | relpath(ROTDIR) }}/{{ head }}atmf{{ '%03d' % fhr }}.ensmean.nc"
         - "{{ COMIN_ATMOS_HISTORY_ENSSTAT | relpath(ROTDIR) }}/{{ head }}sfcf{{ '%03d' % fhr }}.ensmean.nc"

--- a/parm/archive/enkf_grp.yaml.j2
+++ b/parm/archive/enkf_grp.yaml.j2
@@ -10,7 +10,7 @@ enkf_grp:
         {% set COMIN_ATMOS_RESTART_MEM = COMIN_ATMOS_RESTART_MEM_list[imem] %}
 
         # Forecast data
-        {% if RUN == 'enkfgdas' %}
+        {% if is_gdas %}
         {% for fhr in range(3, 10, 3) %}
         - "{{ COMIN_ATMOS_HISTORY_MEM | relpath(ROTDIR) }}/{{ head }}atmf{{ "%03d" % fhr }}.nc"
         {% endfor %}

--- a/parm/archive/enkf_marine_grp.yaml.j2
+++ b/parm/archive/enkf_marine_grp.yaml.j2
@@ -14,7 +14,7 @@ enkf_marine_grp:
 
 
         # Forecast data
-        {% if RUN == 'enkfgdas' %}
+        {% if is_gdas %}
         {% for fhr in range(3, 10, 3) %}
         - "{{ COMIN_OCEAN_HISTORY_MEM | relpath(ROTDIR) }}/{{ head_ocean }}inst.f{{ "%03d" % fhr }}.nc"
         {% endfor %}

--- a/parm/archive/enkf_restartb_grp.yaml.j2
+++ b/parm/archive/enkf_restartb_grp.yaml.j2
@@ -22,7 +22,7 @@ enkf_restartb_grp:
         {% endfor %}
 
         # Now get the restart files.
-        {% if RUN == 'enkfgdas' %}
+        {% if is_gdas %}
         {% for r_time in range(restart_interval, fhmax + 1, restart_interval) %}
         {% set r_timedelta = (r_time | string + "H") | to_timedelta %}
         {% set r_dt = current_cycle | add_to_datetime(r_timedelta) %}

--- a/parm/archive/master_enkf.yaml.j2
+++ b/parm/archive/master_enkf.yaml.j2
@@ -3,6 +3,7 @@
 {% set cycle_YMD = current_cycle | to_YMD %}
 {% set cycle_YMDH = current_cycle | to_YMDH %}
 {% set head = RUN + ".t" + cycle_HH + "z." %}
+# TODO Should enkfgdas be replaced with RUN?
 {% set head_ocean = "enkfgdas.ocean.t" + cycle_HH + "z." %}
 {% set head_ice = "enkfgdas.ice.t" + cycle_HH + "z." %}
 
@@ -92,7 +93,7 @@ datasets:
     # Save the increments and restarts every ARCH_WARMICFREQ days
     # The ensemble increments (group a) should be saved on the ARCH_CYC
     # The forecasts are only run for enkfgdas RUNs, so skip for enkfgfs
-    {% if (current_cycle - SDATE).days % ARCH_WARMICFREQ == 0 and "gdas" in RUN %}
+    {% if (current_cycle - SDATE).days % ARCH_WARMICFREQ == 0 and is_gdas %}
         {% if ARCH_CYC == cycle_HH | int %}
             {% filter indent(width=4) %}
 {% include "enkf_restarta_grp.yaml.j2" %}
@@ -102,7 +103,7 @@ datasets:
 
     # The ensemble ICs (group b) are restarts and always lag increments by assim_freq
     {% set ics_offset = (assim_freq | string + "H") | to_timedelta %}
-    {% if (current_cycle | add_to_datetime(ics_offset) - SDATE).days % ARCH_WARMICFREQ == 0 and "gdas" in RUN %}
+    {% if (current_cycle | add_to_datetime(ics_offset) - SDATE).days % ARCH_WARMICFREQ == 0 and is_gdas %}
         {% if (ARCH_CYC - assim_freq) % 24 == cycle_HH | int %}
             {% filter indent(width=4) %}
 {% include "enkf_restartb_grp.yaml.j2" %}

--- a/parm/archive/master_enkf.yaml.j2
+++ b/parm/archive/master_enkf.yaml.j2
@@ -91,7 +91,8 @@ datasets:
 
     # Save the increments and restarts every ARCH_WARMICFREQ days
     # The ensemble increments (group a) should be saved on the ARCH_CYC
-    {% if (current_cycle - SDATE).days % ARCH_WARMICFREQ == 0 %}
+    # The forecasts are only run for enkfgdas RUNs, so skip for enkfgfs
+    {% if (current_cycle - SDATE).days % ARCH_WARMICFREQ == 0 and "gdas" in RUN %}
         {% if ARCH_CYC == cycle_HH | int %}
             {% filter indent(width=4) %}
 {% include "enkf_restarta_grp.yaml.j2" %}
@@ -101,7 +102,7 @@ datasets:
 
     # The ensemble ICs (group b) are restarts and always lag increments by assim_freq
     {% set ics_offset = (assim_freq | string + "H") | to_timedelta %}
-    {% if (current_cycle | add_to_datetime(ics_offset) - SDATE).days % ARCH_WARMICFREQ == 0 %}
+    {% if (current_cycle | add_to_datetime(ics_offset) - SDATE).days % ARCH_WARMICFREQ == 0 and "gdas" in RUN %}
         {% if (ARCH_CYC - assim_freq) % 24 == cycle_HH | int %}
             {% filter indent(width=4) %}
 {% include "enkf_restartb_grp.yaml.j2" %}

--- a/parm/archive/master_enkfgdas.yaml.j2
+++ b/parm/archive/master_enkfgdas.yaml.j2
@@ -3,4 +3,6 @@
 {% set do_calc_increment = DO_CALC_INCREMENT %}
 {% set nmem_ens = NMEM_ENS %}
 {% set restart_interval = restart_interval_enkfgdas %}
+{% set is_gdas = True %}
+{% set is_gfs = False %}
 {% include "master_enkf.yaml.j2" %}

--- a/parm/archive/master_enkfgfs.yaml.j2
+++ b/parm/archive/master_enkfgfs.yaml.j2
@@ -3,4 +3,6 @@
 {% set do_calc_increment = DO_CALC_INCREMENT_ENKF_GFS %}
 {% set nmem_ens = NMEM_ENS_GFS %}
 {% set restart_interval = restart_interval_enkfgfs %}
+{% set is_gdas = False %}
+{% set is_gfs = True %}
 {% include "master_enkf.yaml.j2" %}


### PR DESCRIPTION
# Description
This disables restart archiving for `enkfgfs`.  Forecasts are not executed during the early cycle ensemble, so they should not be archived.

Resolves #3627 

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
enkfgfs archiving test on C6

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added