### PR TITLE
HOTFIX: Revert core specification

### DIFF
--- a/dev/workflow/build_opts.yaml
+++ b/dev/workflow/build_opts.yaml
@@ -5,7 +5,7 @@ host_override:  # over-ride options for host
     walltime_ratio: 1.5  # Uniformly adjust the wallclock by this factor (builds are slower on head nodes)
     build:
       gdas:
-        memory: "60G"
+        memory: "30G"
         cores: 8
         walltime: "02:30:00"
 systems:

--- a/dev/workflow/rocoto/rocoto.py
+++ b/dev/workflow/rocoto/rocoto.py
@@ -123,7 +123,6 @@ def _create_innermost_task(task_dict: Dict[str, Any]) -> List[str]:
     native = resources_dict.get('native', None)
     memory = resources_dict.get('memory', None)
     nodes = resources_dict.get('nodes', 1)
-    scheduler = resources_dict.get('scheduler', 'unknown')
     ppn = resources_dict.get('ppn', 1)
     threads = resources_dict.get('threads', 1)
     log = task_dict.get('log', 'demo.log')
@@ -145,12 +144,7 @@ def _create_innermost_task(task_dict: Dict[str, Any]) -> List[str]:
     if partition is not None:
         strings.append(f'\t<partition>{partition}</partition>\n')
     strings.append(f'\t<walltime>{walltime}</walltime>\n')
-    # Construct resources string based on ppn, nodes, and threads
-    if nodes > 1 or threads > 1 or scheduler == "pbspro":
-        strings.append(f'\t<nodes>{nodes}:ppn={ppn}:tpp={threads}</nodes>\n')
-    else:
-        strings.append(f'\t<cores>{ppn}</cores>\n')
-
+    strings.append(f'\t<nodes>{nodes}:ppn={ppn}:tpp={threads}</nodes>\n')
     if memory is not None:
         strings.append(f'\t<memory>{memory}</memory>\n')
     if native is not None:

--- a/dev/workflow/rocoto/tasks.py
+++ b/dev/workflow/rocoto/tasks.py
@@ -503,9 +503,6 @@ class Tasks:
             if task_constraint:
                 native += ' --constraint=' + task_constraint
 
-        else:
-            raise NotImplementedError(f"Scheduler type '{scheduler}' has not been implemented!")
-
         # Finally, construct and return the task resource dictionary
         task_resource = {'account': account,
                          'walltime': walltime,
@@ -514,7 +511,6 @@ class Tasks:
                          'ppn': ppn,
                          'threads': threads,
                          'memory': memory,
-                         'scheduler': scheduler,
                          'native': native,
                          'queue': task_queue,
                          'partition': task_partition}


### PR DESCRIPTION
This reverts commit 4c1274e8b4a144c8c849230b235a2f3bb07dc72b.
# Description
This reverts the use of the `<cores>` rocoto tag, which is causing failures on Hera.
Reopens #3932 
# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? YES (this breaks compute builds of GDASApp on C6; however, compute builds of GDASApp are currently disabled, so this has no immediate effect)
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Manual testing on Hera.