### PR TITLE
Place `scron` `LOCKFILE` check inside if to return 0 status (#4617)

### DIFF
--- a/dev/workflow/rocoto/rocoto_scron.sh.j2
+++ b/dev/workflow/rocoto/rocoto_scron.sh.j2
@@ -69,6 +69,8 @@ if [[ -n "${ROCOTOSTAT}" ]]; then
         echo "${FAILED_JOBS}" > "${LOCKFILE}"
     else
         # No failures, remove lockfile if it exists
-        [[ -f "${LOCKFILE}" ]] && rm -f "${LOCKFILE}"
+        if [[ -f "${LOCKFILE}" ]]; then
+            rm -f "${LOCKFILE}"
+        fi
     fi
 fi


### PR DESCRIPTION
This places the LOCKFILE check of the templated `scron.sh` script into an `if` block. This guarantees a 0 status if the `LOCKFILE` is not present.

This is a cherry-pick of #4617.