### PR TITLE
Hotfix: submodule updates for PR checkouts in GitLab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,6 +123,7 @@ include:
         git remote add github "${GW_REPO_URL}"
         git fetch github
         ${GH} pr checkout "${PR_NUMBER}"
+        git submodule update --init --recursive -j 8
       fi
 
       dev/ci/scripts/utils/ci_utils.sh build


### PR DESCRIPTION
Hotfix update to GitLab Pipeline for checking out PR branches to include the git submodules.

resolves #3947 