### PR TITLE
Update the path for fix files on WCOSS2 (#4627)

### DIFF
--- a/sorc/link_fv3gfs.sh
+++ b/sorc/link_fv3gfs.sh
@@ -35,7 +35,7 @@ if [ $machine == "cray" ]; then
 elif [ $machine = "dell" ]; then
     FIX_DIR="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix_nco_gfsv16.3.0"
 elif [ $machine = "wcoss2" ]; then
-    FIX_DIR="/lfs/h2/emc/global/noscrub/emc.global/FIX/fix_nco_gfsv16.3.22"
+    FIX_DIR="/lfs/h2/emc/global/noscrub/emc.global/FIX/fix_nco_gfsv16.3.30"
 elif [ $machine = "hera" ]; then
     FIX_DIR="/scratch1/NCEPDEV/global/glopara/fix_nco_gfsv16.3.22"
 elif [ $machine = "orion" ]; then


### PR DESCRIPTION
This updates the fix directory to link from on WCOSS2 to point to the most up to date CO2 fix files.
Resolves https://github.com/NOAA-EMC/global-workflow/issues/4592

# Description
This brings the most recent update of dev/gfs.v16 into release/gfs.v16.3.31 to resolve an issue with fix files.

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# How has this been tested?
@RussTreadon-NOAA ran a forecast test on the precursor PR #4627.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings