### PR TITLE
Fix GDAS group b warm restart archiving

### DIFF
--- a/ush/python/pygfs/task/archive.py
+++ b/ush/python/pygfs/task/archive.py
@@ -762,7 +762,7 @@ class Archive(Task):
         cycle_HH = int(strftime(arch_dict.current_cycle, "%H"))
         arch_cyc = arch_dict.ARCH_CYC
         SDATE = arch_dict.SDATE
-        assim_freq = to_timedelta(f"+{arch_dict.assim_freq}H")
+        assim_freq = arch_dict.assim_freq
 
         if cycle_HH != arch_cyc:
             # Not the right cycle hour

--- a/ush/python/pygfs/task/archive.py
+++ b/ush/python/pygfs/task/archive.py
@@ -766,7 +766,8 @@ class Archive(Task):
             # Not the right cycle hour
             return False
 
-        days_since_sdate = (arch_dict.current_cycle - SDATE).days
+        ics_offset_cycle = add_to_datetime(arch_dict.current_cycle, to_timedelta(f"+{assim_freq}H"))
+        days_since_sdate = (ics_offset_cycle - SDATE).days
         if arch_dict.ARCH_FCSTICFREQ > 0 and days_since_sdate % arch_dict.ARCH_FCSTICFREQ == 0:
             # We are on the right cycle hour and the right day
             return True

--- a/ush/python/pygfs/task/archive.py
+++ b/ush/python/pygfs/task/archive.py
@@ -8,7 +8,8 @@ from logging import getLogger
 from typing import List
 from wxflow import (AttrDict, FileHandler, Hsi, Htar, Task, to_timedelta,
                     chgrp, get_gid, logit, mkdir_p, parse_j2yaml, rm_p, rmdir,
-                    strftime, to_YMDH, which, chdir, ProcessError, save_as_yaml)
+                    strftime, to_YMDH, which, chdir, ProcessError, save_as_yaml,
+                    add_to_datetime)
 
 git_filename = "git_info.log"
 logger = getLogger(__name__.split('.')[-1])
@@ -761,6 +762,7 @@ class Archive(Task):
         cycle_HH = int(strftime(arch_dict.current_cycle, "%H"))
         arch_cyc = arch_dict.ARCH_CYC
         SDATE = arch_dict.SDATE
+        assim_freq = to_timedelta(f"+{arch_dict.assim_freq}H")
 
         if cycle_HH != arch_cyc:
             # Not the right cycle hour


### PR DESCRIPTION
# Description
This fixes the GDAS-cycle warm restart archiving for group b (previous cycle) by adding `assim_freq` to the current cycle when checking the number of days since `SDATE`. This is a companion PR to #4502, which fixes the same issue in the dev/gfs.v17 branch.

Resolves #4501 for develop

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs YES
  - [x] GFS (warm restarts)
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Will test warm restart capability

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added