### PR TITLE
If merged, this PR will Remove a blank string that is causing  exglobal_cleanup.sh to crash

### DIFF
--- a/scripts/exglobal_cleanup.sh
+++ b/scripts/exglobal_cleanup.sh
@@ -24,6 +24,7 @@ fi
 last_date=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} -${RMOLDEND:-24} hours")
 first_date=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} -${RMOLDSTD:-120} hours")
 last_rtofs=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} -${RMOLDRTOFS:-48} hours")
+
 function remove_files() {
     local directory=$1
     shift
@@ -33,37 +34,32 @@ function remove_files() {
         return
     fi
 
-    local find_exclude_string=""
+    local find_args=()
 
-    # Build the exclusion clause
-    for exclude in "$@"; do
-        [[ -n "$exclude" ]] && find_exclude_string+=" -name \"$exclude\" -or"
-    done
+    if [[ "$#" -gt 0 ]]; then
+        find_args+=( \( )
+        local first=1
+        for exclude in "$@"; do
+            if [[ -n "$exclude" ]]; then
+                [[ $first -eq 0 ]] && find_args+=( -or )
+                find_args+=( -name "$exclude" )
+                first=0
+            fi
+        done
+        find_args+=( \) )
+    fi
 
-    # Remove trailing -or if it exists
-    find_exclude_string="${find_exclude_string% -or}"
-
-    # Print for debugging
-    echo "DEBUG: directory = '${directory}'"
-    echo "DEBUG: find_exclude_string = ${find_exclude_string}"
-
-    if [[ -n "$find_exclude_string" ]]; then
-        # shellcheck disable=SC2086
-        eval find "${directory}" -type f -not \( ${find_exclude_string} \) -ignore_readdir_race -delete
-        eval find "${directory}" -type l -not \( ${find_exclude_string} \) -ignore_readdir_race -delete
+    if [[ "${#find_args[@]}" -gt 0 ]]; then
+        find "${directory}" -type f -not "${find_args[@]}" -ignore_readdir_race -delete
+        find "${directory}" -type l -not "${find_args[@]}" -ignore_readdir_race -delete
     else
         echo "WARNING: No exclusion patterns provided. Deleting all files and symlinks in ${directory}."
         find "${directory}" -type f -ignore_readdir_race -delete
         find "${directory}" -type l -ignore_readdir_race -delete
     fi
 
-    # Always remove empty directories
     find "${directory}" -type d -empty -delete
 }
-
-
-# Always remove empty directories
-
 
 for (( current_date=first_date; current_date <= last_date; \
   current_date=$(date --utc +%Y%m%d%H -d "${current_date:0:8} ${current_date:8:2} +${assim_freq} hours") )); do
@@ -81,7 +77,7 @@ for (( current_date=first_date; current_date <= last_date; \
                 IFS=", " read -r -a exclude_list <<< "${exclude_string:-}"
                 remove_files "${COMOUT_TOP}" "${exclude_list[@]:-}"
             fi
-            if [[ -d "${rtofs_dir}" ]] && (( current_date < last_rtofs )); then rm -rf "${rtofs_dir}" ; fi
+            if [[ -d "${rtofs_dir}" ]] && (( current_date < last_rtofs )); then rm -rf "${rtofs_dir}"; fi
         fi
     fi
 done
@@ -122,3 +118,4 @@ if [[ -d ${deletion_target} ]]; then rm -rf "${deletion_target}"; fi
 
 # sync and wait to avoid filesystem synchronization issues
 sync && sleep 1
+

--- a/scripts/exglobal_cleanup.sh
+++ b/scripts/exglobal_cleanup.sh
@@ -27,25 +27,43 @@ last_rtofs=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} -${RMOLDRTOFS:-48} hours")
 function remove_files() {
     local directory=$1
     shift
-    if [[ ! -d ${directory} ]]; then
-        echo "No directory ${directory} to remove files from, skiping"
+
+    if [[ ! -d "${directory}" ]]; then
+        echo "No directory ${directory} to remove files from, skipping"
         return
     fi
+
     local find_exclude_string=""
+
+    # Build the exclusion clause
     for exclude in "$@"; do
-        find_exclude_string+="${find_exclude_string} -name ${exclude} -or"
+        [[ -n "$exclude" ]] && find_exclude_string+=" -name \"$exclude\" -or"
     done
-    # Chop off any trailing or
-    find_exclude_string="${find_exclude_string[*]/%-or}"
-    # Remove all regular files that do not match
-    # shellcheck disable=SC2086
-    find "${directory}" -type f -not \( ${find_exclude_string} \) -ignore_readdir_race -delete
-    # Remove all symlinks that do not match
-    # shellcheck disable=SC2086
-    find "${directory}" -type l -not \( ${find_exclude_string} \) -ignore_readdir_race -delete
-    # Remove any empty directories
+
+    # Remove trailing -or if it exists
+    find_exclude_string="${find_exclude_string% -or}"
+
+    # Print for debugging
+    echo "DEBUG: directory = '${directory}'"
+    echo "DEBUG: find_exclude_string = ${find_exclude_string}"
+
+    if [[ -n "$find_exclude_string" ]]; then
+        # shellcheck disable=SC2086
+        eval find "${directory}" -type f -not \( ${find_exclude_string} \) -ignore_readdir_race -delete
+        eval find "${directory}" -type l -not \( ${find_exclude_string} \) -ignore_readdir_race -delete
+    else
+        echo "WARNING: No exclusion patterns provided. Deleting all files and symlinks in ${directory}."
+        find "${directory}" -type f -ignore_readdir_race -delete
+        find "${directory}" -type l -ignore_readdir_race -delete
+    fi
+
+    # Always remove empty directories
     find "${directory}" -type d -empty -delete
 }
+
+
+# Always remove empty directories
+
 
 for (( current_date=first_date; current_date <= last_date; \
   current_date=$(date --utc +%Y%m%d%H -d "${current_date:0:8} ${current_date:8:2} +${assim_freq} hours") )); do

--- a/scripts/exglobal_cleanup.sh
+++ b/scripts/exglobal_cleanup.sh
@@ -39,9 +39,9 @@ function remove_files() {
         find_args+=( \( )
         local first=1
         for exclude in "$@"; do
-            if [[ -n "$exclude" ]]; then
-                [[ $first -eq 0 ]] && find_args+=( -or )
-                find_args+=( -name "$exclude" )
+            if [[ -n "${exclude}" ]]; then
+                [[ ${first} -eq 0 ]] && find_args+=( -or )
+                find_args+=( -name "${exclude}" )
                 first=0
             fi
         done
@@ -60,7 +60,7 @@ function remove_files() {
     find "${directory}" -type d -empty -delete
 }
 
-for (( current_date=${first_date}; current_date <= ${last_date}; \
+for (( current_date=first_date; current_date <= last_date; \
   current_date=$(date --utc +%Y%m%d%H -d "${current_date:0:8} ${current_date:8:2} +${assim_freq} hours") )); do
     current_PDY="${current_date:0:8}"
     current_cyc="${current_date:8:2}"

--- a/scripts/exglobal_cleanup.sh
+++ b/scripts/exglobal_cleanup.sh
@@ -61,7 +61,7 @@ function remove_files() {
     find "${directory}" -type d -empty -delete
 }
 
-for (( current_date={first_date}; current_date <= {last_date}; \
+for (( current_date=${first_date}; current_date <= ${last_date}; \
   current_date=$(date --utc +%Y%m%d%H -d "${current_date:0:8} ${current_date:8:2} +${assim_freq} hours") )); do
     current_PDY="${current_date:0:8}"
     current_cyc="${current_date:8:2}"

--- a/scripts/exglobal_cleanup.sh
+++ b/scripts/exglobal_cleanup.sh
@@ -7,7 +7,6 @@ echo "Begin Cleanup ${DATAROOT}!"
 # TODO: Handle this better
 DATAfcst="${DATAROOT}/${RUN}fcst.${PDY:-}${cyc}"
 if [[ -d "${DATAfcst}" ]]; then rm -rf "${DATAfcst}"; fi
-#DATAefcs="${DATAROOT}/${RUN}efcs???${PDY:-}${cyc}"
 rm -rf "${DATAROOT}/${RUN}efcs"*"${PDY:-}${cyc}"
 ###############################################################
 
@@ -96,7 +95,7 @@ if [[ "${RUN}" == "gfs" ]]; then
     fi
 
     touch_date=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} -${FHMAX_FITS} hours")
-    while (( touch_date < "${PDY}${cyc}" )); do
+    while (( touch_date < ${PDY}${cyc} )); do
         touch_PDY="${touch_date:0:8}"
         touch_cyc="${touch_date:8:2}"
         touch_dir="${ROTDIR}/vrfyarch/${RUN}.${touch_PDY}/${touch_cyc}"
@@ -114,7 +113,7 @@ if (( GDATE < RDATE )); then
     RDATE=${GDATE}
 fi
 deletion_target="${ROTDIR}/${RUN}.${RDATE:0:8}"
-if [[ -d ${deletion_target} ]]; then rm -rf "${deletion_target}"; fi
+if [[ -d "${deletion_target}" ]]; then rm -rf "${deletion_target}"; fi
 
 # sync and wait to avoid filesystem synchronization issues
 sync && sleep 1

--- a/scripts/exglobal_cleanup.sh
+++ b/scripts/exglobal_cleanup.sh
@@ -61,7 +61,7 @@ function remove_files() {
     find "${directory}" -type d -empty -delete
 }
 
-for (( current_date=first_date; current_date <= last_date; \
+for (( current_date={first_date}; current_date <= {last_date}; \
   current_date=$(date --utc +%Y%m%d%H -d "${current_date:0:8} ${current_date:8:2} +${assim_freq} hours") )); do
     current_PDY="${current_date:0:8}"
     current_cyc="${current_date:8:2}"


### PR DESCRIPTION
  

# Description

This draft PR is a potential fix to the crashing of the cleanup step for GCAFS. The problem is caused by an empty string and this fix checks for the empty string and changes the script to leave it out. 

 

  

  Resolves #3786 


# Type of change
- Bug fix

# Change characteristics

- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO
 

# How has this been tested?

Cycling many days on gaea.




# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
