### PR TITLE
Ignore 'unused' variables in config.resources* files

### DIFF
--- a/dev/parm/config/gcafs/config.resources
+++ b/dev/parm/config/gcafs/config.resources
@@ -41,54 +41,44 @@ case ${machine} in
   "WCOSS2")
               max_tasks_per_node=128
               # WCOSS2 nodes have 512GB of RAM, but only 500GB are reservable
-              # shellcheck disable=SC2034
               mem_node_max="500GB"
     ;;
   "HERA")
               max_tasks_per_node=40
-              # shellcheck disable=SC2034
               mem_node_max="96GB"
     ;;
   "GAEAC5")
               max_tasks_per_node=128
-              # shellcheck disable=SC2034
               mem_node_max="251GB"
     ;;
   "GAEAC6")
               max_tasks_per_node=192
-              # shellcheck disable=SC2034
               mem_node_max="384GB"
     ;;
   "ORION")
               max_tasks_per_node=40
-              # shellcheck disable=SC2034
               mem_node_max="180GB"
     ;;
   "HERCULES")
               max_tasks_per_node=80
-              # shellcheck disable=SC2034
               mem_node_max="500GB"
     ;;
   "JET")
     case ${PARTITION_BATCH} in
       "xjet")
               max_tasks_per_node=24
-              # shellcheck disable=SC2034
               mem_node_max="61GB"
         ;;
       "vjet")
               max_tasks_per_node=16
-              # shellcheck disable=SC2034
               mem_node_max="61GB"
         ;;
       "sjet")
               max_tasks_per_node=16
-              # shellcheck disable=SC2034
               mem_node_max="29GB"
         ;;
       "kjet")
               max_tasks_per_node=40
-              # shellcheck disable=SC2034
               mem_node_max="88GB"
         ;;
       *)
@@ -99,12 +89,10 @@ case ${machine} in
   "S4")
     case ${PARTITION_BATCH} in
       "s4")   max_tasks_per_node=32
-              # shellcheck disable=SC2034
               mem_node_max="168GB"
         ;;
       "ivy")
               max_tasks_per_node=20
-              # shellcheck disable=SC2034
               mem_node_max="128GB"
         ;;
       *)
@@ -117,7 +105,6 @@ case ${machine} in
     npe_node_max=48
     max_tasks_per_node=48
     # TODO Supply a max mem/node value for AWS
-    # shellcheck disable=SC2034
     mem_node_max=""
     ;;
   "AZUREPW")
@@ -125,7 +112,6 @@ case ${machine} in
     npe_node_max=36
     max_tasks_per_node=36
     # TODO Supply a max mem/node value for AZURE
-    # shellcheck disable=SC2034
     mem_node_max=""
     ;;
   "GOOGLEPW")
@@ -133,13 +119,11 @@ case ${machine} in
     npe_node_max=30
     max_tasks_per_node=30
     # TODO Supply a max mem/node value for GOOGLE
-    # shellcheck disable=SC2034
     mem_node_max=""
     ;;
   "CONTAINER")
     max_tasks_per_node=1
     # TODO Supply a max mem/node value for a container
-    # shellcheck disable=SC2034
     mem_node_max=""
     ;;
   *)

--- a/dev/parm/config/gefs/config.resources
+++ b/dev/parm/config/gefs/config.resources
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2034
 
 ########## config.resources ##########
 # Set resource information for job tasks

--- a/dev/parm/config/gefs/config.resources.AWSPW
+++ b/dev/parm/config/gefs/config.resources.AWSPW
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2034
 
 # AWS-specific job resources
 

--- a/dev/parm/config/gefs/config.resources.AZUREPW
+++ b/dev/parm/config/gefs/config.resources.AZUREPW
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2034
 
 # AZURE-specific job resources
 

--- a/dev/parm/config/gefs/config.resources.GOOGLEPW
+++ b/dev/parm/config/gefs/config.resources.GOOGLEPW
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2034
 
 # GOOGLE-specific job resources
 

--- a/dev/parm/config/gfs/config.resources
+++ b/dev/parm/config/gfs/config.resources
@@ -39,32 +39,26 @@ case ${machine} in
   "WCOSS2")
               max_tasks_per_node=128
               # WCOSS2 nodes have 512GB of RAM, but only 500GB are reservable
-              # shellcheck disable=SC2034
               mem_node_max="500GB"
     ;;
   "HERA")
               max_tasks_per_node=40
-              # shellcheck disable=SC2034
               mem_node_max="96GB"
     ;;
   "GAEAC5")
               max_tasks_per_node=128
-              # shellcheck disable=SC2034
               mem_node_max="251GB"
     ;;
   "GAEAC6")
               max_tasks_per_node=192
-              # shellcheck disable=SC2034
               mem_node_max="384GB"
     ;;
   "ORION")
               max_tasks_per_node=40
-              # shellcheck disable=SC2034
               mem_node_max="180GB"
     ;;
   "HERCULES")
               max_tasks_per_node=80
-              # shellcheck disable=SC2034
               mem_node_max="500GB"
     ;;
   "AWSPW")
@@ -72,7 +66,6 @@ case ${machine} in
     npe_node_max=48
     max_tasks_per_node=48
     # TODO Supply a max mem/node value for AWS
-    # shellcheck disable=SC2034
     mem_node_max=""
     ;;
   "AZUREPW")
@@ -80,7 +73,6 @@ case ${machine} in
     npe_node_max=36
     max_tasks_per_node=36
     # TODO Supply a max mem/node value for AZURE
-    # shellcheck disable=SC2034
     mem_node_max=""
     ;;
   "GOOGLEPW")
@@ -88,13 +80,11 @@ case ${machine} in
     npe_node_max=30
     max_tasks_per_node=30
     # TODO Supply a max mem/node value for GOOGLE
-    # shellcheck disable=SC2034
     mem_node_max=""
     ;;
   "CONTAINER")
     max_tasks_per_node=1
     # TODO Supply a max mem/node value for a container
-    # shellcheck disable=SC2034
     mem_node_max=""
     ;;
   *)

--- a/dev/parm/config/gfs/config.resources.AWSPW
+++ b/dev/parm/config/gfs/config.resources.AWSPW
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2034
 
 # AWS-specific job resources
 

--- a/dev/parm/config/gfs/config.resources.AZUREPW
+++ b/dev/parm/config/gfs/config.resources.AZUREPW
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2034
 
 # AZURE-specific job resources
 

--- a/dev/parm/config/gfs/config.resources.GAEAC5
+++ b/dev/parm/config/gfs/config.resources.GAEAC5
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2034
 
 # GaeaC5-specific job resources
 

--- a/dev/parm/config/gfs/config.resources.GAEAC6
+++ b/dev/parm/config/gfs/config.resources.GAEAC6
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2034
 
 # GaeaC6-specific job resources
 

--- a/dev/parm/config/gfs/config.resources.GOOGLEPW
+++ b/dev/parm/config/gfs/config.resources.GOOGLEPW
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2034
 
 # GOOGLE-specific job resources
 

--- a/dev/parm/config/gfs/config.resources.HERA
+++ b/dev/parm/config/gfs/config.resources.HERA
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2034
 
 # Hera-specific job resources
 

--- a/dev/parm/config/gfs/config.resources.HERCULES
+++ b/dev/parm/config/gfs/config.resources.HERCULES
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2034
 
 # Hercules-specific job resources
 

--- a/dev/parm/config/gfs/config.resources.ORION
+++ b/dev/parm/config/gfs/config.resources.ORION
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2034
 
 # Orion-specific job resources
 

--- a/dev/parm/config/gfs/config.resources.WCOSS2
+++ b/dev/parm/config/gfs/config.resources.WCOSS2
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2034
 
 # WCOSS2-specific job resources
 

--- a/dev/parm/config/sfs/config.resources
+++ b/dev/parm/config/sfs/config.resources
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# shellcheck disable=SC2034
 
 ########## config.resources ##########
 # Set resource information for job tasks


### PR DESCRIPTION
# Description
This adds `#shellcheck disable=SC2034` to all `config.resources*` files to prevent erroneously detecting 'unused' variables.

This was was performed by copilot in https://github.com/DavidHuber-NOAA/global-workflow/pull/28.

Resolves #3876 

# Type of change
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Tested using shellcheck.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added