### PR TITLE
update logic for ARCH_GAUSSIAN check in gfs_tasks.py

### DIFF
--- a/dev/workflow/rocoto/gfs_tasks.py
+++ b/dev/workflow/rocoto/gfs_tasks.py
@@ -2227,7 +2227,7 @@ class GFSTasks(Tasks):
             tarball_types = ['gfsa', 'gfsb']
 
             # Add optional tarballs based on configuration
-            if self._configs['arch_tars'].get('ARCH_GAUSSIAN', 'YES') == 'YES':
+            if self._configs['arch_tars'].get('ARCH_GAUSSIAN', True):
                 tarball_types.extend(['gfs_flux', 'gfs_netcdfb', 'gfs_pgrb2b'])
                 if self.app_config.mode == 'cycled':
                     tarball_types.append('gfs_netcdfa')


### PR DESCRIPTION
# Description
This PR replaces `YES` with `True` in the logical check on `ARCH_GAUSSIAN` in `dev/workflow/rocoto/gfs_tasks.py`.

Resolves #4016

# Type of change
- [ ] Bug fix (fixes something broken)


# Change characteristics
- Is this a breaking change (a change in existing functionality)? **NO**
- Does this change require a documentation update? **NO**
- Does this change require an update to any of the following submodules? **NO**

# How has this been tested?
Execute `dev/workflow/create_experiment.py` for CI case C96C48_ufs_hybatmDA.  Confirm that the resulting xml contains
```
<metatask name="gfs_arch_tars" mode="parallel">

        <var name="tartype">gfsa gfsb gfs_flux gfs_netcdfb gfs_pgrb2b gfs_netcdfa gfs_restarta</var>
```

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings

