### PR TITLE
Initialize LETKF solver after running observer

### DIFF
--- a/ush/python/pygfs/task/atmens_analysis.py
+++ b/ush/python/pygfs/task/atmens_analysis.py
@@ -122,8 +122,8 @@ class AtmEnsAnalysis(Analysis):
         None
         """
 
-        # Initialize solver immediately before execution so that obs space files are staged
-        # for cleaning empty obs spaces
+        # Initialize solver immediately before execution so that obs space files are
+        # available for cleaning after running the observer
         if jedi_dict_key == 'atmensanlsol':
             self.jedi_dict['atmensanlsol'].initialize(clean_empty_obsspaces=True)
 

--- a/ush/python/pygfs/task/atmens_analysis.py
+++ b/ush/python/pygfs/task/atmens_analysis.py
@@ -88,7 +88,6 @@ class AtmEnsAnalysis(Analysis):
         # initialize JEDI applications
         logger.info(f"Initializing JEDI LETKF observer application")
         self.jedi_dict['atmensanlobs'].initialize(clean_empty_obsspaces=True)
-        self.jedi_dict['atmensanlsol'].initialize()
         self.jedi_dict['atmensanlfv3inc'].initialize()
 
     @logit(logger)
@@ -122,6 +121,11 @@ class AtmEnsAnalysis(Analysis):
         ----------
         None
         """
+
+        # Initialize solver immediately before execution so that obs space files are staged
+        # for cleaning empty obs spaces
+        if jedi_dict_key == 'atmensanlsol':
+            self.jedi_dict['atmensanlsol'].initialize(clean_empty_obsspaces=True)
 
         self.jedi_dict[jedi_dict_key].execute()
 


### PR DESCRIPTION
# Description

This PR fixes a problem whereby the JEDI LETKF solver job, `atmensanlsol`, attempts to process observation inputs that don't exist. With these changes, the input YAML for the `atmensanlsol` JEDI application is rendered after the LETKF observer job, `atmensanlobs`, runs, and the rendering is performed using the `clean_empty_obsspaces` option in the `initialize()` method of the `Jedi` class. This ensures that the observation inputs that the solver needs, produced by the observer, are present before initialization, so that missing observation inputs can be removed using the `clean_empty_obsspaces` option.

  Resolves #4420

# Type of change
- [X] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO (If YES, please indicate to which system(s))
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? YES/NO
- Does this change require a documentation update? YES/NO
- Does this change require an update to any of the following submodules? YES/NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?



# Checklist
- [X] Any dependent changes have been merged and published
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [X] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
