### PR TITLE
[GCAFSv1] Create a jinja2 template for the Atmos Init J-job

### DIFF
--- a/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS.j2
+++ b/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS.j2
@@ -46,7 +46,11 @@ mkdir -p "${COMOUT_ATMOS_ANALYSIS}"
 mkdir -p "${COMOUT_OBS}"
 
 # Execute generation of increments from offline analysis
-EXSCRIPT=${OFFLINEANLPY:-${SCRglobal}/exglobal_offline_atmos_analysis.py}
+{% if RUN == "gcdas" %}
+EXSCRIPT=${SCRglobal}/exgcdas_atmos_initialize.py && true
+{% else %}
+EXSCRIPT=${SCRglobal}/exglobal_offline_atmos_analysis.py && true
+{% endif %}
 ${EXSCRIPT} && true
 
 export err=$?

--- a/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS.j2
+++ b/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS.j2
@@ -47,9 +47,9 @@ mkdir -p "${COMOUT_OBS}"
 
 # Execute generation of increments from offline analysis
 {% if RUN == "gcdas" %}
-EXSCRIPT=${SCRglobal}/exgcdas_atmos_initialize.py && true
+EXSCRIPT=${SCRglobal}/exgcdas_atmos_initialize.py
 {% else %}
-EXSCRIPT=${SCRglobal}/exglobal_offline_atmos_analysis.py && true
+EXSCRIPT=${SCRglobal}/exglobal_offline_atmos_analysis.py
 {% endif %}
 ${EXSCRIPT} && true
 

--- a/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS.j2
+++ b/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS.j2
@@ -26,15 +26,15 @@ export APREFIX_IN="gdas.t${cyc}z."
 export APREFIX="${RUN}.t${cyc}z."
 export GPREFIX="${GDUMP}.t${gcyc}z."
 
-#{% if RUN == "gcdas" %}
+{% if RUN == "gcdas" %}
 COMINobsproc=$(compath.py "${envir}/obsproc/${obsproc_ver}")/"gdas.${PDY}/${cyc}/atmos"
 declare -rx COMINobsproc
 COMINgfs=$(compath.py "${envir}/gfs/${gfs_ver}")
 declare -rx COMINgfs
-#{% else %}
+{% else %}
 declare -rx COMINobsproc="${DMPDIR}/gdas.${PDY}/${cyc}/atmos"
 declare -rx COMINgfs=${ROTDIR}
-#{% endif %}
+{% endif %}
 declare -rx COMINgfs_ATMOS_ANALYSIS=${COMINgfs}/gdas.${PDY}/${cyc}/atmos/
 
 declare -rx COMOUT_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"

--- a/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS.j2
+++ b/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS.j2
@@ -1,0 +1,68 @@
+#! /usr/bin/env bash
+set -x
+source "${HOMEglobal}/ush/jjob_header.sh" -e "offlineanl" -c "base offlineanl"
+
+source "${HOMEglobal}/ush/jjob_standard_vars.sh"
+
+source "${USHglobal}/jjob_shell_setup.sh"
+
+##############################################
+# Set variables used in the script
+##############################################
+# Setup Python path for pygfs
+PYTHONPATH="${HOMEglobal}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"
+export PYTHONPATH
+
+##############################################
+# Begin JOB SPECIFIC work
+##############################################
+# shellcheck disable=SC2153
+GDATE=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} - ${assim_freq} hours")
+export gPDY=${GDATE:0:8}
+export gcyc=${GDATE:8:2}
+export GDUMP="${RUN}"
+
+export APREFIX_IN="gdas.t${cyc}z."
+export APREFIX="${RUN}.t${cyc}z."
+export GPREFIX="${GDUMP}.t${gcyc}z."
+
+#{% if RUN == "gcdas" %}
+COMINobsproc=$(compath.py "${envir}/obsproc/${obsproc_ver}")/"gdas.${PDY}/${cyc}/atmos"
+declare -rx COMINobsproc
+COMINgfs=$(compath.py "${envir}/gfs/${gfs_ver}")
+declare -rx COMINgfs
+#{% else %}
+declare -rx COMINobsproc="${DMPDIR}/gdas.${PDY}/${cyc}/atmos"
+declare -rx COMINgfs=${ROTDIR}
+#{% endif %}
+declare -rx COMINgfs_ATMOS_ANALYSIS=${COMINgfs}/gdas.${PDY}/${cyc}/atmos/
+
+declare -rx COMOUT_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
+declare -rx COMOUT_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+
+declare -rx COMIN_ATMOS_HISTORY_PREV="${ROTDIR}/${RUN}.${gPDY}/${gcyc}/model/atmos/history"
+
+mkdir -p "${COMOUT_ATMOS_ANALYSIS}"
+mkdir -p "${COMOUT_OBS}"
+
+# Execute generation of increments from offline analysis
+EXSCRIPT=${OFFLINEANLPY:-${SCRglobal}/exglobal_offline_atmos_analysis.py}
+${EXSCRIPT} && true
+
+export err=$?
+if [[ ${err} -ne 0 ]]; then
+    err_exit "${EXSCRIPT} returned a non-zero status!"
+fi
+
+##########################################
+# Remove the Temporary working directory
+##########################################
+cd "${DATAROOT}" || (
+    echo "${DATAROOT} does not exist. ABORT!"
+    exit 1
+)
+if [[ "${KEEPDATA}" == "NO" ]]; then
+    rm -rf "${DATA}"
+fi
+
+exit 0

--- a/dev/ush/setup_gcafs_for_nco.py
+++ b/dev/ush/setup_gcafs_for_nco.py
@@ -240,6 +240,13 @@ def setup_gcafs_for_nco():
     print(f"Rendered surface analysis template and saved to {dest_surface_job_path}")
     os.chmod(dest_surface_job_path, 0o755)
 
+    # Render the offline atmospheric analysis template
+    offline_atmos_template_path = os.path.join(global_workflow_dir, 'dev', 'jobs', 'JGLOBAL_OFFLINE_ATMOS_ANALYSIS.j2')
+    dest_offline_atmos_job_path = os.path.join(global_workflow_dir, 'jobs', "JGCDAS_ATMOS_INITIALIZE")
+    Jinja(offline_atmos_template_path, {'RUN': 'gcdas'}).save(dest_offline_atmos_job_path)
+    print(f"Rendered offline atmospheric analysis template and saved to {dest_offline_atmos_job_path}")
+    os.chmod(dest_offline_atmos_job_path, 0o755)
+
     # Now for all jobs, we need a line that exports HOMEglobal
     for job_name in os.listdir(jobs_dir):
         job_file_path = os.path.join(jobs_dir, job_name)


### PR DESCRIPTION
# Description
This PR makes a Jinja2 template for the Atmos Init J-Job so that when `setup_gcafs_for_nco` is executed, only the if-block where `$RUN_ENVIR` is `nco` is included. This works for v1 T2O and lays groundwork for future changes for development where the Jinja templates are more fully rendered.

Resolves https://github.com/NOAA-EMC/global-workflow/issues/4670