### PR TITLE
Update Fit2Obs to `v1.1.7.1`

### DIFF
--- a/dev/parm/config/gfs/config.fit2obs
+++ b/dev/parm/config/gfs/config.fit2obs
@@ -11,6 +11,8 @@ echo "BEGIN: config.fit2obs"
 export PRVT=${FIXgfs}/gsi/prepobs_errtable.global
 export HYBLEVS=${FIXgfs}/am/global_hyblev.l${LEVS}.txt
 
+export COM_VRFYARCH="${ROTDIR}/vrfyarch"
+
 export VBACKUP_FITS=24
 export OUTPUT_FILETYPE="netcdf"
 export CONVNETC="YES"

--- a/jobs/JGDAS_FIT2OBS
+++ b/jobs/JGDAS_FIT2OBS
@@ -17,9 +17,7 @@ vcyc=${CDATE:8:2}
 YMD=${vday} HH=${vcyc} declare_from_tmpl -rx COMIN_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
 RUN=${RUN/enkf} YMD=${vday} HH=${vcyc} declare_from_tmpl -rx COMIN_OBS:COM_OBS_TMPL
 
-# We want to defer variable expansion, so ignore warning about single quotes
-# shellcheck disable=SC2016
-export COMIN_HISTORY='$ROTDIR/vrfyarch/gfs.$fdy/$fzz'
+export COM_VRFYARCH=${COM_VRFYARCH:-${ROTDIR}/vrfyarch}
 
 export PRPI=${COMIN_OBS}/${RUN}.t${vcyc}z.prepbufr
 # shellcheck disable=SC2153

--- a/versions/run.wcoss2.ver
+++ b/versions/run.wcoss2.ver
@@ -49,4 +49,4 @@ export obsproc_run_ver=1.2.0
 export prepobs_run_ver=1.1.0
 
 export ens_tracker_ver=v1.2.0
-export fit2obs_ver=1.1.7
+export fit2obs_ver=1.1.7.1

--- a/versions/spack.ver
+++ b/versions/spack.ver
@@ -44,4 +44,4 @@ export obsproc_run_ver=1.2.0
 export prepobs_run_ver=1.1.0
 
 export ens_tracker_ver=v1.2.0
-export fit2obs_ver=1.1.7
+export fit2obs_ver=1.1.7.1


### PR DESCRIPTION
# Description

This PR updates the version of the Fit2Obs package to the new `v1.1.7.1` tag. This tag includes a bug fix for `COMIN_HISTORY` setting. To use this new tag the workflow needs to add a new `COM_VRFYARCH` variable and update `fit2obs_ver=1.1.7.1`.

The new package has been installed on all supported platforms.

Resolves #3799

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics

- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?

Ran `C96_atm3DVar_extended` test (which was further extended to invoke Fit2Obs) on WCOSS2. @jack-woollen reviewed run and confirmed the `gdas_fit2obs` job ran correctly.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
