### PR TITLE
Delay ocean post-processing trigger to next-next forecast

### DIFF
--- a/dev/workflow/rocoto/gfs_tasks.py
+++ b/dev/workflow/rocoto/gfs_tasks.py
@@ -1221,7 +1221,7 @@ class GFSTasks(Tasks):
                                    'history_file_tmpl': f'{self.run}.t@Hz.master.grb2f#fhr3_last#'},
                          'ocean': {'config': 'oceanice_products',
                                    'history_path_tmpl': 'COM_OCEAN_HISTORY_TMPL',
-                                   'history_file_tmpl': f'{self.run}.t@Hz.6hr_avg.f#fhr3_next#.nc'},
+                                   'history_file_tmpl': f'{self.run}.t@Hz.6hr_avg.f#fhr3_nextp1#.nc'},
                          'ice': {'config': 'oceanice_products',
                                  'history_path_tmpl': 'COM_ICE_HISTORY_TMPL',
                                  'history_file_tmpl': f'{self.run}.t@Hz.6hr_avg.f#fhr3_last#.nc'}}
@@ -1241,6 +1241,13 @@ class GFSTasks(Tasks):
             fhrs.remove(0)
 
         fhr_var_dict = self.get_grouped_fhr_dict(fhrs=fhrs, ngroups=max_tasks)
+
+        # Delay triggering ocean products task to next next forecast hour to ensure all data is available
+        if component == 'ocean':
+            fhr3_next = fhr_var_dict['fhr3_next'].split(' ')
+            fhr3_nextp1 = fhr3_next[1:]
+            fhr3_nextp1.append(fhr3_next[-1])  # repeat last forecast hour to maintain same number of groups
+            fhr_var_dict['fhr3_nextp1'] = ' '.join(fhr3_nextp1)
 
         # Adjust walltime based on the largest group
         largest_group = max([len(grp.split(',')) for grp in fhr_var_dict['fhr_list'].split(' ')])


### PR DESCRIPTION
# Description
This PR:
- partially addresses #3822 
- delays the start of ocean post-processing by one extra forecast output interval to allow for data to be available

# Type of change
- [X] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
The resulting XML is generated correctly as expected
 
```diff
232a233
>       <var name="fhr3_nextp1">018 024 030 036 042 048 054 060 066 072 078 084 090 096 102 108 114 120 126 126</var>
263c264
<                               <datadep age="120"><cyclestr>&ROTDIR;/gfs.@Y@m@d/@H//model/ocean/history/gfs.t@Hz.6hr_avg.f#fhr3_next#.nc</cyclestr></datadep>
---
>                               <datadep age="120"><cyclestr>&ROTDIR;/gfs.@Y@m@d/@H//model/ocean/history/gfs.t@Hz.6hr_avg.f#fhr3_nextp1#.nc</cyclestr></datadep>
```

The last 2 forecast hours are outside the forecast length (120h here).  The other dependency of completion of the forecast segment takes over and triggers the ocean post-processing for the final 2 forecast hours.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
