### PR TITLE
Return all gaea head nodes to the building rotation

### DIFF
--- a/sorc/build_opts.yaml
+++ b/sorc/build_opts.yaml
@@ -3,6 +3,7 @@ host_override:  # over-ride options for host
   GAEAC6:
     max_cores: 8
     walltime_ratio: 1.5  # Uniformly adjust the wallclock by this factor (builds are slower on head nodes)
+#    exclude_nodes: "gaea61"  # Use this field to black-list out any malfunctioning nodes.
     build:
       gdas:
         cores: 8

--- a/sorc/build_opts.yaml
+++ b/sorc/build_opts.yaml
@@ -3,7 +3,6 @@ host_override:  # over-ride options for host
   GAEAC6:
     max_cores: 8
     walltime_ratio: 1.5  # Uniformly adjust the wallclock by this factor (builds are slower on head nodes)
-    exclude_nodes: "gaea61,gaea65,gaea67"
     build:
       gdas:
         cores: 8


### PR DESCRIPTION
# Description
This removes excluded nodes from GAEAC6 configuration.

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Ran test GDASApp, GFS, SFS, GEFS, and GCAFS builds on gaea61,5,7.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners