### PR TITLE
Refactor build_compute.py to optionally support node exclusion

### DIFF
--- a/dev/workflow/build_compute.py
+++ b/dev/workflow/build_compute.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Entry point for setting up a compute-node build
+Entry point for setting up a compute-node build with node exclusion support.
 """
 
 import os
@@ -99,12 +99,20 @@ def get_build_specs(build_specs: Dict, host_spec: Dict) -> Dict:
         Overridden build specifications
     """
 
+    # Initialize exclude_nodes from the top-level of the YAML if present
+    build_specs.exclude_nodes = build_specs.get("exclude_nodes", None)
+
     # Get host overrides, if present
     if build_specs.get("host_override", None) is None or build_specs.host_override.get(host_spec.machine, None) is None:
         # Nothing to override, return with original build_specs
         return build_specs
 
     override = build_specs.host_override[host_spec.machine]
+
+    # Check for host-specific node exclusions
+    if "exclude_nodes" in override:
+        build_specs.exclude_nodes = override.exclude_nodes
+
     override_build = override.get("build", {})
     for key in build_specs.build:
         # Override the specific build specs if the key and spec is present in the
@@ -189,6 +197,16 @@ def main(*argv):
     # Retrieve build specificatiosn from user provided yaml
     user_yaml_dict = AttrDict(parse_yaml(user_inputs.yaml))
     build_specs = get_build_specs(user_yaml_dict, host_specs)
+
+    # Apply node exclusions to the native scheduler flags
+    if build_specs.exclude_nodes:
+        if host_specs.scheduler == 'slurm':
+            host_specs.native += f" --exclude={build_specs.exclude_nodes}"
+        elif host_specs.scheduler == 'pbspro':
+            # PBS logic: -l host!=node1 -l host!=node2 ...
+            nodes = build_specs.exclude_nodes.split(',')
+            pbs_exclude = " ".join([f"-l host!={n.strip()}" for n in nodes])
+            host_specs.native += f" {pbs_exclude}"
 
     systems = user_inputs.systems.split() if "all" not in user_inputs.systems else ["all"]
 

--- a/dev/workflow/build_opts.yaml
+++ b/dev/workflow/build_opts.yaml
@@ -3,6 +3,7 @@ host_override:  # over-ride options for host
   GAEAC6:
     max_cores: 8
     walltime_ratio: 1.5  # Uniformly adjust the wallclock by this factor (builds are slower on head nodes)
+    exclude_nodes: "gaea61,gaea67"
     build:
       gdas:
         cores: 8


### PR DESCRIPTION
# Description
This PR refactors `build_compute.py` to allow for the optional exclusion of nodes to which build jobs are submitted.

Resolves #4444 

# Type of change
- [ ] New feature (adds functionality)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? **NO**
- Is this a breaking change (a change in existing functionality)? **NO**
- Does this change require a documentation update? **NO**
- Does this change require an update to any of the following submodules? **NO**YES/NO

# How has this been tested?
1. clone [`RussTreadon-NOAA:/feature/exclude_nodes`](https://github.com/RussTreadon-NOAA/global-workflow/tree/feature/exclude_nodes) on Gaea C6
2. cd `sorc/`
3. execute `./build_compute.sh -A gfs-cpu gfs gcafs gsi gdas`

All build successfully completed.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
