### PR TITLE
Load spack-stack 1.6.0 for metp jobs on Hera and fix build_compute.sh on WCOSS2

### DIFF
--- a/dev/jobs/metp.sh
+++ b/dev/jobs/metp.sh
@@ -3,7 +3,7 @@
 set -x
 
 ###############################################################
-source "${HOMEgfs}/dev/ush/load_fv3gfs_modules.sh"
+source "${HOMEgfs}/dev/ush/load_gw_verif_modules.sh"
 status=$?
 if (( status != 0 )); then exit "${status}"; fi
 

--- a/dev/ush/load_gw_verif_modules.sh
+++ b/dev/ush/load_gw_verif_modules.sh
@@ -1,0 +1,104 @@
+#! /usr/bin/env bash
+
+###############################################################
+if [[ "$-" == *x* ]]; then
+  set_x=YES
+else
+  set_x=NO
+fi
+
+if [[ "${DEBUG_WORKFLOW:-NO}" == "NO" ]]; then
+  echo "Loading modules quietly..."
+  set +x
+fi
+
+# Setup runtime environment by loading modules
+ulimit_s=$( ulimit -S -s )
+
+# Test if HOMEgfs is defined.  If not, then try to determine it with git rev-parse
+_unset_homegfs="NO"
+if [[ -z ${HOMEgfs+x} ]]; then
+  echo "INFO HOMEgfs is not defined.  Attempting to find the global-workflow root directory"
+  # HOMEgfs will be removed from the environment at the end of this script
+  _unset_homegfs="YES"
+
+  script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+  HOMEgfs=$(cd "${script_dir}" && git rev-parse --show-toplevel)
+  export HOMEgfs
+  err=$?
+  if [[ ${err} -ne 0 ]]; then
+    is_git_dir=$( cd -- "${script_dir}" &> /dev/null && git rev-parse --is-inside-work-tree)
+    git_stat=$?
+    if [[ ${git_stat} -ne 0 || ${is_git_dir} != "true" ]]; then
+      echo "FATAL ERROR unable to determine the root because it is not a git repository."
+    else
+      echo "FATAL ERROR unable to determine the root because git rev-parse --show-toplevel failed for an unknown reason"
+    fi
+    echo "            Unable to load modules.  Exiting"
+    exit 1
+  fi
+fi
+
+# Find module command and purge:
+source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEgfs}/ush/module-setup.sh"
+
+# Source versions file for runtime
+if [[ -f "${HOMEgfs}/versions/run.ver" ]]; then
+    source "${HOMEgfs}/versions/run.ver"
+else
+    echo "FATAL ERROR ${HOMEgfs}/versions/run.ver does not exist!"
+    echo "HINT: Run link_workflow.sh first."
+    exit 1
+fi
+
+# Load our modules:
+module use "${HOMEgfs}/modulefiles"
+
+case "${MACHINE_ID}" in
+"wcoss2")
+  target_module="gw_run.${MACHINE_ID}"
+  ;;
+"hera")
+  target_module="gw_verif.${MACHINE_ID}"
+  ;;
+*)
+  echo "FATAL ERROR: UNKNOWN/UNSUPPORTED PLATFORM: '${MACHINE_ID}'"
+  exit 1
+  ;;
+esac
+
+module load "${target_module}"
+export err=$?
+if [[ ${err} -ne 0 ]]; then
+  echo "FATAL ERROR: Failed to load ${target_module}"
+  exit 1
+fi
+
+module list
+
+# If this function exists in the environment, run it; else set -x if it was set on entering this script
+ftype=$(type -t set_trace || echo "")
+if [[ "${ftype}" == "function" ]]; then
+  set_trace
+elif [[ "${set_x}" == "YES" ]]; then
+  set -x
+fi
+
+# Set up the PYTHONPATH to include wxflow from HOMEgfs
+if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+fi
+
+# Add HOMEgfs/ush/python to PYTHONPATH
+PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/ush/python"
+export PYTHONPATH
+
+# Restore stack soft limit:
+ulimit -S -s "${ulimit_s}"
+unset ulimit_s
+
+# Unset HOMEgfs if it was not set at the beginning of this script
+if [[ ${_unset_homegfs} == "YES" ]]; then
+    unset HOMEgfs
+fi

--- a/dev/ush/load_gw_verif_modules.sh
+++ b/dev/ush/load_gw_verif_modules.sh
@@ -63,8 +63,8 @@ case "${MACHINE_ID}" in
   target_module="gw_verif.${MACHINE_ID}"
   ;;
 *)
-  echo "FATAL ERROR: UNKNOWN/UNSUPPORTED PLATFORM: '${MACHINE_ID}'"
-  exit 1
+  echo "WARNING: UNKNOWN/UNSUPPORTED PLATFORM: '${MACHINE_ID}'"
+  target_module="gw_run.${MACHINE_ID}"
   ;;
 esac
 

--- a/dev/workflow/build_compute.py
+++ b/dev/workflow/build_compute.py
@@ -77,6 +77,7 @@ def get_task_spec(task_name: str, task_spec: Dict, host_spec: Dict) -> Dict:
     task_dict.resources.nodes = 1
     task_dict.resources.ntasks = task_spec.cores
     task_dict.resources.ppn = task_spec.cores
+    task_dict.resources.scheduler=host_spec.scheduler
     task_dict.resources.threads = 1
 
     return task_dict

--- a/dev/workflow/build_compute.py
+++ b/dev/workflow/build_compute.py
@@ -77,7 +77,7 @@ def get_task_spec(task_name: str, task_spec: Dict, host_spec: Dict) -> Dict:
     task_dict.resources.nodes = 1
     task_dict.resources.ntasks = task_spec.cores
     task_dict.resources.ppn = task_spec.cores
-    task_dict.resources.scheduler=host_spec.scheduler
+    task_dict.resources.scheduler = host_spec.scheduler
     task_dict.resources.threads = 1
 
     return task_dict

--- a/modulefiles/gw_verif.hera.lua
+++ b/modulefiles/gw_verif.hera.lua
@@ -9,6 +9,7 @@ load("stack-intel-oneapi-mpi")
 load("met/9.1.3")
 load("metplus/3.1.1")
 load("grib-util")
+load("prod_util")
 load("wgrib2")
 
 whatis("Description: EMC_verif-global run environment")

--- a/modulefiles/gw_verif.hera.lua
+++ b/modulefiles/gw_verif.hera.lua
@@ -1,9 +1,7 @@
 help([[
-Load environment to run GFS on Hera
+Load environment to run EMC_verif-global on Hera
 ]])
 
--- Test that HOMEgfs is set.
--- If not, load_gw_run_modules.sh was not sourced to load this module.
 prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-fms-2024.01/install/modulefiles/Core")
 load("stack-intel")
 load("stack-python")
@@ -13,6 +11,4 @@ load("metplus/3.1.1")
 load("grib-util")
 load("wgrib2")
 
-whatis("Description: GFS run environment")
-
-load(pathJoin("imagemagick", (os.getenv("imagemagick_ver") or "None")))
+whatis("Description: EMC_verif-global run environment")

--- a/modulefiles/gw_verif.hera.lua
+++ b/modulefiles/gw_verif.hera.lua
@@ -1,0 +1,18 @@
+help([[
+Load environment to run GFS on Hera
+]])
+
+-- Test that HOMEgfs is set.
+-- If not, load_gw_run_modules.sh was not sourced to load this module.
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-fms-2024.01/install/modulefiles/Core")
+load("stack-intel")
+load("stack-python")
+load("stack-intel-oneapi-mpi")
+load("met/9.1.3")
+load("metplus/3.1.1")
+load("grib-util")
+load("wgrib2")
+
+whatis("Description: GFS run environment")
+
+load(pathJoin("imagemagick", (os.getenv("imagemagick_ver") or "None")))


### PR DESCRIPTION
# Description
This adds a fix for the metp jobs on Hera so that spack-stack 1.6.0 MET and METplus are used and adds a warning for unsupported platforms (C6 and MSU).

Resolves #3992 
Resolves #4003 
Refs #4001 

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
C48_ATM test case on Hera with `DO_METP=YES`.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added