### PR TITLE
Create a UPP module for the global workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,7 +82,7 @@ jobs/JGLOBAL_WAVE_* @JessicaMeixner-NOAA @sbanihash
 
 # System-specific modules
 modulefiles/gw_gsi_wcoss2.lua @RussTreadon-NOAA @CoryMartin-NOAA
-modulefiles/gw_gsi_wcoss2.lua @RussTreadon-NOAA @CoryMartin-NOAA
+modulefiles/gw_upp_wcoss2.lua @WenMeng-NOAA
 
 # scripts
 scripts/exgdas_aero_analysis_generate_bmatrix.py @CoryMartin-NOAA

--- a/dev/jobs/upp.sh
+++ b/dev/jobs/upp.sh
@@ -14,39 +14,10 @@ set -x
 #if (( status != 0 )); then exit "${status}"; fi
 # Temporarily load modules from UPP on WCOSS2
 source "${HOMEgfs}/ush/detect_machine.sh"
-if [[ "${MACHINE_ID}" == "wcoss2" ]]; then
-    set +x
-    source "${HOMEgfs}/ush/module-setup.sh"
-    module use "${HOMEgfs}/sorc/ufs_model.fd/UFSATM/upp/modulefiles"
-    module load "${MACHINE_ID}_intel"
-    module load prod_util
-    module load cray-pals
-    module load cfp
-    module load libjpeg
-    module load grib_util/1.2.3
-    module load wgrib2/2.0.8
-    export WGRIB2=wgrib2
-    module load python/3.8.6
-    if [[ "${UPP_RUN:-}" == "goes" ]]; then
-        module load crtm/2.4.0
-    fi
-    set -x
-
-    # Set up the PYTHONPATH to include wxflow from HOMEgfs
-    if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-        PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
-    fi
-
-    # Add HOMEgfs/ush/python to PYTHONPATH
-    PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/ush/python"
-    export PYTHONPATH
-
-else
-    source "${HOMEgfs}/dev/ush/load_modules.sh" run
-    status=$?
-    if [[ ${status} -ne 0 ]]; then
-        exit "${status}";
-    fi
+source "${HOMEgfs}/dev/ush/load_modules.sh" upp
+status=$?
+if [[ ${status} -ne 0 ]]; then
+    exit "${status}";
 fi
 
 export job="upp"

--- a/dev/ush/load_modules.sh
+++ b/dev/ush/load_modules.sh
@@ -156,11 +156,10 @@ case "${MODULE_TYPE}" in
     export PYTHONPATH
     ;;
 
-  "run" | "gsi" | "verif" | "setup")
-    # Source versions file for runtime
-    if [[ -f "${HOMEgfs}/versions/run.ver" ]]; then
-      source "${HOMEgfs}/versions/run.ver"
-    else
+  "run" | "gsi" | "verif" | "setup" | "upp")
+
+    # Test that the version file exists
+    if [[ ! -f "${HOMEgfs}/versions/run.ver" ]]; then
       echo "FATAL ERROR: ${HOMEgfs}/versions/run.ver does not exist!"
       echo "HINT: Run link_workflow.sh first."
       exit 1
@@ -176,8 +175,16 @@ case "${MODULE_TYPE}" in
     if ! module is-avail "${target_module}" 2>/dev/null; then
       if [[ "${MODULE_TYPE}" != "run" ]]; then
         echo "INFO: ${target_module} module not available, falling back to gw_run.${MACHINE_ID}"
+        mod_type="run"
       fi
       target_module="gw_run.${MACHINE_ID}"
+    else
+      mod_type="${MODULE_TYPE}"
+    fi
+
+    # Source versions file (except for upp)
+    if [[ "${mod_type}" != "upp" ]]; then
+      source "${HOMEgfs}/versions/run.ver"
     fi
 
     if [[ -n "${target_module}" ]]; then

--- a/modulefiles/gw_upp.wcoss2.lua
+++ b/modulefiles/gw_upp.wcoss2.lua
@@ -1,0 +1,26 @@
+help([[
+Load environment to run the UPP on WCOSS2
+]])
+
+local homegfs=os.getenv("HOMEgfs") or ""
+prepend_path("MODULEPATH", pathJoin(homegfs,"/sorc/ufs_model.fd/UFSATM/upp/modulefiles"))
+-- Load UPP modules
+load("wcoss2_intel")
+
+load(pathJoin("cray-pals", "1.0.17"))
+load(pathJoin("cfp", "2.0.4"))
+setenv("USE_CFP","YES")
+
+-- Load workflow modules
+load(pathJoin("prod_util", "2.0.9"))
+load(pathJoin("python", "3.12.0"))
+load(pathJoin("libjpeg", "9c"))
+load(pathJoin("wgrib2", "2.0.8"))
+load(pathJoin("grib_util","1.2.3"))
+setenv("WGRIB2","wgrib2")
+
+-- Load the GW Python environment
+prepend_path("MODULEPATH", "/apps/dev/modulefiles")
+load(pathJoin("ve","gw", "1.0"))
+
+whatis("Description: GFS run environment")

--- a/modulefiles/gw_upp.wcoss2.lua
+++ b/modulefiles/gw_upp.wcoss2.lua
@@ -8,8 +8,6 @@ prepend_path("MODULEPATH", pathJoin(homegfs,"/sorc/ufs_model.fd/UFSATM/upp/modul
 load("wcoss2_intel")
 
 load(pathJoin("cray-pals", "1.0.17"))
-load(pathJoin("cfp", "2.0.4"))
-setenv("USE_CFP","YES")
 
 -- Load workflow modules
 load(pathJoin("prod_util", "2.0.9"))

--- a/modulefiles/gw_upp.wcoss2.lua
+++ b/modulefiles/gw_upp.wcoss2.lua
@@ -23,4 +23,4 @@ setenv("WGRIB2","wgrib2")
 prepend_path("MODULEPATH", "/apps/dev/modulefiles")
 load(pathJoin("ve","gw", "1.0"))
 
-whatis("Description: GFS run environment")
+whatis("Description: UPP run environment")


### PR DESCRIPTION
# Description
This adds a global workflow module for `upp` jobs running on WCOSS2.  This will ensure that the same `crtm` module (and other modules) used to build the UPP are loaded at runtime.

Resolves https://github.com/NOAA-EMC/global-workflow/issues/4125
# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Full testing suite on WCOS2/Cactus.  Extended tests are still running, but have completed the first full cycle.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners