### PR TITLE
Add compression to SBN atmospheric product generation

### DIFF
--- a/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh
+++ b/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh
@@ -183,7 +183,7 @@ for GRID in conus ak prico pac 003; do
         export err=$?
         if [[ ${err} -ne 0 ]]; then
             err_exit "Failed to generate the awips Grib2 file!"
-	fi
+        fi
         echo "Complex2 compression/packing for grib2.awpgfs${fcsthr}.${GRID}"
         cpreq "grib2.awpgfs${fcsthr}.${GRID}" "tmp_grib2_${fcsthr}_${GRID}"
         ${WGRIB2} "tmp_grib2_${fcsthr}_${GRID}" -set_grib_type complex2 \

--- a/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh
+++ b/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh
@@ -229,7 +229,7 @@ for GRID in conus ak prico pac 003; do
         export err=$?
         if [[ ${err} -ne 0 ]]; then
             err_exit "Failed to compress and repack the AWIPS grib2 file!"
-        fi 
+        fi
 
         ##############################
         # Post Files to ${COMOUT_ATMOS_WMO}

--- a/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh
+++ b/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh
@@ -221,7 +221,7 @@ for GRID in conus ak prico pac 003; do
         export err=$?
         if [[ ${err} -ne 0 ]]; then
             err_exit "Failed to write the AWIPS grib2 file"
-	fi
+        fi
         echo "Complex2 compression/packing for grib2.awpgfs_20km_${GRID}_f${fcsthr}"
         cpreq "grib2.awpgfs_20km_${GRID}_f${fcsthr}" "tmp_grib2_${GRID}_f${fcsthr}"
         ${WGRIB2} "tmp_grib2_${GRID}_f${fcsthr}" -set_grib_type complex2 \

--- a/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh
+++ b/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh
@@ -225,7 +225,7 @@ for GRID in conus ak prico pac 003; do
         echo "Complex2 compression/packing for grib2.awpgfs_20km_${GRID}_f${fcsthr}"
         cpreq "grib2.awpgfs_20km_${GRID}_f${fcsthr}" "tmp_grib2_${GRID}_f${fcsthr}"
         ${WGRIB2} "tmp_grib2_${GRID}_f${fcsthr}" -set_grib_type complex2 \
-                   -grib_out "grib2.awpgfs_20km_${GRID}_f${fcsthr}"
+            -grib_out "grib2.awpgfs_20km_${GRID}_f${fcsthr}"
         export err=$?
         if [[ ${err} -ne 0 ]]; then
             err_exit "Failed to compress and repack the AWIPS grib2 file!"

--- a/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh
+++ b/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh
@@ -64,8 +64,8 @@ echo " "
 set_trace
 
 # Set type of Interpolation for WGRIB2
-export opt1=' -set_grib_type same -new_grid_winds earth '
-export opt1uv=' -set_grib_type same -new_grid_winds grid '
+export opt1=' -set_grib_type complex2 -new_grid_winds earth '
+export opt1uv=' -set_grib_type complex2 -new_grid_winds grid '
 export opt21=' -new_grid_interpolation bilinear -if '
 export opt22=":(CSNOW|CRAIN|CFRZR|CICEP|ICSEV):"
 export opt23=' -new_grid_interpolation neighbor -fi '

--- a/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh
+++ b/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh
@@ -64,8 +64,8 @@ echo " "
 set_trace
 
 # Set type of Interpolation for WGRIB2
-export opt1=' -set_grib_type complex2 -new_grid_winds earth '
-export opt1uv=' -set_grib_type complex2 -new_grid_winds grid '
+export opt1=' -set_grib_type same -new_grid_winds earth '
+export opt1uv=' -set_grib_type same -new_grid_winds grid '
 export opt21=' -new_grid_interpolation bilinear -if '
 export opt22=":(CSNOW|CRAIN|CFRZR|CICEP|ICSEV):"
 export opt23=' -new_grid_interpolation neighbor -fi '
@@ -183,6 +183,14 @@ for GRID in conus ak prico pac 003; do
         export err=$?
         if [[ ${err} -ne 0 ]]; then
             err_exit "Failed to generate the awips Grib2 file!"
+	fi
+        echo "Complex2 compression/packing for grib2.awpgfs${fcsthr}.${GRID}"
+        cpreq "grib2.awpgfs${fcsthr}.${GRID}" "tmp_grib2_${fcsthr}_${GRID}"
+        ${WGRIB2} "tmp_grib2_${fcsthr}_${GRID}" -set_grib_type complex2 \
+                   -grib_out "grib2.awpgfs${fcsthr}.${GRID}"
+        export err=$?
+        if [[ ${err} -ne 0 ]]; then
+            err_exit "Failed to compress and repack the awips Grib2 file!"
         fi
 
         ##############################
@@ -213,7 +221,15 @@ for GRID in conus ak prico pac 003; do
         export err=$?
         if [[ ${err} -ne 0 ]]; then
             err_exit "Failed to write the AWIPS grib2 file"
-        fi
+	fi
+        echo "Complex2 compression/packing for grib2.awpgfs_20km_${GRID}_f${fcsthr}"
+        cpreq "grib2.awpgfs_20km_${GRID}_f${fcsthr}" "tmp_grib2_${GRID}_f${fcsthr}"
+        ${WGRIB2} "tmp_grib2_${GRID}_f${fcsthr}" -set_grib_type complex2 \
+                   -grib_out "grib2.awpgfs_20km_${GRID}_f${fcsthr}"
+        export err=$?
+        if [[ ${err} -ne 0 ]]; then
+            err_exit "Failed to compress and repack the AWIPS grib2 file!"
+        fi 
 
         ##############################
         # Post Files to ${COMOUT_ATMOS_WMO}

--- a/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh
+++ b/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh
@@ -187,7 +187,7 @@ for GRID in conus ak prico pac 003; do
         echo "Complex2 compression/packing for grib2.awpgfs${fcsthr}.${GRID}"
         cpreq "grib2.awpgfs${fcsthr}.${GRID}" "tmp_grib2_${fcsthr}_${GRID}"
         ${WGRIB2} "tmp_grib2_${fcsthr}_${GRID}" -set_grib_type complex2 \
-                   -grib_out "grib2.awpgfs${fcsthr}.${GRID}"
+            -grib_out "grib2.awpgfs${fcsthr}.${GRID}"
         export err=$?
         if [[ ${err} -ne 0 ]]; then
             err_exit "Failed to compress and repack the awips Grib2 file!"


### PR DESCRIPTION
<!--
  *** PLEASE READ ***

  Any PRs not following this template will be closed.

  Please delete all these comments before submitting the PR.

  Please use a short (<60 char), descriptive title for the PR title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

  No content should appear above the "Description" header.

  If this PR is not merge-ready (e.g. it depends on other PRs not yet merged), please mark it as draft until it is ready.

  PRs should meet these guidelines:
  - Each PR should address ONE topic and have an associated issue.
  - No hard-coded paths or personal directories.
  - No temporary or backup files should be committed (including logs).
  - Any code that you disabled by being commented out should be removed or reenabled.
-->
# Description
NCO requires that the total volume of post-processing products to be transmitted through the SBN <ins>not</ins> exceed current operational levels.  The generation of these products in retrospective runs of GFSv17 have marginally exceeded operational levels, and the files must be reduced in size (in lieu of the outright removal of some).

This PR simply adds a compression/packing attribute to the generation of WMO-headed atmospheric products within the script [exgfs_atmos_awips_20km_1p0deg.sh](https://github.com/ChristopherHill-NOAA/global-workflow/blob/035d50609e23554a20a0c7324e488ee628c1ab1f/dev/scripts/exgfs_atmos_awips_20km_1p0deg.sh#L67), accomplished by revising the `-set_grib_type` option of WGRIB2 from "same" to "complex2".

This PR is intended to resolve #4614.

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? YES (If YES, please indicate to which system(s))
  - [x] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
The GFS workflow was cloned and built on WCOSS.  A CI test only confirmed nominal functionality with the code change, as the products resulting from the low resolution run were too small for the code change to produce the necessary effect.

Offline tests executing a segment of `exgfs_atmos_awips_20km_1p0deg.sh` with files from `products/atmos/grib2/0p25` as input resulted in a reduction to the size of the products.

It is recommended that the changes from this PR be tested in a single cycle, high-resolution test of GFSv17, to confirm its intended effect to reduce SBN product volume to the extent required by NCO.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
