### PR TITLE
replace 2014-2023 MERRA2 climatology with updated 6 year mean with time frame update automatically

### DIFF
--- a/ush/forecast_predet.sh
+++ b/ush/forecast_predet.sh
@@ -531,10 +531,20 @@ FV3_predet(){
 
   ## merra2 aerosol climo
   if (( IAER == 1011 )); then
-    local month mm
+    year=${current_cycle:0:4}
+    for i in {1980..2300..5}
+    do
+      if [ $year -le $i ]
+      then
+        Eyear=$(printf %04d "${i}")
+        Syear=$(($i-5))
+        break
+      fi
+    done
+#   local month mm
     for (( month = 1; month <=12; month++ )); do
       mm=$(printf %02d "${month}")
-      cpreq "${FIXgfs}/aer/merra2.aerclim.2014-2023.m${mm}.nc" "aeroclim.m${mm}.nc"
+      ${NCP} "/lfs/h2/emc/physics/noscrub/anning.cheng/MERRA2_6ym/y${Syear}-${Eyear}/merra2_${Syear}-${Eyear}_${mm}.nc" "aeroclim.m${mm}.nc"
     done
   fi
 


### PR DESCRIPTION
# Description
Replace 2014-2023 mean merra2 climatology with 6 year mean with time frame updated automatically from 1980 to now. The new update will give more realistic aerosol forcing for retrospective or back forecast tests. 

This PR use most updated aerosol for retrospective runs. for example, the old runs use 2014-2023 mean  aerosol for 2012 year runs. The new one uses 2010-2015 mean aerosol for 2012 year tests. A more realistic results should be obtained. 

# Type of change
- [ ] Bug fix (fixes something broken)
- [X] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? YES/NO (If YES, please add a link to any PRs that are pending.) None of them below
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
- Forecast-only on WCOSS

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [X] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary