### PR TITLE
Conclude building on head node when all are successful

### DIFF
--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -249,7 +249,18 @@ if [[ "${compute_build}" != "YES" ]]; then
             done
             builds_in_progress=false
         else
-            builds_in_progress=true
+            # Check if any builds are still in progress or all have succeeded
+            all_succeeded=true
+            for name in "${build_names[@]}"; do
+                if [[ ${build_status[${name}]} != "SUCCEEDED" ]]; then
+                    all_succeeded=false
+                fi
+            done
+            if [[ ${all_succeeded} == true ]]; then
+                builds_in_progress=false
+            else
+                builds_in_progress=true
+            fi
         fi
 
         # Move the cursor up nback lines before printing the build status again


### PR DESCRIPTION
# Description
This PR:
- fixes a bug in the `build_all.sh` script, where the build script does not exit after all builds are done (and successful) on the head node.

The bug was reported by @weihuang-jedi 

# Type of change
- [X] Bug fix (fixes something broken)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
build on gaea with
`./build_all.sh gsi`
Compare with `develop` and it will appear to "hang" after all builds are successful.  The script does not exit.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
