### PR TITLE
Update Windborne filename in exglobal_atmos_analysis.sh (#4588)

### DIFF
--- a/dev/scripts/exglobal_atmos_analysis.sh
+++ b/dev/scripts/exglobal_atmos_analysis.sh
@@ -151,7 +151,7 @@ OMPSNPNC=${OMPSNPNC:-${COMIN_OBS}/OMPSNP.${PDY}_${cyc}z.nc}
 OMPSLPNC=${OMPSLPNC:-${COMIN_OBS}/OMPS-LPoz-Vis.${PDY}_${cyc}z.nc}
 MLS55NC=${MLS55NC:-${COMIN_OBS}/MLS-v5.0-oz.${PDY}_${cyc}z.nc}
 SAILDRONE=${SAILDRONE:-${COMIN_OBS}/${OPREFIX}saldrn.tm00.bufr_d${OSUFFIX}}
-GSBBF=${GSBBF:-${COMIN_OBS}/${OPREFIX}gsbprf.tm00.bufr_d${OSUFFIX}}
+GSBBF=${GSBBF:-${COMIN_OBS}/${OPREFIX}gsbpfl.tm00.bufr_d${OSUFFIX}}
 
 # Guess files
 GPREFIX=${GPREFIX:-""}


### PR DESCRIPTION
# Description
Windborne data is assimilated in the operational GFS. Late in development, the bufr filename for this data was changed from ${OPREFIX}gsbprf.tm00.bufr_d${OSUFFIX}} to ${OPREFIX}gsbpfl.tm00.bufr_d${OSUFFIX}}. This was updated in the v16 branch and operations, but was not included in the develop branch or dev/gfs.v17.

This PR updates the bufr filename within the exglobal atmos analysis script. The build_gsinfo files are already configured to assimilate these datatypes (301/401) when available.

Refs https://github.com/NOAA-EMC/global-workflow/issues/4588

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? YES - After 2025081312 only
    - GFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
* -G generate workflow tests pass on WCOSS2 and Gaea C6 (results will be posted in the comments). These dates are too early to exercise this data type.
* 4 S2S GDAS cycles for Feb 2026 at C384/C192 on WCOSS2. Gsistat files were confirmed to properly assimilate Windborne as described in https://github.com/NOAA-EMC/global-workflow/issues/4588.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
