### PR TITLE
merge dev/gfs.v16, resolve conflicts and update release notes

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ protocol = git
 required = True
 
 [GSI]
-tag = gfsda.v16.3.25
+tag = gfsda.v16.3.26
 local_path = sorc/gsi.fd
 repo_url = https://github.com/NOAA-EMC/GSI.git
 protocol = git
@@ -36,14 +36,14 @@ protocol = git
 required = True
 
 [GSI_Utils]
-tag = gsiutil.v16.3.25
+tag = gsiutil.v16.3.26
 local_path = sorc/gsi_utils.fd
 repo_url = https://github.com/NOAA-EMC/GSI-Utils.git
 protocol = git
 required = True
 
 [GSI_Monitor]
-tag = gsimon_v16.3.25
+tag = gsimon_v16.3.26
 local_path = sorc/gsi_monitor.fd
 repo_url = https://github.com/NOAA-EMC/GSI-Monitor.git
 protocol = git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,7 @@
 # External sub-modules of global-workflow
 
 [FV3GFS]
-tag = GFS.v16.3.25
+tag = GFS.v16.3.26
 local_path = sorc/fv3gfs.fd
 repo_url = https://github.com/ufs-community/ufs-weather-model.git
 protocol = git

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -31,11 +31,11 @@ The checkout script extracts the following GFS components:
 | ---------- | ---------------------------- | ----------------------- |
 | MODEL      | GFS.v16.3.25                 | Jun.Wang@noaa.gov       |
 | GLDAS      | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov      |
-| GSI        | gfsda.v16.3.25               | Andrew.Collard@noaa.gov |
+| GSI        | gfsda.v16.3.26               | Andrew.Collard@noaa.gov |
 | UFS_UTILS  | ops-gfsv16.3.20              | George.Gayno@noaa.gov   |
 | POST       | upp_v8.3.0                   | Wen.Meng@noaa.gov       |
-| GSI-Utils  | gsiutil.v16.3.25             | Andrew.Collard@noaa.gov |
-| GSI-Monitor| gsimon_v16.3.25              | Edward.Safford@noaa.gov |
+| GSI-Utils  | gsiutil.v16.3.26             | Andrew.Collard@noaa.gov |
+| GSI-Monitor| gsimon_v16.3.26              | Edward.Safford@noaa.gov |
 
 To build all the GFS components, execute:
 ```bash
@@ -67,14 +67,14 @@ SORC CHANGES
 * New EMC_verif-global tag: `verif_global_v2.10.0.1` (Gulf of America changes)
 
 The GSI has been updated from an older release branch (gfsda.v16.3.20) to one much closer to the develop
-branch (gfsda.v16.3.25) with a large number of changes to the code that do not affect results.
+branch (gfsda.v16.3.26) with a large number of changes to the code that do not affect results.
 Between these versions there has been a reorganisation of the repositories
 resulting in some functionality moving from GSI to new repositories.
 Therefore the following new repositories are checked out:
 
-GSI:  gfsda.v16.3.25
-GSI-Utils:  gsiutil.v16.3.25
-GSI-Monitor: gsimon_v16.3.25
+GSI:  gfsda.v16.3.26
+GSI-Utils:  gsiutil.v16.3.26
+GSI-Monitor: gsimon_v16.3.26
 
 JOBS CHANGES
 ------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -29,7 +29,7 @@ The checkout script extracts the following GFS components:
 
 | Component  | Tag                          | POC                     |
 | ---------- | ---------------------------- | ----------------------- |
-| MODEL      | GFS.v16.3.25                 | Jun.Wang@noaa.gov       |
+| MODEL      | GFS.v16.3.26                 | Jun.Wang@noaa.gov       |
 | GLDAS      | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov      |
 | GSI        | gfsda.v16.3.26               | Andrew.Collard@noaa.gov |
 | UFS_UTILS  | ops-gfsv16.3.20              | George.Gayno@noaa.gov   |
@@ -63,7 +63,7 @@ VERSION FILE CHANGES
 SORC CHANGES
 ------------
 
-* New MODEL tag: `GFS.v16.3.25`
+* New MODEL tag: `GFS.v16.3.26`
 * New EMC_verif-global tag: `verif_global_v2.10.0.1` (Gulf of America changes)
 
 The GSI has been updated from an older release branch (gfsda.v16.3.20) to one much closer to the develop

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -1,12 +1,12 @@
-GFS V16.3.25 RELEASE NOTES
+GFS V16.3.26 RELEASE NOTES
 
 -------
 PRELUDE
 -------
-Data assimilation upgrade which implements a version of GSI closer to the head of the develop branch and 
-includes the following new data types for assimilation: Windborne Balloon Sondes; Saildrone surface obs; 
+Data assimilation upgrade which implements a version of GSI closer to the head of the develop branch and
+includes the following new data types for assimilation: Windborne Balloon Sondes; Saildrone surface obs;
 GOES-19 clear sky radiances; GMI radiances; NOAA-19 Ozone Profile Retreievals.   Preparation for Metop-SG
-instruments.  Also include minor modifications to ATMS thinning; treatment of surface ship pressure 
+instruments.  Also include minor modifications to ATMS thinning; treatment of surface ship pressure
 observations and quality control of humidity Jacobians.
 
 Also included in this upgrade are changes to add an indicator log file for WW3 gridded output.
@@ -66,15 +66,15 @@ SORC CHANGES
 * New MODEL tag: `GFS.v16.3.25`
 * New EMC_verif-global tag: `verif_global_v2.10.0.1` (Gulf of America changes)
 
-The GSI has been updated from an older release branch (gfsda.v16.3.20) to one much closer to the develop 
-branch (gfsda.v16.3.25) with a large number of changes to the code that do not affect results.   
-Between these versions there has been a reorganisation of the repositories 
-resulting in some functionality moving from GSI to new repositories.  
+The GSI has been updated from an older release branch (gfsda.v16.3.20) to one much closer to the develop
+branch (gfsda.v16.3.25) with a large number of changes to the code that do not affect results.
+Between these versions there has been a reorganisation of the repositories
+resulting in some functionality moving from GSI to new repositories.
 Therefore the following new repositories are checked out:
 
 GSI:  gfsda.v16.3.25
 GSI-Utils:  gsiutil.v16.3.25
-GSI-Monitor: gsimon_v16.3.25 
+GSI-Monitor: gsimon_v16.3.25
 
 JOBS CHANGES
 ------------
@@ -132,7 +132,7 @@ The following GSI-fix files have been modified to include new data:
 * `global_satinfo.txt` (Add GOES-19 CSRs, modify GMI, preparation for Metop-SG)
 * `global_scaninfo.txt` (Add MWS and GOES-19)
 * `prepobs_errtable.global` (Add Windborne (301/401) and Saildrone (302/402))
-* `mws_beamwidth.txt` has been added to support future implementation of MWS when available 
+* `mws_beamwidth.txt` has been added to support future implementation of MWS when available
 
 MODULE CHANGES
 --------------
@@ -160,12 +160,12 @@ PRE-IMPLEMENTATION TESTING REQUIREMENTS
 * Does this change require a 30-day evaluation?
   * No
 * Building GSI requires CRTMv2.4.0.2
-* GOES-19 and GMI bias correction files need to be updated before implementation. We usually spin up 
-  the bias correction for a couple of weeks before turning on active assimilation. This can either be 
-  done by a two step implementation (starting with monitoring and then switching to active once the 
-  bias correction is spun up) or by taking the coefficients from a parallel.  A second wrinkle here 
-  is that the GMI bias correction is already spun up - but is wrong so we need to zero it first in 
-  the bias correction file. We suggest discussing how precisely to do this before any pre-operational 
+* GOES-19 and GMI bias correction files need to be updated before implementation. We usually spin up
+  the bias correction for a couple of weeks before turning on active assimilation. This can either be
+  done by a two step implementation (starting with monitoring and then switching to active once the
+  bias correction is spun up) or by taking the coefficients from a parallel.  A second wrinkle here
+  is that the GMI bias correction is already spun up - but is wrong so we need to zero it first in
+  the bias correction file. We suggest discussing how precisely to do this before any pre-operational
   parallel runs are started.
 
 DISSEMINATION INFORMATION
@@ -194,3 +194,4 @@ Kate.Friedman@noaa.gov
 Andrew.Collard@noaa.gov
 Matthew.Masarik@noaa.gov
 Jessica.Meixner@noaa.gov
+Rahul.Mahajan@noaa.gov

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -32,7 +32,7 @@ fi
 echo gsi checkout ...
 if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
-    git clone --recursive --branch gfsda.v16.3.25 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
+    git clone --recursive --branch gfsda.v16.3.26 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
     git submodule update --init
     cd ${topdir}
@@ -43,7 +43,7 @@ fi
 echo gsi_utils checkout ...
 if [[ ! -d gsi_utils.fd ]] ; then
     rm -f ${topdir}/checkout-gsi_utils.log
-    git clone --branch gsiutil.v16.3.25 https://github.com/NOAA-EMC/GSI-Utils.git gsi_utils.fd >> ${topdir}/checkout-gsi_utils.log 2>&1
+    git clone --branch gsiutil.v16.3.26 https://github.com/NOAA-EMC/GSI-Utils.git gsi_utils.fd >> ${topdir}/checkout-gsi_utils.log 2>&1
     cd gsi_utils.fd
     cd ${topdir}
 else
@@ -54,7 +54,7 @@ echo gsi_monitor checkout ...
 if [[ ! -d gsi_monitor.fd ]] ; then
     rm -f ${topdir}/checkout-gsi_monitor.log
     # Check out a version before changes for the new directory structure were introduced.
-    git clone --branch gsimon_v16.3.25 https://github.com/NOAA-EMC/GSI-Monitor.git gsi_monitor.fd >> ${topdir}/checkout-gsi_monitor.log 2>&1
+    git clone --branch gsimon_v16.3.26 https://github.com/NOAA-EMC/GSI-Monitor.git gsi_monitor.fd >> ${topdir}/checkout-gsi_monitor.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory gsi_monitor.fd already exists.'

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -23,7 +23,7 @@ echo $topdir
 echo fv3gfs checkout ...
 if [[ ! -d fv3gfs.fd ]] ; then
     rm -f ${topdir}/checkout-fv3gfs.log
-    git clone --recursive --branch GFS.v16.3.25 https://github.com/ufs-community/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
+    git clone --recursive --branch GFS.v16.3.26 https://github.com/ufs-community/ufs-weather-model.git fv3gfs.fd >> ${topdir}/checkout-fv3gfs.log 2>&1
     cd ${topdir}
 else
     echo 'Skip.  Directory fv3gfs.fd already exists.'


### PR DESCRIPTION
# Description
This PR:
- updates release notes in preparation for v16.3.26

@ADCollard 
Since this is v16.3.26, we need 16.3.26 tags of GSI, GSI-utils and GSI-monitor since they are currently named as 16.3.25

@junwang-noaa 
Since this is v16.3.26, we need 16.3.26 tags of Model.  The model tag is presently GFS.v16.3.25

# Type of change
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Just an update to a markdown file

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
