### PR TITLE
sorc: use absolute HOMEgfs_ paths in build scripts

### DIFF
--- a/dev/ci/scripts/utils/ci_utils.sh
+++ b/dev/ci/scripts/utils/ci_utils.sh
@@ -202,7 +202,14 @@ function build () {
 
   source "${HOMEgfs_}/dev/ci/platforms/config.${MACHINE_ID}"
   # TODO: when it is safe to build the GDASApp on the compute nodes again, do so (issues #3933 and #3932)
-  "${HOMEgfs_}/sorc/build_gdas.sh" &  # Run in the background while the compute build is running
+  logs_dir="${HOMEgfs_}/sorc/logs"
+  if [[ ! -d "${logs_dir}" ]]; then
+    echo "Creating logs folder"
+    mkdir -p "${logs_dir}" || exit 1
+  fi
+  # Run in the background while the compute build is running
+  rm -f "${logs_dir}/build_gdas.log"
+  "${HOMEgfs_}/sorc/build_gdas.sh" > "${logs_dir}/build_gdas.log" 2>&1 &
   "${HOMEgfs_}/sorc/build_compute.sh" -A "${HPC_ACCOUNT}" gfs gcafs gefs sfs gsi
   # Wait for the GDASApp to finish building
   wait

--- a/dev/workflow/build_opts.yaml
+++ b/dev/workflow/build_opts.yaml
@@ -56,7 +56,7 @@ build:
   sfs_model:
     command: "./build_ufs.sh -y -e sfs_model.x"
     cores: 12
-    walltime: "00:40:00"
+    walltime: "00:50:00"
 
   gcafs_model:
     command: "./build_ufs.sh -a ATMAERO -e gcafs_model.x"
@@ -96,4 +96,4 @@ build:
   gdas:
     command: "./build_gdas.sh"
     cores: 40
-    walltime: "01:30:00"
+    walltime: "01:45:00"

--- a/sorc/build_gdas.sh
+++ b/sorc/build_gdas.sh
@@ -28,6 +28,6 @@ shift $((OPTIND-1))
 BUILD_JOBS="${BUILD_JOBS:-8}" \
 WORKFLOW_BUILD="${WORKFLOW_BUILD:-"ON"}" \
 WORKFLOW_TESTS="${WORKFLOW_TESTS:-"OFF"}" \
-./gdas.cd/build.sh ${_opts} -f -w ${HOMEgfs_}
+"${HOMEgfs_}/gdas.cd/build.sh" ${_opts} -f -w ${HOMEgfs_}
 
 exit

--- a/sorc/build_gdas.sh
+++ b/sorc/build_gdas.sh
@@ -28,6 +28,6 @@ shift $((OPTIND-1))
 BUILD_JOBS="${BUILD_JOBS:-8}" \
 WORKFLOW_BUILD="${WORKFLOW_BUILD:-"ON"}" \
 WORKFLOW_TESTS="${WORKFLOW_TESTS:-"OFF"}" \
-"${HOMEgfs_}/gdas.cd/build.sh" ${_opts} -f -w ${HOMEgfs_}
+"${HOMEgfs_}/sorc/gdas.cd/build.sh" ${_opts} -f -w ${HOMEgfs_}
 
 exit

--- a/sorc/build_gdas.sh
+++ b/sorc/build_gdas.sh
@@ -28,6 +28,6 @@ shift $((OPTIND-1))
 BUILD_JOBS="${BUILD_JOBS:-8}" \
 WORKFLOW_BUILD="${WORKFLOW_BUILD:-"ON"}" \
 WORKFLOW_TESTS="${WORKFLOW_TESTS:-"OFF"}" \
-"${HOMEgfs_}/sorc/gdas.cd/build.sh" ${_opts} -f -w ${HOMEgfs_}
+"${HOMEgfs_}/sorc/gdas.cd/build.sh" ${_opts} -w ${HOMEgfs_}
 
 exit

--- a/sorc/build_gfs_utils.sh
+++ b/sorc/build_gfs_utils.sh
@@ -39,9 +39,12 @@ while getopts ":j:dvh" option; do
 done
 shift $((OPTIND-1))
 
+# shellcheck disable=SC2155
+readonly HOMEgfs_=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}")")/.." && pwd -P)
+
 BUILD_TYPE=${BUILD_TYPE:-"Release"} \
 BUILD_VERBOSE=${BUILD_VERBOSE:-"NO"} \
 BUILD_JOBS=${BUILD_JOBS:-8} \
-"./gfs_utils.fd/ush/build.sh"
+"${HOMEgfs_}/sorc/gfs_utils.fd/ush/build.sh"
 
 exit

--- a/sorc/build_gsi_enkf.sh
+++ b/sorc/build_gsi_enkf.sh
@@ -19,13 +19,16 @@ while getopts ":j:dv" option; do
 done
 shift $((OPTIND-1))
 
+# shellcheck disable=SC2155
+readonly HOMEgfs_=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}")")/.." && pwd -P)
+
 BUILD_TYPE=${BUILD_TYPE:-"Release"} \
 BUILD_VERBOSE=${BUILD_VERBOSE:-"NO"} \
 BUILD_JOBS=${BUILD_JOBS:-8} \
 GSI_MODE=GFS \
 ENKF_MODE=GFS \
 REGRESSION_TESTS=NO \
-./gsi_enkf.fd/ush/build.sh
+"${HOMEgfs_}/sorc/gsi_enkf.fd/ush/build.sh"
 
 exit
 

--- a/sorc/build_gsi_monitor.sh
+++ b/sorc/build_gsi_monitor.sh
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 set -eux
 
+# shellcheck disable=SC2155
+readonly HOMEgfs_=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}")")/.." && pwd -P)
+
 OPTIND=1
 while getopts ":j:dv" option; do
   case "${option}" in
@@ -22,6 +25,6 @@ shift $((OPTIND-1))
 BUILD_TYPE=${BUILD_TYPE:-"Release"} \
 BUILD_VERBOSE=${BUILD_VERBOSE:-"NO"} \
 BUILD_JOBS=${BUILD_JOBS:-8} \
-"./gsi_monitor.fd/ush/build.sh"
+"${HOMEgfs_}/sorc/gsi_monitor.fd/ush/build.sh"
 
 exit

--- a/sorc/build_gsi_utils.sh
+++ b/sorc/build_gsi_utils.sh
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 set -eux
 
+# shellcheck disable=SC2155
+readonly HOMEgfs_=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}")")/.." && pwd -P)
+
 OPTIND=1
 while getopts ":j:dv" option; do
   case "${option}" in
@@ -23,6 +26,6 @@ BUILD_TYPE=${BUILD_TYPE:-"Release"} \
 BUILD_VERBOSE=${BUILD_VERBOSE:-"NO"} \
 BUILD_JOBS=${BUILD_JOBS:-8} \
 UTIL_OPTS="-DBUILD_UTIL_ENKF_GFS=ON -DBUILD_UTIL_NCIO=ON" \
-"./gsi_utils.fd/ush/build.sh"
+"${HOMEgfs_}/sorc/gsi_utils.fd/ush/build.sh"
 
 exit

--- a/sorc/build_ufs.sh
+++ b/sorc/build_ufs.sh
@@ -1,7 +1,8 @@
 #! /usr/bin/env bash
 set -eux
 
-cwd=$(pwd)
+# shellcheck disable=SC2155
+readonly HOMEgfs_=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}")")/.." && pwd -P)
 
 # Default settings
 APP="S2SWA"
@@ -33,10 +34,10 @@ while getopts ":da:fj:e:pvwy" option; do
   esac
 done
 
-cd "${cwd}/ufs_model.fd"
+cd "${HOMEgfs_}/sorc/ufs_model.fd"
 
-source "./tests/detect_machine.sh"
-source "./tests/module-setup.sh"
+source "${HOMEgfs_}/sorc/ufs_model.fd/tests/detect_machine.sh"
+source "${HOMEgfs_}/sorc/ufs_model.fd/tests/module-setup.sh"
 
 MAKE_OPT="-DAPP=${APP} -D32BIT=ON -DCCPP_SUITES=${CCPP_SUITES}"
 if [[ ${PDLIB:-"OFF"} = "ON" ]]; then
@@ -66,7 +67,7 @@ CLEAN_AFTER=NO
 # TODO: when ufs-weather-model#2716 is fixed, return to using tests/compile.sh
 if [[ "${MACHINE_ID}" == "wcoss2" && "${PARALLEL_RESTART}" == "NO" ]]; then
    set +x
-   module use modulefiles
+   module use "${HOMEgfs_}/sorc/ufs_model.fd/modulefiles"
    module load "ufs_wcoss2.intel"
    module list
    set -x
@@ -93,7 +94,7 @@ if [[ "${MACHINE_ID}" == "wcoss2" && "${PARALLEL_RESTART}" == "NO" ]]; then
       rm -rf "${BUILD_DIR}"
    fi
 else
-   BUILD_JOBS=${BUILD_JOBS:-8} ./tests/compile.sh "${MACHINE_ID}" "${MAKE_OPT}" "${COMPILE_ID}" "intel" "${CLEAN_BEFORE}" "${CLEAN_AFTER}"
+   BUILD_JOBS=${BUILD_JOBS:-8} "${HOMEgfs_}/sorc/ufs_model.fd/tests/compile.sh" "${MACHINE_ID}" "${MAKE_OPT}" "${COMPILE_ID}" "intel" "${CLEAN_BEFORE}" "${CLEAN_AFTER}"
 fi
 mv "./tests/fv3_${COMPILE_ID}.exe" "./tests/${EXEC_NAME}"
 if [[ ! -f "./tests/modules.ufs_model.lua" ]]; then mv "./tests/modules.fv3_${COMPILE_ID}.lua" "./tests/modules.ufs_model.lua"; fi

--- a/sorc/build_ufs_utils.sh
+++ b/sorc/build_ufs_utils.sh
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 set -eux
 
+# shellcheck disable=SC2155
+readonly HOMEgfs_=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}")")/.." && pwd -P)
+
 OPTIND=1
 while getopts ":j:dv" option; do
   case "${option}" in
@@ -23,7 +26,7 @@ CMAKE_OPTS="-DGFS=ON" \
 BUILD_TYPE=${BUILD_TYPE:-"Release"} \
 BUILD_JOBS=${BUILD_JOBS:-8} \
 BUILD_VERBOSE=${BUILD_VERBOSE:-} \
-./ufs_utils.fd/build_all.sh
+"${HOMEgfs_}/sorc/ufs_utils.fd/build_all.sh"
 
 exit
 

--- a/sorc/build_upp.sh
+++ b/sorc/build_upp.sh
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 set -eux
 
+# shellcheck disable=SC2155
+readonly HOMEgfs_=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}")")/.." && pwd -P)
+
 script_dir=$(dirname "${BASH_SOURCE[0]}")
 cd "${script_dir}" || exit 1
 
@@ -21,8 +24,8 @@ while getopts ":dj:v" option; do
 done
 shift $((OPTIND-1))
 
-cd ufs_model.fd/FV3/upp/tests
+cd "${HOMEgfs_}/sorc/ufs_model.fd/FV3/upp/tests"
 # shellcheck disable=SC2086
-BUILD_JOBS=${BUILD_JOBS:-8} "./compile_upp.sh" ${_opts}
+BUILD_JOBS=${BUILD_JOBS:-8} "${HOMEgfs_}/sorc/ufs_model.fd/FV3/upp/tests/compile_upp.sh" ${_opts}
 
 exit 0

--- a/sorc/build_ww3prepost.sh
+++ b/sorc/build_ww3prepost.sh
@@ -1,9 +1,9 @@
 #! /usr/bin/env bash
 set -x
 
-# shellcheck disable=SC2312
-_HOMEgfs=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )/.." && pwd -P)
-cd "${_HOMEgfs}/sorc" || exit 1
+# shellcheck disable=SC2312,SC2155
+readonly HOMEgfs_=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )/.." && pwd -P)
+cd "${HOMEgfs_}/sorc" || exit 1
 
 # Default settings
 PDLIB="ON"
@@ -27,14 +27,14 @@ done
 
 # Determine machine and load modules
 set +x
-source "${_HOMEgfs}/sorc/ufs_model.fd/tests/detect_machine.sh"
-source "${_HOMEgfs}/sorc/ufs_model.fd/tests/module-setup.sh"
-module use "${_HOMEgfs}/sorc/ufs_model.fd/modulefiles"
+source "${HOMEgfs_}/sorc/ufs_model.fd/tests/detect_machine.sh"
+source "${HOMEgfs_}/sorc/ufs_model.fd/tests/module-setup.sh"
+module use "${HOMEgfs_}/sorc/ufs_model.fd/modulefiles"
 module load "ufs_${MACHINE_ID}.intel"
 set -x
 
 #Set WW3 directory
-cd "${_HOMEgfs}/sorc/ufs_model.fd/WW3" || exit 1
+cd "${HOMEgfs_}/sorc/ufs_model.fd/WW3" || exit 1
 WW3_DIR=$(pwd -P)
 export WW3_DIR
 


### PR DESCRIPTION
# Description

When running build scripts in `HOMEgfs_/sorc` from within pipeline scripts would sometimes fail because they mostly contain non-full paths to subsequent bash calls relative to $PWD.  This update uses the pattern where `HOMEgfs_` is applied to use full paths within the build scripts so they are not depended on being launched from $PWD.

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? YES
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 
# How has this been tested?

This PR will be tested directly on the pipeline running on Gaea C6
