### PR TITLE
update gfs URSA resources, add gcafs URSA resources

### DIFF
--- a/dev/parm/config/gcafs/config.resources.URSA
+++ b/dev/parm/config/gcafs/config.resources.URSA
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-# Hera-specific job resources
+# Ursa-specific job resources
 
 case ${step} in
   "fcst" | "efcs")

--- a/dev/parm/config/gcafs/config.resources.URSA
+++ b/dev/parm/config/gcafs/config.resources.URSA
@@ -11,6 +11,11 @@ case ${step} in
       "C1152")
         export tasks_per_node=144
         ;;
+      "C96")
+        if [[ "${RUN}" = "gcdas" ]]; then
+          export walltime="01:00:00"
+        fi	    
+        ;;  
       *)
         # Nothing to do for other resolutions
         true


### PR DESCRIPTION
# Description
This PR reverts an erroneous change to the C96 fcst section of `dev/parm/config/gfs/config.resources.URSA` in g-w PR #3967.  The C96 fcst section of `dev/parm/config/gcafs/config.resources.URSA` needs updating. 

File `dev/parm/config/gcafs/config.resources.URSA` does not exist so this PR adds this file.

Contributes to #3674
 

# Type of change
- [ ] Maintenance - port g-w to Ursa


# Change characteristics
- Is this a breaking change (a change in existing functionality)? **NO**
- Does this change require a documentation update? **NO**
- Does this change require an update to any of the following submodules? **NO**

# How has this been tested?
Install `feature/ursa` with GDASApp `feature/stable-nightly` as `sorc/gdas.cd`.  Run GDASApp ctests, including g-w CI for select DA configurations.  All ctests [_Passed_](url).  See GDASpp PR [#1869](https://github.com/NOAA-EMC/GDASApp/pull/1869) for details.


# Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added

