### PR TITLE
Edit AWS env to configure UPP job env under step "upp"

### DIFF
--- a/env/AWSPW.env
+++ b/env/AWSPW.env
@@ -69,7 +69,7 @@ elif [[ "${step}" = "fcst" ]] || [[ "${step}" = "efcs" ]]; then
     export APRUN_UFS="${launcher} -n ${ufs_ntasks}"
     unset nnodes ufs_ntasks
 
-elif [[ "${step}" = "post" ]]; then
+elif [[ "${step}" = "upp" ]]; then
 
     export NTHREADS_UPP=${NTHREADS1}
     export APRUN_UPP="${APRUN_default} --cpus-per-task=${NTHREADS_UPP}"


### PR DESCRIPTION
<!--
  *** PLEASE READ ***

  Any PRs not following this template will be closed.

  Please delete all these comments before submitting the PR.

  Please use a short (<60 char), descriptive title for the PR title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

  No content should appear above the "Description" header.

  If this PR is not merge-ready (e.g. it depends on other PRs not yet merged), please mark it as draft until it is ready.

  PRs should meet these guidelines:
  - Each PR should address ONE topic and have an associated issue.
  - No hard-coded paths or personal directories.
  - No temporary or backup files should be committed (including logs).
  - Any code that you disabled by being commented out should be removed or reenabled.
-->
# Description
<!-- This description will become the commit message for the PR. -->
<!--
  Solely pointing to an issue is not an adequate description!

  Please use this format for your description:

  Describe your changes. Focus on the *what* and *why*. The *how* will be evident from the changes. In particular, be sure to note any interface changes, such as command line syntax, that will need to be communicated to users.

  At the end of your description, please be sure to add the issue this PR solves using the word "Resolves". If there are any issues that are related but not yet resolved (including in other repos), you may use "Refs".

  Resolves #1234
  Refs #4321
  Refs NOAA-EMC/repo#5678
-->
<!-- For more on writing good commit messages, see https://cbea.ms/git-commit/ -->

This PR edits `env/AWSPW.env` to make sure UPP job run env is set within the appropriate if-block. 

Resolves #3927 

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->

The cloud build environments are messy at the moment. Currently, cloud is working from `spack-stack@1.9.2`, and the cloud porting to 1.9.2 includes fixes that caused builds to fail with latest RDHPCS /apps stack. Therefore, submodule hashes need to be manually updated locally to include cloud modulefile updates. Testing was done from DavidHuber-NOAA's global-workflow `feature/191 branch` with necessary submodules checked out at earliest hashes that includes cloud 1.9.2 updates (unless if current g-w specified hash includes these updates).

- Clone and build GFS, GSI, and GDASApp on AWS
- Run C96_atm3DVar test
- UPP jobs ran successfully; log files can be found on Hera/Ursa at `/scratch3/BMC/qosap/Taylor.Roper/shared/fix_cloud_upp`.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes (for current level of cloud support)
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
