### PR TITLE
Remove extraneous module use from build_fv3.sh (GFS v16.3.29->16.3.30)

### DIFF
--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -71,9 +71,7 @@ PARM/CONFIG CHANGES
 SCRIPT CHANGES
 --------------
 
-* Remove COM declarations UKMET and ECMWF from the JGDAS_ATMOS_GEMPAK_META_NCDC and JGFS_ATMOS_GEMPAK_META J-Jobs.
-* Remove the gdas_ecmwf_meta_var.sh and gdas_ukmet_meta_var.sh scripts from gempak/ush.
-* Remove references to UKMET and ECMWF from the gempak/ush gfs_meta_comp.sh, gfs_meta_crb.sh, gfs_meta_hur.sh, gfs_meta_mar_comp.sh, gfs_meta_sa2.sh, and gfs_meta_usext.sh scripts.
+* No changes from GFS v16.3.29.
 
 FIX CHANGES
 -----------
@@ -83,7 +81,7 @@ FIX CHANGES
 MODULE CHANGES
 --------------
 
-* No changes from GFS v16.3.29.
+* An extraneous ``module use`` was removed from ``build_all.sh``.  This module path was required when building GFS v16.3.25, but is no longer required.
 
 CHANGES TO FILE AND FILE SIZES
 ------------------------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -1,9 +1,9 @@
-GFS V16.3.29 RELEASE NOTES
+GFS V16.3.30 RELEASE NOTES
 
 -------
 PRELUDE
 -------
-Remove UKMET reference from gfs gempak jobs.
+This removes an extraneous module path from the build script.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -13,9 +13,9 @@ The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub are used t
 ```bash
 cd $PACKAGEROOT
 
-mkdir gfs.v16.3.29
-cd gfs.v16.3.29
-git clone -b EMC-v16.3.29 https://github.com/NOAA-EMC/global-workflow.git .
+mkdir gfs.v16.3.30
+cd gfs.v16.3.30
+git clone -b EMC-v16.3.30 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```
@@ -51,22 +51,22 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* in `versions/run.ver` change `version=v16.3.29` and `gfs_ver=v16.3.29`
+* in `versions/run.ver` change `version=v16.3.30` and `gfs_ver=v16.3.30`
 
 SORC CHANGES
 ------------
 
-* No changes from GFS v16.3.28
+* No changes from GFS v16.3.29
 
 JOBS CHANGES
 ------------
 
-* No changes from GFS v16.3.28
+* No changes from GFS v16.3.29
 
 PARM/CONFIG CHANGES
 -------------------
 
-* No changes from GFS v16.3.28
+* No changes from GFS v16.3.29
 
 SCRIPT CHANGES
 --------------
@@ -78,22 +78,22 @@ SCRIPT CHANGES
 FIX CHANGES
 -----------
 
-* No changes from GFS v16.3.28.
+* No changes from GFS v16.3.29.
 
 MODULE CHANGES
 --------------
 
-* No changes from GFS v16.3.28.
+* No changes from GFS v16.3.29.
 
 CHANGES TO FILE AND FILE SIZES
 ------------------------------
 
-* No significant changes from GFS v16.3.28.
+* No significant changes from GFS v16.3.29.
 
 ENVIRONMENT AND RESOURCE CHANGES
 --------------------------------
 
-* No changes from GFS v16.3.28.
+* No changes from GFS v16.3.29.
 
 PRE-IMPLEMENTATION TESTING REQUIREMENTS
 ---------------------------------------
@@ -106,22 +106,22 @@ PRE-IMPLEMENTATION TESTING REQUIREMENTS
 DISSEMINATION INFORMATION
 -------------------------
 
-* No changes from GFS v16.3.28
+* No changes from GFS v16.3.29
 
 HPSS ARCHIVE
 ------------
 
-* No changes from GFS v16.3.28
+* No changes from GFS v16.3.29
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
 
-* No changes from GFS v16.3.28
+* No changes from GFS v16.3.29
 
 DOCUMENTATION
 -------------
 
-* No changes from GFS v16.3.28
+* No changes from GFS v16.3.29
 
 PREPARED BY
 -----------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -81,7 +81,7 @@ FIX CHANGES
 MODULE CHANGES
 --------------
 
-* An extraneous ``module use`` was removed from ``build_all.sh``.  This module path was required when building GFS v16.3.25, but is no longer required.
+* An extraneous ``module use`` was removed from ``build_fv3.sh``.  This module path was required when building GFS v16.3.25, but is no longer required.
 
 CHANGES TO FILE AND FILE SIZES
 ------------------------------

--- a/sorc/build_fv3.sh
+++ b/sorc/build_fv3.sh
@@ -20,7 +20,6 @@ if [ $target = hera ]; then target=hera.intel ; fi
 if [ $target = orion ]; then target=orion.intel ; fi
 
 cd fv3gfs.fd/tests
-module use  /apps/ops/para/libs/modulefiles/compiler/intel/19.1.3.304/
 if [ $target = wcoss2 ]; then
   ./compile.sh $(pwd)/../FV3 $target "WW3=Y 32BIT=Y" 1
 else # Only supporting waves on WCOSS2 for v16.2

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.29
-export gfs_ver=v16.3.29
+export version=v16.3.30
+export gfs_ver=v16.3.30
 export nam_ver=v4.2
 export rtofs_ver=v2.5
 export radarl2_ver=v1.2


### PR DESCRIPTION
# Description
This GFS v16 production update removes an extraneous `module use` from the `build_fv3.sh` build script. I only tested that the build was successful after removing this `module use`. The model was not rebuilt in production following this update.

# Type of change
- [x] Production