### PR TITLE
Save MOM6 runtime configuration file to tape and archive

### DIFF
--- a/parm/archive/gdasocean.yaml.j2
+++ b/parm/archive/gdasocean.yaml.j2
@@ -11,3 +11,4 @@ gdasocean:
         - "{{ COMIN_OCEAN_HISTORY | relpath(ROTDIR) }}/{{ head }}inst.f{{ '%03d' % fhr }}.nc"
         {% endfor %}
         - '{{ COMIN_CONF | relpath(ROTDIR) }}/ufs.MOM_input'
+        - '{{ COMIN_CONF | relpath(ROTDIR) }}/MOM_parameter_doc.all'

--- a/parm/archive/gfsa.yaml.j2
+++ b/parm/archive/gfsa.yaml.j2
@@ -13,6 +13,7 @@ gfsa:
 
         # UFS configuration
         - "{{ COMIN_CONF | relpath(ROTDIR) }}/ufs.input.nml"
+        - "{{ COMIN_CONF | relpath(ROTDIR) }}/MOM_parameter_doc.all"
 
         {% if MODE == "cycled" %}
         # Analysis GRIB2 (gridded) data

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -693,7 +693,9 @@ MOM6_out() {
 
   # Copy MOM_input from DATA to COMOUT_CONF after the forecast is run (and successfull)
   cpfs "${DATA}/INPUT/MOM_input" "${COMOUT_CONF}/ufs.MOM_input"
-
+  # Copy runtime configuration of MOM: MOM_parameter_doc.all that was used in the forecast
+  cpfs "${DATA}/MOM6_OUTPUT/MOM_parameter_doc.all" "${COMOUT_CONF}/MOM_parameter_doc.all"
+  
   # Create a list of MOM6 restart files
   # Coarser than 1/2 degree has a single MOM restart
   local mom6_restart_files mom6_restart_file restart_file

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -694,7 +694,9 @@ MOM6_out() {
   # Copy MOM_input from DATA to COMOUT_CONF after the forecast is run (and successfull)
   cpfs "${DATA}/INPUT/MOM_input" "${COMOUT_CONF}/ufs.MOM_input"
   # Copy runtime configuration of MOM: MOM_parameter_doc.all that was used in the forecast
-  cpfs "${DATA}/MOM6_OUTPUT/MOM_parameter_doc.all" "${COMOUT_CONF}/MOM_parameter_doc.all"
+  if [[ -f "${DATA}/MOM6_OUTPUT/MOM_parameter_doc.all" ]]; then
+    cpfs "${DATA}/MOM6_OUTPUT/MOM_parameter_doc.all" "${COMOUT_CONF}/MOM_parameter_doc.all"
+  fi
   
   # Create a list of MOM6 restart files
   # Coarser than 1/2 degree has a single MOM restart


### PR DESCRIPTION
# Description

## What?
This PR adds [MOM_parameter_doc.all](https://mom6.readthedocs.io/en/main/api/generated/pages/Runtime_Parameter_System.html?highlight=parameter_doc#getting-parameters-into-mom6) to those files that are saved on to the tape and archive.

## Why?
 Having the configuration of the ocean model, namely MOM6 for:
- Future reference 
- Reproducibility.

# Type of change
- [ ] Bug fix (fixes something broken)
- [x] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO; In fact it creates documentation for later use and referencing!
- Does this change require an update to any of the following submodules? NO 

  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?

- Forecast test on Orion
⬇️ file was saved upon completion of the job. ✅ Intended configuration saved.
`/work2/noaa/stmp/santa/COMROOT/sfs_x1a_cpc_ic/sfs.19940501/00/mem000/conf/MOM_parameter_doc.all`
-->

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary

