### PR TITLE
Modify formating for xml dependency

### DIFF
--- a/dev/workflow/rocoto/rocoto.py
+++ b/dev/workflow/rocoto/rocoto.py
@@ -432,18 +432,18 @@ def create_dependency(dep_condition=None, dep=[]) -> List[str]:
     if len(dep) > 0:
         if dep_condition is not None:
             strings.append(f'<{dep_condition}>')
-            
+
         # Flatten any nested lists/tuples and return plain XML strings (no leading tabs)
         for d in dep:
             for e in _traverse(d):
                 strings.append(str(e))
-                    
+
         if dep_condition is not None:
             strings.append(f'</{dep_condition}>')
-            
+
     return strings
 
- 
+
 def create_envar(name: str, value: Union[str, float, int]) -> str:
     """
     create a Rocoto environment variable given name and value

--- a/dev/workflow/rocoto/rocoto.py
+++ b/dev/workflow/rocoto/rocoto.py
@@ -433,7 +433,8 @@ def create_dependency(dep_condition=None, dep=[]) -> List[str]:
         if dep_condition is not None:
             strings.append(f'<{dep_condition}>')
 
-        # Flatten any nested lists/tuples and return plain XML strings (no leading tabs)
+        # Flatten any nested lists/tuples and return plain XML strings
+        # Note: tabbing is handled at task creation by create_innermost_task
         for d in dep:
             for e in _traverse(d):
                 strings.append(str(e))

--- a/dev/workflow/rocoto/rocoto.py
+++ b/dev/workflow/rocoto/rocoto.py
@@ -164,10 +164,14 @@ def _create_innermost_task(task_dict: Dict[str, Any]) -> List[str]:
             strings.append(f'\t{e}\n')
         strings.append('\n')
 
+    # Write dependency block: flatten any nested items and strip leading tabs
     if dependency is not None and len(dependency) > 0:
         strings.append('\t<dependency>\n')
         for d in dependency:
-            strings.append(f'\t\t{d}\n')
+            # Flatten nested lists/tuples and write each element as an XML line
+            for e in _traverse(d):
+                s = str(e).lstrip('\t')  # remove accidental leading tabs from pieces
+                strings.append(f'\t\t{s}\n')
         strings.append('\t</dependency>\n')
         strings.append('\n')
 
@@ -428,20 +432,18 @@ def create_dependency(dep_condition=None, dep=[]) -> List[str]:
     if len(dep) > 0:
         if dep_condition is not None:
             strings.append(f'<{dep_condition}>')
-
+            
+        # Flatten any nested lists/tuples and return plain XML strings (no leading tabs)
         for d in dep:
-            if dep_condition is None:
-                strings.append(f'{d}')
-            else:
-                for e in _traverse(d):
-                    strings.append(f'\t{e}')
-
+            for e in _traverse(d):
+                strings.append(str(e))
+                    
         if dep_condition is not None:
             strings.append(f'</{dep_condition}>')
-
+            
     return strings
 
-
+ 
 def create_envar(name: str, value: Union[str, float, int]) -> str:
     """
     create a Rocoto environment variable given name and value


### PR DESCRIPTION
# Description
github copilot was used to troubleshoot the problem described in issue #4366.  This PR contains copilot generated changes to `rocoto.py` which remove the extraneous `\t` characters in the metpg dependency included for task gfs_cleanup.

Resolves #4366


# Type of change
- [x] Bug fix (fixes something broken)


# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? **NO**
- Is this a breaking change (a change in existing functionality)? **NO**
- Does this change require a documentation update? **NO**
- Does this change require an update to any of the following submodules? **NO**


# How has this been tested?
Run GDASApp ctests including select g-w CI on Hera.  All 137 tests _Passed_.

# Checklist
- [ ] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
