### PR TITLE
Add atmos stochastic physics tuning with SKEB, and add river runoff at 1-deg

### DIFF
--- a/dev/parm/config/gefs/config.ufs
+++ b/dev/parm/config/gefs/config.ufs
@@ -306,7 +306,7 @@ if [[ "${skip_mom6}" == "false" ]]; then
       FRUNOFF="runoff.daitren.clim.1deg.nc"
       CHLCLIM="seawifs_1998-2006_smoothed_2X.nc"
       MOM6_RESTART_SETTING=${MOM6_RESTART_SETTING:-'r'}
-      MOM6_RIVER_RUNOFF='False'
+      MOM6_RIVER_RUNOFF='True'
       eps_imesh="2.5e-1"
       TOPOEDITS="ufs.topo_edits_011818.nc"
       case ${RUN} in

--- a/dev/parm/config/sfs/config.efcs
+++ b/dev/parm/config/sfs/config.efcs
@@ -28,8 +28,8 @@ source "${EXPDIR}/config.resources" efcs
 
 # Stochastic physics parameters (only for ensemble forecasts)
 if [[ "${TYPE}" == "hydro" ]] ; then
-    export DO_SKEB="NO" # SKEB turned off for C96
-    export SKEB=-999.
+    export DO_SKEB="YES" # SKEB turned off for C96
+    export SKEB="0.08,-999,-999,-999,-999"
 else
     export DO_SKEB="YES" # SKEB turned on for all other resolutions
     export SKEB="0.8,-999,-999,-999,-999"
@@ -37,12 +37,12 @@ fi
 export SKEB_TAU="2.16E4,2.592E5,2.592E6,7.776E6,3.1536E7"
 export SKEB_LSCALE="500.E3,1000.E3,2000.E3,2000.E3,2000.E3"
 export SKEBNORM=1
-export SKEB_NPASS=30
+export SKEB_NPASS=15
 export SKEB_VDOF=5
 export DO_SPPT="YES"
-export SPPT="0.56,0.28,0.14,0.056,0.028"
-export SPPT_TAU="2.16E4,2.592E5,2.592E6,7.776E6,3.1536E7"
-export SPPT_LSCALE="500.E3,1000.E3,2000.E3,2000.E3,2000.E3"
+export SPPT="0.5,0.2,0.1"
+export SPPT_TAU="2.16E4,2.592E5,1.296E6"
+export SPPT_LSCALE="500.E3,1000.E3,2000.E3"
 export SPPT_LOGIT=".true."
 export SPPT_SFCLIMIT=".true."
 # OCN options


### PR DESCRIPTION
# Description
<!-- This description will become the commit message for the PR. -->
<!--
  This PR turns on SKEB for the hydrostatic version of the model, and has stochastic physics tuning for the SFS application.  In addition, I noticed that for the 1-degree ocean, MOM6_RIVER_RUNOFF was still set to false. That is now changed to true.
-->
<!-- For more on writing good commit messages, see https://cbea.ms/git-commit/ -->

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [X] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? YES/NO (If YES, please indicate to which system(s))
  - [ ] GFS
  - [ ] GEFS
  - [X] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? YES/NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [X] UFS-weather-model https://github.com/ufs-community/ufs-weather-model/pull/2997 
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
Forecast-only on Orion and Hercules in SFS mode

# Checklist
- [ ] Any dependent changes have been merged and published
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
