### PR TITLE
Update YAMLs for the GFSv17 realtime/retros to point to obsforge from role account

### DIFF
--- a/dev/ci/cases/gfsv17/s2sw_realtime.yaml
+++ b/dev/ci/cases/gfsv17/s2sw_realtime.yaml
@@ -29,7 +29,7 @@ prepoceanobs:
   # retro
   # dmpdir_exp: /lfs/h2/emc/da/noscrub/common_obsForge
   # realtime
-  dmpdir_exp: /lfs/h2/emc/da/noscrub/mindo.choi/MARINE_obs/COMROOT/realtime
+  dmpdir_exp: /lfs/h2/emc/da/noscrub/emc.da/obsForge/COMROOT/realtime
 
 marinebmat:
   SOCA_INPUT_FIX_DIR: {{ HOMEgfs }}/fix/gdas/soca/1440x1080x75/soca

--- a/dev/ci/cases/gfsv17/s2sw_stream2.yaml
+++ b/dev/ci/cases/gfsv17/s2sw_stream2.yaml
@@ -27,7 +27,7 @@ base:
 prepoceanobs:
   use_exp_obs: "YES"
   # retro
-  dmpdir_exp: /lfs/h2/emc/da/noscrub/common_obsForge
+  dmpdir_exp: /lfs/h2/emc/da/noscrub/emc.da/obsForge/COMROOT/realtime
   # realtime
   # dmpdir_exp: /lfs/h2/emc/da/noscrub/mindo.choi/MARINE_obs/COMROOT/realtime
 

--- a/dev/ci/cases/gfsv17/s2sw_stream3.yaml
+++ b/dev/ci/cases/gfsv17/s2sw_stream3.yaml
@@ -27,7 +27,7 @@ base:
 prepoceanobs:
   use_exp_obs: "YES"
   # retro
-  dmpdir_exp: /lfs/h2/emc/da/noscrub/common_obsForge
+  dmpdir_exp: /lfs/h2/emc/da/noscrub/emc.da/obsForge/COMROOT/realtime
   # realtime
   # dmpdir_exp: /lfs/h2/emc/da/noscrub/mindo.choi/MARINE_obs/COMROOT/realtime
 


### PR DESCRIPTION
# Description
The YAMLs under `dev/ci/cases/gfsv17` for the GFSv17 real time and retrospective experiments point to obsForge marine observations under a personal account:

[global-workflow/dev/ci/cases/gfsv17/s2sw_realtime.yaml](https://github.com/NOAA-EMC/global-workflow/blob/a04b54a06fddcc6e1a30f054db56a8509846649a/dev/ci/cases/gfsv17/s2sw_realtime.yaml#L32)

Line 32 in [a04b54a](https://github.com/NOAA-EMC/global-workflow/commit/a04b54a06fddcc6e1a30f054db56a8509846649a)
 dmpdir_exp: /lfs/h2/emc/da/noscrub/mindo.choi/MARINE_obs/COMROOT/realtime 

These observations are being migrated to the `emc.da` role account as part of https://github.com/NOAA-EMC/obsForge/issues/139. This PR updates the YAML files to point to the role account space.  This role account space will be used for both the retrospectives and real time parallel (they were previously different directories):

`/lfs/h2/emc/da/noscrub/emc.da/obsForge/COMROOT/realtime`

Keeping this PR in draft until the new directory is confirmed by @apchoiCMD 

Resolves #4252

# Type of change
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO
- **Directory staging needs to be confirmed by @apchoiCMD** 

# How has this been tested?
YAMLs have been used for GFSv17 experiments regularly.  New obs location was tested by @JohnSteffen-NOAA and @apchoiCMD.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
