### PR TITLE
Minor bug fixes to minmon and radmon

### DIFF
--- a/scripts/exgdas_atmos_verfrad.sh
+++ b/scripts/exgdas_atmos_verfrad.sh
@@ -122,8 +122,7 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
 
    #-------------------------------------------------------------
    #  Update the SATYPE if any new sat/instrument was 
-   #  found in $radstat_satype.  Write the SATYPE contents back 
-   #  to $TANKverf/radmon.$PDY.
+   #  found in $radstat_satype.  
    #-------------------------------------------------------------
    satype_changes=0
    new_satype=$SATYPE
@@ -139,7 +138,10 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
       fi
    done
 
- 
+   if (( satype_changes == 1 )); then
+      SATYPE=${new_satype}
+   fi
+	
    #------------------------------------------------------------------
    # Rename the diag files and uncompress
    #------------------------------------------------------------------

--- a/ush/minmon_xtrct_costs.pl
+++ b/ush/minmon_xtrct_costs.pl
@@ -208,7 +208,7 @@ if( (-e $infile) ) {
       #--------------------------
       #  move files to $M_TANKverf
       #--------------------------
-      my $tankdir = $ENV{"M_TANKverfM0"};
+      my $tankdir = $ENV{"M_TANKverf"};
       if(! -d $tankdir) {
          system( "mkdir -p $tankdir" );
       } 

--- a/ush/minmon_xtrct_gnorms.pl
+++ b/ush/minmon_xtrct_gnorms.pl
@@ -414,7 +414,7 @@ if( $rc == 0 ) {
       #--------------------------
       #  move files to $M_TANKverf
       #--------------------------
-      my $tankdir = $ENV{"M_TANKverfM0"};
+      my $tankdir = $ENV{"M_TANKverf"};
       if(! -d $tankdir) {
          system( "mkdir -p $tankdir" );
       }

--- a/ush/minmon_xtrct_reduct.pl
+++ b/ush/minmon_xtrct_reduct.pl
@@ -72,7 +72,7 @@ if( (-e $infile) ) {
    #----------------------------
    #  copy outfile to $M_TANKverf
    #----------------------------
-   my $tankdir = $ENV{"M_TANKverfM0"};
+   my $tankdir = $ENV{"M_TANKverf"};
    if(! -d $tankdir) {
       system( "mkdir -p $tankdir" );
    }


### PR DESCRIPTION
Introduce two changes to allow new satellites to be added automatically to RadMon and to fix a naming inconsistency between the minmon shell and perl scripts.   Both changes are already in `develop`.

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO (If YES, please add a link to any PRs that are pending.)
 

# How has this been tested?
Single cycle global workflow

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
