### PR TITLE
Custom workflow name to include PR_NUMBER

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,9 @@ variables:
   PR_NUMBER: 0 # PR number is set by GitHub Actions
                # when the pipeline is triggered from a PR
 
+workflow:
+  name: "PR ${PR_NUMBER} - ${RUN_ON_MACHINES} (${GFS_CI_RUN_TYPE})"
+
 # Include specialized pipeline configuration files
 include:
   - local: 'dev/ci/gitlab-ci-ctests.yml'  # CTest framework configuration


### PR DESCRIPTION
# Description

We add a custom tile for the pipeline view in GitLab to include PR number and Hostname 

Resolves #4034

# How has this been tested?

<img width="750" height="161" alt="image" src="https://github.com/user-attachments/assets/86bcb51d-dec5-4e64-b980-1ca83df79477" />
