### PR TITLE
[dev/gfs.v17] Bring in updated MOM6 logging feature

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "sorc/ufs_model.fd"]
   path = sorc/ufs_model.fd
-  url = https://github.com/dpsarmie/ufs-weather-model
+  url = https://github.com/ufs-community/ufs-weather-model
   ignore = dirty
 [submodule "sorc/wxflow"]
   path = sorc/wxflow

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "sorc/ufs_model.fd"]
   path = sorc/ufs_model.fd
-  url = https://github.com/ufs-community/ufs-weather-model
+  url = https://github.com/dpsarmie/ufs-weather-model
   ignore = dirty
 [submodule "sorc/wxflow"]
   path = sorc/wxflow

--- a/parm/ufs/fv3/diag_table
+++ b/parm/ufs/fv3/diag_table
@@ -1,60 +1,60 @@
 "fv3_history",    0,  "hours",  1,  "hours",  "time"
 "fv3_history2d",  0,  "hours",  1,  "hours",  "time"
-"@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", @[FHOUT_OCN],  "hours",  1,  "hours",  "time",  @[FHOUT_OCN],  "hours",  "@[SYEAR] @[SMONTH] @[SDAY] @[CHOUR] 0 0"
+"@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", @[FHOUT_OCN],  "hours",  1,  "hours",  "time",  @[FHOUT_OCN],  "hours",  "@[SYEAR] @[SMONTH] @[SDAY] @[CHOUR] 0 0"
 
 ##############
 # Ocean fields
 ##############
 # static fields
-"ocean_model", "geolon",      "geolon",      "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
-"ocean_model", "geolat",      "geolat",      "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
-"ocean_model", "geolon_c",    "geolon_c",    "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
-"ocean_model", "geolat_c",    "geolat_c",    "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
-"ocean_model", "geolon_u",    "geolon_u",    "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
-"ocean_model", "geolat_u",    "geolat_u",    "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
-"ocean_model", "geolon_v",    "geolon_v",    "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
-"ocean_model", "geolat_v",    "geolat_v",    "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
-#"ocean_model", "depth_ocean", "depth_ocean", "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
-#"ocean_model", "wet",         "wet",         "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
-"ocean_model", "wet_c",       "wet_c",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
-"ocean_model", "wet_u",       "wet_u",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
-"ocean_model", "wet_v",       "wet_v",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
-"ocean_model", "sin_rot",     "sin_rot",     "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
-"ocean_model", "cos_rot",     "cos_rot",     "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+"ocean_model", "geolon",      "geolon",      "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
+"ocean_model", "geolat",      "geolat",      "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
+"ocean_model", "geolon_c",    "geolon_c",    "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
+"ocean_model", "geolat_c",    "geolat_c",    "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
+"ocean_model", "geolon_u",    "geolon_u",    "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
+"ocean_model", "geolat_u",    "geolat_u",    "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
+"ocean_model", "geolon_v",    "geolon_v",    "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
+"ocean_model", "geolat_v",    "geolat_v",    "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
+#"ocean_model", "depth_ocean", "depth_ocean", "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
+#"ocean_model", "wet",         "wet",         "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
+"ocean_model", "wet_c",       "wet_c",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
+"ocean_model", "wet_u",       "wet_u",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
+"ocean_model", "wet_v",       "wet_v",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
+"ocean_model", "sin_rot",     "sin_rot",     "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
+"ocean_model", "cos_rot",     "cos_rot",     "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi", "all", .false., "none", 2
 
 # ocean output TSUV and others
-"ocean_model", "SSH",        "SSH",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
-"ocean_model", "SST",        "SST",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
-"ocean_model", "SSS",        "SSS",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
-"ocean_model", "speed",      "speed",     "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
-"ocean_model", "SSU",        "SSU",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
-"ocean_model", "SSV",        "SSV",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
-"ocean_model", "frazil",     "frazil",    "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
-"ocean_model", "ePBL_h_ML",  "ePBL",      "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
-"ocean_model", "MLD_003",    "MLD_003",   "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
-"ocean_model", "MLD_0125",   "MLD_0125",  "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
-"ocean_model", "tob",        "tob",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
+"ocean_model", "SSH",        "SSH",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
+"ocean_model", "SST",        "SST",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
+"ocean_model", "SSS",        "SSS",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
+"ocean_model", "speed",      "speed",     "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
+"ocean_model", "SSU",        "SSU",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
+"ocean_model", "SSV",        "SSV",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
+"ocean_model", "frazil",     "frazil",    "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
+"ocean_model", "ePBL_h_ML",  "ePBL",      "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
+"ocean_model", "MLD_003",    "MLD_003",   "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
+"ocean_model", "MLD_0125",   "MLD_0125",  "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
+"ocean_model", "tob",        "tob",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
 
 # Z-Space Fields Provided for CMIP6 (CMOR Names):
-"ocean_model_z", "uo",       "uo",        "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
-"ocean_model_z", "vo",       "vo",        "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
-"ocean_model_z", "so",       "so",        "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
-"ocean_model_z", "temp",     "temp",      "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr",  "all",  .true.,  "none",  2
+"ocean_model_z", "uo",       "uo",        "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
+"ocean_model_z", "vo",       "vo",        "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
+"ocean_model_z", "so",       "so",        "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
+"ocean_model_z", "temp",     "temp",      "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi",  "all",  .true.,  "none",  2
 
 # forcing
-"ocean_model", "taux",      "taux",          "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
-"ocean_model", "tauy",      "tauy",          "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
-"ocean_model", "latent",    "latent",        "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
-"ocean_model", "sensible",  "sensible",      "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
-"ocean_model", "SW",        "SW",            "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
-"ocean_model", "LW",        "LW",            "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
-"ocean_model", "evap",      "evap",          "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
-#"ocean_model", "lprec",     "lprec",         "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
-"ocean_model", "lrunoff",   "lrunoff",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
-#"ocean_model", "frunoff",   "frunoff",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
-#"ocean_model", "fprec",     "fprec",         "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
-"ocean_model", "LwLatSens", "LwLatSens",     "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
-"ocean_model", "Heat_PmE",  "Heat_PmE",      "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+"ocean_model", "taux",      "taux",          "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi","all",.true.,"none",2
+"ocean_model", "tauy",      "tauy",          "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi","all",.true.,"none",2
+"ocean_model", "latent",    "latent",        "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi","all",.true.,"none",2
+"ocean_model", "sensible",  "sensible",      "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi","all",.true.,"none",2
+"ocean_model", "SW",        "SW",            "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi","all",.true.,"none",2
+"ocean_model", "LW",        "LW",            "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi","all",.true.,"none",2
+"ocean_model", "evap",      "evap",          "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi","all",.true.,"none",2
+#"ocean_model", "lprec",     "lprec",         "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi","all",.true.,"none",2
+"ocean_model", "lrunoff",   "lrunoff",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi","all",.true.,"none",2
+#"ocean_model", "frunoff",   "frunoff",       "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi","all",.true.,"none",2
+#"ocean_model", "fprec",     "fprec",         "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi","all",.true.,"none",2
+"ocean_model", "LwLatSens", "LwLatSens",     "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi","all",.true.,"none",2
+"ocean_model", "Heat_PmE",  "Heat_PmE",      "@[MOM6_OUTPUT_DIR]/ocn%4yr%2mo%2dy%2hr%2mi","all",.true.,"none",2
 
 ###################
 # Atmosphere fields

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -653,7 +653,7 @@ MOM6_postdet() {
 		ihour=$(printf %02i "${interval}")
 		source_file_log="${vdate:0:8}.${vdate:8:2}0000.mom6.${ihour}h"
                 dest_file="${RUN}.t${cyc}z.${interval}hr_avg.f${fhr3}.nc"
-		dest_file_log="${RUN}.t${cyc}z.${interval}hr_avg.log.f${fhr3}.txt"
+                dest_file_log="${RUN}.t${cyc}z.${interval}hr_avg.log.f${fhr3}.txt"
                 ${NLN} "${COMOUT_OCEAN_HISTORY}/${dest_file}" "${DATAoutput}/MOM6_OUTPUT/${source_file}"
                 ${NLN} "${COMOUT_OCEAN_HISTORY}/${dest_file_log}" "${DATA}/${source_file_log}"
 

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -650,8 +650,8 @@ MOM6_postdet() {
                 else
                     source_file="ocn_${vdate_mid:0:4}_${vdate_mid:4:2}_${vdate_mid:6:2}_${vdate_mid:8:2}_00.nc"
                 fi
-		ihour=$(printf %02i "${interval}")
-		source_file_log="${vdate:0:8}.${vdate:8:2}0000.mom6.${ihour}h"
+                ihour=$(printf %02i "${interval}")
+                source_file_log="${vdate:0:8}.${vdate:8:2}0000.mom6.${ihour}h"
                 dest_file="${RUN}.t${cyc}z.${interval}hr_avg.f${fhr3}.nc"
                 dest_file_log="${RUN}.t${cyc}z.${interval}hr_avg.log.f${fhr3}.txt"
                 ${NLN} "${COMOUT_OCEAN_HISTORY}/${dest_file}" "${DATAoutput}/MOM6_OUTPUT/${source_file}"

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -648,7 +648,7 @@ MOM6_postdet() {
                 if ((OFFSET_START_HOUR > 0)) && ((fhr == FHOUT_OCN)); then
                     source_file="ocn_lead1_${vdate_mid:0:4}_${vdate_mid:4:2}_${vdate_mid:6:2}_${vdate_mid:8:2}.nc"
                 else
-                    source_file="ocn_${vdate_mid:0:4}_${vdate_mid:4:2}_${vdate_mid:6:2}_${vdate_mid:8:2}.nc"
+                    source_file="ocn_${vdate_mid:0:4}_${vdate_mid:4:2}_${vdate_mid:6:2}_${vdate_mid:8:2}_00.nc"
                 fi
                 dest_file="${RUN}.t${cyc}z.${interval}hr_avg.f${fhr3}.nc"
                 ${NLN} "${COMOUT_OCEAN_HISTORY}/${dest_file}" "${DATAoutput}/MOM6_OUTPUT/${source_file}"

--- a/ush/forecast_postdet.sh
+++ b/ush/forecast_postdet.sh
@@ -624,7 +624,7 @@ MOM6_postdet() {
     case ${RUN} in
         gfs | enkfgfs | gefs | sfs | gcafs) # Link output files for RUN=gfs|enkfgfs|gefs|sfs
             # Looping over MOM6 output hours
-            local fhr fhr3 last_fhr interval midpoint vdate vdate_mid source_file dest_file
+            local fhr fhr3 last_fhr interval midpoint vdate vdate_mid source_file dest_file ihour source_file_log dest_file_log
             for fhr in ${MOM6_OUTPUT_FH}; do
                 fhr3=$(printf %03i "${fhr}")
 
@@ -650,8 +650,12 @@ MOM6_postdet() {
                 else
                     source_file="ocn_${vdate_mid:0:4}_${vdate_mid:4:2}_${vdate_mid:6:2}_${vdate_mid:8:2}_00.nc"
                 fi
+		ihour=$(printf %02i "${interval}")
+		source_file_log="${vdate:0:8}.${vdate:8:2}0000.mom6.${ihour}h"
                 dest_file="${RUN}.t${cyc}z.${interval}hr_avg.f${fhr3}.nc"
+		dest_file_log="${RUN}.t${cyc}z.${interval}hr_avg.log.f${fhr3}.txt"
                 ${NLN} "${COMOUT_OCEAN_HISTORY}/${dest_file}" "${DATAoutput}/MOM6_OUTPUT/${source_file}"
+                ${NLN} "${COMOUT_OCEAN_HISTORY}/${dest_file_log}" "${DATA}/${source_file_log}"
 
                 last_fhr=${fhr}
 

--- a/ush/parsing_ufs_configure.sh
+++ b/ush/parsing_ufs_configure.sh
@@ -69,6 +69,9 @@ UFS_configure() {
         local MED_history_n=1000000
 
         local histaux_enabled=".false."
+        local MOM6_OUTPUT_DIR="./MOM6_OUTPUT"
+        local MOM6_RESTART_DIR="./MOM6_RESTART"
+        local MOM6_HISTFREQ_N=${FHOUT_OCN:-6}
     fi
 
     if [[ "${cplice}" = ".true." ]]; then


### PR DESCRIPTION
# Description

This PR will bring in MOM6 logging changes that are in the UFSWM develop branch to the GFSv17 branch in Global Workflow.

This PR will change the MOM6 output filenames by adding a `_00` string to the name. This was a feature that was originally  needed by the SFS project and now requested by GFS.

This update is related to #4249 , which is the original request from SFS.

Refs #4717 

# Type of change
- [ ] Bug fix (fixes something broken)
- [X] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? YES/NO (If YES, please indicate to which system(s))
  - [X] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? YES 
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [X] UFS-weather-model -- No pending PR until tests are done via GW
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
These changes were tested just using the UFSWM regression tests. The WM itself passed testing, however this will still need to be tested in the GW.


# Checklist
- [X] Any dependent changes have been merged and published
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have documented my code, including function, input, and output descriptions
- [X] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [X] This change is covered by an existing CI test or a new one has been added
- [X] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [X] I have made corresponding changes to the system documentation if necessary
