### PR TITLE
Fix v17 group b warm restart archiving

### DIFF
--- a/ush/python/pygfs/task/archive.py
+++ b/ush/python/pygfs/task/archive.py
@@ -688,7 +688,8 @@ class Archive(Task):
             # Not the right cycle hour
             return False
 
-        days_since_sdate = (arch_dict.current_cycle - SDATE).days
+        ics_offset_cycle = add_to_datetime(arch_dict.current_cycle, to_timedelta(f"+{assim_freq}H"))
+        days_since_sdate = (ics_offset_cycle - SDATE).days
         if arch_dict.ARCH_WARMICFREQ > 0 and days_since_sdate % arch_dict.ARCH_WARMICFREQ == 0:
             # We are on the right cycle hour and the right day
             return True

--- a/ush/python/pygfs/task/archive.py
+++ b/ush/python/pygfs/task/archive.py
@@ -9,7 +9,8 @@ from typing import Any, Dict, List
 
 from wxflow import (AttrDict, FileHandler, Hsi, Htar, Task, to_timedelta,
                     chgrp, get_gid, logit, mkdir_p, parse_j2yaml, rm_p, rmdir,
-                    strftime, to_YMDH, which, chdir, ProcessError, save_as_yaml)
+                    strftime, to_YMDH, which, chdir, ProcessError, save_as_yaml,
+                    add_to_datetime)
 
 git_filename = "git_info.log"
 logger = getLogger(__name__.split('.')[-1])


### PR DESCRIPTION
# Description
This fixes warm restart archiving for the v17 branch. For group b, the number of days between SDATE and the archive cycle is now correct.

Resolves #4501

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs Yes
  - [x] GFS (restart archiving)
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
To be tested in a C96C48 case and in retros

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added