### PR TITLE
Update GFS to v16.3.27 to disable encrypted transfers

### DIFF
--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_1.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_1.list
@@ -34,7 +34,7 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVE
 + /00/atmos/mem???/gdas.t??z.atmf006.nc
 + /00/atmos/mem???/gdas.t??z.atmf009.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
 _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
@@ -44,7 +44,7 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_
 + /00/atmos/mem???/gdas.t??z.atmf006.nc
 + /00/atmos/mem???/gdas.t??z.atmf009.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
 

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_2.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_2.list
@@ -34,7 +34,7 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVE
 + /06/atmos/mem???/gdas.t??z.atmf006.nc
 + /06/atmos/mem???/gdas.t??z.atmf009.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
 _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
@@ -44,6 +44,6 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_
 + /06/atmos/mem???/gdas.t??z.atmf006.nc
 + /06/atmos/mem???/gdas.t??z.atmf009.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_3.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_3.list
@@ -27,7 +27,6 @@
 # This directory is a good candidate for compression
 #Z
 
-#_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDYm1_/
 _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDYm1_/
 + /12/
 + /12/atmos/
@@ -35,10 +34,9 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVE
 + /12/atmos/mem???/gdas.t??z.atmf006.nc
 + /12/atmos/mem???/gdas.t??z.atmf009.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
-#_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
 _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
 + /12/
 + /12/atmos/
@@ -46,7 +44,7 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_
 + /12/atmos/mem???/gdas.t??z.atmf006.nc
 + /12/atmos/mem???/gdas.t??z.atmf009.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
 

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_4.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_4.list
@@ -27,7 +27,6 @@
 # This directory is a good candidate for compression
 #Z
 
-#_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDYm1_/
 _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDYm1_/
 + /18/
 + /18/atmos/
@@ -35,10 +34,9 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVE
 + /18/atmos/mem???/gdas.t??z.atmf006.nc
 + /18/atmos/mem???/gdas.t??z.atmf009.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
-#_COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
 _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
 + /18/
 + /18/atmos/
@@ -46,7 +44,7 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_
 + /18/atmos/mem???/gdas.t??z.atmf006.nc
 + /18/atmos/mem???/gdas.t??z.atmf009.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
 

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_5.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_5.list
@@ -35,7 +35,7 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVE
 + /00/atmos/gdas.t??z.atmf006.ensmean.nc
 + /00/atmos/gdas.t??z.atmf009.ensmean.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
 _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
@@ -46,7 +46,7 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_
 + /00/atmos/gdas.t??z.atmf006.ensmean.nc
 + /00/atmos/gdas.t??z.atmf009.ensmean.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
 

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_6.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_6.list
@@ -35,7 +35,7 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVE
 + /06/atmos/gdas.t??z.atmf006.ensmean.nc
 + /06/atmos/gdas.t??z.atmf009.ensmean.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
 _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
@@ -46,7 +46,7 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_
 + /06/atmos/gdas.t??z.atmf006.ensmean.nc
 + /06/atmos/gdas.t??z.atmf009.ensmean.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
 

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_7.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_7.list
@@ -35,7 +35,7 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVE
 + /12/atmos/gdas.t??z.atmf006.ensmean.nc
 + /12/atmos/gdas.t??z.atmf009.ensmean.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
 _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
@@ -46,7 +46,7 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_
 + /12/atmos/gdas.t??z.atmf006.ensmean.nc
 + /12/atmos/gdas.t??z.atmf009.ensmean.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
 

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_8.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_enkf_enkf_8.list
@@ -35,7 +35,7 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVE
 + /18/atmos/gdas.t??z.atmf006.ensmean.nc
 + /18/atmos/gdas.t??z.atmf009.ensmean.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
 _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/enkfgdas._PDY_/
@@ -46,7 +46,7 @@ _COMROOT_/gfs/_SHORTVER_/enkfgdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_
 + /18/atmos/gdas.t??z.atmf006.ensmean.nc
 + /18/atmos/gdas.t??z.atmf009.ensmean.nc
 - *
-E
+W
 # This directory is a good candidate for compression
 #Z
 

--- a/parm/transfer/transfer_rdhpcs_gfs_gdas_gdas.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gdas_gdas.list
@@ -24,7 +24,13 @@
 # directory are included, so if no exclude patterns match that file, it will be
 # transferred.
 
-#_COMROOT_/gfs/_SHORTVER_/gdas._PDYm1_/ _REMOTEPATH_/com/gfs/_ENVIR_/gdas._PDYm1_/
+_COMROOT_/gfs/_SHORTVER_/gdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gdas._PDYm1_/
++ /??/
++ /??/atmos/
++ /??/atmos/gdas.t??z.radstat
+- *
+E
+
 _COMROOT_/gfs/_SHORTVER_/gdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gdas._PDYm1_/
 + /??/
 + /??/atmos/
@@ -36,17 +42,21 @@ _COMROOT_/gfs/_SHORTVER_/gdas._PDYm1_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/g
 + /??/atmos/gdas.t??z.sfcf*.nc
 + /??/atmos/gdas.t??z.engicegrb
 + /??/atmos/gdas.t??z.atmf0*.nc
-+ /??/atmos/gdas.t??z.radstat
 + /??/atmos/gdas.t??z.atmanl.nc
 + /??/atmos/gdas.t??z.atmges.nc
 + /??/atmos/gdas.t??z.atmgm3.nc
 + /??/atmos/gdas.t??z.atmgp3.nc
 + /??/atmos/gdas.t??z.sfcanl.nc
 - *
+W
+
+_COMROOT_/gfs/_SHORTVER_/gdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gdas._PDY_/
++ /??/
++ /??/atmos/
++ /??/atmos/gdas.t??z.radstat
+- *
 E
-# This directory is a good candidate for compression
-#Z
-#_COMROOT_/gfs/_SHORTVER_/gdas._PDY_/ _REMOTEPATH_/com/gfs/_ENVIR_/gdas._PDY_/
+
 _COMROOT_/gfs/_SHORTVER_/gdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gdas._PDY_/
 + /??/
 + /??/atmos/
@@ -58,7 +68,6 @@ _COMROOT_/gfs/_SHORTVER_/gdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gda
 + /??/atmos/gdas.t??z.sfcf*.nc
 + /??/atmos/gdas.t??z.engicegrb
 + /??/atmos/gdas.t??z.atmf0*.nc
-+ /??/atmos/gdas.t??z.radstat
 + /??/atmos/gdas.t??z.atmanl.nc
 + /??/atmos/gdas.t??z.atmges.nc
 + /??/atmos/gdas.t??z.atmgm3.nc
@@ -66,7 +75,5 @@ _COMROOT_/gfs/_SHORTVER_/gdas._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gda
 + /??/atmos/gdas.t??z.sfcanl.nc
 + /??/atmos/gdas.t??z.sstgrb
 - *
-E
-# This directory is a good candidate for compression
-#Z
+W
 

--- a/parm/transfer/transfer_rdhpcs_gfs_gempak.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gempak.list
@@ -24,7 +24,6 @@
 # directory are included, so if no exclude patterns match that file, it will be
 # transferred.
 
-#_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/  _REMOTEPATH_/com/nawips/_ENVIR_/gfs._PDY_/
 _COMROOT_/gfs/_SHORTVER_/gfs._PDY_/  _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gfs._PDY_/
 + /??/
 + /??/atmos/
@@ -34,7 +33,6 @@ _COMROOT_/gfs/_SHORTVER_/gfs._PDY_/  _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gfs
 + /??/atmos/gempak/gfs_*.snd
 + /??/atmos/gempak/gfs_*.sfc
 - *
-E
 # This directory is a good candidate for compression
 #Z
 

--- a/parm/transfer/transfer_rdhpcs_gfs_gfs.list
+++ b/parm/transfer/transfer_rdhpcs_gfs_gfs.list
@@ -24,7 +24,6 @@
 # directory are included, so if no exclude patterns match that file, it will be
 # transferred.
 
-#_COMROOT_/gfs/_SHORTVER_/gfs._PDY_/ _REMOTEPATH_/com/gfs/_ENVIR_/gfs._PDY_/
 _COMROOT_/gfs/_SHORTVER_/gfs._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gfs._PDY_/
 + /??/
 + /??/atmos/
@@ -64,7 +63,6 @@ _COMROOT_/gfs/_SHORTVER_/gfs._PDY_/ _REMOTEPATH_/_ENVIR_/com/gfs/_SHORTVER_/gfs.
 + /??/atmos/gfs.t??z.sfcf045.nc
 + /??/atmos/gfs.t??z.sfcf048.nc
 - *
-E
-# This directory is a good candidate for compression
-#Z
+W
+# E is not needed since no restricted data is mirrored by this job
 

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.26
-export gfs_ver=v16.3.26
+export version=v16.3.27
+export gfs_ver=v16.3.27
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
 export nam_ver=v4.2


### PR DESCRIPTION
# Description
This PR:
- brings changes that went into ops 0m 9/17/2025 with the 12z cycle
- enables fast transfers from WCOSS2 to Ursa
- closes #4074 

# Type of change
- [X] Maintenance (code refactor, clean-up, new CI test, etc.)