### PR TITLE
Correct parametric and ensemble background error statistics filenames in marine DA

### DIFF
--- a/dev/parm/config/gfs/config.marinebmat
+++ b/dev/parm/config/gfs/config.marinebmat
@@ -10,5 +10,6 @@ source "${EXPDIR}/config.resources" marinebmat
 
 export JEDI_CONFIG_YAML="${PARMgfs}/gdas/marine/marine_bmat_jedi_config.yaml.j2"
 export SAVE_YAML="${PARMgfs}/gdas/marine/marine_bmat_save.yaml.j2"
+export COPY_BMAT_BKGERR_YAML="${PARMgfs}/gdas/marine/marine_bmat_copy_bkgerr.yaml.j2"
 
 echo "END: config.marinebmat"

--- a/parm/archive/gdasocean_analysis.yaml.j2
+++ b/parm/archive/gdasocean_analysis.yaml.j2
@@ -18,8 +18,8 @@ gdasocean_analysis:
         {% endfor %}
 
         # static background error
-        - '{{ COMIN_OCEAN_BMATRIX | relpath(ROTDIR) }}/{{ head }}ocean.bkgerr_ens_stddev.nc'
-        - '{{ COMIN_ICE_BMATRIX | relpath(ROTDIR) }}/{{ head }}ice.bkgerr_ens_stddev.nc'
+        - '{{ COMIN_OCEAN_BMATRIX | relpath(ROTDIR) }}/{{ head }}ocean.bkgerr_parametric_stddev.nc'
+        - '{{ COMIN_ICE_BMATRIX | relpath(ROTDIR) }}/{{ head }}ice.bkgerr_parametric_stddev.nc'
 
         # ensemble background error
         {% if NMEM_ENS > 2 %}
@@ -27,6 +27,8 @@ gdasocean_analysis:
         - '{{ COMIN_OCEAN_BMATRIX | relpath(ROTDIR) }}/{{ head }}ocean.ens_weights.nc'
         - '{{ COMIN_OCEAN_BMATRIX | relpath(ROTDIR) }}/{{ head }}ocean.recentering_error.nc'
         - '{{ COMIN_ICE_BMATRIX | relpath(ROTDIR) }}/{{ head }}ice.recentering_error.nc'
+        - '{{ COMIN_OCEAN_BMATRIX | relpath(ROTDIR) }}/{{ head }}ocean.bkgerr_ens_stddev.nc'
+        - '{{ COMIN_ICE_BMATRIX | relpath(ROTDIR) }}/{{ head }}ice.bkgerr_ens_stddev.nc'
         {% for diag_type in ["ssh_steric_stddev", "ssh_unbal_stddev", "ssh_total_stddev", "steric_explained_variance"] %}
         - '{{ COMIN_OCEAN_BMATRIX | relpath(ROTDIR) }}/{{ head }}ocean.{{ diag_type }}.nc'
         {% endfor %}

--- a/parm/archive/gfsocean_analysis.yaml.j2
+++ b/parm/archive/gfsocean_analysis.yaml.j2
@@ -19,8 +19,8 @@ gfsocean_analysis:
         {% endfor %}
 
         # static background error
-        - '{{ COMIN_OCEAN_BMATRIX | relpath(ROTDIR) }}/{{ head }}ocean.bkgerr_ens_stddev.nc'
-        - '{{ COMIN_ICE_BMATRIX | relpath(ROTDIR) }}/{{ head }}ice.bkgerr_ens_stddev.nc'
+        - '{{ COMIN_OCEAN_BMATRIX | relpath(ROTDIR) }}/{{ head }}ocean.bkgerr_parametric_stddev.nc'
+        - '{{ COMIN_ICE_BMATRIX | relpath(ROTDIR) }}/{{ head }}ice.bkgerr_parametric_stddev.nc'
 
         # runtime configs
         - '{{ COMIN_CONF | relpath(ROTDIR) }}/*.yaml'

--- a/ush/python/pygfs/task/marine_bmat.py
+++ b/ush/python/pygfs/task/marine_bmat.py
@@ -212,21 +212,9 @@ class MarineBMat(Task):
         None
         """
 
-        # TODO(AFE) the following should probably be a jinja template
-        # ocean diag B
-        os.rename(os.path.join(self.task_config.DATAstaticb,
-                  f"ocn.bkgerr_parametric_stddev.incr.{self.task_config.MARINE_WINDOW_END_ISO}.nc"),
-                  os.path.join(self.task_config.DATAstaticb, f"ocn.bkgerr_parametric_stddev.nc"))
-        os.rename(os.path.join(self.task_config.DATAstaticb,
-                  f"ice.bkgerr_parametric_stddev.incr.{self.task_config.MARINE_WINDOW_END_ISO}.nc"),
-                  os.path.join(self.task_config.DATAstaticb, f"ice.bkgerr_parametric_stddev.nc"))
-        if self.task_config.DOHYBVAR_OCN == "YES" or self.task_config.NMEM_ENS >= 2:
-            os.rename(os.path.join(self.task_config.DATAstaticb,
-                      f"ocn.bkgerr_ens_stddev.incr.{self.task_config.MARINE_WINDOW_BEGIN_ISO}.nc"),
-                      os.path.join(self.task_config.DATAstaticb, f"ocn.bkgerr_ens_stddev.nc"))
-            os.rename(os.path.join(self.task_config.DATAstaticb,
-                      f"ice.bkgerr_ens_stddev.incr.{self.task_config.MARINE_WINDOW_BEGIN_ISO}.nc"),
-                      os.path.join(self.task_config.DATAstaticb, f"ice.bkgerr_ens_stddev.nc"))
+        logger.info(f"Copying background error files to new filenames")
+        bkgerr_list = parse_j2yaml(self.task_config.COPY_BMAT_BKGERR_YAML, self.task_config)
+        FileHandler(bkgerr_list).sync()
 
         # Save output files to COM
         logger.info(f"Copy files to ROTDIR")

--- a/ush/python/pygfs/task/marine_bmat.py
+++ b/ush/python/pygfs/task/marine_bmat.py
@@ -212,7 +212,7 @@ class MarineBMat(Task):
         None
         """
 
-        # TODO(AFE) the two renames are to accomodate yaml settings in var task, which should changed
+        # TODO(AFE) the following should probably be a jinja template
         # ocean diag B
         os.rename(os.path.join(self.task_config.DATAstaticb,
                   f"ocn.bkgerr_parametric_stddev.incr.{self.task_config.MARINE_WINDOW_END_ISO}.nc"),

--- a/ush/python/pygfs/task/marine_bmat.py
+++ b/ush/python/pygfs/task/marine_bmat.py
@@ -214,10 +214,19 @@ class MarineBMat(Task):
 
         # TODO(AFE) the two renames are to accomodate yaml settings in var task, which should changed
         # ocean diag B
-        os.rename(os.path.join(self.task_config.DATAstaticb, f"ocn.bkgerr_stddev.incr.{self.task_config.MARINE_WINDOW_END_ISO}.nc"),
-                  os.path.join(self.task_config.DATAstaticb, f"ocn.bkgerr_stddev.nc"))
-        os.rename(os.path.join(self.task_config.DATAstaticb, f"ice.bkgerr_stddev.incr.{self.task_config.MARINE_WINDOW_END_ISO}.nc"),
-                  os.path.join(self.task_config.DATAstaticb, f"ice.bkgerr_stddev.nc"))
+        os.rename(os.path.join(self.task_config.DATAstaticb,
+                  f"ocn.bkgerr_parametric_stddev.incr.{self.task_config.MARINE_WINDOW_END_ISO}.nc"),
+                  os.path.join(self.task_config.DATAstaticb, f"ocn.bkgerr_parametric_stddev.nc"))
+        os.rename(os.path.join(self.task_config.DATAstaticb,
+                  f"ice.bkgerr_parametric_stddev.incr.{self.task_config.MARINE_WINDOW_END_ISO}.nc"),
+                  os.path.join(self.task_config.DATAstaticb, f"ice.bkgerr_parametric_stddev.nc"))
+        if self.task_config.DOHYBVAR_OCN == "YES" or self.task_config.NMEM_ENS >= 2:
+            os.rename(os.path.join(self.task_config.DATAstaticb,
+                      f"ocn.bkgerr_ens_stddev.incr.{self.task_config.MARINE_WINDOW_BEGIN_ISO}.nc"),
+                      os.path.join(self.task_config.DATAstaticb, f"ocn.bkgerr_ens_stddev.nc"))
+            os.rename(os.path.join(self.task_config.DATAstaticb,
+                      f"ice.bkgerr_ens_stddev.incr.{self.task_config.MARINE_WINDOW_BEGIN_ISO}.nc"),
+                      os.path.join(self.task_config.DATAstaticb, f"ice.bkgerr_ens_stddev.nc"))
 
         # Save output files to COM
         logger.info(f"Copy files to ROTDIR")


### PR DESCRIPTION
# Description

This PR will preserve correct filenames for the marine DA parametric and ensemble background error statistics files and archive both.

Resolves https://github.com/NOAA-EMC/global-workflow/issues/4119

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics

- Is this a breaking change (a change in existing functionality)? YES/NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? YES/NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [x] GDAS ~~(https://github.com/NOAA-EMC/GDASApp/pull/1922)~~ (https://github.com/NOAA-EMC/GDASApp/pull/1928)
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?

`C48mx500_3DVarAOWCDA` and `C48mx500_hybAOWCDA` in full cycle tests (not just GDASApp ctests), the latter with `nens=3` on Ursa


# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
