### PR TITLE
Increase C96 gcdas fcst wall time to 1.5 hours

### DIFF
--- a/dev/parm/config/gcafs/config.resources.URSA
+++ b/dev/parm/config/gcafs/config.resources.URSA
@@ -13,7 +13,7 @@ case ${step} in
         ;;
       "C96")
         if [[ "${RUN}" = "gcdas" ]]; then
-          export walltime="01:00:00"
+          export walltime="01:30:00"
         fi	    
         ;;  
       *)


### PR DESCRIPTION
# Description
This PR increases the wall time for the C96 gcdas (gcafs da) forecast to `01:30:00` on Ursa.  

This is done due to highly variable  Ursa job run times.  The GCAFS forecast takes an unusually long time to complete on Ursa.  Developers are aware of this and are working on a long term solution.  Increasing the job wall time is a patch until the model run time stabilizes and is in line with the run time on other machines.

Resolves #4107 

# Type of change
- [x] Bug fix - prevent CI failure due to long running C96_gcafs forecast

# Change characteristics
- Is this a breaking change (a change in existing functionality)? **NO**
- Does this change require a documentation update? **NO**
- Does this change require an update to any of the following submodules? **NO**

# How has this been tested?

Clone, build, and run C96_gcafs_cycled on Ursa with the increase wall time for the forecast.


# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] This change is covered by an existing CI test or a new one has been added
