### PR TITLE
Use compath.py to define ROTDIR for GCAFS

### DIFF
--- a/dev/jobs/JGCDAS_PREPARE_OBS
+++ b/dev/jobs/JGCDAS_PREPARE_OBS
@@ -19,7 +19,7 @@ source "${USHglobal}/jjob_shell_setup.sh"
 # Setup Python path for pygfs
 PYTHONPATH="${HOMEglobal}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"
 export PYTHONPATH
-export COMOUT_OBS="${COMROOT}/${RUN}.${PDY}/${cyc}/obs/chem"
+export COMOUT_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs/chem"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/parm/config/gcafs/config.base
+++ b/parm/config/gcafs/config.base
@@ -90,7 +90,7 @@ export assim_freq="6" # Assimilation frequency in hours
 export PSLOT=""
 #export EXPDIR="/lfs/h2/emc/da/noscrub/cory.r.martin/gcafs/runtests2/EXPDIR/${PSLOT}"
 #export ROTDIR="/lfs/h2/emc/da/noscrub/cory.r.martin/gcafs/runtests2/COMROOT/${PSLOT}"
-export ROTDIR=${COMROOT}
+export ROTDIR=$(compath.py "${envir}/gcafs/${gcafs_ver}")
 export DUMP_SUFFIX=""
 if [[ "${PDY}${cyc}" -ge "2019092100" && "${PDY}${cyc}" -le "2019110700" ]]; then
     export DUMP_SUFFIX="p"              # Use dumps from NCO GFS v15.3 parallel

--- a/parm/config/gcafs/config.base
+++ b/parm/config/gcafs/config.base
@@ -90,7 +90,7 @@ export assim_freq="6" # Assimilation frequency in hours
 export PSLOT=""
 #export EXPDIR="/lfs/h2/emc/da/noscrub/cory.r.martin/gcafs/runtests2/EXPDIR/${PSLOT}"
 #export ROTDIR="/lfs/h2/emc/da/noscrub/cory.r.martin/gcafs/runtests2/COMROOT/${PSLOT}"
-export ROTDIR=$(compath.py "${envir}/gcafs/${gcafs_ver}")
+export ROTDIR=$(compath.py "${envir}/${NET}/${gcafs_ver}")
 export DUMP_SUFFIX=""
 if [[ "${PDY}${cyc}" -ge "2019092100" && "${PDY}${cyc}" -le "2019110700" ]]; then
     export DUMP_SUFFIX="p"              # Use dumps from NCO GFS v15.3 parallel

--- a/versions/run.wcoss2.ver
+++ b/versions/run.wcoss2.ver
@@ -1,6 +1,5 @@
 #! /usr/bin/env bash
 export version=v1.0.0
-export gcafs_ver=v1.0.0
 export gfs_ver=v16.3.7
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1
@@ -56,4 +55,4 @@ export prepobs_run_ver=1.1.3
 export ens_tracker_ver=v1.3.0
 export fit2obs_ver=1.1.10
 
-export COMPATH="/lfs/h2/emc/ptmp/cory.r.martin/gcafs/ops/para/com/gcafs"
+export COMPATH="/lfs/h2/emc/ptmp/${USER}/gcafs/ops/para/com/gcafs"

--- a/versions/run.wcoss2.ver
+++ b/versions/run.wcoss2.ver
@@ -1,5 +1,6 @@
 #! /usr/bin/env bash
-export version=v16.3.7
+export version=v1.0.0
+export gcafs_ver=v1.0.0
 export gfs_ver=v16.3.7
 export ukmet_ver=v2.2
 export ecmwf_ver=v2.1

--- a/versions/run.wcoss2.ver
+++ b/versions/run.wcoss2.ver
@@ -55,3 +55,5 @@ export prepobs_run_ver=1.1.3
 
 export ens_tracker_ver=v1.3.0
 export fit2obs_ver=1.1.10
+
+export COMPATH="/lfs/h2/emc/ptmp/cory.r.martin/gcafs/ops/para/com/gcafs"


### PR DESCRIPTION
# Description
This PR allows for the use of compath.py to define ROTDIR for GCAFS cycling. Please note that this is not intended as a _**final**_ solution but rather a temporary one moving in the right direction to allow for testing and evaluation to proceed.

For example, eventually the export of COMPATH will be removed from the run.ver file. Also, we should probably define ROTDIR/use compath.py in each j-job rather than in config.base