### PR TITLE
HOTFIX: Update `verif_global` Submodule to Fix GFS-to-Global Variable Conversion Bug

### DIFF
--- a/dev/scripts/exgfs_wave_prdgen_gridded.sh
+++ b/dev/scripts/exgfs_wave_prdgen_gridded.sh
@@ -85,7 +85,7 @@ while [[ "${fhcnt}" -le "${FHMAX_WAV}" ]]; do
 
         iparam=1
         while [[ ${iparam} -le ${nparam} ]]; do
-            nip=${arrpar[${iparam} - 1]}
+            nip=${arrpar[${iparam}-1]}
             prepar=${nip::-1} # Part prefix (assumes 1 digit index)
             paridx="${nip:0-1}"
             npart=0


### PR DESCRIPTION
<!--
  *** PLEASE READ ***

  Any PRs not following this template will be closed.

  Please delete all these comments before submitting the PR.

  Please use a short (<60 char), descriptive title for the PR title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

  No content should appear above the "Description" header.

  If this PR is not merge-ready (e.g. it depends on other PRs not yet merged), please mark it as draft until it is ready.

  PRs should meet these guidelines:
  - Each PR should address ONE topic and have an associated issue.
  - No hard-coded paths or personal directories.
  - No temporary or backup files should be committed (including logs).
  - Any code that you disabled by being commented out should be removed or reenabled.
-->
# Description
- Fixes a missed update from [#4540](https://github.com/NOAA-EMC/global-workflow/pull/4540), which was intended to replace all gfs variables with global variables. One location in `verif-global` submodule was overlooked; this PR corrects it.

  Refs #4540 
  Refs [Verif Global#223](https://github.com/NOAA-EMC/EMC_verif-global/pull/223)

<!-- For more on writing good commit messages, see https://cbea.ms/git-commit/ -->

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO (If YES, please indicate to which system(s))
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? YES (If YES, please add a link to any PRs that are pending.)
  - [x] EMC verif-global [NOAA-EMC/EMC_verif-global#223](https://github.com/NOAA-EMC/EMC_verif-global/pull/223) 
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
- Tested this PR with C96_atm3DVar_extended, and the stat files are successfully generated in the `metp` jobs.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
