### PR TITLE
Changes so that setup_data_dir is now sourced instead of a bash function

### DIFF
--- a/ush/jjob_shell_setup.sh
+++ b/ush/jjob_shell_setup.sh
@@ -45,8 +45,7 @@ export SHELLOPTS
 ##############################################
 # Create and enter the working directory
 ##############################################
-source "${USHglobal}/setup_data_dir.sh"
-setup_data_dir "${DATA}"
+source "${USHglobal}/setup_data_dir.sh" "${DATA}"
 
 # Activate tracing
 set_trace

--- a/ush/setup_data_dir.sh
+++ b/ush/setup_data_dir.sh
@@ -1,15 +1,10 @@
 #! /usr/bin/env bash
 
 #######
-# Defines the setup_data_dir function for use in J-jobs.
-#
 # Creates a working directory and cd's into it.
 #
-# Source this file to load the function into the current shell:
-#   source "${HOMEglobal}/ush/setup_data_dir.sh"
-#
-# Usage:
-#   setup_data_dir <dir>
+# Source this file with a directory argument:
+#   source "${HOMEglobal}/ush/setup_data_dir.sh" <dir>
 #
 # Requires in environment:
 #   err_exit  - (from err_exit.sh)
@@ -17,16 +12,12 @@
 #   WIPE_DATA - whether to delete any existing directory [default: "YES"]
 #######
 
-setup_data_dir() {
-    local dir="${1:?setup_data_dir requires a directory argument}"
-    if [[ ${WIPE_DATA:-YES} == "YES" ]]; then
-        rm -rf "${dir}"
-    fi
-    mkdir -p "${dir}"
-    if ! cd "${dir}"; then
-        export err=1
-        err_exit "[${BASH_SOURCE[0]}]: ${dir} does not exist"
-    fi
-}
-
-declare -xf setup_data_dir
+local dir="${1:?setup_data_dir.sh requires a directory argument}"
+if [[ ${WIPE_DATA:-YES} == "YES" ]]; then
+    rm -rf "${dir}"
+fi
+mkdir -p "${dir}"
+if ! cd "${dir}"; then
+    export err=1
+    err_exit "[${BASH_SOURCE[0]}]: ${dir} does not exist"
+fi

--- a/ush/setup_data_dir.sh
+++ b/ush/setup_data_dir.sh
@@ -4,7 +4,7 @@
 # Creates a working directory and cd's into it.
 #
 # Source this file with a directory argument:
-#   source "${HOMEglobal}/ush/setup_data_dir.sh" <dir>
+#   source "${HOMEglobal}/ush/setup_data_dir.sh" <dir_to_create_>
 #
 # Requires in environment:
 #   err_exit  - (from err_exit.sh)
@@ -12,12 +12,12 @@
 #   WIPE_DATA - whether to delete any existing directory [default: "YES"]
 #######
 
-local dir="${1:?setup_data_dir.sh requires a directory argument}"
+dir_to_create_="${1:?setup_data_dir.sh requires a directory argument}"
 if [[ ${WIPE_DATA:-YES} == "YES" ]]; then
-    rm -rf "${dir}"
+    rm -rf "${dir_to_create_}"
 fi
-mkdir -p "${dir}"
-if ! cd "${dir}"; then
+mkdir -p "${dir_to_create_}"
+if ! cd "${dir_to_create_}"; then
     export err=1
-    err_exit "[${BASH_SOURCE[0]}]: ${dir} does not exist"
+    err_exit "[${BASH_SOURCE[0]}]: ${dir_to_create_} does not exist"
 fi


### PR DESCRIPTION
# Description
This PR changes the setup_data_dir ush script so that it is intended to be sourced when executed rather than sourced once and then called as a bash function.

  Resolves #4685

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics

- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?



# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
