### PR TITLE
Skip generating IMS snow depth obs when the IMS SFC input data is missing

### DIFF
--- a/ush/python/pygfs/task/snow_analysis.py
+++ b/ush/python/pygfs/task/snow_analysis.py
@@ -143,7 +143,7 @@ class SnowAnalysis(Task):
         FileHandler({'mkdir': newdirs}).sync()
 
         # if 00z, do SCF preprocessing
-        infile = os.path.join(self.task_config.COMIN_OBS,f'{self.task_config.OPREFIX}imssnow96.asc')
+        infile = os.path.join(self.task_config.COMIN_OBS, f'{self.task_config.OPREFIX}imssnow96.asc')
         if self.task_config.cyc == 0 and os.path.exists(infile):
             ims_scf_to_ioda_staging_dict = parse_j2yaml(self.task_config.STAGE_IMS_SCF2IODA_YAML, self.task_config)
             FileHandler(ims_scf_to_ioda_staging_dict).sync()
@@ -169,7 +169,7 @@ class SnowAnalysis(Task):
         None
         """
 
-        infile = os.path.join(self.task_config.DATA,f'{jedi_dict_key}.yaml')
+        infile = os.path.join(self.task_config.DATA, f'{jedi_dict_key}.yaml')
         if os.path.exists(infile):
             self.jedi_dict[jedi_dict_key].execute()
 

--- a/ush/python/pygfs/task/snow_analysis.py
+++ b/ush/python/pygfs/task/snow_analysis.py
@@ -143,7 +143,7 @@ class SnowAnalysis(Task):
         FileHandler({'mkdir': newdirs}).sync()
 
         # if 00z, do SCF preprocessing
-        infile = f'{self.task_config.COMIN_OBS}/{self.task_config.OPREFIX}imssnow96.asc'
+        infile = os.path.join(self.task_config.COMIN_OBS,f'{self.task_config.OPREFIX}imssnow96.asc')
         if self.task_config.cyc == 0 and os.path.exists(infile):
             ims_scf_to_ioda_staging_dict = parse_j2yaml(self.task_config.STAGE_IMS_SCF2IODA_YAML, self.task_config)
             FileHandler(ims_scf_to_ioda_staging_dict).sync()
@@ -169,7 +169,7 @@ class SnowAnalysis(Task):
         None
         """
 
-        infile = f'{self.task_config.DATA}/{jedi_dict_key}.yaml'
+        infile = os.path.join(self.task_config.DATA,f'{jedi_dict_key}.yaml')
         if os.path.exists(infile):
             self.jedi_dict[jedi_dict_key].execute()
 

--- a/ush/python/pygfs/task/snow_analysis.py
+++ b/ush/python/pygfs/task/snow_analysis.py
@@ -143,7 +143,8 @@ class SnowAnalysis(Task):
         FileHandler({'mkdir': newdirs}).sync()
 
         # if 00z, do SCF preprocessing
-        if self.task_config.cyc == 0:
+        infile = f'{self.task_config.COMIN_OBS}/{self.task_config.OPREFIX}imssnow96.asc'
+        if self.task_config.cyc == 0 and os.path.exists(infile):
             ims_scf_to_ioda_staging_dict = parse_j2yaml(self.task_config.STAGE_IMS_SCF2IODA_YAML, self.task_config)
             FileHandler(ims_scf_to_ioda_staging_dict).sync()
             self.jedi_dict['scf_to_ioda'].initialize(self.task_config)
@@ -168,7 +169,9 @@ class SnowAnalysis(Task):
         None
         """
 
-        self.jedi_dict[jedi_dict_key].execute()
+        infile = f'{self.task_config.DATA}/{jedi_dict_key}.yaml'
+        if os.path.exists(infile):
+            self.jedi_dict[jedi_dict_key].execute()
 
     @logit(logger)
     def finalize(self) -> None:

--- a/ush/python/pygfs/task/snowens_analysis.py
+++ b/ush/python/pygfs/task/snowens_analysis.py
@@ -161,7 +161,7 @@ class SnowEnsAnalysis(Task):
         FileHandler({'mkdir': newdirs}).sync()
 
         # if 00z, do SCF preprocessing
-        infile = os.path.join(self.task_config.COMIN_OBS,f'{self.task_config.OPREFIX}imssnow96.asc')
+        infile = os.path.join(self.task_config.COMIN_OBS, f'{self.task_config.OPREFIX}imssnow96.asc')
         if self.task_config.cyc == 0 and os.path.exists(infile):
             ims_scf_to_ioda_staging_dict = parse_j2yaml(self.task_config.STAGE_IMS_SCF2IODA_YAML, self.task_config)
             FileHandler(ims_scf_to_ioda_staging_dict).sync()
@@ -191,7 +191,7 @@ class SnowEnsAnalysis(Task):
         None
         """
 
-        infile = os.path.join(self.task_config.DATA,f'{jedi_dict_key}.yaml')
+        infile = os.path.join(self.task_config.DATA, f'{jedi_dict_key}.yaml')
         if os.path.exists(infile):
             self.jedi_dict[jedi_dict_key].execute()
 

--- a/ush/python/pygfs/task/snowens_analysis.py
+++ b/ush/python/pygfs/task/snowens_analysis.py
@@ -161,7 +161,7 @@ class SnowEnsAnalysis(Task):
         FileHandler({'mkdir': newdirs}).sync()
 
         # if 00z, do SCF preprocessing
-        infile = f'{self.task_config.COMIN_OBS}/{self.task_config.OPREFIX}imssnow96.asc’ 
+        infile = os.path.join(self.task_config.COMIN_OBS,f'{self.task_config.OPREFIX}imssnow96.asc')
         if self.task_config.cyc == 0 and os.path.exists(infile):
             ims_scf_to_ioda_staging_dict = parse_j2yaml(self.task_config.STAGE_IMS_SCF2IODA_YAML, self.task_config)
             FileHandler(ims_scf_to_ioda_staging_dict).sync()
@@ -191,7 +191,7 @@ class SnowEnsAnalysis(Task):
         None
         """
 
-        infile = f'{self.task_config.DATA}/{jedi_dict_key}.yaml’
+        infile = os.path.join(self.task_config.DATA,f'{jedi_dict_key}.yaml')
         if os.path.exists(infile):
             self.jedi_dict[jedi_dict_key].execute()
 

--- a/ush/python/pygfs/task/snowens_analysis.py
+++ b/ush/python/pygfs/task/snowens_analysis.py
@@ -161,7 +161,8 @@ class SnowEnsAnalysis(Task):
         FileHandler({'mkdir': newdirs}).sync()
 
         # if 00z, do SCF preprocessing
-        if self.task_config.cyc == 0:
+        infile = f'{self.task_config.COMIN_OBS}/{self.task_config.OPREFIX}imssnow96.asc’ 
+        if self.task_config.cyc == 0 and os.path.exists(infile):
             ims_scf_to_ioda_staging_dict = parse_j2yaml(self.task_config.STAGE_IMS_SCF2IODA_YAML, self.task_config)
             FileHandler(ims_scf_to_ioda_staging_dict).sync()
             self.jedi_dict['scf_to_ioda'].initialize(self.task_config)
@@ -190,7 +191,9 @@ class SnowEnsAnalysis(Task):
         None
         """
 
-        self.jedi_dict[jedi_dict_key].execute()
+        infile = f'{self.task_config.DATA}/{jedi_dict_key}.yaml’
+        if os.path.exists(infile):
+            self.jedi_dict[jedi_dict_key].execute()
 
     @logit(logger)
     def finalize(self) -> None:


### PR DESCRIPTION
# Description
This PR skips generating IMS snow depth observations to prevent the job from crashing when the IMS SFC input data is missing. 

  Companion PRs: https://github.com/NOAA-EMC/GDASApp/pull/1898
  Resolves #4005 
-->
<!-- For more on writing good commit messages, see https://cbea.ms/git-commit/ -->

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? YES/NO
- Does this change require a documentation update? YES/NO
- Does this change require an update to any of the following submodules? YES/NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
Cycled test was conducted on Ursa

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
