### PR TITLE
Quick Fix: added path in stack stack 1.9 for loading gh on gaeac6

### DIFF
--- a/modulefiles/gw_setup.gaeac6.lua
+++ b/modulefiles/gw_setup.gaeac6.lua
@@ -18,6 +18,7 @@ load("py-jinja2")
 load("py-pyyaml")
 load("py-numpy")
 load("git-lfs")
+prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/c6/spack-stack-1.9.2/envs/ue-intel-2023.2.0/install/modulefiles/gcc/12.3.0")
 load("gh")
 
 unload("cray-libsci")


### PR DESCRIPTION
This is a quick fix to load GitHub CLI from Spack Stack 1.9x on Gaea C6