### PR TITLE
Release/gfs.v16.3.25

### DIFF
--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -49,7 +49,7 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* `versions/run.ver` - change `rtofs_ver=v2.5`,`version=v16.3.25`, and `gfs_ver=v16.3.25`
+* `versions/run.ver` - change `rtofs_ver=v2.5`, `version=v16.3.25`, and `gfs_ver=v16.3.25`
 
 SORC CHANGES
 ------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -1,10 +1,10 @@
-GFS V16.3.24 RELEASE NOTES
+GFS V16.3.25 RELEASE NOTES
 
 -------
 PRELUDE
 -------
 
-Tropical storm name updates for the 2025-2026 hurricane seasons are made in the GFS syndat_stmnames fix file.
+The upstream RTOFS system is updated to v2.5.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -13,9 +13,9 @@ The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub are used t
 
 ```bash
 cd $PACKAGEROOT
-mkdir gfs.v16.3.24
-cd gfs.v16.3.24
-git clone -b EMC-v16.3.24 https://github.com/NOAA-EMC/global-workflow.git .
+mkdir gfs.v16.3.25
+cd gfs.v16.3.25
+git clone -b EMC-v16.3.25 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```
@@ -49,7 +49,7 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* `versions/run.ver` - change `version=v16.3.24` and `gfs_ver=v16.3.24`
+* `versions/run.ver` - change `rtofs_ver=v2.5`,`version=v16.3.25`, and `gfs_ver=v16.3.25`
 
 SORC CHANGES
 ------------
@@ -74,7 +74,7 @@ SCRIPT CHANGES
 FIX CHANGES
 -----------
 
-The `fix_am/syndat_stmnames` file is updated to adjust some hurricane names for 2025/2026 seasons.
+* No changes from GFS v16.3.24
 
 MODULE CHANGES
 --------------
@@ -122,4 +122,3 @@ DOCUMENTATION
 PREPARED BY
 -----------
 Kate.Friedman@noaa.gov
-Qingfu.Liu@noaa.gov

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,9 +1,9 @@
-export version=v16.3.24
-export gfs_ver=v16.3.24
+export version=v16.3.25
+export gfs_ver=v16.3.25
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2
-export rtofs_ver=v2.4
+export rtofs_ver=v2.5
 export radarl2_ver=v1.2
 export obsproc_ver=v1.2
 


### PR DESCRIPTION
# Description
This PR is for the operational RTOFS upgrade to v2.5. It:
- adds Release Notes for v16.3.25 
- updates `run.ver` to include the upgraded RTOFS operational version to 2.5

# Type of change
- [X] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Bringing meaningful changes from ops upgrade from WCOSS2 disk (`run.ver`)

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
