### PR TITLE
Add error checking to module loading scripts

### DIFF
--- a/ush/load_fv3gfs_modules.sh
+++ b/ush/load_fv3gfs_modules.sh
@@ -22,12 +22,20 @@ source "${HOMEgfs}/ush/module-setup.sh"
 # Source versions file for runtime
 source "${HOMEgfs}/versions/run.ver"
 
+# Enable exit on error for robust module loading
+set -e
+
 # Load our modules:
 module use "${HOMEgfs}/modulefiles"
 
 case "${MACHINE_ID}" in
   "wcoss2" | "hera" | "orion" | "hercules" | "gaeac5" | "gaeac6" | "noaacloud")
     module load "module_base.${MACHINE_ID}"
+    export err=$?
+    if [[ ${err} -ne 0 ]]; then
+      echo "FATAL ERROR: Failed to load module_base.${MACHINE_ID}"
+      exit 1
+    fi
     ;;
   *)
     echo "WARNING: UNKNOWN PLATFORM"

--- a/ush/load_fv3gfs_modules.sh
+++ b/ush/load_fv3gfs_modules.sh
@@ -22,9 +22,6 @@ source "${HOMEgfs}/ush/module-setup.sh"
 # Source versions file for runtime
 source "${HOMEgfs}/versions/run.ver"
 
-# Enable exit on error for robust module loading
-set -e
-
 # Load our modules:
 module use "${HOMEgfs}/modulefiles"
 

--- a/ush/load_ufsda_modules.sh
+++ b/ush/load_ufsda_modules.sh
@@ -36,9 +36,6 @@ ulimit_s=$( ulimit -S -s )
 source "${HOMEgfs}/ush/detect_machine.sh"
 source "${HOMEgfs}/ush/module-setup.sh"
 
-# Enable exit on error for robust module loading
-set -e
-
 # Load our modules:
 module use "${HOMEgfs}/sorc/gdas.cd/modulefiles"
 

--- a/ush/load_ufsda_modules.sh
+++ b/ush/load_ufsda_modules.sh
@@ -36,6 +36,9 @@ ulimit_s=$( ulimit -S -s )
 source "${HOMEgfs}/ush/detect_machine.sh"
 source "${HOMEgfs}/ush/module-setup.sh"
 
+# Enable exit on error for robust module loading
+set -e
+
 # Load our modules:
 module use "${HOMEgfs}/sorc/gdas.cd/modulefiles"
 
@@ -50,6 +53,11 @@ case "${MACHINE_ID}" in
       export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/cray/pe/mpich/8.1.19/ofi/intel/19.0/lib"
     fi
     module load "${MODS}/${MACHINE_ID}"
+    export err=$?
+    if [[ ${err} -ne 0 ]]; then
+      echo "FATAL ERROR: Failed to load ${MODS}/${MACHINE_ID}"
+      exit 1
+    fi
     ncdump=$( command -v ncdump )
     NETCDF=$( echo "${ncdump}" | cut -d " " -f 3 )
     export NETCDF

--- a/ush/load_ufswm_modules.sh
+++ b/ush/load_ufswm_modules.sh
@@ -12,8 +12,16 @@ ulimit_s=$( ulimit -S -s )
 source "${HOMEgfs}/ush/detect_machine.sh"
 source "${HOMEgfs}/ush/module-setup.sh"
 
+# Enable exit on error for robust module loading
+set -e
+
 module use "${HOMEgfs}/sorc/ufs_model.fd/modulefiles"
 module load "ufs_${MACHINE_ID}.intel"
+export err=$?
+if [[ ${err} -ne 0 ]]; then
+  echo "FATAL ERROR: Failed to load ufs_${MACHINE_ID}.intel"
+  exit 1
+fi
 module load prod_util
 if [[ "${MACHINE_ID}" = "wcoss2" ]]; then
   module load cray-pals

--- a/ush/load_ufswm_modules.sh
+++ b/ush/load_ufswm_modules.sh
@@ -12,9 +12,6 @@ ulimit_s=$( ulimit -S -s )
 source "${HOMEgfs}/ush/detect_machine.sh"
 source "${HOMEgfs}/ush/module-setup.sh"
 
-# Enable exit on error for robust module loading
-set -e
-
 module use "${HOMEgfs}/sorc/ufs_model.fd/modulefiles"
 module load "ufs_${MACHINE_ID}.intel"
 export err=$?


### PR DESCRIPTION
The module loading scripts (`load_fv3gfs_modules.sh`, `load_ufsda_modules.sh`, and `load_ufswm_modules.sh`) were not checking for module loading failures. These scripts previously included `source preamble.sh` which provided `set -e` error handling, but this was removed at some point, leaving the scripts vulnerable to silent failures.

Co-authored by @Copilot

Resolves #3831 
## Changes Made

- **Added explicit error checking** after critical `module load` commands using:
  ```bash
  module load "module_name"
  export err=$?
  if [[ ${err} -ne 0 ]]; then
    echo "FATAL ERROR: Failed to load module_name"
    exit 1
  fi
  ```
- **Preserved existing behavior** including quiet mode logic and debug tracing functionality
- **Added descriptive error messages** that clearly identify which module failed to load

## Impact

Previously, if a module failed to load, the scripts would continue silently, potentially leading to runtime failures later in the workflow. Now:

- Module loading failures are caught immediately
- Clear error messages help with debugging
- Scripts exit with non-zero status on failure for proper error propagation

## Testing

- All scripts pass shellcheck validation
- Error detection verified to work correctly
- Backward compatibility maintained
- Minimal changes (15 lines added across 3 files)

This addresses the issue found during the spack-stack 1.9.2 upgrade where module loading errors were not being detected.

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Tested on C6
- [x] tested without first running link_workflow.sh, so the version files were unavailable; this returned a non-zero status
- [x] tested after running link_workflow.sh.  This was successful.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added