### PR TITLE
associate C192 atm with 0.25 ocn in setup_expt.py

### DIFF
--- a/dev/workflow/setup_expt.py
+++ b/dev/workflow/setup_expt.py
@@ -599,7 +599,7 @@ def get_ocean_resolution(resdetatmos):
     """
     atmos_to_ocean_map = {
         1152: 0.25, 768: 0.25, 384: 0.25,
-        192: 1.0,
+        192: 0.25,
         96: 5.0, 48: 5.0}
     try:
         return atmos_to_ocean_map[resdetatmos]


### PR DESCRIPTION
# Description

`atmos_to_ocean_map` in `dev/workflow/setup_expt.py` is modified to map the C192 atmosphere to the 0.25 degree ocean resolution.   The `192: 0.25` mapping is based on the [discussion](https://github.com/NOAA-EMC/global-workflow/issues/3825#issuecomment-3258268392) in g-w issue #3825.

Resolves #4019 

# Type of change
- [x] Bug fix (fixes something broken)


# Change characteristics
- Is this a breaking change (a change in existing functionality)? **NO**
- Does this change require a documentation update? **NO**
- Does this change require an update to any of the following submodules? **NO**

# How has this been tested?
1. clone and install `RussTreadon-NOAA:bugfix/c192ocnres` on Hera
2. change `resdetatmos` in `dev/ci/cases/pr/C96C48_ufs_hybatmDA.yaml` from `96` to `192`
3. execute `dev/workflow/create_experiment.py` for CI case `C96C48_ufs_hybatmDA`
4. confirm that `config.base` in EXPDIR contains
```
export CASE="C192"
export OCNRES="025"
```

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
