### PR TITLE
hotfix -- getopts argument parsing in rocoto_helpers.sh

### DIFF
--- a/dev/ush/rocoto_helpers.sh
+++ b/dev/ush/rocoto_helpers.sh
@@ -17,6 +17,7 @@
 gw_expstat() {
     local expdir=""
     local summarize_flag=""
+    local OPTIND=1
 
     while getopts "e:s" opt; do
         case "${opt}" in
@@ -102,6 +103,8 @@ _gw_pad_str() {
 #######################################
 gw_cistat() {
     local RUNTESTS=""
+    local OPTIND=1
+
     while getopts "r:" opt; do
         case "${opt}" in
             r)


### PR DESCRIPTION
# Fix getopts argument parsing in rocoto_helpers.sh

## Summary
Fixes a bug where command-line arguments passed to `gw_expstat` and `gw_cistat` functions were being ignored.

## Problem
When calling these functions with arguments (e.g., `gw_expstat -e /path/to/expdir`), the `-e` option was not being parsed and `expdir` remained empty. This caused the function to default to using `PWD` instead of the specified experiment directory.

## Root Cause
The shell variable `OPTIND` (used by `getopts` to track argument processing position) is global by default. If these functions are called after other `getopts` usage in the same shell session, `OPTIND` retains its previous value, causing `getopts` to skip argument parsing entirely.

## Solution
Added `local OPTIND=1` at the start of both `gw_expstat()` and `gw_cistat()` functions to:
1. Reset `OPTIND` to 1 (first argument) before processing
2. Scope `OPTIND` locally so it doesn't affect the parent shell

## Testing
Verified fix by sourcing the script and calling:
```bash
gw_expstat -e /gpfs/f6/drsa-precip3/world-shared/global/CI/GITLAB/stable/RUNTESTS/EXPDIR/C48_S2SWA_gefs_16241307-6226
```
Confirmed the experiment directory is now correctly parsed and `rocotostat` output is displayed.

## Files Changed
- `dev/ush/rocoto_helpers.sh` - Added `local OPTIND=1` to `gw_expstat()` and `gw_cistat()` functions