### PR TITLE
No anlstat job if no JEDI

### DIFF
--- a/dev/parm/config/gcafs/config.base.j2
+++ b/dev/parm/config/gcafs/config.base.j2
@@ -497,15 +497,17 @@ export CLIENT_GLOBUS_UUID="{{ CLIENT_GLOBUS_UUID }}"
 
 # The monitor jobs are not yet supported for JEDIATMVAR.
 if [[ "${DO_JEDIATMVAR}" = "YES" ]]; then
-   export DO_FIT2OBS="NO"     # Run fit to observations package
-   export DO_VERFOZN="NO"     # Ozone data assimilation monitoring
-   export DO_VERFRAD="NO"     # Radiance data assimilation monitoring
-   export DO_VMINMON="NO"     # GSI minimization monitoring
-   export DO_ANLSTAT="YES"    # JEDI-based analysis statistics
+    export DO_FIT2OBS="NO"     # Run fit to observations package
+    export DO_VERFOZN="NO"     # Ozone data assimilation monitoring
+    export DO_VERFRAD="NO"     # Radiance data assimilation monitoring
+    export DO_VMINMON="NO"     # GSI minimization monitoring
+    export DO_ANLSTAT="YES"    # JEDI-based analysis statistics
 else
-   if [[ ${DO_AERO_ANL} = "YES" || ${DO_JEDIOCNVAR} = "YES" || ${DO_JEDISNOWDA} = "YES" ]]; then
-     export DO_ANLSTAT="YES"  # JEDI-based analysis statistics
-   fi
+    if [[ ${DO_AERO_ANL} = "YES" || ${DO_JEDIOCNVAR} = "YES" || ${DO_JEDISNOWDA} = "YES" ]]; then
+      export DO_ANLSTAT="YES"  # JEDI-based analysis statistics
+    else
+      export DO_ANLSTAT="NO"
+    fi
 fi
 
 # If starting ICs that are not at cycle hour

--- a/dev/parm/config/gfs/config.base.j2
+++ b/dev/parm/config/gfs/config.base.j2
@@ -513,6 +513,11 @@ if [[ "${DO_JEDIATMVAR}" = "YES" ]]; then
    export DO_VERFOZN="NO"     # Ozone data assimilation monitoring
    export DO_VERFRAD="NO"     # Radiance data assimilation monitoring
    export DO_VMINMON="NO"     # GSI minimization monitoring
+   export DO_ANLSTAT="YES"    # JEDI-based analysis statistics
+else
+   if [[ ${DO_AERO_ANL} = "YES" || ${DO_JEDIOCNVAR} = "YES" || ${DO_JEDISNOWDA} = "YES" ]]; then
+     export DO_ANLSTAT="YES"  # JEDI-based analysis statistics
+   fi
 fi
 
 # TODO: Enable METplus on Ursa when verif-global has been upgraded to spack-stack 1.9.x+

--- a/dev/parm/config/gfs/config.base.j2
+++ b/dev/parm/config/gfs/config.base.j2
@@ -509,15 +509,17 @@ export CLIENT_GLOBUS_UUID="{{ CLIENT_GLOBUS_UUID }}"
 
 # The monitor jobs are not yet supported for JEDIATMVAR.
 if [[ "${DO_JEDIATMVAR}" = "YES" ]]; then
-   export DO_FIT2OBS="NO"     # Run fit to observations package
-   export DO_VERFOZN="NO"     # Ozone data assimilation monitoring
-   export DO_VERFRAD="NO"     # Radiance data assimilation monitoring
-   export DO_VMINMON="NO"     # GSI minimization monitoring
-   export DO_ANLSTAT="YES"    # JEDI-based analysis statistics
+    export DO_FIT2OBS="NO"     # Run fit to observations package
+    export DO_VERFOZN="NO"     # Ozone data assimilation monitoring
+    export DO_VERFRAD="NO"     # Radiance data assimilation monitoring
+    export DO_VMINMON="NO"     # GSI minimization monitoring
+    export DO_ANLSTAT="YES"    # JEDI-based analysis statistics
 else
-   if [[ ${DO_AERO_ANL} = "YES" || ${DO_JEDIOCNVAR} = "YES" || ${DO_JEDISNOWDA} = "YES" ]]; then
-     export DO_ANLSTAT="YES"  # JEDI-based analysis statistics
-   fi
+  if [[ ${DO_AERO_ANL} = "YES" || ${DO_JEDIOCNVAR} = "YES" || ${DO_JEDISNOWDA} = "YES" ]]; then
+    export DO_ANLSTAT="YES"  # JEDI-based analysis statistics
+  else
+    export DO_ANLSTAT="NO"
+  fi
 fi
 
 # TODO: Enable METplus on Ursa when verif-global has been upgraded to spack-stack 1.9.x+


### PR DESCRIPTION
# Description

This PR turns off the `anlstat` job if JEDI is not being used. The motivation is that the `anlstat` job in JEDI-based and will fail if GDSASApp is not built.

There is one niche application where the JEDI-based `anlstat` job will be used in conjunction with a GSI-based analysis, but that is only used for comparing GSI and JEDI anlayses via the same observation statistics framework (JEDI-based `anlstat`), and that can be turned on manually when necessary.

Resolves #4450 

# Type of change
- [X] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? YES/NO (If YES, please indicate to which system(s))
  - [X] GFS
  - [ ] GEFS
  - [ ] SFS
  - [X] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?

Ensure that `gdas_anlstat` is turned off after initializing `C96C48_hybatmDA` experiment.

# Checklist
- [X] Any dependent changes have been merged and published
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [X] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
