### PR TITLE
Set Intel MPI options for Ursa

### DIFF
--- a/env/URSA.env
+++ b/env/URSA.env
@@ -24,6 +24,12 @@ if [[ -n "${SLURM_JOB_ID:-}" ]]; then
   ulimit -a
 fi
 
+# Intel MPI settings needed to prevent memory bloat on AMD EPYC CPUs
+# These were specifically tested with the GSI, but adding them to the top
+# for all jobs.
+export I_MPI_ADJUST_GATHER=0
+export I_MPI_COLL_INTRANODE=pt2pt
+
 # Calculate common variables
 # Check first if the dependent variables are set
 if [[ -n "${ntasks:-}" && -n "${max_tasks_per_node:-}" && -n "${tasks_per_node:-}" ]]; then


### PR DESCRIPTION
# Description
This adds Intel MPI directives to avoid certain algorithms that perform sub-optimally on Ursa's AMD EPYC chips.  This is a temporary workaround, but may help high resolution runs on the platform.

References #4042 

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Worked for @ClaraDraper-NOAA at C192/C96.  Full testing will commence shortly.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added