### PR TITLE
copy/link abias_int to satbias_in in the eupd run directory

### DIFF
--- a/dev/scripts/exglobal_enkf_update.sh
+++ b/dev/scripts/exglobal_enkf_update.sh
@@ -31,7 +31,7 @@ ENKFEXEC=${ENKFEXEC:-${EXECgfs}/enkf.x}
 APREFIX=${APREFIX:-${RUN}.t${cyc}z.}
 GPREFIX=${GPREFIX:-${RUN}.t${GDATE:8:2}z.}
 
-# GBIASe=${GBIASe:-${APREFIX}abias_int.ensmean.txt}  # TODO: remove (see comment and TODO below) Also, this is not a "G"BIAS (See the name, it has APREFIX in its name)
+ABIASe=${ABIASe:-${APREFIX}abias_int.txt}
 CNVSTAT="${APREFIX}cnvstat_ensmean.tar"
 OZNSTAT="${APREFIX}oznstat_ensmean.tar"
 RADSTAT="${APREFIX}radstat_ensmean.tar"
@@ -111,7 +111,7 @@ else
 fi
 
 # Bias correction coefficients based on the ensemble mean
-#${NLN} "${COMIN_ATMOS_ANALYSIS_STAT}/${GBIASe}" "satbias_in"  # This file does not exist when test was run # TODO: remove
+${NLN} "${COMIN_ATMOS_ANALYSIS_STAT}/${ABIASe}" "satbias_in"
 
 ################################################################################
 # Ensemble guess, observational data and analyses/increments

--- a/dev/scripts/exglobal_enkf_update.sh
+++ b/dev/scripts/exglobal_enkf_update.sh
@@ -111,7 +111,7 @@ else
 fi
 
 # Bias correction coefficients based on the ensemble mean
-${NLN} "${COMIN_ATMOS_ANALYSIS_STAT}/${ABIASe}" "satbias_in"
+cpreq "${COMIN_ATMOS_ANALYSIS_STAT}/${ABIASe}" "satbias_in"
 
 ################################################################################
 # Ensemble guess, observational data and analyses/increments


### PR DESCRIPTION
# Description
This PR links `abias_int` to `satbias_in` in the eupd run directory.

Resolves #4331 


# Type of change
- [ ] Bug fix (fixes something broken)


# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? **YES**
  - [x] GFS
  - [ ] GEFS 
  - [ ] SFS
  - [ ] GCAFS

This PR alters ensemble analysis increments generated by the eupd job if radiances from satellites besides amsua and atms are assimilated.  I do not know if GEFS, SFS, or GCAFS cycling runs with eupd.

- Is this a breaking change (a change in existing functionality)? **NO**

- Does this change require an update to any of the following submodules? **NO**


# How has this been tested?
- Clone, build, and install in GFS v17 GSI and JEDI parallels running on WCOSS2 (Cactus)


# Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
