### PR TITLE
Add check for prepbufr at end of prep job

### DIFF
--- a/dev/jobs/prep.sh
+++ b/dev/jobs/prep.sh
@@ -130,6 +130,10 @@ if [[ ${err} -ne 0 ]]; then
    err_exit "JOBSPROC_GLOBAL_PREP job failed!"
 fi
 
+if [[ ! -f ${COMOUT_OBS}/${OPREFIX}prepbufr ]]; then
+   err_exit "The prepbufr file does not exist!"
+fi
+
 # If creating NSSTBUFR was disabled, copy from DMPDIR if appropriate.
 if [[ ${MAKE_NSSTBUFR:-"NO"} = "NO" ]]; then
     if [[ ${DONST} = "YES" ]]; then

--- a/dev/jobs/prep.sh
+++ b/dev/jobs/prep.sh
@@ -130,8 +130,9 @@ if [[ ${err} -ne 0 ]]; then
    err_exit "JOBSPROC_GLOBAL_PREP job failed!"
 fi
 
-if [[ ! -f ${COMOUT_OBS}/${OPREFIX}prepbufr ]]; then
-   err_exit "The prepbufr file does not exist!"
+if [[ ! -f "${COMOUT_OBS}/${OPREFIX}prepbufr" ]]; then
+   export err=1
+   err_exit "JOBSPROC_GLOBAL_PREP failed to create the prepbufr file, ABORT!"
 fi
 
 # If creating NSSTBUFR was disabled, copy from DMPDIR if appropriate.


### PR DESCRIPTION
# Description

This PR adds a check for the existence of a prepbufr file to the end of the prep job script. This check will help resolve a silent failure when the prepbufr file generation fails but the error code does not get sent up to the workflow level from the obsproc/prepobs package.

Resolves #691

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics

- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?

Ran `gdas_prep` and `gfs_prep` job on WCOSS2. Forced job failure to test check worked.