### PR TITLE
Disable pres_b archiving of gcafs products

### DIFF
--- a/parm/archive/master_gcafs.yaml.j2
+++ b/parm/archive/master_gcafs.yaml.j2
@@ -14,6 +14,7 @@ datasets:
             - "{{ COMIN_ATMOS_HISTORY | relpath(ROTDIR) }}/{{ head }}atm.f{{ '%03d' % fhr }}.nc"
             - "{{ COMIN_ATMOS_HISTORY | relpath(ROTDIR) }}/{{ head }}sfc.f{{ '%03d' % fhr }}.nc"
             {% endfor %}
+{# TODO: reenable when pres_b files are ready to archive
             {% if ARCH_GAUSSIAN %}
             {% for fhr in range(0, FHMAX_GFS + FHOUT_GFS, FHOUT_GFS) %}
             - "{{ COMIN_ATMOS_GRIB_0p25 | relpath(ROTDIR) }}/{{ head }}pres_b.0p25.f{{ '%03d' % fhr }}.grib2"
@@ -22,6 +23,7 @@ datasets:
             - "{{ COMIN_ATMOS_GRIB_1p00 | relpath(ROTDIR) }}/{{ head }}pres_b.1p00.f{{ '%03d' % fhr }}.grib2.idx"
             {% endfor %}
             {% endif %}
+end TODO #}
             - "{{ COMIN_CONF | relpath(ROTDIR) }}/ufs.input.nml"
             # Forecast GRIB2 products
             {% for fhr in range(FHMIN_GFS, FHMAX_GFS + FHOUT_GFS, FHOUT_GFS) %}


### PR DESCRIPTION
# Description
This is a hotfix PR to disable non-existent `pres_b` product archiving from the GCAFS system.

# Type of change
- [X] Bug fix (fixes something broken)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Tested in one of #4328 

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
