### PR TITLE
HOTFIX: Increase build time for the GSI on compute nodes

### DIFF
--- a/dev/workflow/build_opts.yaml
+++ b/dev/workflow/build_opts.yaml
@@ -71,7 +71,7 @@ build:
   gsi_enkf:
     command: "./build_gsi_enkf.sh"
     cores: 8
-    walltime: "00:15:00"
+    walltime: "00:20:00"
 
   gsi_monitor:
     command: "./build_gsi_monitor.sh"


### PR DESCRIPTION
# Description
Hera is failing its nightly testing due to a timed out GSI build.  This increases the build time by 5 minutes to get it to build.  That said, /scratch1 is running very slowly (possibly because of I/O from users moving data to /scratch3 and /scratch4?), so there may be additional failures on tonight's build.

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Test build on Hera.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added