### PR TITLE
Add CHGRP_RSTPROD check to exglobal_diag.sh

### DIFF
--- a/scripts/exglobal_diag.sh
+++ b/scripts/exglobal_diag.sh
@@ -221,14 +221,16 @@ EOFdiag
    fi
 
    # Restrict diagnostic files containing rstprod data
-   rlist="conv_gps conv_ps conv_pw conv_q conv_sst conv_t conv_uv saphir"
-   for rtype in ${rlist}; do
-      for rfile in *"${rtype}"*; do
-         if [[ -s "${rfile}" ]]; then
-            ${CHGRP_CMD} "${rfile}"
-         fi
+   if [[ "${CHGRP_RSTPROD}" == "YES" ]]; then
+      rlist="conv_gps conv_ps conv_pw conv_q conv_sst conv_t conv_uv saphir"
+      for rtype in ${rlist}; do
+         for rfile in *"${rtype}"*; do
+            if [[ -s "${rfile}" ]]; then
+               ${CHGRP_CMD} "${rfile}"
+            fi
+         done
       done
-   done
+   fi
 
    # If requested, create diagnostic file tarballs
    if [[ ${DIAG_TARBALL} == "YES" ]]; then
@@ -251,11 +253,15 @@ EOFdiag
 
       # Restrict CNVSTAT
       chmod 750 "${CNVSTAT}"
-      ${CHGRP_CMD} "${CNVSTAT}"
+      if [[ "${CHGRP_RSTPROD}" == "YES" ]]; then
+         ${CHGRP_CMD} "${CNVSTAT}"
+      fi
 
       # Restrict RADSTAT
       chmod 750 "${RADSTAT}"
-      ${CHGRP_CMD} "${RADSTAT}"
+      if [[ "${CHGRP_RSTPROD}" == "YES" ]]; then
+         ${CHGRP_CMD} "${RADSTAT}"
+      fi
 
       echo "$(date) END tar diagnostic files" >&2
    fi


### PR DESCRIPTION
<!--
  *** PLEASE READ ***

  Any PRs not following this template will be closed.

  Please delete all these comments before submitting the PR.

  Please use a short (<60 char), descriptive title for the PR title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

  No content should appear above the "Description" header.

  If this PR is not merge-ready (e.g. it depends on other PRs not yet merged), please mark it as draft until it is ready.

  PRs should meet these guidelines:
  - Each PR should address ONE topic and have an associated issue.
  - No hard-coded paths or personal directories.
  - No temporary or backup files should be committed (including logs).
  - Any code that you disabled by being commented out should be removed or reenabled.
-->
# Description
<!-- This description will become the commit message for the PR. -->
<!--
  Solely pointing to an issue is not an adequate description!

  Please use this format for your description:

  Describe your changes. Focus on the *what* and *why*. The *how* will be evident from the changes. In particular, be sure to note any interface changes, such as command line syntax, that will need to be communicated to users.

  At the end of your description, please be sure to add the issue this PR solves using the word "Resolves". If there are any issues that are related but not yet resolved (including in other repos), you may use "Refs".

  Resolves #1234
  Refs #4321
  Refs NOAA-EMC/repo#5678
-->
<!-- For more on writing good commit messages, see https://cbea.ms/git-commit/ -->

This PR adds if blocks to check `CHGRP_RSTPROD` before attempting `chgrp rstprod` in `scripts/exglobal_diag.sh`. This is needed for the cloud where `CHGRP_RSTPROD` is set to `'NO'` since the `rstprod` group is not yet supported. 

Resolves #3774  

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO (If YES, please add a link to any PRs that are pending.)

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->

Ran `gdas_analdaig` job within `C96_atm3DVar` test on cloud (where `CHGRP_RSTPROD='NO'`) and on Hera (where `CHGRP_RSTPROD='YES'`).

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
