### PR TITLE
Fix RUN comparison in marine ecen (early cycle)

### DIFF
--- a/jobs/JGLOBAL_MARINE_ANALYSIS_ECEN
+++ b/jobs/JGLOBAL_MARINE_ANALYSIS_ECEN
@@ -30,7 +30,7 @@ RUN=${GDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
    COMOUT_ICE_ANALYSIS:COM_ICE_ANALYSIS_TMPL
 
 export NMEM_ENS_MAX=${NMEM_ENS}
-if [[ "${RUN}" == "gfs" ]]; then
+if [[ "${RUN}" == "enkfgfs" ]]; then
    NMEM_ENS=${NMEM_ENS_GFS}
 fi
 


### PR DESCRIPTION

# Description

Updates expected assignment of RUN from gfs to enkfgfs to set proper NMEM_ENS in early cycle marine recentering task.

Resolves https://github.com/NOAA-EMC/global-workflow/issues/3916

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?

Experiment `C1152mx025_S2SW` on WCOSS2

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
