### PR TITLE
Restart capability from pre-EE2-compliant filenames

### DIFF
--- a/dev/ush/get_warm_s2sw_restart_tarballs.sh
+++ b/dev/ush/get_warm_s2sw_restart_tarballs.sh
@@ -7,9 +7,9 @@ set -eu
 # TODO: Modify this script to accept a different number of ensemble groups.
 # TODO: Enable ATM-only and other coupled configurations
 # TODO: Extend support to additional systems.
-# Usage : get_warm_s2sw_restart_tarballs.sh YYYYMMDDHH HPSS_ROOT_DIR UNTAR_ROOT_DIR
+# Usage : get_warm_s2sw_restart_tarballs.sh YYYYMMDDHH HPSS_ROOT_DIR UNTAR_DIR
 if [[ $# -ne 4 ]]; then
-    echo "Usage: $0 YYYYMMDDHH HPSS_ROOT_DIR UNTAR_ROOT_DIR HPC_ACCOUNT"
+    echo "Usage: $0 YYYYMMDDHH HPSS_ROOT_DIR UNTAR_DIR HPC_ACCOUNT"
     exit 1
 fi
 # Cycle is in YYYYMMDDHH format and is passed as an argument.
@@ -17,7 +17,7 @@ cycle=$1
 # The location on HPSS where the tarballs are stored
 hpss_root_dir=$2
 # The local directory where the tarballs will be untarred
-untar_root_dir=$3
+untar_dir=$3
 # HPC account for sbatch jobs
 hpc_account=$4
 # The previous cycle is 6 hours earlier
@@ -26,22 +26,18 @@ pcycle=$(date -d "${cycle:0:8} ${cycle:8:2} -6 hours" +%Y%m%d%H)
 hpss_dir="${hpss_root_dir}/${cycle}"
 phpss_dir="${hpss_root_dir}/${pcycle}"
 
-if ! mkdir -p "${untar_root_dir}"; then
-    echo "Error: Unable to create untar directory ${untar_root_dir}"
+if ! mkdir -p "${untar_dir}"; then
+    echo "Error: Unable to create untar directory ${untar_dir}"
     exit 1
 fi
 
-untar_dir="${untar_root_dir}/${cycle}"
-puntar_dir="${untar_root_dir}/${pcycle}"
-
-mkdir -p "${untar_dir}"
-mkdir -p "${puntar_dir}"
+cd "${untar_dir}"
 
 ptargets=( "enkfgdas_restartb_grp1.tar" "enkfgdas_restartb_grp2.tar" "enkfgdas_restartb_grp3.tar" "enkfgdas_restartb_grp4.tar" "enkfgdas_restartb_grp5.tar" "enkfgdas_restartb_grp6.tar" "enkfgdas_restartb_grp7.tar" "enkfgdas_restartb_grp8.tar" "gdas_restartb.tar" "gdasocean_restart.tar" "gdaswave_restart.tar" )
 
 targets=( "enkfgdas_restarta_grp1.tar" "enkfgdas_restarta_grp2.tar" "enkfgdas_restarta_grp3.tar" "enkfgdas_restarta_grp4.tar" "enkfgdas_restarta_grp5.tar" "enkfgdas_restarta_grp6.tar" "enkfgdas_restarta_grp7.tar" "enkfgdas_restarta_grp8.tar" "gdas_restarta.tar" "gdasocean_analysis.tar")
 
-# Construct a wrapper script in a loop to submit to the sbatch system
+# This is all specific to Gaea C6
 clusters="es"
 partition="dtn_f5_f6"
 constraint="f6"
@@ -50,6 +46,7 @@ time="12:00:00"
 nodes=1
 tasks=1
 
+# Construct a wrapper script in a loop to submit to the sbatch system
 for tarball in "${targets[@]}"; do
   sbatch << EOF
 #!/bin/bash
@@ -81,7 +78,6 @@ for tarball in "${targets[@]}"; do
   fi
 EOF
 done
-
 
 # Now do the same for the previous cycle tarballs
 for tarball in "${ptargets[@]}"; do

--- a/dev/ush/get_warm_s2sw_restart_tarballs.sh
+++ b/dev/ush/get_warm_s2sw_restart_tarballs.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -eu
+
+# This script untars retro tarballs from HPSS to a local directory.
+# Note that this script assumes that there are 80 ensemble members at high res (C384)
+# Also, this only works on Gaea C6 right now.
+# TODO: Modify this script to accept a different number of ensemble groups.
+# TODO: Enable ATM-only and other coupled configurations
+# TODO: Extend support to additional systems.
+# Usage : get_warm_s2sw_restart_tarballs.sh YYYYMMDDHH HPSS_ROOT_DIR UNTAR_ROOT_DIR
+if [[ $# -ne 4 ]]; then
+    echo "Usage: $0 YYYYMMDDHH HPSS_ROOT_DIR UNTAR_ROOT_DIR HPC_ACCOUNT"
+    exit 1
+fi
+# Cycle is in YYYYMMDDHH format and is passed as an argument.
+cycle=$1
+# The location on HPSS where the tarballs are stored
+hpss_root_dir=$2
+# The local directory where the tarballs will be untarred
+untar_root_dir=$3
+# HPC account for sbatch jobs
+hpc_account=$4
+# The previous cycle is 6 hours earlier
+pcycle=$(date -d "${cycle:0:8} ${cycle:8:2} -6 hours" +%Y%m%d%H)
+
+hpss_dir="${hpss_root_dir}/${cycle}"
+phpss_dir="${hpss_root_dir}/${pcycle}"
+
+if ! mkdir -p "${untar_root_dir}"; then
+    echo "Error: Unable to create untar directory ${untar_root_dir}"
+    exit 1
+fi
+
+untar_dir="${untar_root_dir}/${cycle}"
+puntar_dir="${untar_root_dir}/${pcycle}"
+
+mkdir -p "${untar_dir}"
+mkdir -p "${puntar_dir}"
+
+ptargets=( "enkfgdas_restartb_grp1.tar" "enkfgdas_restartb_grp2.tar" "enkfgdas_restartb_grp3.tar" "enkfgdas_restartb_grp4.tar" "enkfgdas_restartb_grp5.tar" "enkfgdas_restartb_grp6.tar" "enkfgdas_restartb_grp7.tar" "enkfgdas_restartb_grp8.tar" "gdas_restartb.tar" "gdasocean_restart.tar" "gdaswave_restart.tar" )
+
+targets=( "enkfgdas_restarta_grp1.tar" "enkfgdas_restarta_grp2.tar" "enkfgdas_restarta_grp3.tar" "enkfgdas_restarta_grp4.tar" "enkfgdas_restarta_grp5.tar" "enkfgdas_restarta_grp6.tar" "enkfgdas_restarta_grp7.tar" "enkfgdas_restarta_grp8.tar" "gdas_restarta.tar" "gdasocean_analysis.tar")
+
+# Construct a wrapper script in a loop to submit to the sbatch system
+clusters="es"
+partition="dtn_f5_f6"
+constraint="f6"
+qos="hpss"
+time="12:00:00"
+nodes=1
+tasks=1
+
+for tarball in "${targets[@]}"; do
+  sbatch << EOF
+#!/bin/bash
+#SBATCH --job-name=get_retro_${tarball}
+#SBATCH --output=get_retro_${tarball}.out
+#SBATCH --partition=${partition}
+#SBATCH --constraint=${constraint}
+#SBATCH --account=${hpc_account}
+#SBATCH --qos=${qos}
+#SBATCH --time=${time}
+#SBATCH --nodes=${nodes}
+#SBATCH --ntasks=${tasks}
+#SBATCH --clusters=${clusters}
+
+  echo "Retrieving and untarring ${tarball} from HPSS..."
+  # What does set -euo pipefail do?
+  # -e: Exit immediately if a command exits with a non-zero status.
+  # -u: Treat unset variables as an error when substituting.
+  # o: Prevents errors in a pipeline from being masked. If any command in a pipeline fails, that return code will be used as the return code of the whole pipeline.
+
+  set -euo pipefail
+  module use /usw/hpss/modulefiles
+  module load hsi
+  htar -xvf "${hpss_dir}/${tarball}"
+  retstat='$?'
+  if [[ '${retstat}' -ne 0 ]]; then
+    echo "Error: htar command failed with return status '${retstat}'"
+    exit '${retstat}'
+  fi
+EOF
+done
+
+
+# Now do the same for the previous cycle tarballs
+for tarball in "${ptargets[@]}"; do
+  sbatch << EOF
+#!/bin/bash
+#SBATCH --job-name=get_retro_${tarball}
+#SBATCH --output=get_retro_${tarball}.out
+#SBATCH --partition=${partition}
+#SBATCH --constraint=${constraint}
+#SBATCH --qos=${qos}
+#SBATCH --time=${time}
+#SBATCH --nodes=${nodes}
+#SBATCH --ntasks=${tasks}
+#SBATCH --clusters=${clusters}
+#SBATCH --mail-type=ALL
+#SBATCH --mail-user=david.huber@noaa.gov
+
+  echo "Retrieving and untarring ${tarball} from HPSS..."
+  module use /usw/hpss/modulefiles
+  module load hsi
+  htar -xvf "${phpss_dir}/${tarball}"
+  retstat='$?'
+  if [[ '${retstat} -ne 0 ]]; then
+    echo "Error: htar command failed with return status '${retstat}'"
+    exit '${retstat}'
+  fi
+EOF
+done

--- a/dev/ush/make_ee2_links.sh
+++ b/dev/ush/make_ee2_links.sh
@@ -47,7 +47,7 @@ link_file() {
         echo "Error: Targeted link ${link} exists and is not a symbolic link. Not overwriting data files."
         return 1
     fi
-    ln -sf "$target" "$link"
+    ln -sf "${target}" "${link}"
     return 0
 }
 

--- a/dev/ush/make_ee2_links.sh
+++ b/dev/ush/make_ee2_links.sh
@@ -295,15 +295,29 @@ for dir in "${enkfgdas_list[@]}" "${enkfgfs_list[@]}"; do
             cd "${cwd}/${dir}/${cyc}/ensstat/analysis/atmos"
             if [[ -f "${system_prefix}.t${cyc}z.abias.ensmean" ]]; then
                 link_file "${system_prefix}.t${cyc}z.abias.ensmean" "${system_prefix}.t${cyc}z.abias.ensmean.txt"
+            fi
+            if [[ -f "${system_prefix}.t${cyc}z.abias_air.ensmean" ]]; then
                 link_file "${system_prefix}.t${cyc}z.abias_air.ensmean" "${system_prefix}.t${cyc}z.abias_air.ensmean.txt"
+            fi
+            if [[ -f "${system_prefix}.t${cyc}z.abias_int.ensmean" ]]; then
                 link_file "${system_prefix}.t${cyc}z.abias_int.ensmean" "${system_prefix}.t${cyc}z.abias_int.ensmean.txt"
+            fi
+            if [[ -f "${system_prefix}.t${cyc}z.abias_pc.ensmean" ]]; then
                 link_file "${system_prefix}.t${cyc}z.abias_pc.ensmean" "${system_prefix}.t${cyc}z.abias_pc.ensmean.txt"
             fi
             if [[ -f "${system_prefix}.t${cyc}z.cnvstat.ensmean" ]]; then
                 link_file "${system_prefix}.t${cyc}z.cnvstat.ensmean" "${system_prefix}.t${cyc}z.cnvstat.ensmean.tar"
+            fi
+            if [[ -f "${system_prefix}.t${cyc}z.enkfstat" ]]; then
                 link_file "${system_prefix}.t${cyc}z.enkfstat" "${system_prefix}.t${cyc}z.enkfstat.txt"
+            fi
+            if [[ -f "${system_prefix}.t${cyc}z.gsistat.ensmean" ]]; then
                 link_file "${system_prefix}.t${cyc}z.gsistat.ensmean" "${system_prefix}.t${cyc}z.gsistat.ensmean.tar"
+            fi
+            if [[ -f "${system_prefix}.t${cyc}z.oznstat.ensmean" ]]; then
                 link_file "${system_prefix}.t${cyc}z.oznstat.ensmean" "${system_prefix}.t${cyc}z.oznstat.ensmean.tar"
+            fi
+            if [[ -f "${system_prefix}.t${cyc}z.radstat.ensmean" ]]; then
                 link_file "${system_prefix}.t${cyc}z.radstat.ensmean" "${system_prefix}.t${cyc}z.radstat.ensmean.tar"
             fi
             # Surface increments

--- a/dev/ush/make_ee2_links.sh
+++ b/dev/ush/make_ee2_links.sh
@@ -23,14 +23,6 @@ fi
 target_dir=$1
 cd "${target_dir}" || exit 1
 
-# Check for existence of at least one of gdas.YYYYMMDD, gfs.YYYYMMDD, or enkfgdas.YYYYMMDD directories
-dir_list=($(ls -d gdas.* gfs.* enkfgdas.* || true ))
-
-if [[ ${#dir_list[@]} -eq 0 ]]; then
-    echo "No gdas.*, gfs.*, or enkfgdas.* directories found in ${target_dir}."
-    exit 1
-fi
-
 # A helper function to create symbolic links with error checking
 link_file() {
     if [[ $# -ne 2 ]]; then
@@ -57,6 +49,12 @@ gcdas_list=($(ls -d gcdas.* || true ))
 gcafs_list=($(ls -d gcafs.* || true ))
 enkfgdas_list=($(ls -d enkfgdas.* || true ))
 enkfgfs_list=($(ls -d enkfgfs.* || true ))
+
+# If the length of all of the arrays is zero, exit with a message
+if [[ ${#gdas_list[@]} -eq 0 && ${#gfs_list[@]} -eq 0 && ${#gcdas_list[@]} -eq 0 && ${#gcafs_list[@]} -eq 0 && ${#enkfgdas_list[@]} -eq 0 && ${#enkfgfs_list[@]} -eq 0 ]]; then
+    echo "No gdas, gfs, gcdas, gcafs, enkfgdas, or enkfgfs directories found in ${target_dir}. Exiting."
+    exit 0
+fi
 
 cwd=${PWD}
 # Loop through the gdas, gfs, gcdas, and gcafs directories
@@ -190,7 +188,7 @@ for dir in "${enkfgdas_list[@]}" "${enkfgfs_list[@]}"; do
     cd "${dir}"
     cycle_list=($(ls -d ./?? || true ))
     for cyc in "${cycle_list[@]}"; do
-            cd "${cwd}/${dir}/${cyc}"
+        cd "${cwd}/${dir}/${cyc}"
         mem_list=($(ls -d mem* || true ))
         for mem in "${mem_list[@]}"; do
             # atmos

--- a/dev/ush/make_ee2_links.sh
+++ b/dev/ush/make_ee2_links.sh
@@ -70,7 +70,7 @@ for dir in "${gdas_list[@]}" "${gfs_list[@]}" "${gcdas_list[@]}" "${gcafs_list[@
         *) echo "Unknown directory prefix: ${dir}"; exit 1 ;;
     esac
 
-    cycle_list=($(ls -d ./?? || true ))
+    cycle_list=($(ls -d -- ?? || true ))
     for cyc in "${cycle_list[@]}"; do
         if [[ -d "${cwd}/${dir}/${cyc}/analysis/atmos" ]]; then
             cd "${cwd}/${dir}/${cyc}/analysis/atmos"
@@ -186,7 +186,7 @@ done
 
 for dir in "${enkfgdas_list[@]}" "${enkfgfs_list[@]}"; do
     cd "${dir}"
-    cycle_list=($(ls -d ./?? || true ))
+    cycle_list=($(ls -d -- ?? || true ))
     for cyc in "${cycle_list[@]}"; do
         cd "${cwd}/${dir}/${cyc}"
         mem_list=($(ls -d mem* || true ))

--- a/dev/ush/make_ee2_links.sh
+++ b/dev/ush/make_ee2_links.sh
@@ -278,12 +278,12 @@ for dir in "${enkfgdas_list[@]}" "${enkfgfs_list[@]}"; do
             # snow
             if [[ -d "${cwd}/${dir}/${cyc}/${mem}/analysis/snow" ]]; then
                 cd "${cwd}/${dir}/${cyc}/${mem}/analysis/snow"
-                for snow_file in snowinc.*.sfc_data.tile1.nc; do
+                # The old snow analysis files start with YYYYMMDD.HHMMSS, which we want to keep
+                for snow_file in ????????.??????.sfc_data.tile1.nc; do
                 if [[ -f "${snow_file}" ]]; then
-                    prefix=$(echo "${snow_file}" | cut -d. -f1-3)
-                    prefix_new=$(echo "${prefix}" | cut -d. -f2-)
+                    prefix=$(echo "${snow_file}" | cut -d. -f1-2)
                     for tile in {1..6}; do
-                        link_file "${prefix}.sfc_data.tile${tile}.nc" "${prefix_new}.snow_analysis.sfc_data.tile${tile}.nc"
+                        link_file "${prefix}.sfc_data.tile${tile}.nc" "${prefix}.snow_analysis.sfc_data.tile${tile}.nc"
                     done
                 fi
                 done

--- a/dev/ush/make_ee2_links.sh
+++ b/dev/ush/make_ee2_links.sh
@@ -49,10 +49,13 @@ gcdas_list=($(ls -d gcdas.* || true ))
 gcafs_list=($(ls -d gcafs.* || true ))
 enkfgdas_list=($(ls -d enkfgdas.* || true ))
 enkfgfs_list=($(ls -d enkfgfs.* || true ))
+enkfgcdas_list=($(ls -d enkfgcdas.* || true ))
 
 # If the length of all of the arrays is zero, exit with a message
-if [[ ${#gdas_list[@]} -eq 0 && ${#gfs_list[@]} -eq 0 && ${#gcdas_list[@]} -eq 0 && ${#gcafs_list[@]} -eq 0 && ${#enkfgdas_list[@]} -eq 0 && ${#enkfgfs_list[@]} -eq 0 ]]; then
-    echo "No gdas, gfs, gcdas, gcafs, enkfgdas, or enkfgfs directories found in ${target_dir}. Exiting."
+if [[ ${#gdas_list[@]} -eq 0 && ${#gfs_list[@]} -eq 0 && ${#gcdas_list[@]} -eq 0 &&
+      ${#gcafs_list[@]} -eq 0 && ${#enkfgdas_list[@]} -eq 0 &&
+      ${#enkfgfs_list[@]} -eq 0 && ${#enkfgcdas_list[@]} -eq 0 ]]; then
+    echo "No gdas, gfs, gcdas, gcafs, enkfgdas, enkfgfs, or enkfgcdas directories found. Exiting."
     exit 0
 fi
 
@@ -187,6 +190,14 @@ done
 for dir in "${enkfgdas_list[@]}" "${enkfgfs_list[@]}"; do
     cd "${dir}"
     cycle_list=($(ls -d -- ?? || true ))
+    # Determine the system prefix
+    system_prefix=""
+    case "${dir}" in
+        enkfgdas.*) system_prefix="enkfgdas" ;;
+        enkfgfs.*) system_prefix="enkfgfs" ;;
+        enkfgcdas.*) system_prefix="enkfgcdas" ;;
+        *) echo "Unknown directory prefix: ${dir}"; exit 1 ;;
+    esac
     for cyc in "${cycle_list[@]}"; do
         cd "${cwd}/${dir}/${cyc}"
         mem_list=($(ls -d mem* || true ))

--- a/dev/ush/make_ee2_links.sh
+++ b/dev/ush/make_ee2_links.sh
@@ -14,16 +14,24 @@ set -eux
 # WARNING: This script does not create all links needed for EE2 compatibility. It only creates links needed to
 #          restart an existing experiment.
 
-# Make a function from the following pseudocode:
-# link_file():
-#{
-#  target=$1
-#  link=$2
-#  if ! -f $target; then error(target doesn't exist); fi
-#  if -f $link and ! is_link($link); then error(do not overwrite data files); return; fi
-#  ln -sf $target $link
-#  return 0
-#}
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <target_directory>"
+    exit 1
+fi
+
+target_dir=$1
+cd "${target_dir}" || exit 1
+
+# Check for existence of at least one of gdas.YYYYMMDD, gfs.YYYYMMDD, or enkfgdas.YYYYMMDD directories
+dir_list=($(ls -d gdas.* gfs.* enkfgdas.* || true ))
+
+if [[ ${#dir_list[@]} -eq 0 ]]; then
+    echo "No gdas.*, gfs.*, or enkfgdas.* directories found in ${target_dir}."
+    exit 1
+fi
+
+# A helper function to create symbolic links with error checking
 link_file() {
     if [[ $# -ne 2 ]]; then
         echo "Error: link_file requires exactly 2 arguments: target and link."
@@ -42,22 +50,6 @@ link_file() {
     ln -sf "$target" "$link"
     return 0
 }
-
-if [[ $# -ne 1 ]]; then
-    echo "Usage: $0 <target_directory>"
-    exit 1
-fi
-
-target_dir=$1
-cd "${target_dir}" || exit 1
-
-# Check for existence of at least one of gdas.YYYYMMDD, gfs.YYYYMMDD, or enkfgdas.YYYYMMDD directories
-dir_list=($(ls -d gdas.* gfs.* enkfgdas.* || true ))
-
-if [[ ${#dir_list[@]} -eq 0 ]]; then
-    echo "No gdas.*, gfs.*, or enkfgdas.* directories found in ${target_dir}."
-    exit 1
-fi
 
 gdas_list=($(ls -d gdas.* || true ))
 gfs_list=($(ls -d gfs.* || true ))

--- a/dev/ush/make_ee2_links.sh
+++ b/dev/ush/make_ee2_links.sh
@@ -14,9 +14,38 @@ set -eux
 # WARNING: This script does not create all links needed for EE2 compatibility. It only creates links needed to
 #          restart an existing experiment.
 
+# Make a function from the following pseudocode:
+# link_file():
+#{
+#  target=$1
+#  link=$2
+#  if ! -f $target; then error(target doesn't exist); fi
+#  if -f $link and ! is_link($link); then error(do not overwrite data files); return; fi
+#  ln -sf $target $link
+#  return 0
+#}
+link_file() {
+    if [[ $# -ne 2 ]]; then
+        echo "Error: link_file requires exactly 2 arguments: target and link."
+        return 1
+    fi
+    local target=$1
+    local link=$2
+    if [[ ! -f "${target}" ]]; then
+        echo "Error: Target file ${target} does not exist."
+        return 1
+    fi
+    if [[ -f "${link}" && ! -L "${link}" ]]; then
+        echo "Error: Targeted link ${link} exists and is not a symbolic link. Not overwriting data files."
+        return 1
+    fi
+    ln -sf "$target" "$link"
+    return 0
+}
+
 if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 <target_directory>"
-  exit 1
+    echo "Usage: $0 <target_directory>"
+    exit 1
 fi
 
 target_dir=$1
@@ -26,8 +55,8 @@ cd "${target_dir}" || exit 1
 dir_list=($(ls -d gdas.* gfs.* enkfgdas.* || true ))
 
 if [[ ${#dir_list[@]} -eq 0 ]]; then
-  echo "No gdas.*, gfs.*, or enkfgdas.* directories found in ${target_dir}."
-  exit 1
+    echo "No gdas.*, gfs.*, or enkfgdas.* directories found in ${target_dir}."
+    exit 1
 fi
 
 gdas_list=($(ls -d gdas.* || true ))
@@ -40,268 +69,269 @@ enkfgfs_list=($(ls -d enkfgfs.* || true ))
 cwd=${PWD}
 # Loop through the gdas, gfs, gcdas, and gcafs directories
 for dir in "${gdas_list[@]}" "${gfs_list[@]}" "${gcdas_list[@]}" "${gcafs_list[@]}"; do
-  cd "${dir}"
-  # Determine the system prefix
-  system_prefix=""
-  case "${dir}" in
-    gdas.*) system_prefix="gdas" ;;
-    gfs.*) system_prefix="gfs" ;;
-    gcdas.*) system_prefix="gcdas" ;;
-    gcafs.*) system_prefix="gcafs" ;;
-    *) echo "Unknown directory prefix: ${dir}"; exit 1 ;;
-  esac
+    cd "${dir}"
+    # Determine the system prefix
+    system_prefix=""
+    case "${dir}" in
+        gdas.*) system_prefix="gdas" ;;
+        gfs.*) system_prefix="gfs" ;;
+        gcdas.*) system_prefix="gcdas" ;;
+        gcafs.*) system_prefix="gcafs" ;;
+        *) echo "Unknown directory prefix: ${dir}"; exit 1 ;;
+    esac
 
-  cycle_list=($(ls -d ./?? || true ))
-  for cyc in "${cycle_list[@]}"; do
-    if [[ -d "${cwd}/${dir}/${cyc}/analysis/atmos" ]]; then
-      cd "${cwd}/${dir}/${cyc}/analysis/atmos"
-      for abias_type in abias abias_air abias_int abias_pc; do
-        if [[ -f "${system_prefix}.t${cyc}z.${abias_type}" ]]; then
-          ln -s "${system_prefix}.t${cyc}z.${abias_type}" "${system_prefix}.t${cyc}z.${abias_type}.txt"
-        fi
-      done
-      if [[ -f "${system_prefix}.t${cyc}z.radstat" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.radstat" "${system_prefix}.t${cyc}z.radstat.tar"
+    cycle_list=($(ls -d ./?? || true ))
+    for cyc in "${cycle_list[@]}"; do
+        if [[ -d "${cwd}/${dir}/${cyc}/analysis/atmos" ]]; then
+            cd "${cwd}/${dir}/${cyc}/analysis/atmos"
+            for abias_type in abias abias_air abias_int abias_pc; do
+                if [[ -f "${system_prefix}.t${cyc}z.${abias_type}" ]]; then
+                    link_file "${system_prefix}.t${cyc}z.${abias_type}" "${system_prefix}.t${cyc}z.${abias_type}.txt"
+                fi
+            done
+          if [[ -f "${system_prefix}.t${cyc}z.radstat" ]]; then
+              link_file "${system_prefix}.t${cyc}z.radstat" "${system_prefix}.t${cyc}z.radstat.tar"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.atmi003.nc" ]]; then
+              link_file "${system_prefix}.t${cyc}z.atmi003.nc" "${system_prefix}.t${cyc}z.increment.atm.i003.nc"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.atminc.nc" ]]; then
+              link_file "${system_prefix}.t${cyc}z.atminc.nc" "${system_prefix}.t${cyc}z.increment.atm.i006.nc"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.atmi009.nc" ]]; then
+              link_file "${system_prefix}.t${cyc}z.atmi009.nc" "${system_prefix}.t${cyc}z.increment.atm.i009.nc"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.atma003.ensres.nc" ]]; then
+              link_file "${system_prefix}.t${cyc}z.atma003.ensres.nc" "${system_prefix}.t${cyc}z.ensres_analysis.atm.a003.nc"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.atmanl.nc" ]]; then
+              link_file "${system_prefix}.t${cyc}z.atmanl.nc" "${system_prefix}.t${cyc}z.analysis.atm.a006.nc"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.atmanl.ensres.nc" ]]; then
+              link_file "${system_prefix}.t${cyc}z.atmanl.ensres.nc" "${system_prefix}.t${cyc}z.ensres_analysis.atm.a006.nc"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.atma009.ensres.nc" ]]; then
+              link_file "${system_prefix}.t${cyc}z.atma009.ensres.nc" "${system_prefix}.t${cyc}z.ensres_analysis.atm.a009.nc"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.cnvstat" ]]; then
+              link_file "${system_prefix}.t${cyc}z.cnvstat" "${system_prefix}.t${cyc}z.cnvstat.tar"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.dtfanl.nc" ]]; then
+              link_file "${system_prefix}.t${cyc}z.dtfanl.nc" "${system_prefix}.t${cyc}z.analysis.dtf.a006.nc"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.gsistat" ]]; then
+              link_file "${system_prefix}.t${cyc}z.gsistat" "${system_prefix}.t${cyc}z.gsistat.txt"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.oznstat" ]]; then
+              link_file "${system_prefix}.t${cyc}z.oznstat" "${system_prefix}.t${cyc}z.oznstat.tar"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.loginc.txt" ]]; then
+              link_file "${system_prefix}.t${cyc}z.loginc.txt" "${system_prefix}.t${cyc}z.increment.done.txt"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.loganl.txt" ]]; then
+              link_file "${system_prefix}.t${cyc}z.loganl.txt" "${system_prefix}.t${cyc}z.analysis.done.txt"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.sfci003.nc" ]]; then
+              link_file "${system_prefix}.t${cyc}z.sfci003.nc" "${system_prefix}.t${cyc}z.increment.sfc.i003.nc"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.sfci006.nc" ]]; then
+              link_file "${system_prefix}.t${cyc}z.sfci006.nc" "${system_prefix}.t${cyc}z.increment.sfc.i006.nc"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.sfci009.nc" ]]; then
+              link_file "${system_prefix}.t${cyc}z.sfci009.nc" "${system_prefix}.t${cyc}z.increment.sfc.i009.nc"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.sfcanl.nc" ]]; then
+              link_file "${system_prefix}.t${cyc}z.sfcanl.nc" "${system_prefix}.t${cyc}z.analysis.sfc.a006.nc"
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.sfcinc.nc" ]]; then
+              link_file "${system_prefix}.t${cyc}z.sfcinc.nc" "${system_prefix}.t${cyc}z.increment.sfc.i006.nc"
+          fi
+          if [[ -f "sfc_inc.tile1.nc" ]]; then
+              for tile in {1..6}; do
+                  link_file "sfc_inc.tile${tile}.nc" "increment.sfc.i006.tile${tile}.nc"
+              done
+          fi
+          if [[ -f "${system_prefix}.t${cyc}z.cubed_sphere_grid_atminc.tile1.nc" ]]; then
+              for tile in {1..6}; do
+                  link_file "${system_prefix}.t${cyc}z.cubed_sphere_grid_atminc.tile${tile}.nc" "${system_prefix}.t${cyc}z.jedi_increment.atm.i006.tile${tile}.nc"
+              done
+          fi
       fi
-      if [[ -f "${system_prefix}.t${cyc}z.atmi003.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.atmi003.nc" "${system_prefix}.t${cyc}z.increment.atm.i003.nc"
+      cd "${cwd}"
+      if [[ -d "${cwd}/${dir}/${cyc}/analysis/ocean" ]]; then
+          cd "${cwd}/${dir}/${cyc}/analysis/ocean"
+          if [[ -f "${system_prefix}.t${cyc}z.ocninc.nc" ]]; then
+              link_file "${system_prefix}.t${cyc}z.ocninc.nc" "${system_prefix}.t${cyc}z.mom6_increment.i006.nc"
+          fi
       fi
-      if [[ -f "${system_prefix}.t${cyc}z.atminc.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.atminc.nc" "${system_prefix}.t${cyc}z.increment.atm.i006.nc"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.atmi009.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.atmi009.nc" "${system_prefix}.t${cyc}z.increment.atm.i009.nc"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.atma003.ensres.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.atma003.ensres.nc" "${system_prefix}.t${cyc}z.ensres_analysis.atm.a003.nc"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.atmanl.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.atmanl.nc" "${system_prefix}.t${cyc}z.analysis.atm.a006.nc"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.atmanl.ensres.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.atmanl.ensres.nc" "${system_prefix}.t${cyc}z.ensres_analysis.atm.a006.nc"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.atma009.ensres.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.atma009.ensres.nc" "${system_prefix}.t${cyc}z.ensres_analysis.atm.a009.nc"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.cnvstat" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.cnvstat" "${system_prefix}.t${cyc}z.cnvstat.tar"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.dtfanl.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.dtfanl.nc" "${system_prefix}.t${cyc}z.analysis.dtf.a006.nc"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.gsistat" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.gsistat" "${system_prefix}.t${cyc}z.gsistat.txt"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.oznstat" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.oznstat" "${system_prefix}.t${cyc}z.oznstat.tar"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.loginc.txt" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.loginc.txt" "${system_prefix}.t${cyc}z.increment.done.txt"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.loganl.txt" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.loganl.txt" "${system_prefix}.t${cyc}z.analysis.done.txt"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.sfci003.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.sfci003.nc" "${system_prefix}.t${cyc}z.increment.sfc.i003.nc"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.sfci006.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.sfci006.nc" "${system_prefix}.t${cyc}z.increment.sfc.i006.nc"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.sfci009.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.sfci009.nc" "${system_prefix}.t${cyc}z.increment.sfc.i009.nc"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.sfcanl.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.sfcanl.nc" "${system_prefix}.t${cyc}z.analysis.sfc.a006.nc"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.sfcinc.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.sfcinc.nc" "${system_prefix}.t${cyc}z.increment.sfc.i006.nc"
-      fi
-      if [[ -f "sfc_inc.tile1.nc" ]]; then
-        for tile in {1..6}; do
-          ln -s "sfc_inc.tile${tile}.nc" "increment.sfc.i006.tile${tile}.nc"
-        done
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.cubed_sphere_grid_atminc.tile1.nc" ]]; then
-        for tile in {1..6}; do
-          ln -s "${system_prefix}.t${cyc}z.cubed_sphere_grid_atminc.tile${tile}.nc" "${system_prefix}.t${cyc}z.jedi_increment.atm.i006.tile${tile}.nc"
-        done
-      fi
-    fi
-    cd "${cwd}"
-    if [[ -d "${cwd}/${dir}/${cyc}/analysis/ocean" ]]; then
-      cd "${cwd}/${dir}/${cyc}/analysis/ocean"
-      if [[ -f "${system_prefix}.t${cyc}z.ocninc.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.ocninc.nc" "${system_prefix}.t${cyc}z.mom6_increment.i006.nc"
-      fi
-    fi
-    cd "${cwd}"
-    if [[ -d "${cwd}/${dir}/${cyc}/analysis/ice" ]]; then
-      cd "${cwd}/${dir}/${cyc}/analysis/ice"
-      for ice_file in *.cice_model_anl.res.nc; do
-        if [[ -f "${ice_file}" ]]; then
-          # This gets the first two fields of the filename separated by dots
-          prefix=$(echo "${ice_file}" | cut -d. -f1-2)
-          ln -s "${ice_file}" "${prefix}.analysis.cice_model.res.nc"
-        fi
-      done
-    fi
-    cd "${cwd}"
-    if [[ -d "${cwd}/${dir}/${cyc}/analysis/snow" ]]; then
-      cd "${cwd}/${dir}/${cyc}/analysis/snow"
-      for snow_file in *.sfc_data.tile1.nc; do
-        if [[ -f "${snow_file}" ]]; then
-          prefix=$(echo "${snow_file}" | cut -d. -f1-3)
-          # Keep the date fields of the prefix (the last two fields)
-          # Lop off the "snowinc."
-          prefix_new=$(echo "${prefix}" | cut -d. -f2-)
-          for tile in {1..6}; do
-            ln -s "${prefix}.tile${tile}.nc" "${prefix_new}.snow_increment.sfc_data.tile${tile}.nc"
+      cd "${cwd}"
+      if [[ -d "${cwd}/${dir}/${cyc}/analysis/ice" ]]; then
+          cd "${cwd}/${dir}/${cyc}/analysis/ice"
+          for ice_file in *.cice_model_anl.res.nc; do
+              if [[ -f "${ice_file}" ]]; then
+                  # This gets the first two fields of the filename separated by dots
+                  prefix=$(echo "${ice_file}" | cut -d. -f1-2)
+                  link_file "${ice_file}" "${prefix}.analysis.cice_model.res.nc"
+              fi
           done
+      fi
+      cd "${cwd}"
+        if [[ -d "${cwd}/${dir}/${cyc}/analysis/snow" ]]; then
+            cd "${cwd}/${dir}/${cyc}/analysis/snow"
+            for snow_file in *.sfc_data.tile1.nc; do
+                if [[ -f "${snow_file}" ]]; then
+                    prefix=$(echo "${snow_file}" | cut -d. -f1-3)
+                    # Keep the date fields of the prefix (the last two fields)
+                    # Lop off the "snowinc."
+                    prefix_new=$(echo "${prefix}" | cut -d. -f2-)
+                    for tile in {1..6}; do
+                        link_file "${prefix}.tile${tile}.nc" "${prefix_new}.snow_increment.sfc_data.tile${tile}.nc"
+                    done
+                fi
+            done
         fi
-      done
-    fi
-  done
-  cd "${cwd}"
+    done
+    cd "${cwd}"
 done
 
 for dir in "${enkfgdas_list[@]}" "${enkfgfs_list[@]}"; do
-  cd "${dir}"
-  cycle_list=($(ls -d ./?? || true ))
-  for cyc in "${cycle_list[@]}"; do
-    mem_list=($(ls -d mem* || true ))
-    for mem in "${mem_list[@]}"; do
-      # atmos
-      if [[ -d "${cwd}/${dir}/${cyc}/${mem}/analysis/atmos" ]]; then
-        cd "${cwd}/${dir}/${cyc}/${mem}/analysis/atmos"
-        if [[ -f "${system_prefix}.t${cyc}z.atmi003.nc" ]]; then
-          ln -s "${system_prefix}.t${cyc}z.atmi003.nc" "${system_prefix}.t${cyc}z.increment.atm.i003.nc"
-        fi
-        if [[ -f "${system_prefix}.t${cyc}z.atminc.nc" ]]; then
-          ln -s "${system_prefix}.t${cyc}z.atminc.nc" "${system_prefix}.t${cyc}z.increment.atm.i006.nc"
-        fi
-        if [[ -f "${system_prefix}.t${cyc}z.atmi009.nc" ]]; then
-          ln -s "${system_prefix}.t${cyc}z.atmi009.nc" "${system_prefix}.t${cyc}z.increment.atm.i009.nc"
-        fi
-        # Handle recentered increments
-        if [[ -f "${system_prefix}.t${cyc}z.ratmi003.nc" ]]; then
-          ln -s "${system_prefix}.t${cyc}z.ratmi003.nc" "${system_prefix}.t${cyc}z.recentered_increment.atm.i003.nc"
-        fi
-        if [[ -f "${system_prefix}.t${cyc}z.ratminc.nc" ]]; then
-          ln -s "${system_prefix}.t${cyc}z.ratminc.nc" "${system_prefix}.t${cyc}z.recentered_increment.atm.i006.nc"
-        fi
-        if [[ -f "${system_prefix}.t${cyc}z.ratmi009.nc" ]]; then
-          ln -s "${system_prefix}.t${cyc}z.ratmi009.nc" "${system_prefix}.t${cyc}z.recentered_increment.atm.i009.nc"
-        fi
-        # Recentered jedi increments
-        if [[ -f "${system_prefix}.t${cyc}z.cubed_sphere_grid_ratminc.tile1.nc" ]]; then
-          for tile in {1..6}; do
-            ln -s "${system_prefix}.t${cyc}z.cubed_sphere_grid_ratminc.tile${tile}.nc" "${system_prefix}.t${cyc}z.recentered_jedi_increment.atm.i006.tile${tile}.nc"
-          done
-        fi
-        # abias
-        for abias_type in abias abias_air abias_int abias_nc; do
-          if [[ -f "${system_prefix}.t${cyc}z.${abias_type}.ensmean" ]]; then
-            ln -s "${system_prefix}.t${cyc}z.${abias_type}.ensmean" "${system_prefix}.t${cyc}z.${abias_type}.ensmean.txt"
-          fi
+    cd "${dir}"
+    cycle_list=($(ls -d ./?? || true ))
+    for cyc in "${cycle_list[@]}"; do
+            cd "${cwd}/${dir}/${cyc}"
+        mem_list=($(ls -d mem* || true ))
+        for mem in "${mem_list[@]}"; do
+            # atmos
+            if [[ -d "${cwd}/${dir}/${cyc}/${mem}/analysis/atmos" ]]; then
+                cd "${cwd}/${dir}/${cyc}/${mem}/analysis/atmos"
+                if [[ -f "${system_prefix}.t${cyc}z.atmi003.nc" ]]; then
+                    link_file "${system_prefix}.t${cyc}z.atmi003.nc" "${system_prefix}.t${cyc}z.increment.atm.i003.nc"
+                fi
+                if [[ -f "${system_prefix}.t${cyc}z.atminc.nc" ]]; then
+                    link_file "${system_prefix}.t${cyc}z.atminc.nc" "${system_prefix}.t${cyc}z.increment.atm.i006.nc"
+                fi
+                if [[ -f "${system_prefix}.t${cyc}z.atmi009.nc" ]]; then
+                    link_file "${system_prefix}.t${cyc}z.atmi009.nc" "${system_prefix}.t${cyc}z.increment.atm.i009.nc"
+                fi
+                # Handle recentered increments
+                if [[ -f "${system_prefix}.t${cyc}z.ratmi003.nc" ]]; then
+                    link_file "${system_prefix}.t${cyc}z.ratmi003.nc" "${system_prefix}.t${cyc}z.recentered_increment.atm.i003.nc"
+                fi
+                if [[ -f "${system_prefix}.t${cyc}z.ratminc.nc" ]]; then
+                    link_file "${system_prefix}.t${cyc}z.ratminc.nc" "${system_prefix}.t${cyc}z.recentered_increment.atm.i006.nc"
+                fi
+                if [[ -f "${system_prefix}.t${cyc}z.ratmi009.nc" ]]; then
+                    link_file "${system_prefix}.t${cyc}z.ratmi009.nc" "${system_prefix}.t${cyc}z.recentered_increment.atm.i009.nc"
+                fi
+                # Recentered jedi increments
+                if [[ -f "${system_prefix}.t${cyc}z.cubed_sphere_grid_ratminc.tile1.nc" ]]; then
+                    for tile in {1..6}; do
+                        link_file "${system_prefix}.t${cyc}z.cubed_sphere_grid_ratminc.tile${tile}.nc" "${system_prefix}.t${cyc}z.recentered_jedi_increment.atm.i006.tile${tile}.nc"
+                    done
+                fi
+                # abias
+                for abias_type in abias abias_air abias_int abias_nc; do
+                    if [[ -f "${system_prefix}.t${cyc}z.${abias_type}.ensmean" ]]; then
+                        link_file "${system_prefix}.t${cyc}z.${abias_type}.ensmean" "${system_prefix}.t${cyc}z.${abias_type}.ensmean.txt"
+                    fi
+                done
+                # stats
+                for stat_type in cnvstat gsistat oznstat radstat; do
+                    if [[ -f "${system_prefix}.t${cyc}z.${stat_type}.ensmean" ]]; then
+                        link_file "${system_prefix}.t${cyc}z.${stat_type}.ensmean" "${system_prefix}.t${cyc}z.${stat_type}.ensmean.tar"
+                    fi
+                done
+                if [[ -f "${system_prefix}.t${cyc}z.enkfstat" ]]; then
+                    link_file "${system_prefix}.t${cyc}z.enkfstat" "${system_prefix}.t${cyc}z.enkfstat.txt"
+                fi
+                # surface increments
+                for inc_time in 003 006 009; do
+                    if [[ -f "${system_prefix}.t${cyc}z.sfci${inc_time}.nc" ]]; then
+                        link_file "${system_prefix}.t${cyc}z.sfci${inc_time}.nc" "${system_prefix}.t${cyc}z.increment.sfc.i${inc_time}.nc"
+                    fi
+                done
+                # sfc_inc tile links
+                if [[ -f "sfc_inc.tile1.nc" ]]; then
+                    for tile in {1..6}; do
+                        link_file "sfc_inc.tile${tile}.nc" "increment.sfc.i006.tile${tile}.nc"
+                    done
+                fi
+            fi
+            # ocean
+            if [[ -d "${cwd}/${dir}/${cyc}/${mem}/analysis/ocean" ]]; then
+                cd "${cwd}/${dir}/${cyc}/${mem}/analysis/ocean"
+                if [[ -f "${system_prefix}.t${cyc}z.ocninc.nc" ]]; then
+                    link_file "${system_prefix}.t${cyc}z.ocninc.nc" "${system_prefix}.t${cyc}z.mom6_increment.i006.nc"
+                fi
+            fi
+            # ice
+            if [[ -d "${cwd}/${dir}/${cyc}/${mem}/analysis/ice" ]]; then
+                cd "${cwd}/${dir}/${cyc}/${mem}/analysis/ice"
+                for ice_file in *.cice_model_anl.res.nc; do
+                    if [[ -f "${ice_file}" ]]; then
+                        prefix=$(echo "${ice_file}" | cut -d. -f1-2)
+                        link_file "${ice_file}" "${prefix}.analysis.cice_model.res.nc"
+                    fi
+                done
+            fi
+            # snow
+            if [[ -d "${cwd}/${dir}/${cyc}/${mem}/analysis/snow" ]]; then
+                cd "${cwd}/${dir}/${cyc}/${mem}/analysis/snow"
+                for snow_file in *.sfc_data.tile1.nc; do
+                if [[ -f "${snow_file}" ]]; then
+                    prefix=$(echo "${snow_file}" | cut -d. -f1-3)
+                    prefix_new=$(echo "${prefix}" | cut -d. -f2-)
+                    for tile in {1..6}; do
+                        link_file "${prefix}.tile${tile}.nc" "${prefix_new}.snow_analysis.sfc_data.tile${tile}.nc"
+                    done
+                fi
+                done
+            fi
+            cd "${cwd}"
         done
-        # stats
-        for stat_type in cnvstat gsistat oznstat radstat; do
-          if [[ -f "${system_prefix}.t${cyc}z.${stat_type}.ensmean" ]]; then
-            ln -s "${system_prefix}.t${cyc}z.${stat_type}.ensmean" "${system_prefix}.t${cyc}z.${stat_type}.ensmean.tar"
-          fi
-        done
-        if [[ -f "${system_prefix}.t${cyc}z.enkfstat" ]]; then
-          ln -s "${system_prefix}.t${cyc}z.enkfstat" "${system_prefix}.t${cyc}z.enkfstat.txt"
+        # ensstat files (no mem subdir)
+        if [[ -d "${cwd}/${dir}/${cyc}/ensstat/analysis/atmos" ]]; then
+            cd "${cwd}/${dir}/${cyc}/ensstat/analysis/atmos"
+            if [[ -f "${system_prefix}.t${cyc}z.abias.ensmean" ]]; then
+                link_file "${system_prefix}.t${cyc}z.abias.ensmean" "${system_prefix}.t${cyc}z.abias.ensmean.txt"
+                link_file "${system_prefix}.t${cyc}z.abias_air.ensmean" "${system_prefix}.t${cyc}z.abias_air.ensmean.txt"
+                link_file "${system_prefix}.t${cyc}z.abias_int.ensmean" "${system_prefix}.t${cyc}z.abias_int.ensmean.txt"
+                link_file "${system_prefix}.t${cyc}z.abias_pc.ensmean" "${system_prefix}.t${cyc}z.abias_pc.ensmean.txt"
+            fi
+            if [[ -f "${system_prefix}.t${cyc}z.cnvstat.ensmean" ]]; then
+                link_file "${system_prefix}.t${cyc}z.cnvstat.ensmean" "${system_prefix}.t${cyc}z.cnvstat.ensmean.tar"
+                link_file "${system_prefix}.t${cyc}z.enkfstat" "${system_prefix}.t${cyc}z.enkfstat.txt"
+                link_file "${system_prefix}.t${cyc}z.gsistat.ensmean" "${system_prefix}.t${cyc}z.gsistat.ensmean.tar"
+                link_file "${system_prefix}.t${cyc}z.oznstat.ensmean" "${system_prefix}.t${cyc}z.oznstat.ensmean.tar"
+                link_file "${system_prefix}.t${cyc}z.radstat.ensmean" "${system_prefix}.t${cyc}z.radstat.ensmean.tar"
+            fi
+            # Surface increments
+            if [[ -f "${system_prefix}.t${cyc}z.sfci003.nc" ]]; then
+                link_file "${system_prefix}.t${cyc}z.sfci003.nc" "${system_prefix}.t${cyc}z.increment.sfc.i003.nc"
+            fi
+            if [[ -f "${system_prefix}.t${cyc}z.sfci006.nc" ]]; then
+                link_file "${system_prefix}.t${cyc}z.sfci006.nc" "${system_prefix}.t${cyc}z.increment.sfc.i006.nc"
+            fi
+            if [[ -f "${system_prefix}.t${cyc}z.sfci009.nc" ]]; then
+                link_file "${system_prefix}.t${cyc}z.sfci009.nc" "${system_prefix}.t${cyc}z.increment.sfc.i009.nc"
+            fi
+            if [[ -f "${system_prefix}.t${cyc}z.loginc.txt" ]]; then
+                link_file "${system_prefix}.t${cyc}z.loginc.txt" "${system_prefix}.t${cyc}z.increment.done.txt"
+            fi
         fi
-        # surface increments
-        for inc_time in 003 006 009; do
-          if [[ -f "${system_prefix}.t${cyc}z.sfci${inc_time}.nc" ]]; then
-            ln -s "${system_prefix}.t${cyc}z.sfci${inc_time}.nc" "${system_prefix}.t${cyc}z.increment.sfc.i${inc_time}.nc"
-          fi
-        done
-        # sfc_inc tile links
-        if [[ -f "sfc_inc.tile1.nc" ]]; then
-          for tile in {1..6}; do
-            ln -s "sfc_inc.tile${tile}.nc" "increment.sfc.i006.tile${tile}.nc"
-          done
+        # snow ensstat
+        if [[ -d "${cwd}/${dir}/${cyc}/ensstat/analysis/snow" ]]; then
+            cd "${cwd}/${dir}/${cyc}/ensstat/analysis/snow"
+            for snow_file in *.sfc_data.tile1.nc; do
+                if [[ -f "${snow_file}" ]]; then
+                    prefix=$(echo "${snow_file}" | cut -d. -f1-3)
+                    prefix_new=$(echo "${prefix}" | cut -d. -f2-)
+                    for tile in {1..6}; do
+                        link_file "${prefix}.tile${tile}.nc" "${prefix_new}.snow_increment.sfc_data.tile${tile}.nc"
+                    done
+                fi
+            done
         fi
-      fi
-      # ocean
-      if [[ -d "${cwd}/${dir}/${cyc}/${mem}/analysis/ocean" ]]; then
-        cd "${cwd}/${dir}/${cyc}/${mem}/analysis/ocean"
-        if [[ -f "${system_prefix}.t${cyc}z.ocninc.nc" ]]; then
-          ln -s "${system_prefix}.t${cyc}z.ocninc.nc" "${system_prefix}.t${cyc}z.mom6_increment.i006.nc"
-        fi
-      fi
-      # ice
-      if [[ -d "${cwd}/${dir}/${cyc}/${mem}/analysis/ice" ]]; then
-        cd "${cwd}/${dir}/${cyc}/${mem}/analysis/ice"
-        for ice_file in *.cice_model_anl.res.nc; do
-          if [[ -f "${ice_file}" ]]; then
-            prefix=$(echo "${ice_file}" | cut -d. -f1-2)
-            ln -s "${ice_file}" "${prefix}.analysis.cice_model.res.nc"
-          fi
-        done
-      fi
-      # snow
-      if [[ -d "${cwd}/${dir}/${cyc}/${mem}/analysis/snow" ]]; then
-        cd "${cwd}/${dir}/${cyc}/${mem}/analysis/snow"
-        for snow_file in *.sfc_data.tile1.nc; do
-        if [[ -f "${snow_file}" ]]; then
-          prefix=$(echo "${snow_file}" | cut -d. -f1-3)
-          prefix_new=$(echo "${prefix}" | cut -d. -f2-)
-          for tile in {1..6}; do
-            ln -s "${prefix}.tile${tile}.nc" "${prefix_new}.snow_analysis.sfc_data.tile${tile}.nc"
-          done
-        fi
-        done
-      fi
-      cd "${cwd}"
     done
-    # ensstat files (no mem subdir)
-    if [[ -d "${cwd}/${dir}/${cyc}/ensstat/analysis/atmos" ]]; then
-      cd "${cwd}/${dir}/${cyc}/ensstat/analysis/atmos"
-      if [[ -f "${system_prefix}.t${cyc}z.abias.ensmean" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.abias.ensmean" "${system_prefix}.t${cyc}z.abias.ensmean.txt"
-        ln -s "${system_prefix}.t${cyc}z.abias_air.ensmean" "${system_prefix}.t${cyc}z.abias_air.ensmean.txt"
-        ln -s "${system_prefix}.t${cyc}z.abias_int.ensmean" "${system_prefix}.t${cyc}z.abias_int.ensmean.txt"
-        ln -s "${system_prefix}.t${cyc}z.abias_pc.ensmean" "${system_prefix}.t${cyc}z.abias_pc.ensmean.txt"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.cnvstat.ensmean" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.cnvstat.ensmean" "${system_prefix}.t${cyc}z.cnvstat.ensmean.tar"
-        ln -s "${system_prefix}.t${cyc}z.enkfstat" "${system_prefix}.t${cyc}z.enkfstat.txt"
-        ln -s "${system_prefix}.t${cyc}z.gsistat.ensmean" "${system_prefix}.t${cyc}z.gsistat.ensmean.tar"
-        ln -s "${system_prefix}.t${cyc}z.oznstat.ensmean" "${system_prefix}.t${cyc}z.oznstat.ensmean.tar"
-        ln -s "${system_prefix}.t${cyc}z.radstat.ensmean" "${system_prefix}.t${cyc}z.radstat.ensmean.tar"
-      fi
-      # Surface increments
-      if [[ -f "${system_prefix}.t${cyc}z.sfci003.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.sfci003.nc" "${system_prefix}.t${cyc}z.increment.sfc.i003.nc"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.sfci006.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.sfci006.nc" "${system_prefix}.t${cyc}z.increment.sfc.i006.nc"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.sfci009.nc" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.sfci009.nc" "${system_prefix}.t${cyc}z.increment.sfc.i009.nc"
-      fi
-      if [[ -f "${system_prefix}.t${cyc}z.loginc.txt" ]]; then
-        ln -s "${system_prefix}.t${cyc}z.loginc.txt" "${system_prefix}.t${cyc}z.increment.done.txt"
-      fi
-    fi
-    # snow ensstat
-    if [[ -d "${cwd}/${dir}/${cyc}/ensstat/analysis/snow" ]]; then
-      cd "${cwd}/${dir}/${cyc}/ensstat/analysis/snow"
-      for snow_file in *.sfc_data.tile1.nc; do
-        if [[ -f "${snow_file}" ]]; then
-          prefix=$(echo "${snow_file}" | cut -d. -f1-3)
-          prefix_new=$(echo "${prefix}" | cut -d. -f2-)
-          for tile in {1..6}; do
-            ln -s "${prefix}.tile${tile}.nc" "${prefix_new}.snow_increment.sfc_data.tile${tile}.nc"
-          done
-        fi
-      done
-    fi
-  done
-  cd "${cwd}"
+    cd "${cwd}"
 done

--- a/dev/ush/make_ee2_links.sh
+++ b/dev/ush/make_ee2_links.sh
@@ -1,0 +1,306 @@
+#!/bin/bash
+PS4='+ $LINENO: '
+set -eux
+
+# USE AT YOUR OWN RISK!  This script is provided as-is without support and is not meant to be
+# a general-purpose solution.  It has only been tested on a limited set of data and directory structures.
+
+# This script converts filenames from the older (v16+) naming convention to EE2-compatible names by creating symbolic links.
+#
+# Usage: make_ee2_links.sh <target_directory>
+# Conversions are available for gdas, gfs, and enkfgdas (but not enkfgfs at this time).
+#
+# WARNING: This script does not create all links needed for EE2 compatibility. It only creates links needed to
+#          restart an existing experiment.
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <target_directory>"
+  exit 1
+fi
+
+target_dir=$1
+cd "${target_dir}" || exit 1
+
+# Check for existence of at least one of gdas.YYYYMMDD, gfs.YYYYMMDD, or enkfgdas.YYYYMMDD directories
+dir_list=($(ls -d gdas.* gfs.* enkfgdas.* || true ))
+
+if [ ${#dir_list[@]} -eq 0 ]; then
+  echo "No gdas.*, gfs.*, or enkfgdas.* directories found in ${target_dir}."
+  exit 1
+fi
+
+gdas_list=($(ls -d gdas.* || true ))
+gfs_list=($(ls -d gfs.* || true ))
+gcdas_list=($(ls -d gcdas.* || true ))
+gcafs_list=($(ls -d gcafs.* || true ))
+enkfgdas_list=($(ls -d enkfgdas.* || true ))
+enkfgfs_list=($(ls -d enkfgfs.* || true ))
+
+cwd=${PWD}
+# Loop through the gdas, gfs, gcdas, and gcafs directories
+for dir in "${gdas_list[@]}" "${gfs_list[@]}" "${gcdas_list[@]}" "${gcafs_list[@]}"; do
+  cd "${dir}"
+  # Determine the system prefix
+  system_prefix=""
+  case "${dir}" in
+    gdas.*) system_prefix="gdas" ;;
+    gfs.*) system_prefix="gfs" ;;
+    gcdas.*) system_prefix="gcdas" ;;
+    gcafs.*) system_prefix="gcafs" ;;
+    *) echo "Unknown directory prefix: ${dir}"; exit 1 ;;
+  esac
+
+  cycle_list=($(ls -d ?? || true ))
+  for cyc in "${cycle_list[@]}"; do
+    if [[ -d "${cwd}/${dir}/${cyc}/analysis/atmos" ]]; then
+      cd "${cwd}/${dir}/${cyc}/analysis/atmos"
+      for abias_type in abias abias_air abias_int abias_pc; do
+        if [[ -f "${system_prefix}.t${cyc}z.${abias_type}" ]]; then
+          ln -s "${system_prefix}.t${cyc}z.${abias_type}" "${system_prefix}.t${cyc}z.${abias_type}.txt"
+        fi
+      done
+      if [[ -f "${system_prefix}.t${cyc}z.radstat" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.radstat" "${system_prefix}.t${cyc}z.radstat.tar"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.atmi003.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.atmi003.nc" "${system_prefix}.t${cyc}z.increment.atm.i003.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.atminc.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.atminc.nc" "${system_prefix}.t${cyc}z.increment.atm.i006.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.atmi009.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.atmi009.nc" "${system_prefix}.t${cyc}z.increment.atm.i009.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.atma003.ensres.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.atma003.ensres.nc" "${system_prefix}.t${cyc}z.ensres_analysis.atm.a003.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.atmanl.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.atmanl.nc" "${system_prefix}.t${cyc}z.analysis.atm.a006.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.atmanl.ensres.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.atmanl.ensres.nc" "${system_prefix}.t${cyc}z.ensres_analysis.atm.a006.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.atma009.ensres.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.atma009.ensres.nc" "${system_prefix}.t${cyc}z.ensres_analysis.atm.a009.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.cnvstat" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.cnvstat" "${system_prefix}.t${cyc}z.cnvstat.tar"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.dtfanl.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.dtfanl.nc" "${system_prefix}.t${cyc}z.analysis.dtf.a006.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.gsistat" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.gsistat" "${system_prefix}.t${cyc}z.gsistat.txt"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.oznstat" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.oznstat" "${system_prefix}.t${cyc}z.oznstat.tar"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.loginc.txt" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.loginc.txt" "${system_prefix}.t${cyc}z.increment.done.txt"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.loganl.txt" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.loganl.txt" "${system_prefix}.t${cyc}z.analysis.done.txt"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.sfci003.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.sfci003.nc" "${system_prefix}.t${cyc}z.increment.sfc.i003.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.sfci006.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.sfci006.nc" "${system_prefix}.t${cyc}z.increment.sfc.i006.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.sfci009.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.sfci009.nc" "${system_prefix}.t${cyc}z.increment.sfc.i009.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.sfcanl.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.sfcanl.nc" "${system_prefix}.t${cyc}z.analysis.sfc.a006.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.sfcinc.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.sfcinc.nc" "${system_prefix}.t${cyc}z.increment.sfc.i006.nc"
+      fi
+      if [[ -f "sfc_inc.tile1.nc" ]]; then
+        for tile in {1..6}; do
+          ln -s "sfc_inc.tile${tile}.nc" "increment.sfc.i006.tile${tile}.nc"
+        done
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.cubed_sphere_grid_atminc.tile1.nc" ]]; then
+        for tile in {1..6}; do
+          ln -s "${system_prefix}.t${cyc}z.cubed_sphere_grid_atminc.tile${tile}.nc" "${system_prefix}.t${cyc}z.jedi_increment.atm.i006.tile${tile}.nc"
+        done
+      fi
+    fi
+    cd "${cwd}"
+    if [[ -d "${cwd}/${dir}/${cyc}/analysis/ocean" ]]; then
+      cd "${cwd}/${dir}/${cyc}/analysis/ocean"
+      if [[ -f "${system_prefix}.t${cyc}z.ocninc.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.ocninc.nc" "${system_prefix}.t${cyc}z.mom6_increment.i006.nc"
+      fi
+    fi
+    cd "${cwd}"
+    if [[ -d "${cwd}/${dir}/${cyc}/analysis/ice" ]]; then
+      cd "${cwd}/${dir}/${cyc}/analysis/ice"
+      for ice_file in *.cice_model_anl.res.nc; do
+        if [[ -f "${ice_file}" ]]; then
+          # This gets the first two fields of the filename separated by dots
+          prefix=$(echo "${ice_file}" | cut -d. -f1-2)
+          ln -s "${ice_file}" "${prefix}.analysis.cice_model.res.nc"
+        fi
+      done
+    fi
+    cd "${cwd}"
+    if [[ -d "${cwd}/${dir}/${cyc}/analysis/snow" ]]; then
+      cd "${cwd}/${dir}/${cyc}/analysis/snow"
+      for snow_file in *.sfc_data.tile1.nc; do
+        if [[ -f "${snow_file}" ]]; then
+          prefix=$(echo "${snow_file}" | cut -d. -f1-3)
+          # Keep the date fields of the prefix (the last two fields)
+          # Lop off the "snowinc."
+          prefix_new=$(echo "${prefix}" | cut -d. -f2-)
+          for tile in {1..6}; do
+            ln -s "${prefix}.tile${tile}.nc" "${prefix_new}.snow_increment.sfc_data.tile${tile}.nc"
+          done
+        fi
+      done
+    fi
+  done
+  cd "${cwd}"
+done
+
+for dir in "${enkfgdas_list[@]}" "${enkfgfs_list[@]}"; do
+  cd "${dir}"
+  cycle_list=($(ls -d ?? || true ))
+  for cyc in "${cycle_list[@]}"; do
+    mem_list=($(ls -d mem* || true ))
+    for mem in "${mem_list[@]}"; do
+      # atmos
+      if [[ -d "${cwd}/${dir}/${cyc}/${mem}/analysis/atmos" ]]; then
+        cd "${cwd}/${dir}/${cyc}/${mem}/analysis/atmos"
+        if [[ -f "${system_prefix}.t${cyc}z.atmi003.nc" ]]; then
+          ln -s "${system_prefix}.t${cyc}z.atmi003.nc" "${system_prefix}.t${cyc}z.increment.atm.i003.nc"
+        fi
+        if [[ -f "${system_prefix}.t${cyc}z.atminc.nc" ]]; then
+          ln -s "${system_prefix}.t${cyc}z.atminc.nc" "${system_prefix}.t${cyc}z.increment.atm.i006.nc"
+        fi
+        if [[ -f "${system_prefix}.t${cyc}z.atmi009.nc" ]]; then
+          ln -s "${system_prefix}.t${cyc}z.atmi009.nc" "${system_prefix}.t${cyc}z.increment.atm.i009.nc"
+        fi
+        # Handle recentered increments
+        if [[ -f "${system_prefix}.t${cyc}z.ratmi003.nc" ]]; then
+          ln -s "${system_prefix}.t${cyc}z.ratmi003.nc" "${system_prefix}.t${cyc}z.recentered_increment.atm.i003.nc"
+        fi
+        if [[ -f "${system_prefix}.t${cyc}z.ratminc.nc" ]]; then
+          ln -s "${system_prefix}.t${cyc}z.ratminc.nc" "${system_prefix}.t${cyc}z.recentered_increment.atm.i006.nc"
+        fi
+        if [[ -f "${system_prefix}.t${cyc}z.ratmi009.nc" ]]; then
+          ln -s "${system_prefix}.t${cyc}z.ratmi009.nc" "${system_prefix}.t${cyc}z.recentered_increment.atm.i009.nc"
+        fi
+        # Recentered jedi increments
+        if [[ -f "${system_prefix}.t${cyc}z.cubed_sphere_grid_ratminc.tile1.nc" ]]; then
+          for tile in {1..6}; do
+            ln -s "${system_prefix}.t${cyc}z.cubed_sphere_grid_ratminc.tile${tile}.nc" "${system_prefix}.t${cyc}z.recentered_jedi_increment.atm.i006.tile${tile}.nc"
+          done
+        fi
+        # abias
+        for abias_type in abias abias_air abias_int abias_nc; do
+          if [[ -f "${system_prefix}.t${cyc}z.${abias_type}.ensmean" ]]; then
+            ln -s "${system_prefix}.t${cyc}z.${abias_type}.ensmean" "${system_prefix}.t${cyc}z.${abias_type}.ensmean.txt"
+          fi
+        done
+        # stats
+        for stat_type in cnvstat gsistat oznstat radstat; do
+          if [[ -f "${system_prefix}.t${cyc}z.${stat_type}.ensmean" ]]; then
+            ln -s "${system_prefix}.t${cyc}z.${stat_type}.ensmean" "${system_prefix}.t${cyc}z.${stat_type}.ensmean.tar"
+          fi
+        done
+        if [[ -f "${system_prefix}.t${cyc}z.enkfstat" ]]; then
+          ln -s "${system_prefix}.t${cyc}z.enkfstat" "${system_prefix}.t${cyc}z.enkfstat.txt"
+        fi
+        # surface increments
+        for inc_time in 003 006 009; do
+          if [[ -f "${system_prefix}.t${cyc}z.sfci${inc_time}.nc" ]]; then
+            ln -s "${system_prefix}.t${cyc}z.sfci${inc_time}.nc" "${system_prefix}.t${cyc}z.increment.sfc.i${inc_time}.nc"
+          fi
+        done
+        # sfc_inc tile links
+        if [[ -f "sfc_inc.tile1.nc" ]]; then
+          for tile in {1..6}; do
+            ln -s "sfc_inc.tile${tile}.nc" "increment.sfc.i006.tile${tile}.nc"
+          done
+        fi
+      fi
+      # ocean
+      if [[ -d "${cwd}/${dir}/${cyc}/${mem}/analysis/ocean" ]]; then
+        cd "${cwd}/${dir}/${cyc}/${mem}/analysis/ocean"
+        if [[ -f "${system_prefix}.t${cyc}z.ocninc.nc" ]]; then
+          ln -s "${system_prefix}.t${cyc}z.ocninc.nc" "${system_prefix}.t${cyc}z.mom6_increment.i006.nc"
+        fi
+      fi
+      # ice
+      if [[ -d "${cwd}/${dir}/${cyc}/${mem}/analysis/ice" ]]; then
+        cd "${cwd}/${dir}/${cyc}/${mem}/analysis/ice"
+        for ice_file in *.cice_model_anl.res.nc; do
+          if [[ -f "${ice_file}" ]]; then
+            prefix=$(echo "${ice_file}" | cut -d. -f1-2)
+            ln -s "${ice_file}" "${prefix}.analysis.cice_model.res.nc"
+          fi
+        done
+      fi
+      # snow
+      if [[ -d "${cwd}/${dir}/${cyc}/${mem}/analysis/snow" ]]; then
+        cd "${cwd}/${dir}/${cyc}/${mem}/analysis/snow"
+        for snow_file in *.sfc_data.tile1.nc; do
+        if [[ -f "${snow_file}" ]]; then
+          prefix=$(echo "${snow_file}" | cut -d. -f1-3)
+          prefix_new=$(echo "${prefix}" | cut -d. -f2-)
+          for tile in {1..6}; do
+            ln -s "${prefix}.tile${tile}.nc" "${prefix_new}.snow_analysis.sfc_data.tile${tile}.nc"
+          done
+        fi
+        done
+      fi
+      cd "${cwd}"
+    done
+    # ensstat files (no mem subdir)
+    if [[ -d "${cwd}/${dir}/${cyc}/ensstat/analysis/atmos" ]]; then
+      cd "${cwd}/${dir}/${cyc}/ensstat/analysis/atmos"
+      if [[ -f "${system_prefix}.t${cyc}z.abias.ensmean" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.abias.ensmean" "${system_prefix}.t${cyc}z.abias.ensmean.txt"
+        ln -s "${system_prefix}.t${cyc}z.abias_air.ensmean" "${system_prefix}.t${cyc}z.abias_air.ensmean.txt"
+        ln -s "${system_prefix}.t${cyc}z.abias_int.ensmean" "${system_prefix}.t${cyc}z.abias_int.ensmean.txt"
+        ln -s "${system_prefix}.t${cyc}z.abias_pc.ensmean" "${system_prefix}.t${cyc}z.abias_pc.ensmean.txt"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.cnvstat.ensmean" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.cnvstat.ensmean" "${system_prefix}.t${cyc}z.cnvstat.ensmean.tar"
+        ln -s "${system_prefix}.t${cyc}z.enkfstat" "${system_prefix}.t${cyc}z.enkfstat.txt"
+        ln -s "${system_prefix}.t${cyc}z.gsistat.ensmean" "${system_prefix}.t${cyc}z.gsistat.ensmean.tar"
+        ln -s "${system_prefix}.t${cyc}z.oznstat.ensmean" "${system_prefix}.t${cyc}z.oznstat.ensmean.tar"
+        ln -s "${system_prefix}.t${cyc}z.radstat.ensmean" "${system_prefix}.t${cyc}z.radstat.ensmean.tar"
+      fi
+      # Surface increments
+      if [[ -f "${system_prefix}.t${cyc}z.sfci003.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.sfci003.nc" "${system_prefix}.t${cyc}z.increment.sfc.i003.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.sfci006.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.sfci006.nc" "${system_prefix}.t${cyc}z.increment.sfc.i006.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.sfci009.nc" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.sfci009.nc" "${system_prefix}.t${cyc}z.increment.sfc.i009.nc"
+      fi
+      if [[ -f "${system_prefix}.t${cyc}z.loginc.txt" ]]; then
+        ln -s "${system_prefix}.t${cyc}z.loginc.txt" "${system_prefix}.t${cyc}z.increment.done.txt"
+      fi
+    fi
+    # snow ensstat
+    if [[ -d "${cwd}/${dir}/${cyc}/ensstat/analysis/snow" ]]; then
+      cd "${cwd}/${dir}/${cyc}/ensstat/analysis/snow"
+      for snow_file in *.sfc_data.tile1.nc; do
+        if [[ -f "${snow_file}" ]]; then
+          prefix=$(echo "${snow_file}" | cut -d. -f1-3)
+          prefix_new=$(echo "${prefix}" | cut -d. -f2-)
+          for tile in {1..6}; do
+            ln -s "${prefix}.tile${tile}.nc" "${prefix_new}.snow_increment.sfc_data.tile${tile}.nc"
+          done
+        fi
+      done
+    fi
+  done
+  cd "${cwd}"
+done

--- a/dev/ush/make_ee2_links.sh
+++ b/dev/ush/make_ee2_links.sh
@@ -171,14 +171,14 @@ for dir in "${gdas_list[@]}" "${gfs_list[@]}" "${gcdas_list[@]}" "${gcafs_list[@
       cd "${cwd}"
         if [[ -d "${cwd}/${dir}/${cyc}/analysis/snow" ]]; then
             cd "${cwd}/${dir}/${cyc}/analysis/snow"
-            for snow_file in *.sfc_data.tile1.nc; do
+            for snow_file in snowinc*.sfc_data.tile1.nc; do
                 if [[ -f "${snow_file}" ]]; then
                     prefix=$(echo "${snow_file}" | cut -d. -f1-3)
                     # Keep the date fields of the prefix (the last two fields)
                     # Lop off the "snowinc."
                     prefix_new=$(echo "${prefix}" | cut -d. -f2-)
                     for tile in {1..6}; do
-                        link_file "${prefix}.tile${tile}.nc" "${prefix_new}.snow_increment.sfc_data.tile${tile}.nc"
+                        link_file "${prefix}.sfc_data.tile${tile}.nc" "${prefix_new}.snow_increment.sfc_data.tile${tile}.nc"
                     done
                 fi
             done
@@ -278,12 +278,12 @@ for dir in "${enkfgdas_list[@]}" "${enkfgfs_list[@]}"; do
             # snow
             if [[ -d "${cwd}/${dir}/${cyc}/${mem}/analysis/snow" ]]; then
                 cd "${cwd}/${dir}/${cyc}/${mem}/analysis/snow"
-                for snow_file in *.sfc_data.tile1.nc; do
+                for snow_file in snowinc.*.sfc_data.tile1.nc; do
                 if [[ -f "${snow_file}" ]]; then
                     prefix=$(echo "${snow_file}" | cut -d. -f1-3)
                     prefix_new=$(echo "${prefix}" | cut -d. -f2-)
                     for tile in {1..6}; do
-                        link_file "${prefix}.tile${tile}.nc" "${prefix_new}.snow_analysis.sfc_data.tile${tile}.nc"
+                        link_file "${prefix}.sfc_data.tile${tile}.nc" "${prefix_new}.snow_analysis.sfc_data.tile${tile}.nc"
                     done
                 fi
                 done
@@ -323,12 +323,12 @@ for dir in "${enkfgdas_list[@]}" "${enkfgfs_list[@]}"; do
         # snow ensstat
         if [[ -d "${cwd}/${dir}/${cyc}/ensstat/analysis/snow" ]]; then
             cd "${cwd}/${dir}/${cyc}/ensstat/analysis/snow"
-            for snow_file in *.sfc_data.tile1.nc; do
+            for snow_file in snowinc*.sfc_data.tile1.nc; do
                 if [[ -f "${snow_file}" ]]; then
                     prefix=$(echo "${snow_file}" | cut -d. -f1-3)
                     prefix_new=$(echo "${prefix}" | cut -d. -f2-)
                     for tile in {1..6}; do
-                        link_file "${prefix}.tile${tile}.nc" "${prefix_new}.snow_increment.sfc_data.tile${tile}.nc"
+                        link_file "${prefix}.sfc_data.tile${tile}.nc" "${prefix_new}.snow_increment.sfc_data.tile${tile}.nc"
                     done
                 fi
             done

--- a/dev/ush/make_ee2_links.sh
+++ b/dev/ush/make_ee2_links.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#shellcheck disable=SC2207
 PS4='+ $LINENO: '
 set -eux
 
@@ -13,7 +14,7 @@ set -eux
 # WARNING: This script does not create all links needed for EE2 compatibility. It only creates links needed to
 #          restart an existing experiment.
 
-if [ "$#" -ne 1 ]; then
+if [[ $# -ne 1 ]]; then
   echo "Usage: $0 <target_directory>"
   exit 1
 fi
@@ -24,7 +25,7 @@ cd "${target_dir}" || exit 1
 # Check for existence of at least one of gdas.YYYYMMDD, gfs.YYYYMMDD, or enkfgdas.YYYYMMDD directories
 dir_list=($(ls -d gdas.* gfs.* enkfgdas.* || true ))
 
-if [ ${#dir_list[@]} -eq 0 ]; then
+if [[ ${#dir_list[@]} -eq 0 ]]; then
   echo "No gdas.*, gfs.*, or enkfgdas.* directories found in ${target_dir}."
   exit 1
 fi
@@ -50,7 +51,7 @@ for dir in "${gdas_list[@]}" "${gfs_list[@]}" "${gcdas_list[@]}" "${gcafs_list[@
     *) echo "Unknown directory prefix: ${dir}"; exit 1 ;;
   esac
 
-  cycle_list=($(ls -d ?? || true ))
+  cycle_list=($(ls -d ./?? || true ))
   for cyc in "${cycle_list[@]}"; do
     if [[ -d "${cwd}/${dir}/${cyc}/analysis/atmos" ]]; then
       cd "${cwd}/${dir}/${cyc}/analysis/atmos"
@@ -166,7 +167,7 @@ done
 
 for dir in "${enkfgdas_list[@]}" "${enkfgfs_list[@]}"; do
   cd "${dir}"
-  cycle_list=($(ls -d ?? || true ))
+  cycle_list=($(ls -d ./?? || true ))
   for cyc in "${cycle_list[@]}"; do
     mem_list=($(ls -d mem* || true ))
     for mem in "${mem_list[@]}"; do


### PR DESCRIPTION
# Description
This adds a script that creates links from the pre-EE2-compliant filenames to EE2-equivalent names.  This will allow experiments to run warm restarts locally or from HPSS.  This is a companion PR to #4205.

Resolves #4242 
Prerequisite for https://github.com/NOAA-EMC/GFS/issues/3
# Type of change
- [ ] Bug fix (fixes something broken)
- [x] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? YES
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Ran on the staged ICs to verify the same links were created as in #4205 

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary