### PR TITLE
Fix build_gsinfo option for eupd

### DIFF
--- a/dev/parm/config/gfs/config.anal
+++ b/dev/parm/config/gfs/config.anal
@@ -160,7 +160,7 @@ if [[ ${USE_BUILD_GSINFO} == "YES" ]]; then
 
    # Use 2m observations when constructing conventional obs info file
    # can use 2m obs without enabling soil DA by setting USE_2M_OBS=YES in config.base
-   export USE_2M_OBS="${USE_2M_OBS:-DO_GSISOILDA}"
+   export USE_2M_OBS="${USE_2M_OBS:-$DO_GSISOILDA}"
 else
    export OBS_INPUT="${BUILD_GSINFO_DIR}/obs_input/obs_input_ops.txt"
 fi

--- a/dev/parm/config/gfs/config.anal
+++ b/dev/parm/config/gfs/config.anal
@@ -160,7 +160,7 @@ if [[ ${USE_BUILD_GSINFO} == "YES" ]]; then
 
    # Use 2m observations when constructing conventional obs info file
    # can use 2m obs without enabling soil DA by setting USE_2M_OBS=YES in config.base
-   export USE_2M_OBS="${USE_2M_OBS:-$DO_GSISOILDA}"
+   export USE_2M_OBS="${USE_2M_OBS:-${DO_GSISOILDA}}"
 else
    export OBS_INPUT="${BUILD_GSINFO_DIR}/obs_input/obs_input_ops.txt"
 fi

--- a/jobs/JGDAS_ENKF_SELECT_OBS
+++ b/jobs/JGDAS_ENKF_SELECT_OBS
@@ -84,7 +84,7 @@ export ABIASAIR="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}abias_air.txt"
 export ABIASe="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}abias_int.txt"
 
 # Diagnostics related to ensemble mean
-export GSISTAT="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}gsistat.ensmean.tar"
+export GSISTAT="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}gsistat.ensmean.txt"
 export CNVSTAT="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}cnvstat.ensmean.tar"
 export OZNSTAT="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}oznstat.ensmean.tar"
 export RADSTAT="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}radstat.ensmean.tar"

--- a/scripts/exgdas_enkf_update.sh
+++ b/scripts/exgdas_enkf_update.sh
@@ -121,20 +121,20 @@ fi
 ################################################################################
 # Fixed files
 ${NLN} "${SATANGL}"    satbias_angle
-if [[ ${SATINFO} == "generate" ]]; then
-   ${USHgfs}/create_gsi_info.sh sat "${PDY}${cyc}" "${DATA}"
+if [[ "${SATINFO}" == "generate" ]]; then
+   "${USHgfs}/create_gsi_info.sh" sat "${PDY}${cyc}" "${DATA}"
 else
-   ${NLN} ${SATINFO}      satinfo
+   ${NLN} "${SATINFO}" satinfo
 fi
-if [[ ${CONVINFO} == "generate" ]]; then
-   ${USHgfs}/create_gsi_info.sh conv "${PDY}${cyc}" "${DATA}" "${USE_2M_OBS}"
+if [[ "${CONVINFO}" == "generate" ]]; then
+   "${USHgfs}/create_gsi_info.sh" conv "${PDY}${cyc}" "${DATA}" "${USE_2M_OBS}"
 else
-   ${NLN} "${CONVINFO}"     convinfo
+   ${NLN} "${CONVINFO}" convinfo
 fi
-if [[ ${OZINFO} == "generate" ]]; then
+if [[ "${OZINFO}" == "generate" ]]; then
    "${USHgfs}/create_gsi_info.sh" oz "${PDY}${cyc}" "${DATA}"
 else
-   ${NLN} "${OZINFO}"       ozinfo
+   ${NLN} "${OZINFO}" ozinfo
 fi
 ${NLN} "${SCANINFO}"   scaninfo
 ${NLN} "${HYBENSINFO}" hybens_info

--- a/scripts/exgdas_enkf_update.sh
+++ b/scripts/exgdas_enkf_update.sh
@@ -132,7 +132,7 @@ else
    ${NLN} "${CONVINFO}"     convinfo
 fi
 if [[ ${OZINFO} == "generate" ]]; then
-   ${USHgfs}/create_gsi_info.sh oz "${PDY}${cyc}" "${DATA}"
+   "${USHgfs}/create_gsi_info.sh" oz "${PDY}${cyc}" "${DATA}"
 else
    ${NLN} "${OZINFO}"       ozinfo
 fi

--- a/scripts/exgdas_enkf_update.sh
+++ b/scripts/exgdas_enkf_update.sh
@@ -121,10 +121,22 @@ fi
 ################################################################################
 # Fixed files
 ${NLN} "${SATANGL}"    satbias_angle
-${NLN} "${SATINFO}"    satinfo
+if [[ ${SATINFO} == "generate" ]]; then
+   ${USHgfs}/create_gsi_info.sh sat "${PDY}${cyc}" "${DATA}"
+else
+   ${NLN} ${SATINFO}      satinfo
+fi
+if [[ ${CONVINFO} == "generate" ]]; then
+   ${USHgfs}/create_gsi_info.sh conv "${PDY}${cyc}" "${DATA}" "${USE_2M_OBS}"
+else
+   ${NLN} "${CONVINFO}"     convinfo
+fi
+if [[ ${OZINFO} == "generate" ]]; then
+   ${USHgfs}/create_gsi_info.sh oz "${PDY}${cyc}" "${DATA}"
+else
+   ${NLN} "${OZINFO}"       ozinfo
+fi
 ${NLN} "${SCANINFO}"   scaninfo
-${NLN} "${CONVINFO}"   convinfo
-${NLN} "${OZINFO}"     ozinfo
 ${NLN} "${HYBENSINFO}" hybens_info
 ${NLN} "${ANAVINFO}"   anavinfo
 ${NLN} "${VLOCALEIG}"  vlocal_eig.dat


### PR DESCRIPTION
# Description
The build_gsinfo option currently results in no satellite data being used for the EnKF.  While the info files are primarily used in the eobs step rather than the eupd, at least the satinfo file needs to be generated for the eupd step as well.  This PR adds the generation of the 3 info files as is done in anal and eobs.

Refs #3293

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
C96C48_hybatmDA and C96C48mx500_S2SW_cyc_gfs on WCOSS2.  Full suite on Gaea C6 pending

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
