### PR TITLE
Enable build in debug mode

### DIFF
--- a/dev/workflow/setup_buildxml.py
+++ b/dev/workflow/setup_buildxml.py
@@ -34,6 +34,7 @@ def input_args(*argv):
     parser.add_argument('--yaml', help='Input YAML file',
                         type=str, required=False, default='build_opts.yaml')
     parser.add_argument('--systems', help='System(s) to build (options: gfs, gefs, sfs, gcafs, gsi, gdas, or all)', required=False, default='gfs')
+    parser.add_argument('--debug', help='Build in debug mode', required=False, store_action=True)
 
     inputs = parser.parse_args(list(*argv) if len(argv) else None)
 
@@ -64,6 +65,8 @@ def get_task_spec(task_name: str, task_spec: Dict, host_spec: Dict) -> Dict:
     task_dict.cycledef = "build"
     task_dict.maxtries = 1
     task_dict.command = f"cd {HOMEgfs}/sorc/; {task_spec.command} -j {task_spec.cores}"
+    if host_spec.debug:
+        task_dict.command = f"{task_dict.command} -d"
     task_dict.job_name = task_name
     task_dict.log = f"{HOMEgfs}/sorc/logs/{task_name}.log"
 
@@ -189,10 +192,11 @@ def main(*argv):
 
     user_inputs = input_args(*argv)
 
-    # Gather host specs and place the user supplied account
-    # into the host_specs dict
+    # Gather host specs and place the user supplied options such as
+    # account and debug into the host_specs dict
     host_specs = get_host_specs(Host())
     host_specs.account = user_inputs.account
+    host_specs.debug = user_inputs.debug
 
     # Retrieve build specificatiosn from user provided yaml
     user_yaml_dict = AttrDict(parse_yaml(user_inputs.yaml))

--- a/dev/workflow/setup_buildxml.py
+++ b/dev/workflow/setup_buildxml.py
@@ -34,7 +34,7 @@ def input_args(*argv):
     parser.add_argument('--yaml', help='Input YAML file',
                         type=str, required=False, default='build_opts.yaml')
     parser.add_argument('--systems', help='System(s) to build (options: gfs, gefs, sfs, gcafs, gsi, gdas, or all)', required=False, default='gfs')
-    parser.add_argument('--debug', help='Build in debug mode', required=False, store_action=True)
+    parser.add_argument('--debug', help='Build in debug mode', required=False, action='store_true')
 
     inputs = parser.parse_args(list(*argv) if len(argv) else None)
 

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -12,6 +12,7 @@ Usage: ${BASH_SOURCE[0]} [-h][-v] -A HPC_ACCOUNT -c [gfs gefs sfs gcafs gsi gdas
   -A:
     HPC account to use for the compute-node builds [REQUIRED when building on compute nodes]
   -c Build on compute nodes (DEFAULT: NO)
+  -d Build in debug mode (DEFAULT: NO)
 
   Input arguments are the system(s) to build.
   Valid options are
@@ -32,14 +33,16 @@ build_db="build.db"
 build_lock_db="build_lock.db"
 HPC_ACCOUNT="UNDEFINED"
 compute_build="NO"
+debug_opt=""
 max_cores=20 # Maximum number of cores to use for builds on head node
 
 OPTIND=1
-while getopts ":hA:vc" option; do
+while getopts ":hA:vcd" option; do
     case "${option}" in
         h) _usage ;;
         A) HPC_ACCOUNT="${OPTARG}" ;;
         c) compute_build="YES" ;;
+        d) debug_opt=" -d" ;;
         v) verbose="YES" && rocoto_verbose_opt="-v10" ;;
         :)
             echo "[${BASH_SOURCE[0]}]: ${option} requires an argument"
@@ -119,9 +122,12 @@ for i in "${!logs[@]}"; do
         fi
     fi
 
+    cmdstr="$(echo "${cmd}" | awk -F';' '{ $1=""; print $0 }' | sed 's/^[[:space:]]*//')"
+    cmdstr="${cmdstr} ${debug_opt}"
+
     build_names["${name}"]="${name}"
     build_dirs["${name}"]="$(echo "${cmd}" | awk -F';' '{ print $1 }' | sed 's/cd //')"
-    build_commands["${name}"]="$(echo "${cmd}" | awk -F';' '{ $1=""; print $0 }' | sed 's/^[[:space:]]*//')"
+    build_commands["${name}"]="${cmdstr}"
     build_logs["${name}"]="${log}"
     build_cores["${name}"]="${cores}"
     build_status["${name}"]="PENDING"

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -42,7 +42,7 @@ while getopts ":hA:vcd" option; do
         h) _usage ;;
         A) HPC_ACCOUNT="${OPTARG}" ;;
         c) compute_build="YES" ;;
-        d) debug_opt=" -d" ;;
+        d) debug_opt=" --debug" ;;
         v) verbose="YES" && rocoto_verbose_opt="-v10" ;;
         :)
             echo "[${BASH_SOURCE[0]}]: ${option} requires an argument"
@@ -91,7 +91,7 @@ rm -f "${build_xml}" "${build_db}" "${build_lock_db}"
 
 echo "Generating build.xml for building global-workflow programs ..."
 yaml="${HOMEgfs}/sorc/build_opts.yaml"
-"${HOMEgfs}/dev/workflow/setup_buildxml.py" --account "${HPC_ACCOUNT}" --yaml "${yaml}" --systems "${systems}"
+"${HOMEgfs}/dev/workflow/setup_buildxml.py" --account "${HPC_ACCOUNT}" --yaml "${yaml}" --systems "${systems}" ${debug_opt:-}
 rc=$?
 if [[ "${rc}" -ne 0 ]]; then
     echo "FATAL ERROR: ${BASH_SOURCE[0]} failed to create 'build.xml' with error code ${rc}"
@@ -122,12 +122,9 @@ for i in "${!logs[@]}"; do
         fi
     fi
 
-    cmdstr="$(echo "${cmd}" | awk -F';' '{ $1=""; print $0 }' | sed 's/^[[:space:]]*//')"
-    cmdstr="${cmdstr} ${debug_opt}"
-
     build_names["${name}"]="${name}"
     build_dirs["${name}"]="$(echo "${cmd}" | awk -F';' '{ print $1 }' | sed 's/cd //')"
-    build_commands["${name}"]="${cmdstr}"
+    build_commands["${name}"]="$(echo "${cmd}" | awk -F';' '{ $1=""; print $0 }' | sed 's/^[[:space:]]*//')"
     build_logs["${name}"]="${log}"
     build_cores["${name}"]="${cores}"
     build_status["${name}"]="PENDING"

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -91,7 +91,7 @@ rm -f "${build_xml}" "${build_db}" "${build_lock_db}"
 
 echo "Generating build.xml for building global-workflow programs ..."
 yaml="${HOMEgfs}/sorc/build_opts.yaml"
-#shellcheck disable=SC2086
+# shellcheck disable=SC2086,SC2248
 "${HOMEgfs}/dev/workflow/setup_buildxml.py" --account "${HPC_ACCOUNT}" --yaml "${yaml}" --systems "${systems}" ${debug_opt:-}
 rc=$?
 if [[ "${rc}" -ne 0 ]]; then

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -42,7 +42,7 @@ while getopts ":hA:vcd" option; do
         h) _usage ;;
         A) HPC_ACCOUNT="${OPTARG}" ;;
         c) compute_build="YES" ;;
-        d) debug_opt=" --debug" ;;
+        d) debug_opt="--debug" ;;
         v) verbose="YES" && rocoto_verbose_opt="-v10" ;;
         :)
             echo "[${BASH_SOURCE[0]}]: ${option} requires an argument"
@@ -91,6 +91,7 @@ rm -f "${build_xml}" "${build_db}" "${build_lock_db}"
 
 echo "Generating build.xml for building global-workflow programs ..."
 yaml="${HOMEgfs}/sorc/build_opts.yaml"
+#shellcheck disable=SC2086
 "${HOMEgfs}/dev/workflow/setup_buildxml.py" --account "${HPC_ACCOUNT}" --yaml "${yaml}" --systems "${systems}" ${debug_opt:-}
 rc=$?
 if [[ "${rc}" -ne 0 ]]; then


### PR DESCRIPTION
# Description
This PR:
- Resolves #4495 
- `./build_all.sh -d` will build all programs in `debug` mode.
-  
# Type of change
- [X] New feature (adds functionality)
- [X] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO (If YES, please indicate to which system(s))
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
- Issues `./build_all.sh` with and without `-d` option and inspected the resulting `build.xml`.  `-d` is added appropriately to each of the build commands as expected.

There is no CI test for building in debug mode.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
- [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] 