### PR TITLE
Bug fixes for CI pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,6 +194,11 @@ include:
         Machine="${machine^}"
         echo "Job failed, performing cleanup actions for ${Machine}"
 
+        # TODO We need to add local python env to support PyGitHub not being in Spack-Stack 1.9
+        # this should be part of the spack environment setup in Spack-Stack 2.x
+        PYTHONPATH=${PYTHONPATH}:$HOME/.local/lib/python3.11/site-packages
+        echo "Updated PYTHONPATH: $PYTHONPATH"       
+
         # Re-setup GH if needed
         export GH=$(which gh 2>/dev/null || echo "${HOME}/bin/gh")
         if [ ! -x "${GH}" ]; then

--- a/dev/ci/scripts/utils/gitlab/launch_gitlab_runner.sh
+++ b/dev/ci/scripts/utils/gitlab/launch_gitlab_runner.sh
@@ -94,7 +94,7 @@ if [[ "${1}" == "register" ]]; then
     # --builds-dir: Directory where builds will be stored (from config.MACHINE_ID)
     # --custom_build_dir-enabled: Enable custom build directories
     # --request-concurrency: Number of concurrent requests that can be handled
-    ./gitlab-runner register -n -t "${GITLAB_RUNNER_TOKEN}" --url "${GITLAB_URL}" --executor shell --shell bash --builds-dir "${GITLAB_BUILDS_DIR}" --custom_build_dir-enabled true --request-concurrency 24
+    ./gitlab-runner register -n -t "${GITLAB_RUNNER_TOKEN}" --url "${GITLAB_URL}" --executor shell --shell bash --builds-dir "${GITLAB_BUILDS_DIR}" --custom_build_dir-enabled=true --request-concurrency 24
 
     # Set the concurrent job limit in the GitLab runner config file
     sed -i 's/concurrent.*/concurrent = 24/' ~/.gitlab-runner/config.toml


### PR DESCRIPTION
## Summary

This PR addresses two bugs discovered during GitLab CI pipeline execution on HPC systems.

## Changes

### 1. PYTHONPATH Fix for Build Failure After-Script (`.gitlab-ci.yml`)

**Problem:** The `after_script` section that runs on build failures was unable to import PyGitHub because the user's local Python packages were not in the `PYTHONPATH`. This caused the failure notification mechanism to break silently.

**Root Cause:** PyGitHub is not included in Spack-Stack 1.9 and must be installed via `pip install --user`. The after-script runs in a fresh environment that doesn't inherit the user's local site-packages path.

**Fix:** Added explicit `PYTHONPATH` extension to include `$HOME/.local/lib/python3.11/site-packages` before the cleanup/notification logic runs.

```yaml
# TODO We need to add local python env to support PyGitHub not being in Spack-Stack 1.9
# this should be part of the spack environment setup in Spack-Stack 2.x
PYTHONPATH=${PYTHONPATH}:$HOME/.local/lib/python3.11/site-packages
```

**Note:** This is a temporary workaround. The proper fix will be addressed when migrating to Spack-Stack 2.x which should include PyGitHub in the environment.

### 2. GitLab Runner Registration Argument Syntax (`launch_gitlab_runner.sh`)

**Problem:** The `--custom_build_dir-enabled` flag was being passed with a space separator (`--custom_build_dir-enabled true`) instead of the equals sign syntax.

**Root Cause:** GitLab Runner CLI expects boolean flags to use `=` assignment syntax for explicit true/false values.

**Fix:** Changed from space-separated to equals-sign syntax:

```diff
- ./gitlab-runner register ... --custom_build_dir-enabled true ...
+ ./gitlab-runner register ... --custom_build_dir-enabled=true ...
```

## Files Changed

| File | Change |
|------|--------|
| `.gitlab-ci.yml` | Added PYTHONPATH to after_script for PyGitHub access |
| `dev/ci/scripts/utils/gitlab/launch_gitlab_runner.sh` | Fixed boolean argument syntax |

## Testing

- [ ] Verified GitLab runner registration succeeds with corrected argument syntax
- [ ] Verified after_script can import PyGitHub on build failure
- [ ] Tested on HERA/Hercules HPC systems

## Related Issues

- Addresses PyGitHub import failures in CI failure notifications
- Fixes GitLab runner registration errors on HPC systems