### PR TITLE
Build the GDASApp with 8 cores on Gaea again

### DIFF
--- a/dev/workflow/build_opts.yaml
+++ b/dev/workflow/build_opts.yaml
@@ -3,17 +3,10 @@ host_override:  # over-ride options for host
   GAEAC6:
     max_cores: 8
     walltime_ratio: 1.5  # Uniformly adjust the wallclock by this factor (builds are slower on head nodes)
-    # Memory requests over 32GB on Gaea are increasing the core count. Instead, we need to limit cores.
-    # TODO: remove this declaration when the system administrators fix the issue.
-    max_memory: "32G"
     build:
       gdas:
-        # Memory requests over 32GB on Gaea are increasing the core count. Instead, we need to limit cores.
-        # TODO: reenable when the system administrators fix the issue.
-        # memory: "60G"
-        # cores: 8
-        memory: "32G"
-        cores: 4
+        cores: 8
+        memory: "60G"
         walltime: "02:30:00"
 systems:
   common:


### PR DESCRIPTION
# Description
This allows the GDASApp to build with 8 cores again on Gaea C6 following an update to the Slurm configuration file by GFDL.

Resolves #4375 
# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Build test on Gaea C6.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added