### PR TITLE
remove obsolete GDASApp logic from build_compute.sh (#4275)

### DIFF
--- a/sorc/build_compute.sh
+++ b/sorc/build_compute.sh
@@ -143,18 +143,6 @@ while [[ "${finished}" == "false" ]]; do
    fi
 done
 
-# Wait for the GDASApp to finish building
-if [[ -n "${build_gdas_id+0}" ]]; then
-  echo "Compute builds have completed successfully, but the GDASApp is still building locally.  Waiting for it to complete."
-  wait "${build_gdas_id}"
-  gdas_stat=$?
-  if [[ ${gdas_stat} -ne 0 ]]; then
-    echo "FATAL ERROR The GDASApp failed to build!  Check log in ${gdas_build_log}"
-    # Capture the error log in logs/error.logs
-    echo "${gdas_build_log}" >> "${err_file}"
-    exit 3
-  fi
-fi
 echo "All builds completed successfully!"
 
 exit 0


### PR DESCRIPTION
# Description
This PR removes obsolete GDASApp logic from build_compute.sh

Resolves #4275 

# Type of change
- [x] Maintenance (clean-up)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? **NO**
- Does this change require a documentation update? **NO**
- Does this change require an update to any of the following submodules? **NO**


# How has this been tested?
Clone `RussTreadon-NOAA:/bugifx/build_compute` on Cactus and build `gdas` on compute node.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

