### PR TITLE
Refactor job scripts to streamline configuration sourcing

### DIFF
--- a/dev/jobs/JGDAS_AERO_ANALYSIS_GENERATE_BMATRIX
+++ b/dev/jobs/JGDAS_AERO_ANALYSIS_GENERATE_BMATRIX
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "aeroanlgenb" -c "base aeroanl aeroanlgenb"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "aeroanlgenb"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.aeroanl"
+source "${EXPDIR}/config.aeroanlgenb"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGDAS_ATMOS_CHGRES_FORENKF
+++ b/dev/jobs/JGDAS_ATMOS_CHGRES_FORENKF
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "anal" -c "base anal echgres"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "anal"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.anal"
+source "${EXPDIR}/config.echgres"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGDAS_ATMOS_GEMPAK
+++ b/dev/jobs/JGDAS_ATMOS_GEMPAK
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak" -c "base gempak"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.gempak"
 
 export GRIB=${GRIB:-pgrb2f}
 export EXT=""

--- a/dev/jobs/JGDAS_ATMOS_GEMPAK_META_NCDC
+++ b/dev/jobs/JGDAS_ATMOS_GEMPAK_META_NCDC
@@ -4,7 +4,10 @@
 # GDAS GEMPAK META NCDC PRODUCT GENERATION
 ############################################
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak_meta" -c "base gempak"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak_meta"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.gempak"
 
 # Now set up GEMPAK/NTRANS environment
 

--- a/dev/jobs/JGDAS_ATMOS_VERFOZN
+++ b/dev/jobs/JGDAS_ATMOS_VERFOZN
@@ -3,7 +3,10 @@
 #############################################################
 # Set up environment for GDAS Ozone Monitor job
 #############################################################
-source "${HOMEgfs}/ush/jjob_header.sh" -e "verfozn" -c "base verfozn"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "verfozn"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.verfozn"
 
 #############################################
 #  determine PDY and cyc for previous cycle

--- a/dev/jobs/JGDAS_ATMOS_VERFRAD
+++ b/dev/jobs/JGDAS_ATMOS_VERFRAD
@@ -3,7 +3,10 @@
 #############################################################
 # Set up environment for GDAS Radiance Monitor job
 #############################################################
-source "${HOMEgfs}/ush/jjob_header.sh" -e "verfrad" -c "base verfrad"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "verfrad"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.verfrad"
 
 #############################################
 #  determine PDY and cyc for previous cycle

--- a/dev/jobs/JGDAS_ENKF_POST
+++ b/dev/jobs/JGDAS_ENKF_POST
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "epos" -c "base epos"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "epos"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.epos"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGDAS_FIT2OBS
+++ b/dev/jobs/JGDAS_FIT2OBS
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "fit2obs" -c "base fit2obs"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "fit2obs"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.fit2obs"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGEFS_WAVE_STAT
+++ b/dev/jobs/JGEFS_WAVE_STAT
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "wave_stat" -c "base wave wave_stat"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "wave_stat"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.wave"
+source "${EXPDIR}/config.wave_stat"
 source "${USHgfs}/wave_domain_grid.sh"
 
 # Set COM Paths

--- a/dev/jobs/JGEFS_WAVE_STAT_PNT
+++ b/dev/jobs/JGEFS_WAVE_STAT_PNT
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "wave_stat_pnt" -c "base wave wave_stat_pnt"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "wave_stat_pnt"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.wave"
+source "${EXPDIR}/config.wave_stat_pnt"
 
 # Set COM Paths
 

--- a/dev/jobs/JGFS_ATMOS_AWIPS_20KM_1P0DEG
+++ b/dev/jobs/JGFS_ATMOS_AWIPS_20KM_1P0DEG
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "awips" -c "base awips"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "awips"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.awips"
 
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
 

--- a/dev/jobs/JGFS_ATMOS_CYCLONE_GENESIS
+++ b/dev/jobs/JGFS_ATMOS_CYCLONE_GENESIS
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "genesis" -c "base genesis"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "genesis"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.genesis"
 
 ##############################################
 # Set variables used in the exglobal script

--- a/dev/jobs/JGFS_ATMOS_CYCLONE_TRACKER
+++ b/dev/jobs/JGFS_ATMOS_CYCLONE_TRACKER
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "tracker" -c "base tracker"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "tracker"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.tracker"
 
 export COMPONENT="atmos"
 

--- a/dev/jobs/JGFS_ATMOS_FBWIND
+++ b/dev/jobs/JGFS_ATMOS_FBWIND
@@ -5,7 +5,10 @@
 ############################################
 # GFS FBWIND PRODUCT GENERATION
 ############################################
-source "${HOMEgfs}/ush/jjob_header.sh" -e "fbwind" -c "base fbwind"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "fbwind"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.fbwind"
 
 export COMPONENT="atmos"
 

--- a/dev/jobs/JGFS_ATMOS_FSU_GENESIS
+++ b/dev/jobs/JGFS_ATMOS_FSU_GENESIS
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "genesis_fsu" -c "base genesis_fsu"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "genesis_fsu"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.genesis_fsu"
 
 ##############################################
 # Define COM and Data directories

--- a/dev/jobs/JGFS_ATMOS_GEMPAK
+++ b/dev/jobs/JGFS_ATMOS_GEMPAK
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak" -c "base gempak"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.gempak"
 
 ############################################
 # Set up model and cycle specific variables

--- a/dev/jobs/JGFS_ATMOS_GEMPAK_META
+++ b/dev/jobs/JGFS_ATMOS_GEMPAK_META
@@ -5,7 +5,10 @@
 ############################################
 # GFS GEMPAK META PRODUCT GENERATION
 ############################################
-source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak_meta" -c "base gempak"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak_meta"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.gempak"
 
 ###############################################
 # Set MP variables

--- a/dev/jobs/JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF
+++ b/dev/jobs/JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF
@@ -3,7 +3,10 @@
 ############################################
 # GFS GEMPAK NCDC PRODUCT GENERATION
 ############################################
-source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak_gif" -c "base gempak"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak_gif"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.gempak"
 
 export MP_PULSE=0
 export MP_TIMEOUT=2000

--- a/dev/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
+++ b/dev/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak_spec" -c "base gempak"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak_spec"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.gempak"
 
 export COMPONENT="atmos"
 export EXT=""

--- a/dev/jobs/JGFS_ATMOS_PGRB2_SPEC_NPOESS
+++ b/dev/jobs/JGFS_ATMOS_PGRB2_SPEC_NPOESS
@@ -5,7 +5,10 @@
 ############################################
 # GFS PGRB2_SPECIAL_POST PRODUCT GENERATION
 ############################################
-source "${HOMEgfs}/ush/jjob_header.sh" -e "npoess" -c "base npoess"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "npoess"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.npoess"
 
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
 

--- a/dev/jobs/JGFS_ATMOS_POSTSND
+++ b/dev/jobs/JGFS_ATMOS_POSTSND
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "postsnd" -c "base postsnd"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "postsnd"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.postsnd"
 
 ########################################
 # Runs GFS BUFR SOUNDINGS

--- a/dev/jobs/JGFS_ATMOS_VERIFICATION
+++ b/dev/jobs/JGFS_ATMOS_VERIFICATION
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "metp" -c "base metp"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "metp"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.metp"
 
 ###############################################################
 ## Abstract:

--- a/dev/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
+++ b/dev/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
@@ -2,7 +2,11 @@
 
 export WIPE_DATA="NO"
 export DATA=${DATA:-${DATAROOT}/${RUN}aeroanl_${cyc}}
-source "${HOMEgfs}/ush/jjob_header.sh" -e "aeroanlfinal" -c "base aeroanl aeroanlfinal"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "aeroanlfinal"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.aeroanl"
+source "${EXPDIR}/config.aeroanlfinal"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
+++ b/dev/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
@@ -1,7 +1,11 @@
 #! /usr/bin/env bash
 
 export DATA=${DATA:-${DATAROOT}/${RUN}aeroanl_${cyc}}
-source "${HOMEgfs}/ush/jjob_header.sh" -e "aeroanlinit" -c "base aeroanl aeroanlinit"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "aeroanlinit"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.aeroanl"
+source "${EXPDIR}/config.aeroanlinit"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_AERO_ANALYSIS_VARIATIONAL
+++ b/dev/jobs/JGLOBAL_AERO_ANALYSIS_VARIATIONAL
@@ -2,7 +2,11 @@
 
 export WIPE_DATA="NO"
 export DATA=${DATA:-${DATAROOT}/${RUN}aeroanl_${cyc}}
-source "${HOMEgfs}/ush/jjob_header.sh" -e "aeroanlvar" -c "base aeroanl aeroanlvar"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "aeroanlvar"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.aeroanl"
+source "${EXPDIR}/config.aeroanlvar"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ANALYSIS_STATS
+++ b/dev/jobs/JGLOBAL_ANALYSIS_STATS
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "anlstat" -c "base anlstat"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "anlstat"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.anlstat"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ARCHIVE_TARS
+++ b/dev/jobs/JGLOBAL_ARCHIVE_TARS
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "arch_vrfy" -c "base arch_tars"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "arch_vrfy"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.arch_tars"
 if [[ "${DO_WAVE}" == "YES" ]]; then
     source "${EXPDIR}/config.wave"
     source "${USHgfs}/wave_domain_grid.sh"

--- a/dev/jobs/JGLOBAL_ARCHIVE_VRFY
+++ b/dev/jobs/JGLOBAL_ARCHIVE_VRFY
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "arch_vrfy" -c "base arch_vrfy"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "arch_vrfy"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.arch_vrfy"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
+++ b/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
@@ -2,7 +2,11 @@
 
 export WIPE_DATA="NO"
 export DATA=${DATA:-${DATAROOT}/${RUN}atmensanl_${cyc}}
-source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlfinal" -c "base atmensanl atmensanlfinal"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlfinal"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.atmensanl"
+source "${EXPDIR}/config.atmensanlfinal"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
+++ b/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
@@ -2,7 +2,11 @@
 
 export WIPE_DATA="NO"
 export DATA=${DATA:-${DATAROOT}/${RUN}atmensanl_${cyc}}
-source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlfv3inc" -c "base atmensanl atmensanlfv3inc"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlfv3inc"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.atmensanl"
+source "${EXPDIR}/config.atmensanlfv3inc"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
+++ b/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
@@ -1,7 +1,11 @@
 #! /usr/bin/env bash
 
 export DATA=${DATA:-${DATAROOT}/${RUN}atmensanl_${cyc}}
-source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlinit" -c "base atmensanl atmensanlinit"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlinit"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.atmensanl"
+source "${EXPDIR}/config.atmensanlinit"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
+++ b/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
@@ -2,7 +2,11 @@
 
 export WIPE_DATA="NO"
 export DATA=${DATA:-${DATAROOT}/${RUN}atmensanl_${cyc}}
-source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlletkf" -c "base atmensanl atmensanlletkf"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlletkf"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.atmensanl"
+source "${EXPDIR}/config.atmensanlletkf"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
+++ b/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
@@ -2,7 +2,11 @@
 
 export WIPE_DATA="NO"
 export DATA=${DATA:-${DATAROOT}/${RUN}atmensanl_${cyc}}
-source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlobs" -c "base atmensanl atmensanlobs"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlobs"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.atmensanl"
+source "${EXPDIR}/config.atmensanlobs"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
+++ b/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
@@ -2,7 +2,11 @@
 
 export WIPE_DATA="NO"
 export DATA=${DATA:-${DATAROOT}/${RUN}atmensanl_${cyc}}
-source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlsol" -c "base atmensanl atmensanlsol"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "atmensanlsol"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.atmensanl"
+source "${EXPDIR}/config.atmensanlsol"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMOS_ANALYSIS
+++ b/dev/jobs/JGLOBAL_ATMOS_ANALYSIS
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "anal" -c "base anal"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "anal"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.anal"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
+++ b/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "analcalc" -c "base anal analcalc"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "analcalc"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.anal"
+source "${EXPDIR}/config.analcalc"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC_FV3JEDI
+++ b/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC_FV3JEDI
@@ -3,7 +3,10 @@
 # Ignore possible spelling error (nothing is misspelled)
 # shellcheck disable=SC2153
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "analcalc_fv3jedi" -c "base analcalc_fv3jedi"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "analcalc_fv3jedi"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.analcalc_fv3jedi"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_DIAG
+++ b/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_DIAG
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "analdiag" -c "base anal analdiag"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "analdiag"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.anal"
+source "${EXPDIR}/config.analdiag"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMOS_CHGRES_GEN_CONTROL
+++ b/dev/jobs/JGLOBAL_ATMOS_CHGRES_GEN_CONTROL
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 # shellcheck disable=SC2153  # PDY is always set in environment
-source "${HOMEgfs}/ush/jjob_header.sh" -e "gen_control_ic" -c "base gen_control_ic"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "gen_control_ic"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.gen_control_ic"
 
 # Initial conditions are from previous GFS cycle, but valid at the end of the cycle
 GDATE=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} - ${assim_freq} hours")

--- a/dev/jobs/JGLOBAL_ATMOS_ENSSTAT
+++ b/dev/jobs/JGLOBAL_ATMOS_ENSSTAT
@@ -4,7 +4,10 @@
 # Caculate the mean, spread, and other probabilistic fields.
 #
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "atmos_ensstat" -c "base atmos_ensstat"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "atmos_ensstat"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.atmos_ensstat"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/dev/jobs/JGLOBAL_ATMOS_POST_MANAGER
+++ b/dev/jobs/JGLOBAL_ATMOS_POST_MANAGER
@@ -2,7 +2,10 @@
 
 # TODO (#1227) This job is not used in the rocoto suite
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "post" -c "base post"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "post"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.post"
 
 ####################################
 # Specify NET and RUN Name and model

--- a/dev/jobs/JGLOBAL_ATMOS_PREP_SFC
+++ b/dev/jobs/JGLOBAL_ATMOS_PREP_SFC
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "prep_sfc" -c "base prep_sfc"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "prep_sfc"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.prep_sfc"
 
 ##############################################
 # Set date and cycle

--- a/dev/jobs/JGLOBAL_ATMOS_PRODUCTS
+++ b/dev/jobs/JGLOBAL_ATMOS_PRODUCTS
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "atmos_products" -c "base atmos_products"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "atmos_products"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.atmos_products"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/dev/jobs/JGLOBAL_ATMOS_SFCANL
+++ b/dev/jobs/JGLOBAL_ATMOS_SFCANL
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "sfcanl" -c "base sfcanl"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "sfcanl"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.sfcanl"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/dev/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
+++ b/dev/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "prep" -c "base prep"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "prep"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.prep"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/dev/jobs/JGLOBAL_ATMOS_UPP
+++ b/dev/jobs/JGLOBAL_ATMOS_UPP
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "upp" -c "base upp"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "upp"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.upp"
 
 ##############################################
 # Set variables used in the exglobal script

--- a/dev/jobs/JGLOBAL_ATMOS_VMINMON
+++ b/dev/jobs/JGLOBAL_ATMOS_VMINMON
@@ -3,7 +3,10 @@
 ###########################################################
 # Global Minimization Monitor (MinMon) job
 ###########################################################
-source "${HOMEgfs}/ush/jjob_header.sh" -e "vminmon" -c "base vminmon"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "vminmon"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.vminmon"
 
 #############################################
 # Determine PDY and cyc for previous cycle

--- a/dev/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
+++ b/dev/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
@@ -2,7 +2,11 @@
 
 export WIPE_DATA="NO"
 export DATA=${DATA:-${DATAROOT}/${RUN}atmanl_${cyc}}
-source "${HOMEgfs}/ush/jjob_header.sh" -e "atmanlfinal" -c "base atmanl atmanlfinal"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "atmanlfinal"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.atmanl"
+source "${EXPDIR}/config.atmanlfinal"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
+++ b/dev/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
@@ -2,7 +2,11 @@
 
 export WIPE_DATA="NO"
 export DATA=${DATA:-${DATAROOT}/${RUN}atmanl_${cyc}}
-source "${HOMEgfs}/ush/jjob_header.sh" -e "atmanlfv3inc" -c "base atmanl atmanlfv3inc"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "atmanlfv3inc"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.atmanl"
+source "${EXPDIR}/config.atmanlfv3inc"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
+++ b/dev/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
@@ -1,7 +1,11 @@
 #! /usr/bin/env bash
 
 export DATA=${DATA:-${DATAROOT}/${RUN}atmanl_${cyc}}
-source "${HOMEgfs}/ush/jjob_header.sh" -e "atmanlinit" -c "base atmanl atmanlinit"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "atmanlinit"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.atmanl"
+source "${EXPDIR}/config.atmanlinit"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
+++ b/dev/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
@@ -2,7 +2,11 @@
 
 export WIPE_DATA="NO"
 export DATA=${DATA:-${DATAROOT}/${RUN}atmanl_${cyc}}
-source "${HOMEgfs}/ush/jjob_header.sh" -e "atmanlvar" -c "base atmanl atmanlvar"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "atmanlvar"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.atmanl"
+source "${EXPDIR}/config.atmanlvar"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_CLEANUP
+++ b/dev/jobs/JGLOBAL_CLEANUP
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "cleanup" -c "base cleanup"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "cleanup"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.cleanup"
 
 "${SCRgfs}/exglobal_cleanup.sh" && true
 export err=$?

--- a/dev/jobs/JGLOBAL_ENKF_ARCHIVE_TARS
+++ b/dev/jobs/JGLOBAL_ENKF_ARCHIVE_TARS
@@ -1,6 +1,11 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "earc_tars" -c "base arch_tars earc_tars earc_groups"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "earc_tars"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.arch_tars"
+source "${EXPDIR}/config.earc_tars"
+source "${EXPDIR}/config.earc_groups"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ENKF_ARCHIVE_VRFY
+++ b/dev/jobs/JGLOBAL_ENKF_ARCHIVE_VRFY
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "earc_vrfy" -c "base earc_vrfy"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "earc_vrfy"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.earc_vrfy"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ENKF_DIAG
+++ b/dev/jobs/JGLOBAL_ENKF_DIAG
@@ -1,6 +1,12 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "ediag" -c "base anal eobs analdiag ediag"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "ediag"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.anal"
+source "${EXPDIR}/config.eobs"
+source "${EXPDIR}/config.analdiag"
+source "${EXPDIR}/config.ediag"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ENKF_ECEN
+++ b/dev/jobs/JGLOBAL_ENKF_ECEN
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "ecen" -c "base ecen"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "ecen"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.ecen"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ENKF_ECEN_FV3JEDI
+++ b/dev/jobs/JGLOBAL_ENKF_ECEN_FV3JEDI
@@ -3,7 +3,10 @@
 # Ignore possible spelling error (nothing is misspelled)
 # shellcheck disable=SC2153
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "ecen_fv3jedi" -c "base ecen_fv3jedi"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "ecen_fv3jedi"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.ecen_fv3jedi"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ENKF_SELECT_OBS
+++ b/dev/jobs/JGLOBAL_ENKF_SELECT_OBS
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "eobs" -c "base anal eobs"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "eobs"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.anal"
+source "${EXPDIR}/config.eobs"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ENKF_SFC
+++ b/dev/jobs/JGLOBAL_ENKF_SFC
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "esfc" -c "base esfc"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "esfc"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.esfc"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ENKF_UPDATE
+++ b/dev/jobs/JGLOBAL_ENKF_UPDATE
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "eupd" -c "base anal eupd"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "eupd"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.anal"
+source "${EXPDIR}/config.eupd"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ENS_GLOBUS_ARCH
+++ b/dev/jobs/JGLOBAL_ENS_GLOBUS_ARCH
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "globus_earc" -c "base globus earc_groups"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "globus_earc"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.globus"
+source "${EXPDIR}/config.earc_groups"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_EXTRACTVARS
+++ b/dev/jobs/JGLOBAL_EXTRACTVARS
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "extractvars" -c "base extractvars"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "extractvars"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.extractvars"
 source "${USHgfs}/wave_domain_grid.sh"
 
 # Set COM Paths

--- a/dev/jobs/JGLOBAL_FETCH
+++ b/dev/jobs/JGLOBAL_FETCH
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "fetch" -c "base fetch"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "fetch"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.fetch"
 
 # Execute fetching
 # Do not export shell opts to the bash scripts in the htar/hsi wrappers

--- a/dev/jobs/JGLOBAL_FORECAST
+++ b/dev/jobs/JGLOBAL_FORECAST
@@ -3,11 +3,18 @@
 if ((10#${ENSMEM:-0} > 0)); then
     export DATAjob="${DATAROOT}/${RUN}efcs${ENSMEM}.${PDY:-}${cyc}"
     export DATA="${DATAjob}/${jobid}"
-    source "${HOMEgfs}/ush/jjob_header.sh" -e "efcs" -c "base fcst efcs"
+    source "${HOMEgfs}/ush/jjob_header.sh" -e "efcs"
+
+    source "${EXPDIR}/config.base"
+    source "${EXPDIR}/config.fcst"
+    source "${EXPDIR}/config.efcs"
 else
     export DATAjob="${DATAROOT}/${RUN}fcst.${PDY:-}${cyc}"
     export DATA="${DATAjob}/${jobid}"
-    source "${HOMEgfs}/ush/jjob_header.sh" -e "fcst" -c "base fcst"
+    source "${HOMEgfs}/ush/jjob_header.sh" -e "fcst"
+
+    source "${EXPDIR}/config.base"
+    source "${EXPDIR}/config.fcst"
 fi
 
 # Create the directory to hold restarts and output from the model in stmp

--- a/dev/jobs/JGLOBAL_GLOBUS_ARCH
+++ b/dev/jobs/JGLOBAL_GLOBUS_ARCH
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "globus_arch" -c "base globus"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "globus_arch"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.globus"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_CHECKPOINT
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_CHECKPOINT
@@ -3,7 +3,11 @@ export WIPE_DATA="NO"
 export DATAjob="${DATAROOT}/marineanalysis.${PDY:-}${cyc}"
 export DATAens="${DATAjob}/ensdata"
 export DATA="${DATAjob}/marineanlvar"
-source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlchkpt" -c "base marineanl marineanlchkpt"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlchkpt"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marineanl"
+source "${EXPDIR}/config.marineanlchkpt"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_ECEN
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_ECEN
@@ -4,7 +4,10 @@ export DATAjob="${DATAROOT/enkf/}/marineanalysis.${PDY:-}${cyc}"
 export DATA="${DATAjob}/marineanlecen"
 export DATAens="${DATAjob}/ensdata"
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlecen" -c "base marineanlecen"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlecen"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marineanlecen"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_FINALIZE
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_FINALIZE
@@ -3,7 +3,11 @@ export WIPE_DATA="NO"
 export DATAjob="${DATAROOT}/marineanalysis.${PDY:-}${cyc}"
 export DATAens="${DATAjob}/ensdata"
 export DATA="${DATAjob}/marineanlvar"
-source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlfinal" -c "base marineanl marineanlfinal"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlfinal"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marineanl"
+source "${EXPDIR}/config.marineanlfinal"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_INITIALIZE
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_INITIALIZE
@@ -3,7 +3,15 @@
 export DATAjob="${DATAROOT}/marineanalysis.${PDY:-}${cyc}"
 export DATAens="${DATAjob}/ensdata"
 export DATA="${DATAjob}/marineanlvar"
-source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlinit" -c "base marineanl marineanlinit"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlinit"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marineanl"
+source "${EXPDIR}/config.marineanlinit"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marineanl"
+source "${EXPDIR}/config.marineanlinit"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_LETKF
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_LETKF
@@ -6,7 +6,13 @@ export DATA="${DATAjob}/marineanlletkf"
 export DATAens="${DATAjob}/ensdata"
 if [[ ! -d "${DATAens}" ]]; then mkdir -p "${DATAens}"; fi
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlletkf" -c "base marineanlletkf"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlletkf"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marineanlletkf"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marineanlletkf"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_VARIATIONAL
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_VARIATIONAL
@@ -4,7 +4,15 @@ export WIPE_DATA="NO"
 export DATAjob="${DATAROOT}/marineanalysis.${PDY:-}${cyc}"
 export DATAens="${DATAjob}/ensdata"
 export DATA="${DATAjob}/marineanlvar"
-source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlvar" -c "base marineanl marineanlvar"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlvar"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marineanl"
+source "${EXPDIR}/config.marineanlvar"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marineanl"
+source "${EXPDIR}/config.marineanlvar"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_BMAT
+++ b/dev/jobs/JGLOBAL_MARINE_BMAT
@@ -12,7 +12,13 @@ if [[ ! -d "${DATAstaticb}" ]]; then mkdir -p "${DATAstaticb}"; fi
 
 # source config.base, config.ocnanal and config.marinebmat
 # and pass marinebmat to ${machine}.env
-source "${HOMEgfs}/ush/jjob_header.sh" -e "marinebmat" -c "base marinebmat"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "marinebmat"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marinebmat"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marinebmat"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_BMAT_INITIALIZE
+++ b/dev/jobs/JGLOBAL_MARINE_BMAT_INITIALIZE
@@ -11,7 +11,15 @@ if [[ ! -d "${DATAstaticb}" ]]; then mkdir -p "${DATAstaticb}"; fi
 
 # source config.base, config.ocnanal and config.marinebmatinit
 # and pass marinebmat to ${machine}.env
-source "${HOMEgfs}/ush/jjob_header.sh" -e "marinebmatinit" -c "base marinebmat marinebmatinit"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "marinebmatinit"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marinebmat"
+source "${EXPDIR}/config.marinebmatinit"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marinebmat"
+source "${EXPDIR}/config.marinebmatinit"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_OCEANICE_PRODUCTS
+++ b/dev/jobs/JGLOBAL_OCEANICE_PRODUCTS
@@ -1,6 +1,12 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "oceanice_products" -c "base oceanice_products"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "oceanice_products"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.oceanice_products"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.oceanice_products"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS
+++ b/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS
@@ -1,7 +1,13 @@
 #! /usr/bin/env bash
 
 source "${HOMEgfs}/ush/preamble.sh"
-source "${HOMEgfs}/ush/jjob_header.sh" -e "offlineanl" -c "base offlineanl"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "offlineanl"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.offlineanl"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.offlineanl"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_PREP_EMISSIONS
+++ b/dev/jobs/JGLOBAL_PREP_EMISSIONS
@@ -1,6 +1,9 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "prep_emissions" -c "base prep_emissions"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "prep_emissions"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.prep_emissions"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_PREP_OCEAN_OBS
+++ b/dev/jobs/JGLOBAL_PREP_OCEAN_OBS
@@ -1,5 +1,13 @@
 #!/bin/bash
-source "${HOMEgfs}/ush/jjob_header.sh" -e "prepoceanobs" -c "base marineanl prepoceanobs"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "prepoceanobs"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marineanl"
+source "${EXPDIR}/config.prepoceanobs"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.marineanl"
+source "${EXPDIR}/config.prepoceanobs"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_SNOWENS_ANALYSIS
+++ b/dev/jobs/JGLOBAL_SNOWENS_ANALYSIS
@@ -1,6 +1,12 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "esnowanl" -c "base esnowanl"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "esnowanl"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.esnowanl"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.esnowanl"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_SNOW_ANALYSIS
+++ b/dev/jobs/JGLOBAL_SNOW_ANALYSIS
@@ -1,6 +1,12 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "snowanl" -c "base snowanl"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "snowanl"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.snowanl"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.snowanl"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_STAGE_IC
+++ b/dev/jobs/JGLOBAL_STAGE_IC
@@ -1,6 +1,12 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "stage_ic" -c "base stage_ic"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "stage_ic"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.stage_ic"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.stage_ic"
 
 # Execute staging
 "${SCRgfs}/exglobal_stage_ic.py"

--- a/dev/jobs/JGLOBAL_WAVE_GEMPAK
+++ b/dev/jobs/JGLOBAL_WAVE_GEMPAK
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "wavegempak" -c "base wave wavegempak"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "wavegempak"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.wave"
+source "${EXPDIR}/config.wavegempak"
 source "${USHgfs}/wave_domain_grid.sh"
 
 ###################################

--- a/dev/jobs/JGLOBAL_WAVE_INIT
+++ b/dev/jobs/JGLOBAL_WAVE_INIT
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "waveinit" -c "base wave waveinit"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "waveinit"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.wave"
+source "${EXPDIR}/config.waveinit"
 
 export MP_PULSE=0
 

--- a/dev/jobs/JGLOBAL_WAVE_POST_BNDPNT
+++ b/dev/jobs/JGLOBAL_WAVE_POST_BNDPNT
@@ -1,6 +1,11 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "wavepostbndpnt" -c "base wave wavepostsbs wavepostbndpnt"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "wavepostbndpnt"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.wave"
+source "${EXPDIR}/config.wavepostsbs"
+source "${EXPDIR}/config.wavepostbndpnt"
 
 export MP_PULSE=0
 

--- a/dev/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
+++ b/dev/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
@@ -1,6 +1,11 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "wavepostbndpntbll" -c "base wave wavepostsbs wavepostbndpntbll"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "wavepostbndpntbll"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.wave"
+source "${EXPDIR}/config.wavepostsbs"
+source "${EXPDIR}/config.wavepostbndpntbll"
 
 export COMPONENT="wave"
 

--- a/dev/jobs/JGLOBAL_WAVE_POST_PNT
+++ b/dev/jobs/JGLOBAL_WAVE_POST_PNT
@@ -1,6 +1,11 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "wavepostpnt" -c "base wave wavepostsbs wavepostpnt"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "wavepostpnt"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.wave"
+source "${EXPDIR}/config.wavepostsbs"
+source "${EXPDIR}/config.wavepostpnt"
 
 export MP_PULSE=0
 

--- a/dev/jobs/JGLOBAL_WAVE_POST_SBS
+++ b/dev/jobs/JGLOBAL_WAVE_POST_SBS
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "wavepostsbs" -c "base wave wavepostsbs"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "wavepostsbs"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.wave"
+source "${EXPDIR}/config.wavepostsbs"
 source "${USHgfs}/wave_domain_grid.sh"
 
 # Set COM Paths

--- a/dev/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
+++ b/dev/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "waveawipsbulls" -c "base wave waveawipsbulls"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "waveawipsbulls"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.wave"
+source "${EXPDIR}/config.waveawipsbulls"
 
 ###################################
 # Set COM Paths

--- a/dev/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
+++ b/dev/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
@@ -1,7 +1,15 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "waveawipsgridded" -c "base wave waveawipsgridded"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "waveawipsgridded"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.wave"
+source "${EXPDIR}/config.waveawipsgridded"
 source "${USHgfs}/wave_domain_grid.sh"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.wave"
+source "${EXPDIR}/config.waveprdgengridded"
 
 ###################################
 # Set COM Paths

--- a/dev/jobs/JGLOBAL_WAVE_PREP
+++ b/dev/jobs/JGLOBAL_WAVE_PREP
@@ -1,6 +1,10 @@
 #! /usr/bin/env bash
 
-source "${HOMEgfs}/ush/jjob_header.sh" -e "waveprep" -c "base wave waveprep"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "waveprep"
+
+source "${EXPDIR}/config.base"
+source "${EXPDIR}/config.wave"
+source "${EXPDIR}/config.waveprep"
 
 # Set rtofs PDY
 # shellcheck disable=SC2153


### PR DESCRIPTION

<!--
  *** PLEASE READ ***

  Any PRs not following this template will be closed.

  Please delete all these comments before submitting the PR.

  Please use a short (<60 char), descriptive title for the PR title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

  No content should appear above the "Description" header.

  If this PR is not merge-ready (e.g. it depends on other PRs not yet merged), please mark it as draft until it is ready.

  PRs should meet these guidelines:
  - Each PR should address ONE topic and have an associated issue.
  - No hard-coded paths or personal directories.
  - No temporary or backup files should be committed (including logs).
  - Any code that you disabled by being commented out should be removed or reenabled.
-->
# Description
<!-- This description will become the commit message for the PR. -->
<!--
  Solely pointing to an issue is not an adequate description!

  Please use this format for your description:

  Describe your changes. Focus on the *what* and *why*. The *how* will be evident from the changes. In particular, be sure to note any interface changes, such as command line syntax, that will need to be communicated to users.

  At the end of your description, please be sure to add the issue this PR solves using the word "Resolves". If there are any issues that are related but not yet resolved (including in other repos), you may use "Refs".

  Resolves #1234
  Refs #4321
  Refs NOAA-EMC/repo#5678
-->

This pull request refactors the initialization of several job scripts to standardize how configuration files are sourced. The main change is to remove the use of the `-c` argument in the `jjob_header.sh` script and instead explicitly source each required config file within the job script itself. This makes the configuration sourcing more transparent and easier to manage.

**Standardization of configuration sourcing in job scripts:**

* Removed the `-c` argument from the `source "${HOMEgfs}/ush/jjob_header.sh"` command in all affected job scripts, simplifying the call and decoupling config sourcing from the header script. [[1]](diffhunk://#diff-bdd2abf6d6732b9ac893f79285eb20ac12092a911098c1c6d318b6221505d85dL3-R7) [[2]](diffhunk://#diff-abbdc35f8e11d9872e099e036e804c81135e4324f61c912fd492f4078886f291L3-R7) [[3]](diffhunk://#diff-432f2b528bd6024d23abcc5cb8da81aaeed359c5f72e1fbdcecfd5d15edb7758L3-R6) [[4]](diffhunk://#diff-4b0ad475842603184dace55679b5bb6fbdb18fedd6f79e186f539afd7e3d16e8L7-R10) [[5]](diffhunk://#diff-70332b275fc18f28f836b998131c247c4bb4c6c81b63b3dd2cc380fad343b187L6-R9) [[6]](diffhunk://#diff-a02f8bc6cece1f5b0a1e0a4f08e7e882e77940ccd278995922a45561fd83da55L6-R9) [[7]](diffhunk://#diff-f8786c516ad19a343112abc1f7496eb146fd1f8ff60288e674f1ee0121019e25L3-R6) [[8]](diffhunk://#diff-8f9a9140d4c0666a99b03508756846f3d76f481c0b60dd07acdcb10151ec74e3L3-R6) [[9]](diffhunk://#diff-36f64cad465bf5d7ce4e3a85c07f0eb1075ce3db9ed78d383bfe89c74082e526L3-R7) [[10]](diffhunk://#diff-96c237974e06ccca84886ca976723b8f8b6fa8f794e900d39138b655f57bd5b0L3-R7) [[11]](diffhunk://#diff-5ca141b129033c05128778b27c825403c52fd21b16a1fc731e69f1d8ffa57aeaL3-R6) [[12]](diffhunk://#diff-d9c40c6376c3f702cc0048f6c539230ea482c9ce3f97e034fa4812c71d97884dL3-R6) [[13]](diffhunk://#diff-66eeab4265212872453ca92d3f715684b2d020bbd80677638f6e285b64a2c0a6L3-R6) [[14]](diffhunk://#diff-79916619dde5349ed76984e04f4f288f08e0c263c3003d683baa82a83f32239cL8-R11) [[15]](diffhunk://#diff-3c2bab00f6cd547a8f69d8930f34bc3c9ed6f553fe6eab951fb8609a83eb8bb1L3-R6) [[16]](diffhunk://#diff-3d14ef147cdcf4960c91318a7ea1ce29009e31ca4ff98fc4eba0304ffaf569a1L3-R6) [[17]](diffhunk://#diff-7f944d594dabed1d90dd27d3153a9551a48f61ebc130bf87900faf0815091cf0L8-R11) [[18]](diffhunk://#diff-796d284eaf14f6b81a79669736ef6e409b3c5155355f226ee4856cea7a0c1b6aL6-R9) [[19]](diffhunk://#diff-9fb33624dd5e2b14b8b3aad25c2749a7e76eae785db52620f6ef6784aab7529dL3-R6) [[20]](diffhunk://#diff-a903a289c53dadf5f9a5e8204d0b01788eccf9e76f640e9c38ebcdf937c7f887L8-R11)
* Explicitly sourced the relevant config files for each job script, such as `config.base` and other job-specific configs (e.g., `config.gempak`, `config.wave_stat`, etc.), immediately after sourcing the header script. This improves clarity and maintainability by making all required configuration files visible at the top of each script. [[1]](diffhunk://#diff-bdd2abf6d6732b9ac893f79285eb20ac12092a911098c1c6d318b6221505d85dL3-R7) [[2]](diffhunk://#diff-abbdc35f8e11d9872e099e036e804c81135e4324f61c912fd492f4078886f291L3-R7) [[3]](diffhunk://#diff-432f2b528bd6024d23abcc5cb8da81aaeed359c5f72e1fbdcecfd5d15edb7758L3-R6) [[4]](diffhunk://#diff-4b0ad475842603184dace55679b5bb6fbdb18fedd6f79e186f539afd7e3d16e8L7-R10) [[5]](diffhunk://#diff-70332b275fc18f28f836b998131c247c4bb4c6c81b63b3dd2cc380fad343b187L6-R9) [[6]](diffhunk://#diff-a02f8bc6cece1f5b0a1e0a4f08e7e882e77940ccd278995922a45561fd83da55L6-R9) [[7]](diffhunk://#diff-f8786c516ad19a343112abc1f7496eb146fd1f8ff60288e674f1ee0121019e25L3-R6) [[8]](diffhunk://#diff-8f9a9140d4c0666a99b03508756846f3d76f481c0b60dd07acdcb10151ec74e3L3-R6) [[9]](diffhunk://#diff-36f64cad465bf5d7ce4e3a85c07f0eb1075ce3db9ed78d383bfe89c74082e526L3-R7) [[10]](diffhunk://#diff-96c237974e06ccca84886ca976723b8f8b6fa8f794e900d39138b655f57bd5b0L3-R7) [[11]](diffhunk://#diff-5ca141b129033c05128778b27c825403c52fd21b16a1fc731e69f1d8ffa57aeaL3-R6) [[12]](diffhunk://#diff-d9c40c6376c3f702cc0048f6c539230ea482c9ce3f97e034fa4812c71d97884dL3-R6) [[13]](diffhunk://#diff-66eeab4265212872453ca92d3f715684b2d020bbd80677638f6e285b64a2c0a6L3-R6) [[14]](diffhunk://#diff-79916619dde5349ed76984e04f4f288f08e0c263c3003d683baa82a83f32239cL8-R11) [[15]](diffhunk://#diff-3c2bab00f6cd547a8f69d8930f34bc3c9ed6f553fe6eab951fb8609a83eb8bb1L3-R6) [[16]](diffhunk://#diff-3d14ef147cdcf4960c91318a7ea1ce29009e31ca4ff98fc4eba0304ffaf569a1L3-R6) [[17]](diffhunk://#diff-7f944d594dabed1d90dd27d3153a9551a48f61ebc130bf87900faf0815091cf0L8-R11) [[18]](diffhunk://#diff-796d284eaf14f6b81a79669736ef6e409b3c5155355f226ee4856cea7a0c1b6aL6-R9) [[19]](diffhunk://#diff-9fb33624dd5e2b14b8b3aad25c2749a7e76eae785db52620f6ef6784aab7529dL3-R6) [[20]](diffhunk://#diff-a903a289c53dadf5f9a5e8204d0b01788eccf9e76f640e9c38ebcdf937c7f887L8-R11)

Impacts #4550 


<!-- For more on writing good commit messages, see https://cbea.ms/git-commit/ -->

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO (If YES, please indicate to which system(s))
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Include the output of `gw_cistat -r /path/to/RUNTESTS/directory` for the tests you ran.
`gw_cistat` is available after sourcing the `gw_setup.sh` script in `dev/ush/`.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->


# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
