### PR TITLE
Source set_strict rather than call it as a function (#4690)

### DIFF
--- a/dev/job_cards/rocoto/prep.sh
+++ b/dev/job_cards/rocoto/prep.sh
@@ -157,10 +157,10 @@ export COMSP=${COMSP:-"${COMIN_OBS}/${RUN_local}.t${cyc}z."}
 # Create or Copy prepbufr, prepbufr.acft_profiles, nsstbufr files
 # Do not fail on external errors
 if [[ ${MAKE_PREPBUFR:-"YES"} == "YES" ]]; then
-    unset_strict
+    source "${USHglobal}/unset_strict.sh"
     "${HOMEobsproc}/jobs/JOBSPROC_GLOBAL_PREP" && true
     export err=$?
-    set_strict
+    source "${USHglobal}/set_strict.sh"
     if [[ ${err} -ne 0 ]]; then
         err_exit "JOBSPROC_GLOBAL_PREP job failed, ABORT!"
     fi

--- a/dev/jobs/JGDAS_AERO_ANALYSIS_GENERATE_BMATRIX
+++ b/dev/jobs/JGDAS_AERO_ANALYSIS_GENERATE_BMATRIX
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGDAS_ATMOS_CHGRES_FORENKF
+++ b/dev/jobs/JGDAS_ATMOS_CHGRES_FORENKF
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGDAS_ATMOS_GEMPAK
+++ b/dev/jobs/JGDAS_ATMOS_GEMPAK
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 export GRIB=${GRIB:-pgrb2f}
 export EXT=""

--- a/dev/jobs/JGDAS_ATMOS_GEMPAK_META_NCDC
+++ b/dev/jobs/JGDAS_ATMOS_GEMPAK_META_NCDC
@@ -15,6 +15,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 # Now set up GEMPAK/NTRANS environment
 

--- a/dev/jobs/JGDAS_ATMOS_VERFOZN
+++ b/dev/jobs/JGDAS_ATMOS_VERFOZN
@@ -14,6 +14,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 #############################################
 #  determine PDY and cyc for previous cycle

--- a/dev/jobs/JGDAS_ATMOS_VERFRAD
+++ b/dev/jobs/JGDAS_ATMOS_VERFRAD
@@ -14,6 +14,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 #############################################
 #  determine PDY and cyc for previous cycle

--- a/dev/jobs/JGDAS_ENKF_POST
+++ b/dev/jobs/JGDAS_ENKF_POST
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGDAS_FIT2OBS
+++ b/dev/jobs/JGDAS_FIT2OBS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGEFS_WAVE_STAT
+++ b/dev/jobs/JGEFS_WAVE_STAT
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 source "${USHglobal}/wave_domain_grid.sh"
 
 # Set COM Paths

--- a/dev/jobs/JGEFS_WAVE_STAT_PNT
+++ b/dev/jobs/JGEFS_WAVE_STAT_PNT
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 # Set COM Paths
 

--- a/dev/jobs/JGFS_ATMOS_AWIPS_20KM_1P0DEG
+++ b/dev/jobs/JGFS_ATMOS_AWIPS_20KM_1P0DEG
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
 

--- a/dev/jobs/JGFS_ATMOS_CYCLONE_GENESIS
+++ b/dev/jobs/JGFS_ATMOS_CYCLONE_GENESIS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the exglobal script
@@ -44,10 +47,10 @@ export JYYYY=${PDY:0:4}
 ##############################################
 
 # Do not fail on errors or unassigned variables in external code
-unset_strict
+source "${USHglobal}/unset_strict.sh"
 "${SCRIPTens_tracker}/exgfs_tc_genesis.sh" && true
 export err=$?
-set_strict
+source "${USHglobal}/set_strict.sh"
 if [[ ${err} -ne 0 ]]; then
     err_exit
 fi

--- a/dev/jobs/JGFS_ATMOS_CYCLONE_TRACKER
+++ b/dev/jobs/JGFS_ATMOS_CYCLONE_TRACKER
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 export COMPONENT="atmos"
 

--- a/dev/jobs/JGFS_ATMOS_FBWIND
+++ b/dev/jobs/JGFS_ATMOS_FBWIND
@@ -16,6 +16,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 export COMPONENT="atmos"
 

--- a/dev/jobs/JGFS_ATMOS_FSU_GENESIS
+++ b/dev/jobs/JGFS_ATMOS_FSU_GENESIS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Define COM and Data directories

--- a/dev/jobs/JGFS_ATMOS_GEMPAK
+++ b/dev/jobs/JGFS_ATMOS_GEMPAK
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ############################################
 # Set up model and cycle specific variables

--- a/dev/jobs/JGFS_ATMOS_GEMPAK_META
+++ b/dev/jobs/JGFS_ATMOS_GEMPAK_META
@@ -16,6 +16,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ###############################################
 # Set MP variables

--- a/dev/jobs/JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF
+++ b/dev/jobs/JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF
@@ -14,6 +14,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 export MP_PULSE=0
 export MP_TIMEOUT=2000

--- a/dev/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
+++ b/dev/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 export COMPONENT="atmos"
 export EXT=""

--- a/dev/jobs/JGFS_ATMOS_PGRB2_SPEC_NPOESS
+++ b/dev/jobs/JGFS_ATMOS_PGRB2_SPEC_NPOESS
@@ -16,6 +16,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
 

--- a/dev/jobs/JGFS_ATMOS_POSTSND
+++ b/dev/jobs/JGFS_ATMOS_POSTSND
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ########################################
 # Runs GFS BUFR SOUNDINGS

--- a/dev/jobs/JGFS_ATMOS_VERIFICATION
+++ b/dev/jobs/JGFS_ATMOS_VERIFICATION
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ###############################################################
 ## Abstract:
@@ -39,11 +42,11 @@ done
 if [[ "${RUN_GRID2GRID_STEP1}" == "YES" || "${RUN_GRID2OBS_STEP1}" == "YES" || "${RUN_PRECIP_STEP1}" == "YES" ]]; then
     # Override the -e in VERIF_GLOBALSH's shebang and un-export SHELLOPTS
     # TODO: clean up the verif-global script so it does not raise false-positive errors
-    unset_strict
+    source "${USHglobal}/unset_strict.sh"
     export -n SHELLOPTS
     bash -x "${VERIF_GLOBALSH}"
     err=$?
-    set_strict
+    source "${USHglobal}/set_strict.sh"
     if [[ ${err} -ne 0 ]]; then
         exit "${err}"
     fi

--- a/dev/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
+++ b/dev/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
@@ -13,6 +13,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
+++ b/dev/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
@@ -12,6 +12,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_AERO_ANALYSIS_VARIATIONAL
+++ b/dev/jobs/JGLOBAL_AERO_ANALYSIS_VARIATIONAL
@@ -13,6 +13,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ANALYSIS_STATS
+++ b/dev/jobs/JGLOBAL_ANALYSIS_STATS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ARCHIVE_TARS
+++ b/dev/jobs/JGLOBAL_ARCHIVE_TARS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 if [[ "${DO_WAVE}" == "YES" ]]; then
     source "${EXPDIR}/config.wave"
     source "${USHglobal}/wave_domain_grid.sh"
@@ -105,10 +108,10 @@ fi
 
 # Do not export shell opts to the bash scripts in the htar/hsi wrappers
 export -n SHELLOPTS
-unset_strict
+source "${USHglobal}/unset_strict.sh"
 ${GLOBALARCHIVESH:-${SCRglobal}/exglobal_archive_tars.py}
 export err=$?
-set_strict
+source "${USHglobal}/set_strict.sh"
 if [[ ${err} -ne 0 ]]; then
     err_exit "failed to archive the COM structure"
 fi

--- a/dev/jobs/JGLOBAL_ARCHIVE_VRFY
+++ b/dev/jobs/JGLOBAL_ARCHIVE_VRFY
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
+++ b/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
@@ -12,6 +12,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
+++ b/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
@@ -13,6 +13,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
+++ b/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
@@ -12,6 +12,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
+++ b/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
@@ -12,6 +12,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
+++ b/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
@@ -12,6 +12,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
+++ b/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
@@ -13,6 +13,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMOS_ANALYSIS
+++ b/dev/jobs/JGLOBAL_ATMOS_ANALYSIS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
+++ b/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 # Setup Python path for pygfs
 PYTHONPATH="${HOMEglobal}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"

--- a/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC_FV3JEDI
+++ b/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC_FV3JEDI
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_DIAG
+++ b/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_DIAG
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATMOS_CHGRES_GEN_CONTROL
+++ b/dev/jobs/JGLOBAL_ATMOS_CHGRES_GEN_CONTROL
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 # Initial conditions are from previous GFS cycle, but valid at the end of the cycle
 GDATE=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} - ${assim_freq} hours")

--- a/dev/jobs/JGLOBAL_ATMOS_ENSSTAT
+++ b/dev/jobs/JGLOBAL_ATMOS_ENSSTAT
@@ -15,6 +15,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/dev/jobs/JGLOBAL_ATMOS_POST_MANAGER
+++ b/dev/jobs/JGLOBAL_ATMOS_POST_MANAGER
@@ -13,6 +13,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ####################################
 # Specify NET and RUN Name and model

--- a/dev/jobs/JGLOBAL_ATMOS_PREP_SFC
+++ b/dev/jobs/JGLOBAL_ATMOS_PREP_SFC
@@ -12,6 +12,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set date and cycle

--- a/dev/jobs/JGLOBAL_ATMOS_PRODUCTS
+++ b/dev/jobs/JGLOBAL_ATMOS_PRODUCTS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/dev/jobs/JGLOBAL_ATMOS_SFCANL
+++ b/dev/jobs/JGLOBAL_ATMOS_SFCANL
@@ -10,6 +10,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/dev/jobs/JGLOBAL_ATMOS_SFCANL.j2
+++ b/dev/jobs/JGLOBAL_ATMOS_SFCANL.j2
@@ -6,6 +6,9 @@ source "${HOMEglobal}/ush/jjob_header.sh" -e "sfcanl" -c "base sfcanl"
 source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/dev/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
+++ b/dev/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/dev/jobs/JGLOBAL_ATMOS_UPP
+++ b/dev/jobs/JGLOBAL_ATMOS_UPP
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the exglobal script

--- a/dev/jobs/JGLOBAL_ATMOS_VMINMON
+++ b/dev/jobs/JGLOBAL_ATMOS_VMINMON
@@ -14,6 +14,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 #############################################
 # Determine PDY and cyc for previous cycle

--- a/dev/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
+++ b/dev/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
@@ -13,6 +13,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
+++ b/dev/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
@@ -13,6 +13,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
+++ b/dev/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
@@ -12,6 +12,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
+++ b/dev/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
@@ -13,6 +13,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ATM_PREP_ANL_BIAS
+++ b/dev/jobs/JGLOBAL_ATM_PREP_ANL_BIAS
@@ -12,6 +12,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_CLEANUP
+++ b/dev/jobs/JGLOBAL_CLEANUP
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 "${SCRglobal}/exglobal_cleanup.sh" && true
 export err=$?

--- a/dev/jobs/JGLOBAL_ENKF_ARCHIVE_TARS
+++ b/dev/jobs/JGLOBAL_ENKF_ARCHIVE_TARS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script
@@ -36,10 +39,10 @@ mkdir -p "${COMIN_CONF}"
 
 # Calls an external bash command; do not fail on unassigned/error
 export -n SHELLOPTS
-unset_strict
+source "${USHglobal}/unset_strict.sh"
 "${SCRglobal}/exglobal_enkf_earc_tars.py"
 export err=$?
-set_strict
+source "${USHglobal}/set_strict.sh"
 if [[ ${err} -ne 0 ]]; then
     err_exit "Failed to archive the ensemble COM structure"
 fi

--- a/dev/jobs/JGLOBAL_ENKF_ARCHIVE_VRFY
+++ b/dev/jobs/JGLOBAL_ENKF_ARCHIVE_VRFY
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ENKF_DIAG
+++ b/dev/jobs/JGLOBAL_ENKF_DIAG
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ENKF_ECEN
+++ b/dev/jobs/JGLOBAL_ENKF_ECEN
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ENKF_ECEN_FV3JEDI
+++ b/dev/jobs/JGLOBAL_ENKF_ECEN_FV3JEDI
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ENKF_SELECT_OBS
+++ b/dev/jobs/JGLOBAL_ENKF_SELECT_OBS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script
@@ -56,7 +59,7 @@ fi
 
 LEVS=$(${NCLEN} "${ATMGES}" pfull) && true
 export err=$?
-set_strict
+source "${USHglobal}/set_strict.sh"
 
 export LEVS
 

--- a/dev/jobs/JGLOBAL_ENKF_SFC
+++ b/dev/jobs/JGLOBAL_ENKF_SFC
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ENKF_UPDATE
+++ b/dev/jobs/JGLOBAL_ENKF_UPDATE
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_ENS_GLOBUS_ARCH
+++ b/dev/jobs/JGLOBAL_ENS_GLOBUS_ARCH
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_EXTRACTVARS
+++ b/dev/jobs/JGLOBAL_EXTRACTVARS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 source "${USHglobal}/wave_domain_grid.sh"
 
 # Set COM Paths

--- a/dev/jobs/JGLOBAL_FETCH
+++ b/dev/jobs/JGLOBAL_FETCH
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 # Setup Python path for pygfs
 PYTHONPATH="${HOMEglobal}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"

--- a/dev/jobs/JGLOBAL_FORECAST
+++ b/dev/jobs/JGLOBAL_FORECAST
@@ -24,6 +24,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 # Setup Python path for pygfs
 PYTHONPATH="${HOMEglobal}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"

--- a/dev/jobs/JGLOBAL_FORECAST.j2
+++ b/dev/jobs/JGLOBAL_FORECAST.j2
@@ -15,6 +15,9 @@ source "${HOMEglobal}/ush/jjob_header.sh" -e "fcst" -c "base fcst"
 source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 # Setup Python path for pygfs
 PYTHONPATH="${HOMEglobal}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"

--- a/dev/jobs/JGLOBAL_GLOBUS_ARCH
+++ b/dev/jobs/JGLOBAL_GLOBUS_ARCH
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_CHECKPOINT
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_CHECKPOINT
@@ -14,6 +14,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_ECEN
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_ECEN
@@ -15,6 +15,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_FINALIZE
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_FINALIZE
@@ -14,6 +14,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_INITIALIZE
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_INITIALIZE
@@ -13,6 +13,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_LETKF
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_LETKF
@@ -17,6 +17,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_VARIATIONAL
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_VARIATIONAL
@@ -14,6 +14,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_BMAT
+++ b/dev/jobs/JGLOBAL_MARINE_BMAT
@@ -21,6 +21,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_MARINE_BMAT_INITIALIZE
+++ b/dev/jobs/JGLOBAL_MARINE_BMAT_INITIALIZE
@@ -22,6 +22,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_OCEANICE_PRODUCTS
+++ b/dev/jobs/JGLOBAL_OCEANICE_PRODUCTS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 # Setup Python path for pygfs
 PYTHONPATH="${HOMEglobal}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"

--- a/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS
+++ b/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS
@@ -10,6 +10,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS.j2
+++ b/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS.j2
@@ -6,6 +6,9 @@ source "${HOMEglobal}/ush/jjob_header.sh" -e "offlineanl" -c "base offlineanl"
 source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_PREP_EMISSIONS
+++ b/dev/jobs/JGLOBAL_PREP_EMISSIONS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_PREP_OCEAN_OBS
+++ b/dev/jobs/JGLOBAL_PREP_OCEAN_OBS
@@ -10,6 +10,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_SNOWENS_ANALYSIS
+++ b/dev/jobs/JGLOBAL_SNOWENS_ANALYSIS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_SNOW_ANALYSIS
+++ b/dev/jobs/JGLOBAL_SNOW_ANALYSIS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ##############################################
 # Set variables used in the script

--- a/dev/jobs/JGLOBAL_STAGE_IC
+++ b/dev/jobs/JGLOBAL_STAGE_IC
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 # Setup Python path for pygfs
 PYTHONPATH="${HOMEglobal}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"

--- a/dev/jobs/JGLOBAL_WAVE_GEMPAK
+++ b/dev/jobs/JGLOBAL_WAVE_GEMPAK
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 source "${USHglobal}/wave_domain_grid.sh"
 
 ###################################

--- a/dev/jobs/JGLOBAL_WAVE_INIT
+++ b/dev/jobs/JGLOBAL_WAVE_INIT
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 export MP_PULSE=0
 

--- a/dev/jobs/JGLOBAL_WAVE_POST_BNDPNT
+++ b/dev/jobs/JGLOBAL_WAVE_POST_BNDPNT
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 export MP_PULSE=0
 

--- a/dev/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
+++ b/dev/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 export COMPONENT="wave"
 

--- a/dev/jobs/JGLOBAL_WAVE_POST_PNT
+++ b/dev/jobs/JGLOBAL_WAVE_POST_PNT
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 export MP_PULSE=0
 

--- a/dev/jobs/JGLOBAL_WAVE_POST_SBS
+++ b/dev/jobs/JGLOBAL_WAVE_POST_SBS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 source "${USHglobal}/wave_domain_grid.sh"
 
 # Set COM Paths

--- a/dev/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
+++ b/dev/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 ###################################
 # Set COM Paths

--- a/dev/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
+++ b/dev/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 source "${USHglobal}/wave_domain_grid.sh"
 
 ###################################

--- a/dev/jobs/JGLOBAL_WAVE_PREP
+++ b/dev/jobs/JGLOBAL_WAVE_PREP
@@ -11,6 +11,9 @@ source "${HOMEglobal}/ush/jjob_standard_vars.sh"
 #{% endif %}
 
 source "${USHglobal}/jjob_shell_setup.sh"
+# Set strict mode which will exit on error or undefined variable
+# and exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+source "${USHglobal}/set_strict.sh"
 
 # Set rtofs PDY
 # shellcheck disable=SC2153

--- a/dev/scripts/exgdas_atmos_verfrad.sh
+++ b/dev/scripts/exgdas_atmos_verfrad.sh
@@ -18,7 +18,7 @@
 ################################################################################
 
 # Do not exit on errors so that restricted data can be protected
-unset_strict
+source "${USHglobal}/unset_strict.sh"
 
 if [[ ! -s "${radstat}" || ! -s "${biascr}" ]]; then
     export err=1

--- a/dev/scripts/exglobal_atmos_products.sh
+++ b/dev/scripts/exglobal_atmos_products.sh
@@ -87,10 +87,10 @@ for ((nset = 1; nset <= downset; nset++)); do
         # if final record of is u-component, add next record v-component
         # if final record is land, add next record icec
         # grep returns 1 if no match is found, so temporarily turn off exit on non-zero rc
-        unset_strict
+        source "${USHglobal}/unset_strict.sh"
         ${WGRIB2} -d "${last}" "${tmpfile}" | grep -E -i "ugrd|ustm|uflx|u-gwd|land|maxuw"
         rc=$?
-        set_strict
+        source "${USHglobal}/set_strict.sh"
         if [[ ${rc} == 0 ]]; then # Matched the grep
             last=$((last + 1))
         fi

--- a/ush/jjob_shell_setup.sh
+++ b/ush/jjob_shell_setup.sh
@@ -7,7 +7,7 @@
 #
 # Handles:
 #   - Sourcing utility functions (wait_for_file, dataroot_com_path, timer,
-#       err_exit, set_strict, postamble)
+#       err_exit, postamble)
 #   - Setting shell options (nullglob)
 #   - Each utility script exports its own functions via declare -xf
 #   - Activating strict mode (set -eu) and tracing (set -x)
@@ -38,10 +38,8 @@ source "${USHglobal}/err_exit.sh"
 shopt -s nullglob # Allow null globs instead of treating * as literal
 
 ##############################################
-# Shell options, strict mode, and tracing
+# Shell options and tracing
 ##############################################
-source "${USHglobal}/set_strict.sh"
-source "${USHglobal}/unset_strict.sh"
 source "${USHglobal}/set_trace.sh"
 export SHELLOPTS
 ##############################################
@@ -50,8 +48,7 @@ export SHELLOPTS
 source "${USHglobal}/setup_data_dir.sh"
 setup_data_dir "${DATA}"
 
-# Activate strict mode and tracing
-set_strict
+# Activate tracing
 set_trace
 
 ##############################################
@@ -65,7 +62,5 @@ trap "postamble ${start_time}" EXIT
 # Temporal variables: PDY, PDYm#, PDYp# (via setpdy.sh)
 ##############################################
 # setpdy.sh may not be available in all environments; failures are non-fatal
-unset_strict
 setpdy.sh || true
 source ./PDY || true
-set_strict

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -105,10 +105,4 @@ else
     echo WARNING: UNKNOWN PLATFORM 1>&2
 fi
 
-# If this function exists in the environment, run it; else do not
-ftype=$(type -t set_strict || echo "")
-if [[ "${ftype}" == "function" ]]; then
-    set_strict
-else
-    set +u
-fi
+set +u

--- a/ush/run_mpmd.sh
+++ b/ush/run_mpmd.sh
@@ -196,10 +196,10 @@ for ((i = 0; i < nm; i += chunk_size)); do
     # Count the number of lines not including commented lines (i.e. shebangs)
     n_mpmd_tasks=$(grep -v -c "^ *#" < "${chunk_file}")
     if [[ "${_mpmd_launcher}" == "srun" ]]; then
-        unset_strict
+        source "${USHglobal}/unset_strict.sh"
         # shellcheck disable=SC2086
         ${launcher:-} ${mpmd_opt:-} -n "${n_mpmd_tasks}" "${chunk_file}"
-        set_strict
+        source "${USHglobal}/set_strict.sh"
     elif [[ "${_mpmd_launcher}" == "mpiexec" ]]; then
         # shellcheck disable=SC2086
         ${launcher:-} -np "${n_mpmd_tasks}" ${mpmd_opt:-} "${chunk_file}"

--- a/ush/set_strict.sh
+++ b/ush/set_strict.sh
@@ -1,19 +1,12 @@
 #! /usr/bin/env bash
-
 #######
-# Defines the set_strict function for use in J-jobs and ex-scripts.
-#
-# Source this file to load the function into the current shell:
+# Source this file to set strict mode in a script.
 #   source "${USHglobal}/set_strict.sh"
 #######
 
-set_strict() {
-    if [[ ${STRICT:-"YES"} == "YES" ]]; then
-        # Exit on error or undefined variable
-        set -eu
-        # Exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
-        set -o pipefail
-    fi
-}
-
-declare -xf set_strict
+if [[ ${STRICT:-"YES"} == "YES" ]]; then
+    # Exit on error or undefined variable
+    set -eu
+    # Exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+    set -o pipefail
+fi

--- a/ush/syndat_getjtbul.sh
+++ b/ush/syndat_getjtbul.sh
@@ -102,9 +102,9 @@ fi
 pgm=$(basename "${EXECglobal}/syndat_getjtbul.x")
 export pgm
 if [[ -s prep_step ]]; then
-    unset_strict
+    source "${USHglobal}/unset_strict.sh"
     source prep_step
-    set_strict
+    source "${USHglobal}/set_strict.sh"
 else
     [[ -f errfile ]] && rm errfile
     #shellcheck disable=SC2046

--- a/ush/syndat_qctropcy.sh
+++ b/ush/syndat_qctropcy.sh
@@ -229,9 +229,9 @@ cpreq "${slmask}" slmask.126
 pgm=$(basename "${EXECglobal}/syndat_qctropcy.x")
 export pgm
 if [[ -s prep_step ]]; then
-    unset_strict
+    source "${USHglobal}/unset_strict.sh"
     source prep_step
-    set_strict
+    source "${USHglobal}/set_strict.sh"
 else
     [[ -f errfile ]] && rm errfile
     # shellcheck disable=SC2046

--- a/ush/unset_strict.sh
+++ b/ush/unset_strict.sh
@@ -1,16 +1,9 @@
 #! /usr/bin/env bash
-
 #######
-# Defines the unset_strict function for use in J-jobs and ex-scripts.
-#
-# Source this file to load the function into the current shell:
+# Source this file to unset strict mode in a script.
 #   source "${USHglobal}/unset_strict.sh"
 #######
 
-unset_strict() {
-    # Turn off strict mode
-    set +eu
-    set +o pipefail
-}
-
-declare -xf unset_strict
+# Turn off strict mode
+set +eu
+set +o pipefail


### PR DESCRIPTION
# Description
To adhere to NWS operational standards, we must, rather than define and execute bash functions to set and unset strict mode, source `ush` scripts that set and unset strict mode. This PR removes the functions and instead creates simplified bash that can be sourced, and all places that previously called the functions have been replaced by a source of the scripts.

Additionally, the set_strict has been removed from jjob_shell_setup and is now explicitly called at the top of every j-job.

  Resolves #https://github.com/NOAA-EMC/global-workflow/issues/4682

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? No - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Include the output of `gw_cistat -r /path/to/RUNTESTS/directory` for the tests you ran.
`gw_cistat` is available after sourcing the `gw_setup.sh` script in `dev/ush/`.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera -->
On Ursa:
```
############################### C48_ATM ################################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202103231200        Done    Mar 20 2026 19:10:07    Mar 20 2026 20:20:05
############################### C48_S2SW ###############################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202103231200        Done    Mar 20 2026 19:10:07    Mar 20 2026 20:20:05
########################## C48_gsienkf_atmDA ###########################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202402231800        Done    Mar 20 2026 19:10:07    Mar 20 2026 19:30:07
202402240000        Done    Mar 20 2026 19:10:07    Mar 20 2026 20:25:06
202402240600        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:10:05
########################## C48_ufsenkf_atmDA ###########################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202402231800        Done    Mar 20 2026 19:10:07    Mar 20 2026 19:30:07
202402240000        Done    Mar 20 2026 19:10:07    Mar 20 2026 20:40:07
202402240600        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:30:08
######################### C48mx500_3DVarAOWCDA #########################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202103241800        Done    Mar 20 2026 19:10:07    Mar 20 2026 20:25:06
202103250000        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:05:07
########################## C48mx500_hybAOWCDA ##########################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202103241800        Done    Mar 20 2026 19:10:07    Mar 20 2026 19:40:06
202103250000        Done    Mar 20 2026 19:10:07    Mar 20 2026 20:45:07
########################### C96C48_hybatmDA ############################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202112201800        Done    Mar 20 2026 19:10:07    Mar 20 2026 19:35:07
202112210000        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:05:07
202112210600        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:40:07
######################### C96C48_hybatmsnowDA ##########################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202112201200        Done    Mar 20 2026 19:10:07    Mar 20 2026 19:40:06
202112201800        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:10:05
202112210000        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:30:08
######################### C96C48_hybatmsoilDA ##########################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202205150600        Done    Mar 20 2026 19:10:07    Mar 20 2026 19:40:06
202205151200        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:20:06
202205151800        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:45:08
######################### C96C48_ufs_hybatmDA ##########################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202402231800        Done    Mar 20 2026 19:10:07    Mar 20 2026 19:40:05
202402240000        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:25:07
202402240600        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:30:08
######################## C96C48_ufsgsi_hybatmDA ########################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202402231800        Done    Mar 20 2026 19:10:07    Mar 20 2026 19:40:05
202402240000        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:25:07
202402240600        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:35:06
####################### C96C48mx500_S2SW_cyc_gfs #######################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202112201200        Done    Mar 20 2026 19:10:07    Mar 20 2026 20:50:07
202112201800        Done    Mar 20 2026 19:10:07    Mar 20 2026 22:10:06
202112210000        Done    Mar 20 2026 19:10:07    Mar 20 2026 22:35:06
############################# C96_atm3DVar #############################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202112201800        Done    Mar 20 2026 19:10:07    Mar 20 2026 19:35:07
202112210000        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:15:07
202112210600        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:40:07
########################### C96_gcafs_cycled ###########################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202112201200        Done    Mar 20 2026 19:10:07    Mar 20 2026 19:30:06
202112201800        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:20:06
202112210000        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:05:07
######################## C96_gcafs_cycled_noDA #########################
   CYCLE         STATE           ACTIVATED              DEACTIVATED     
202112201200        Done    Mar 20 2026 19:10:07    Mar 20 2026 19:30:06
202112201800        Done    Mar 20 2026 19:10:07    Mar 20 2026 21:00:08
202112210000        Done    Mar 20 2026 19:10:07    Mar 20 2026 20:40:07
```

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary

<!--
  *** PLEASE READ ***

  Any PRs not following this template will be closed.

  Please delete all these comments before submitting the PR.

  Please use a short (<60 char), descriptive title for the PR title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

  No content should appear above the "Description" header.

  If this PR is not merge-ready (e.g. it depends on other PRs not yet merged), please mark it as draft until it is ready.

  PRs should meet these guidelines:
  - Each PR should address ONE topic and have an associated issue.
  - No hard-coded paths or personal directories.
  - No temporary or backup files should be committed (including logs).
  - Any code that you disabled by being commented out should be removed or reenabled.
-->
# Description
<!-- This description will become the commit message for the PR. -->
<!--
  Solely pointing to an issue is not an adequate description!

  Please use this format for your description:

  Describe your changes. Focus on the *what* and *why*. The *how* will be evident from the changes. In particular, be sure to note any interface changes, such as command line syntax, that will need to be communicated to users.

  At the end of your description, please be sure to add the issue this PR solves using the word "Resolves". If there are any issues that are related but not yet resolved (including in other repos), you may use "Refs".

  Resolves #1234
  Refs #4321
  Refs NOAA-EMC/repo#5678
-->
<!-- For more on writing good commit messages, see https://cbea.ms/git-commit/ -->

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? YES/NO (If YES, please indicate to which system(s))
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? YES/NO
- Does this change require a documentation update? YES/NO
- Does this change require an update to any of the following submodules? YES/NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Include the output of `gw_cistat -r /path/to/RUNTESTS/directory` for the tests you ran.
`gw_cistat` is available after sourcing the `gw_setup.sh` script in `dev/ush/`.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->


# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
