### PR TITLE
Update the path for fix files on WCOSS2

### DIFF
--- a/sorc/link_fv3gfs.sh
+++ b/sorc/link_fv3gfs.sh
@@ -35,7 +35,7 @@ if [ $machine == "cray" ]; then
 elif [ $machine = "dell" ]; then
     FIX_DIR="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix_nco_gfsv16.3.0"
 elif [ $machine = "wcoss2" ]; then
-    FIX_DIR="/lfs/h2/emc/global/noscrub/emc.global/FIX/fix_nco_gfsv16.3.22"
+    FIX_DIR="/lfs/h2/emc/global/noscrub/emc.global/FIX/fix_nco_gfsv16.3.30"
 elif [ $machine = "hera" ]; then
     FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix_nco_gfsv16.3.22"
 elif [ $machine = "orion" ]; then


### PR DESCRIPTION
# Description
This updates the fix directory to link from on WCOSS2 to point to the most up to date CO2 fix files.
Refs #4592 

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# How has this been tested?
Ran `link_fv3gfs.sh emc wcoss2` and verified that the links in `fix` now point to `/lfs/h2/emc/global/noscrub/emc.global/FIX/fix_nco_gfsv16.3.30`.