### PR TITLE
Add safeguard dependency for prep step when cycling

### DIFF
--- a/dev/workflow/rocoto/gfs_tasks.py
+++ b/dev/workflow/rocoto/gfs_tasks.py
@@ -114,6 +114,8 @@ class GFSTasks(Tasks):
         data = f'{dump_path}/{self.run}.t@Hz.updated.status.tm00.bufr_d'
         dep_dict = {'type': 'data', 'data': data}
         deps.append(rocoto.add_dependency(dep_dict))
+        dep_dict = {'type': 'metatask', 'name': 'gdas_fcst', 'offset': f"-{timedelta_to_HMS(self._base['interval_gdas'])}"}
+        deps.append(rocoto.add_dependency(dep_dict))
         if self.options['do_prep_sfc']:
             dep_dict = {'type': 'task', 'name': f'{self.run}_prep_sfc'}
             deps.append(rocoto.add_dependency(dep_dict))


### PR DESCRIPTION
# Description
The prep step depends on the atmos_prod step.  Most of the time, this is sufficient for cycling, but occasionally, the forecast step fails after running the model but before completing the job due to disk or wall time issues.  Since the model completed, the atmos_prod steps will run, but the forecast will also rerun.  This can cause failures in the following cycle's analysis since the next cycle has begun while the previous cycle's forecast is rerunning, resulting in either reading files that are actively being rewritten or attempting to read files that have not yet be copied.

This PR will force the prep step to wait until both the atmos_prod and the forecast tasks are complete before kicking off the next cycle.

Resolves #3887

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Generate_workflows.sh -G -E -S -C on WCOSS2

# Checklist
- [ ] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
