### PR TITLE
Only run wave bnd pnt for gfs

### DIFF
--- a/dev/parm/config/gfs/config.base.j2
+++ b/dev/parm/config/gfs/config.base.j2
@@ -179,7 +179,11 @@ aero_fcst_runs="gdas" # When to run aerosol forecast: gdas, gfs, or both
 aero_anl_runs="gdas gfs" # When to run aerosol analysis: gdas, gfs, or both
 export DO_AERO_FCST="NO"
 export DO_AERO_ANL="NO"
-export DOBNDPNT_WAVE="YES" # Option to create point outputs for downstream boundary points 
+if [[ "${RUN}" == "gfs" ]] ; then
+   export DOBNDPNT_WAVE="YES" # Create point outputs for downstream boundary points
+else
+   export DOBNDPNT_WAVE="NO" 
+fi
 export FRAC_GRID=".true."
 export DO_NEST="NO" # Whether to run a global-nested domain
 if [[ "${DO_NEST:-NO}" == "YES" ]] ; then


### PR DESCRIPTION
<!--
  *** PLEASE READ ***

  Any PRs not following this template will be closed.

  Please delete all these comments before submitting the PR.

  Please use a short (<60 char), descriptive title for the PR title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

  No content should appear above the "Description" header.

  If this PR is not merge-ready (e.g. it depends on other PRs not yet merged), please mark it as draft until it is ready.

  PRs should meet these guidelines:
  - Each PR should address ONE topic and have an associated issue.
  - No hard-coded paths or personal directories.
  - No temporary or backup files should be committed (including logs).
  - Any code that you disabled by being commented out should be removed or reenabled.
-->
# Description
This PR updates gfs config so that the boundary point jobs are only run for GFS, not gdas. 

Fixes #3899 
<!-- For more on writing good commit messages, see https://cbea.ms/git-commit/ -->

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
I ran C96C48mx500_S2SW_cyc_gfs on WCOSS2.   Test is here: /lfs/h2/emc/couple/noscrub/jessica.meixner/wavegwissues/RUNTESTS Note at the time of writing, the test was not complete, but it was past the main parts. The XML also shows that boundary points are only in the gfs jobs, not gdas now. 

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
