### PR TITLE
HOTFIX: Change build script to build_all.sh

### DIFF
--- a/dev/ci/scripts/utils/ci_utils.sh
+++ b/dev/ci/scripts/utils/ci_utils.sh
@@ -244,7 +244,9 @@ function build() {
         echo "Creating logs folder"
         mkdir -p "${logs_dir}" || exit 1
     fi
-    "${HOMEgfs_}/sorc/build_compute.sh" -A "${HPC_ACCOUNT}" all
+    # TODO: return to build_compute.sh when the GDASApp can be built on compute nodes again
+    "${HOMEgfs_}/sorc/build_all.sh" all
+    # "${HOMEgfs_}/sorc/build_compute.sh" -A "${HPC_ACCOUNT}" all
 
 }
 


### PR DESCRIPTION
# Description
This temporarily disables build_compute.sh when running CI. This should work to resolve issues with both Gaea C6 where the number of build cores is restricted, as well as with the GDASApp on all systems, as that App needs to be able to reach the internet and cannot do so from a compute node.

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? YES -- temporarily disable build_compute.sh
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Ran build_all.sh on WCOSS2. Will test on C6 through the build step on automated CI.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] This change is covered by an existing CI test or a new one has been added
- [x] I have made corresponding changes to the system documentation if necessary