### PR TITLE
Place `scron` `LOCKFILE` check inside if to return 0 status

### DIFF
--- a/dev/workflow/rocoto/rocoto_scron.sh.j2
+++ b/dev/workflow/rocoto/rocoto_scron.sh.j2
@@ -68,6 +68,8 @@ if [[ -n "${ROCOTOSTAT}" ]]; then
         echo "${FAILED_JOBS}" > "${LOCKFILE}"
     else
         # No failures, remove lockfile if it exists
-        [[ -f "${LOCKFILE}" ]] && rm -f "${LOCKFILE}"
+        if [[ -f "${LOCKFILE}" ]]; then
+            rm -f "${LOCKFILE}"
+        fi
     fi
 fi


### PR DESCRIPTION
# Description
This places the LOCKFILE check of the templated `scron.sh` script into an `if` block. This guarantees a 0 status if the `LOCKFILE` is not present.

Fixes https://github.com/NOAA-EMC/global-workflow/issues/4616

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Ran the resulting scron script at the command line and checked the resulting status to be 0.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings