### PR TITLE
Red Hotfix for misspelling of emc in Jenkins NodeParameter

### DIFF
--- a/dev/ci/Jenkinsfile
+++ b/dev/ci/Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
                     Machine = machine[0].toUpperCase() + machine.substring(1)
                     echo "Getting Common Workspace for ${Machine}"
                     ws("${custom_workspace[machine]}/${env.CHANGE_ID}") {
-                        properties([parameters([[$class: 'NodeParameterDefinition', allowedSlaves: ['built-in', 'hercules-ecm', 'hera-emc', 'orion-emc', 'gaeaC5', 'gaeaC6-emc'], defaultSlaves: ['built-in'], name: '', nodeEligibility: [$class: 'AllNodeEligibility'], triggerIfResult: 'allCases']])])
+                        properties([parameters([[$class: 'NodeParameterDefinition', allowedSlaves: ['built-in', 'hercules-emc', 'hera-emc', 'orion-emc', 'gaeaC5', 'gaeaC6-emc'], defaultSlaves: ['built-in'], name: '', nodeEligibility: [$class: 'AllNodeEligibility'], triggerIfResult: 'allCases']])])
                         GH = sh(script: "which gh || echo '~/bin/gh'", returnStdout: true).trim()
                         CUSTOM_WORKSPACE = "${WORKSPACE}"
                         HOMEgfs = "${CUSTOM_WORKSPACE}/global-workflow"


### PR DESCRIPTION
Red Hotfix with one CHAR update for a misspelling of **hercules-emc**in NodeParameterDefinition