### PR TITLE
bug fix for IAU: move restart frequency calculation

### DIFF
--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -856,6 +856,7 @@ GOCART_out() {
   done
 }
 
+# shellcheck disable=SC2178
 CMEPS_postdet() {
   echo "SUB ${FUNCNAME[0]}: Linking output data for CMEPS mediator"
 
@@ -892,6 +893,37 @@ CMEPS_postdet() {
     fi
 
   fi  # [[ "${warm_start}" == ".true." ]];
+
+  # For CMEPS, CICE, MOM6 and WW3 determine restart writes
+  # Note FV3 has its own restart intervals
+  cmeps_restart_interval=${restart_interval:-${FHMAX}}
+  # restart_interval = 0 implies write restart at the END of the forecast i.e. at FHMAX
+  # Convert restart interval into an explicit list for CMEPS/CICE/MOM6/WW3
+  # Note, this must be computed after determination IAU in forecast_det and fhrot.
+  if (( cmeps_restart_interval == 0 )); then
+    if [[ "${DOIAU:-NO}" == "YES" ]]; then
+      CMEPS_RESTART_FH=$(( FHMAX + half_window ))
+    else
+      CMEPS_RESTART_FH=("${FHMAX}")
+    fi
+  else
+    if [[ "${DOIAU:-NO}" == "YES" ]]; then
+      if [[ "${MODE}" = "cycled" && "${SDATE}" = "${PDY}${cyc}" && ${EXP_WARM_START} = ".false." ]]; then
+         local restart_interval_start=${cmeps_restart_interval}
+         local restart_interval_end=${FHMAX}
+      else
+         local restart_interval_start=$(( cmeps_restart_interval + half_window ))
+         local restart_interval_end=$(( FHMAX + half_window ))
+      fi
+    else
+      local restart_interval_start=${cmeps_restart_interval}
+      local restart_interval_end=${FHMAX}
+    fi
+    CMEPS_RESTART_FH="$(seq -s ' ' "${restart_interval_start}" "${cmeps_restart_interval}" "${restart_interval_end}")"
+  fi
+  export CMEPS_RESTART_FH
+  # TODO: For GEFS, once cycling waves "self-cycles" and therefore needs to have a restart at 6 hour
+
 }
 
 CMEPS_out() {

--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -732,35 +732,6 @@ CMEPS_predet(){
 
   if [[ ! -d "${DATArestart}/CMEPS_RESTART" ]]; then mkdir -p "${DATArestart}/CMEPS_RESTART"; fi
   ${NLN} "${DATArestart}/CMEPS_RESTART" "${DATA}/CMEPS_RESTART"
-
-  # For CMEPS, CICE, MOM6 and WW3 determine restart writes
-  # Note FV3 has its own restart intervals
-  cmeps_restart_interval=${restart_interval:-${FHMAX}}
-  # restart_interval = 0 implies write restart at the END of the forecast i.e. at FHMAX
-  # Convert restart interval into an explicit list for FV3
-  if (( cmeps_restart_interval == 0 )); then
-    if [[ "${DOIAU:-NO}" == "YES" ]]; then
-      CMEPS_RESTART_FH=$(( FHMAX + half_window ))
-    else
-      CMEPS_RESTART_FH=("${FHMAX}")
-    fi
-  else
-    if [[ "${DOIAU:-NO}" == "YES" ]]; then
-      if [[ "${MODE}" = "cycled" && "${SDATE}" = "${PDY}${cyc}" && ${EXP_WARM_START} = ".false." ]]; then
-         local restart_interval_start=${cmeps_restart_interval}
-         local restart_interval_end=${FHMAX}
-      else
-         local restart_interval_start=$(( cmeps_restart_interval + half_window ))
-         local restart_interval_end=$(( FHMAX + half_window ))
-      fi
-    else
-      local restart_interval_start=${cmeps_restart_interval}
-      local restart_interval_end=${FHMAX}
-    fi
-    CMEPS_RESTART_FH="$(seq -s ' ' "${restart_interval_start}" "${cmeps_restart_interval}" "${restart_interval_end}")"
-  fi
-  export CMEPS_RESTART_FH
-  # TODO: For GEFS, once cycling waves "self-cycles" and therefore needs to have a restart at 6 hour
 }
 
 # shellcheck disable=SC2034


### PR DESCRIPTION
<!--
  *** PLEASE READ ***

  Any PRs not following this template will be closed.

  Please delete all these comments before submitting the PR.

  Please use a short (<60 char), descriptive title for the PR title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

  No content should appear above the "Description" header.

  If this PR is not merge-ready (e.g. it depends on other PRs not yet merged), please mark it as draft until it is ready.

  PRs should meet these guidelines:
  - Each PR should address ONE topic and have an associated issue.
  - No hard-coded paths or personal directories.
  - No temporary or backup files should be committed (including logs).
  - Any code that you disabled by being commented out should be removed or reenabled.
-->
# Description
<!-- This description will become the commit message for the PR. -->
<!--
  Solely pointing to an issue is not an adequate description!

  Please use this format for your description:

  Describe your changes. Focus on the *what* and *why*. The *how* will be evident from the changes. In particular, be sure to note any interface changes, such as command line syntax, that will need to be communicated to users.

  At the end of your description, please be sure to add the issue this PR solves using the word "Resolves". If there are any issues that are related but not yet resolved (including in other repos), you may use "Refs".

  Resolves #1234
  Refs #4321
  Refs NOAA-EMC/repo#5678
-->

This PR provides a bug fix for #3611 in which it has been found in several cases for the restart output times to be out of sync between the marine components and atmosphere.  One reason is that the creation of the array for restart output times occurred in forecast_predet.sh but it used the "DO_IAU" variable as a trigger.  However, "DO_IAU" value can change in forecast_det if it is a restart run.   Therefore, I have moved the calculation to forecast_postdet and this showed tests like the extended S2SW test properly started from the segment time instead of restarting at the beginning.  

Resolves https://github.com/NOAA-EMC/global-workflow/issues/3611

This bugfix has been separated after originally being in PR https://github.com/NOAA-EMC/global-workflow/pull/3670 


<!-- For more on writing good commit messages, see https://cbea.ms/git-commit/ -->

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
- The S2SW extended test, ensuring that we restarted from the segement.  This test was with #3670 On WCOSS2 the dev/ci/cases/pr/C48_S2SW_extended test was run. Output is here:
/lfs/h2/emc/couple/noscrub/jessica.meixner/testwavedownstream_20250508/C48_S2SW_extended

Current tests requested by code managers underway: 
- A full test of the regression tests on one platform are underway. 
- Additionally I will run 1 test where I force a test to quit half-way through a run and then do a re-run and save the directory output for 
- Any other requested test (please leave comments). 

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
