### PR TITLE
HOTFIX: Disable PROCESS_TROPCY by default

### DIFF
--- a/dev/ci/cases/gfsv17/s2sw_realtime.yaml
+++ b/dev/ci/cases/gfsv17/s2sw_realtime.yaml
@@ -33,7 +33,7 @@ prepoceanobs:
 
 prep:
   # This can only be enabled in realtime
-  PROCESS_TROPCY: "YES"
+  PROCESS_TROPCY: "NO"
 
 marinebmat:
   SOCA_INPUT_FIX_DIR: {{ HOMEglobal }}/fix/gdas/soca/1440x1080x75/soca


### PR DESCRIPTION
# Description
This disables the tropical cyclone QA job by default in the real-time. This matches what is currently in the dev/gfs.v17 branch.

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Tested in v17 and develop previously.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] I have made corresponding changes to the system documentation if necessary