### PR TITLE
Simplify rocoto module loading instructions

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -2,9 +2,7 @@
 Start your run
 ==============
 
-Make sure a rocoto module is loaded: ``module load rocoto``
-
-If needed check for available rocoto modules on machine: ``module avail rocoto`` or ``module spider rocoto``
+Make sure a rocoto module is loaded. The easiest way to do this is ``source dev/ush/gw_setup.sh``.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Start your run from within your EXPDIR

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -4,6 +4,13 @@ Start your run
 
 Make sure a rocoto module is loaded. The easiest way to do this is ``source dev/ush/gw_setup.sh``.
 
+.. warning::
+   Sourcing gw_setup.sh will wipe your existing lmod environment
+
+.. note::
+   Bash shell is required to source gw_setup.sh
+
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Start your run from within your EXPDIR
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
# Description
This generalizes the documented approach to loading the rocoto module by sourcing `gw_setup.sh`.

# Type of change
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)