### PR TITLE
Set memory requests for builds and exit build_compute.sh on failure

### DIFF
--- a/dev/workflow/build_opts.yaml
+++ b/dev/workflow/build_opts.yaml
@@ -5,8 +5,8 @@ host_override:  # over-ride options for host
     walltime_ratio: 1.5  # Uniformly adjust the wallclock by this factor (builds are slower on head nodes)
     build:
       gdas:
-        memory: "60G"
         cores: 8
+        memory: "60G"
         walltime: "02:30:00"
 systems:
   common:
@@ -37,6 +37,7 @@ build:
     command: "./build_ufs.sh -e gfs_model.x"
     cores: 12
     walltime: "00:40:00"
+    memory: "40G"
 
   gfs_ww3prepost:
     command: "./build_ww3prepost.sh"
@@ -47,6 +48,7 @@ build:
     command: "./build_ufs.sh -w -e gefs_model.x"
     cores: 12
     walltime: "00:40:00"
+    memory: "40G"
 
   gefs_ww3_prepost:
     command: "./build_ww3prepost.sh -w"
@@ -57,11 +59,13 @@ build:
     command: "./build_ufs.sh -y -e sfs_model.x"
     cores: 12
     walltime: "00:50:00"
+    memory: "40G"
 
   gcafs_model:
     command: "./build_ufs.sh -a ATMAERO -e gcafs_model.x"
     cores: 12
     walltime: "00:40:00"
+    memory: "40G"
 
   upp:
     command: "./build_upp.sh"
@@ -72,6 +76,7 @@ build:
     command: "./build_gsi_enkf.sh"
     cores: 8
     walltime: "00:20:00"
+    memory: "40G"
 
   gsi_monitor:
     command: "./build_gsi_monitor.sh"

--- a/sorc/build_compute.sh
+++ b/sorc/build_compute.sh
@@ -99,6 +99,12 @@ runcmd="rocotorun -w ${build_xml} -d ${build_db} ${rocoto_verbose_opt}"
 
 finished=false
 ${runcmd}
+rc=$?
+if [[ "${rc}" -ne 0 ]]; then
+  echo "FATAL ERROR: ${BASH_SOURCE[0]} failed to run rocoto on the first attempt!"
+  exit 1
+fi
+
 echo "Monitoring builds on compute nodes"
 while [[ "${finished}" == "false" ]]; do
    sleep 1m
@@ -139,7 +145,7 @@ while [[ "${finished}" == "false" ]]; do
             echo "Rocoto reported that the build failed for ${job}"
          fi
       done < rocotostat.out
-
+      exit 1
    fi
 done
 


### PR DESCRIPTION
# Description
This adds checks to build_compute.sh to exit on a rocoto failure to prevent infinite loops and sets memory requests for model and gdas builds.

Resolves #4333 
Resolves #4335 

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO (If YES, please indicate to which system(s))
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Build test on Gaea where one build job was intentionally killed.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added