### PR TITLE
De-template COM in v17

### DIFF
--- a/dev/job_cards/rocoto/prep.sh
+++ b/dev/job_cards/rocoto/prep.sh
@@ -28,18 +28,16 @@ GDUMP="gdas"
 
 export OPREFIX="${RUN_local}.t${cyc}z."
 
-RUN=${RUN_local} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL \
-    COMOUT_OBS:COM_OBS_TMPL \
-    COMINobsproc:COM_OBSPROC_TMPL \
-    COMINobsforge:COM_OBSFORGE_TMPL \
-    COMIN_TCVITAL:COM_TCVITAL_TMPL \
-    COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN_local}.${PDY}/${cyc}/obs"
+declare -rx COMOUT_OBS="${ROTDIR}/${RUN_local}.${PDY}/${cyc}/obs"
+declare -rx COMINobsproc="${DMPDIR}/${RUN}.${PDY}/${cyc}/atmos"
+declare -rx COMINobsforge="${IODADIR}/${RUN_local}.${PDY}/${cyc}"
+declare -rx COMIN_TCVITAL="${DMPDIR}/${RUN_local}.${PDY}/${cyc}/atmos"
+declare -rx COMOUT_ATMOS_ANALYSIS="${ROTDIR}/${RUN_local}.${PDY}/${cyc}/analysis/atmos"
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMOUT_OBS_PREV:COM_OBS_TMPL \
-    COMINobsproc_PREV:COM_OBSPROC_TMPL \
-    COMOUT_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMOUT_OBS_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/obs"
+declare -rx COMINobsproc_PREV="${DMPDIR}/${GDUMP}.${gPDY}/${gcyc}/atmos"
+declare -rx COMOUT_ATMOS_ANALYSIS_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/analysis/atmos"
 
 mkdir -p "${COMOUT_OBS}"
 
@@ -138,8 +136,8 @@ rm -f "${COMOUT_OBS}/${OPREFIX}prepbufr"
 rm -f "${COMOUT_OBS}/${OPREFIX}prepbufr.acft_profiles"
 rm -f "${COMOUT_OBS}/${OPREFIX}nsstbufr"
 
-RUN="gdas" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMIN_ATMOS_HISTORY_GDAS:COM_ATMOS_HISTORY_TMPL
-RUN="gfs" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMIN_ATMOS_HISTORY_GFS:COM_ATMOS_HISTORY_TMPL
+declare -rx COMIN_ATMOS_HISTORY_GDAS="${ROTDIR}/gdas.${PDY}/${cyc}/model/atmos/history"
+declare -rx COMIN_ATMOS_HISTORY_GFS="${ROTDIR}/gfs.${PDY}/${cyc}/model/atmos/history"
 
 export job="j${RUN_local}_prep_${cyc}"
 

--- a/dev/jobs/JGDAS_AERO_ANALYSIS_GENERATE_BMATRIX
+++ b/dev/jobs/JGDAS_AERO_ANALYSIS_GENERATE_BMATRIX
@@ -11,10 +11,10 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "aeroanlgenb" -c "base aeroanl aeroanl
 ##############################################
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMIN_OBS:COM_OBS_TMPL \
-    COMOUT_CHEM_BMAT:COM_CHEM_BMAT_TMPL \
-    COMIN_ATMOS_RESTART:COM_ATMOS_RESTART_TMPL \
-    COMOUT_CONF:COM_CONF_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
+declare -rx COMOUT_CHEM_BMAT="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/chem/bmatrix"
+declare -rx COMIN_ATMOS_RESTART="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/atmos/restart"
+declare -rx COMOUT_CONF="${ROTDIR}/${RUN}.${PDY}/${cyc}/conf"
 
 mkdir -p "${COMOUT_CHEM_BMAT}"
 mkdir -p "${COMOUT_CONF}"

--- a/dev/jobs/JGDAS_ATMOS_CHGRES_FORENKF
+++ b/dev/jobs/JGDAS_ATMOS_CHGRES_FORENKF
@@ -14,12 +14,10 @@ export DO_CALC_ANALYSIS=${DO_CALC_ANALYSIS:-"YES"}
 export APREFIX="${RUN/enkf/}.t${cyc}z."
 export APREFIX_ENS="${RUN}.t${cyc}z."
 
-RUN=${RUN/enkf/} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL \
-    COMOUT_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL
+declare -rx COMIN_ATMOS_HISTORY="${ROTDIR}/${RUN/enkf/}.${PDY}/${cyc}/model/atmos/history"
+declare -rx COMOUT_ATMOS_HISTORY="${ROTDIR}/${RUN/enkf/}.${PDY}/${cyc}/model/atmos/history"
 
-MEMDIR="mem001" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_HISTORY_MEM:COM_ATMOS_HISTORY_TMPL
+declare -rx COMIN_ATMOS_HISTORY_MEM="${ROTDIR}/${RUN}.${PDY}/${cyc}/mem001/model/atmos/history"
 
 ###############################################################
 # Run relevant script

--- a/dev/jobs/JGDAS_ATMOS_GEMPAK
+++ b/dev/jobs/JGDAS_ATMOS_GEMPAK
@@ -10,12 +10,12 @@ export DBN_ALERT_TYPE=${DBN_ALERT_TYPE:-GDAS_GEMPAK}
 # Define COM directories
 ##############################################
 for grid in 0p25 1p00; do
-    GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COMOUT_ATMOS_GRIB_${grid}:COM_ATMOS_GRIB_GRID_TMPL"
+    declare -rx "COMIN_ATMOS_GRIB_${grid}"="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/grib2/${grid}"
 done
 
 for grid in 0p25 1p00; do
     prod_dir="COMOUT_ATMOS_GEMPAK_${grid}"
-    GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COMOUT_ATMOS_GEMPAK_${grid}:COM_ATMOS_GEMPAK_TMPL"
+    declare -rx "COMOUT_ATMOS_GEMPAK_${grid}"="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/gempak/${grid}"
 
     if [[ ! -d "${!prod_dir}" ]]; then
         mkdir -m 775 -p "${!prod_dir}"

--- a/dev/jobs/JGDAS_ATMOS_GEMPAK_META_NCDC
+++ b/dev/jobs/JGDAS_ATMOS_GEMPAK_META_NCDC
@@ -30,15 +30,15 @@ export DBN_ALERT_TYPE=GDAS_METAFILE
 ##############################################
 # Define COM directories
 ##############################################
-GRID=1p00 YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COMIN_ATMOS_GEMPAK_1p00:COM_ATMOS_GEMPAK_TMPL"
+declare -rx COMIN_ATMOS_GEMPAK_1p00="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/gempak/1p00"
 
-GRID="meta" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COMOUT_ATMOS_GEMPAK_META:COM_ATMOS_GEMPAK_TMPL"
+declare -rx COMOUT_ATMOS_GEMPAK_META="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/gempak/meta"
 if [[ ! -d "${COMOUT_ATMOS_GEMPAK_META}" ]]; then
     mkdir -m 775 -p "${COMOUT_ATMOS_GEMPAK_META}"
 fi
 
 if ((cyc % 12 == 0)); then
-    GRID="gif" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COMOUT_ATMOS_GEMPAK_GIF:COM_ATMOS_GEMPAK_TMPL"
+    declare -rx COMOUT_ATMOS_GEMPAK_GIF="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/gempak/gif"
     if [[ ! -d "${COMOUT_ATMOS_GEMPAK_GIF}" ]]; then
         mkdir -m 775 -p "${COMOUT_ATMOS_GEMPAK_GIF}"
     fi

--- a/dev/jobs/JGDAS_ATMOS_VERFOZN
+++ b/dev/jobs/JGDAS_ATMOS_VERFOZN
@@ -16,10 +16,8 @@ export gcyc=${GDATE:8:2}
 #---------------------------------------------
 # OZN_TANKDIR - WHERE OUTPUT DATA WILL RESIDE
 #
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_ATMOS_OZNMON:COM_ATMOS_OZNMON_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMOUT_ATMOS_OZNMON="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/oznmon"
 
 export oznstat="${COMIN_ATMOS_ANALYSIS}/gdas.t${cyc}z.oznstat.tar"
 export TANKverf_ozn=${TANKverf_ozn:-${COMOUT_ATMOS_OZNMON}}

--- a/dev/jobs/JGDAS_ATMOS_VERFRAD
+++ b/dev/jobs/JGDAS_ATMOS_VERFRAD
@@ -17,12 +17,9 @@ export gcyc=${GDATE:8:2}
 # COMOUT - WHERE GSI OUTPUT RESIDES
 # TANKverf - WHERE OUTPUT DATA WILL RESIDE
 #############################################
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_ATMOS_RADMON:COM_ATMOS_RADMON_TMPL
-YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_RADMON_PREV:COM_ATMOS_RADMON_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMOUT_ATMOS_RADMON="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/radmon"
+declare -rx COMIN_ATMOS_RADMON_PREV="${ROTDIR}/${RUN}.${gPDY}/${gcyc}/products/atmos/radmon"
 
 export biascr="${COMIN_ATMOS_ANALYSIS}/gdas.t${cyc}z.abias.txt"
 export radstat="${COMIN_ATMOS_ANALYSIS}/gdas.t${cyc}z.radstat.tar"

--- a/dev/jobs/JGDAS_FIT2OBS
+++ b/dev/jobs/JGDAS_FIT2OBS
@@ -13,8 +13,8 @@ vcyc=${CDATE:8:2}
 
 # These are used by fit2obs, so we can't change them to the standard COM variable names
 # shellcheck disable=SC2153
-YMD=${vday} HH=${vcyc} declare_from_tmpl -rx COMIN_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
-RUN=${RUN/enkf/} YMD=${vday} HH=${vcyc} declare_from_tmpl -rx COMIN_OBS:COM_OBS_TMPL
+declare -rx COMIN_ANALYSIS="${ROTDIR}/${RUN}.${vday}/${vcyc}/analysis/atmos"
+declare -rx COMIN_OBS="${ROTDIR}/${RUN/enkf/}.${vday}/${vcyc}/obs"
 
 export COM_VRFYARCH=${COM_VRFYARCH:-${ROTDIR}/vrfyarch}
 

--- a/dev/jobs/JGEFS_WAVE_STAT
+++ b/dev/jobs/JGEFS_WAVE_STAT
@@ -8,14 +8,12 @@ source "${USHgfs}/wave_domain_grid.sh"
 for grid in ${wavepostGRD}; do
     process_grdID "${grid}"
     prod_dir_grid="COMOUT_WAVE_GRID_${grid}"
-    MEMDIR="ensstat" GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-        "${prod_dir_grid}:COM_WAVE_GRID_TMPL"
+    declare -rx "${prod_dir_grid}"="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/products/wave/gridded"
     if [[ ! -d "${!prod_dir_grid}" ]]; then
         mkdir -m 775 -p "${!prod_dir_grid}"
     fi
 done
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_WAVE_STATION_ENS:COM_WAVE_STATION_TMPL
+declare -rx COMOUT_WAVE_STATION_ENS="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/products/wave/station"
 if [[ ! -d "${COMOUT_WAVE_STATION_ENS}" ]]; then
     mkdir -m 775 -p "${COMOUT_WAVE_STATION_ENS}"
 fi

--- a/dev/jobs/JGEFS_WAVE_STAT_PNT
+++ b/dev/jobs/JGEFS_WAVE_STAT_PNT
@@ -4,8 +4,7 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "wave_stat_pnt" -c "base wave wave_sta
 
 # Set COM Paths
 
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_WAVE_STATION_ENS:COM_WAVE_STATION_TMPL
+declare -rx COMOUT_WAVE_STATION_ENS="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/products/wave/station"
 if [[ ! -d "${COMOUT_WAVE_STATION_ENS}" ]]; then
     mkdir -m 775 -p "${COMOUT_WAVE_STATION_ENS}"
 fi

--- a/dev/jobs/JGFS_ATMOS_AWIPS_20KM_1P0DEG
+++ b/dev/jobs/JGFS_ATMOS_AWIPS_20KM_1P0DEG
@@ -10,10 +10,8 @@ export COMPONENT="atmos"
 # Define COM directories
 ##############################################
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_ATMOS_WMO:COM_ATMOS_WMO_TMPL
-GRID="0p25" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
+declare -rx COMOUT_ATMOS_WMO="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/wmo"
+declare -rx COMIN_ATMOS_GRIB_0p25="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/grib2/0p25"
 
 if [[ ! -d "${COMOUT_ATMOS_WMO}" ]]; then
     mkdir -m 775 -p "${COMOUT_ATMOS_WMO}"

--- a/dev/jobs/JGFS_ATMOS_CYCLONE_GENESIS
+++ b/dev/jobs/JGFS_ATMOS_CYCLONE_GENESIS
@@ -10,8 +10,8 @@ export cmodel=${RUN}
 ##############################################
 # Define COM directories
 ##############################################
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMOUT_ATMOS_GENESIS:COM_ATMOS_GENESIS_TMPL
-YMD=${PDY} HH=${cyc} GRID="0p25" declare_from_tmpl -rx COMIN_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
+declare -rx COMOUT_ATMOS_GENESIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/cyclone/genesis_vital"
+declare -rx COMIN_ATMOS_GRIB_0p25="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/grib2/0p25"
 
 # The following variables are used by the tracker scripts which are outside
 #   of global-workflow and therefore can't be standardized at this time

--- a/dev/jobs/JGFS_ATMOS_CYCLONE_TRACKER
+++ b/dev/jobs/JGFS_ATMOS_CYCLONE_TRACKER
@@ -7,11 +7,9 @@ export COMPONENT="atmos"
 ##############################################
 # Define COM and Data directories
 ##############################################
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_ATMOS_TRACK:COM_ATMOS_TRACK_TMPL \
-    COMIN_ATMOS_GENESIS:COM_ATMOS_GENESIS_TMPL
-YMD=${PDY} HH=${cyc} GRID="0p25" declare_from_tmpl -rx \
-    COMIN_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
+declare -rx COMOUT_ATMOS_TRACK="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/cyclone/tracks"
+declare -rx COMIN_ATMOS_GENESIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/cyclone/genesis_vital"
+declare -rx COMIN_ATMOS_GRIB_0p25="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/grib2/0p25"
 
 if [[ ! -d "${COMOUT_ATMOS_TRACK}" ]]; then mkdir -p "${COMOUT_ATMOS_TRACK}"; fi
 

--- a/dev/jobs/JGFS_ATMOS_FBWIND
+++ b/dev/jobs/JGFS_ATMOS_FBWIND
@@ -13,8 +13,8 @@ export COMPONENT="atmos"
 # Define COM directories
 ##############################################
 
-GRID="0p25" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMIN_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMOUT:COM_ATMOS_WMO_TMPL
+declare -rx COMIN_ATMOS_GRIB_0p25="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/grib2/0p25"
+declare -rx COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/wmo"
 if [[ ! -d "${COMOUT}" ]]; then
     mkdir -m 775 -p "${COMOUT}"
 fi

--- a/dev/jobs/JGFS_ATMOS_FSU_GENESIS
+++ b/dev/jobs/JGFS_ATMOS_FSU_GENESIS
@@ -5,8 +5,8 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "genesis_fsu" -c "base genesis_fsu"
 ##############################################
 # Define COM and Data directories
 ##############################################
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMOUT_ATMOS_GENESIS:COM_ATMOS_GENESIS_TMPL
-YMD=${PDY} HH=${cyc} GRID="0p25" declare_from_tmpl -rx COMIN_ATMOS_GRIB_0p25:COM_ATMOS_GRIB_GRID_TMPL
+declare -rx COMOUT_ATMOS_GENESIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/cyclone/genesis_vital"
+declare -rx COMIN_ATMOS_GRIB_0p25="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/grib2/0p25"
 
 # The following variables are used by the tracker scripts which are outside
 #   of global-workflow and therefore can't be standardized at this time

--- a/dev/jobs/JGFS_ATMOS_GEMPAK
+++ b/dev/jobs/JGFS_ATMOS_GEMPAK
@@ -16,12 +16,12 @@ export DO_HD_PGRB=${DO_HD_PGRB:-YES}
 # Define COM directories
 ##############################################
 for grid in 0p25 0p50 1p00; do
-    GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COMIN_ATMOS_GRIB_${grid}:COM_ATMOS_GRIB_GRID_TMPL"
+    declare -rx "COMIN_ATMOS_GRIB_${grid}"="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/grib2/${grid}"
 done
 
 for grid in 1p00 0p50 0p25 40km 35km_atl 35km_pac; do
     prod_dir="COMOUT_ATMOS_GEMPAK_${grid}"
-    GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COMOUT_ATMOS_GEMPAK_${grid}:COM_ATMOS_GEMPAK_TMPL"
+    declare -rx "COMOUT_ATMOS_GEMPAK_${grid}"="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/gempak/${grid}"
 
     if [[ ! -d "${!prod_dir}" ]]; then
         mkdir -m 775 -p "${!prod_dir}"

--- a/dev/jobs/JGFS_ATMOS_GEMPAK_META
+++ b/dev/jobs/JGFS_ATMOS_GEMPAK_META
@@ -43,9 +43,9 @@ export COMINukmet=${COMINukmet:-$(compath.py "${envir}/ukmet/${ukmet_ver}")/ukme
 export COMINecmwf=${COMINecmwf:-$(compath.py "${envir}/ecmwf/${ecmwf_ver}")/ecmwf}
 export COMINnam=${COMINnam:-$(compath.py "${envir}/nam/${nam_ver}")/nam}
 
-GRID=1p00 YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COMIN_ATMOS_GEMPAK_1p00:COM_ATMOS_GEMPAK_TMPL"
+declare -rx COMIN_ATMOS_GEMPAK_1p00="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/gempak/1p00"
 
-GRID="meta" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COMOUT_ATMOS_GEMPAK_META:COM_ATMOS_GEMPAK_TMPL"
+declare -rx COMOUT_ATMOS_GEMPAK_META="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/gempak/meta"
 mkdir -m 775 -p "${COMOUT_ATMOS_GEMPAK_META}"
 
 ########################################################

--- a/dev/jobs/JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF
+++ b/dev/jobs/JGFS_ATMOS_GEMPAK_NCDC_UPAPGIF
@@ -24,18 +24,18 @@ export COMPONENT="atmos"
 ##############################################
 # Define COM directories
 ##############################################
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMIN_OBS:COM_OBS_TMPL
-GRID=1p00 YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COMIN_ATMOS_GEMPAK_1p00:COM_ATMOS_GEMPAK_TMPL"
+declare -rx COMIN_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
+declare -rx COMIN_ATMOS_GEMPAK_1p00="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/gempak/1p00"
 
 # Declare COMOUT_ATMOS_GEMPAK_GIF and COMOUT_ATMOS_GEMPAK_UPPER_AIR
 for grid in gif upper_air; do
     _GRID="${grid^^}"
     gempak_dir="COMOUT_ATMOS_GEMPAK_${_GRID}"
-    GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "${gempak_dir}:COM_ATMOS_GEMPAK_TMPL"
+    declare -rx "${gempak_dir}"="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/gempak/${grid}"
     if [[ ! -d "${!gempak_dir}" ]]; then mkdir -m 775 -p "${!gempak_dir}"; fi
 done
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMOUT_ATMOS_WMO:COM_ATMOS_WMO_TMPL
+declare -rx COMOUT_ATMOS_WMO="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/wmo"
 if [[ ! -d "${COMOUT_ATMOS_WMO}" ]]; then mkdir -m 775 -p "${COMOUT_ATMOS_WMO}"; fi
 
 export pgmout=OUTPUT.$$

--- a/dev/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
+++ b/dev/jobs/JGFS_ATMOS_GEMPAK_PGRB2_SPEC
@@ -8,8 +8,10 @@ export EXT=""
 ##############################################
 # Define COM directories
 ##############################################
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMOUT_ATMOS_GOES:COM_ATMOS_GOES_TMPL
-GRID=0p25 YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "COMOUT_ATMOS_GEMPAK_0p25:COM_ATMOS_GEMPAK_TMPL"
+# shellcheck disable=SC2153
+declare -rx COMIN_ATMOS_GOES="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/goes_sim"
+# shellcheck disable=SC2153
+declare -rx COMOUT_ATMOS_GEMPAK_0p25="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/gempak/0p25"
 if [[ ! -d "${COMOUT_ATMOS_GEMPAK_0p25}" ]]; then
     mkdir -m 775 -p "${COMOUT_ATMOS_GEMPAK_0p25}"
 fi

--- a/dev/jobs/JGFS_ATMOS_PGRB2_SPEC_NPOESS
+++ b/dev/jobs/JGFS_ATMOS_PGRB2_SPEC_NPOESS
@@ -13,11 +13,9 @@ export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
 # Define COM directories
 ##############################################
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_MASTER:COM_ATMOS_MASTER_TMPL \
-    COMOUT_ATMOS_GOES:COM_ATMOS_GOES_TMPL
-GRID="0p50" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_GRIB_0p50:COM_ATMOS_GRIB_GRID_TMPL
+declare -rx COMIN_ATMOS_MASTER="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/atmos/master"
+declare -rx COMOUT_ATMOS_GOES="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/goes_sim"
+declare -rx COMIN_ATMOS_GRIB_0p50="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/grib2/0p50"
 
 mkdir -m 775 -p "${COMOUT_ATMOS_GOES}"
 

--- a/dev/jobs/JGFS_ATMOS_POSTSND
+++ b/dev/jobs/JGFS_ATMOS_POSTSND
@@ -10,12 +10,11 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "postsnd" -c "base postsnd"
 # Define COM Directories
 ##############################
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL \
-    COMIN_ATMOS_BUFR:COM_ATMOS_BUFR_TMPL \
-    COMOUT_ATMOS_BUFR:COM_ATMOS_BUFR_TMPL \
-    COMOUT_ATMOS_WMO:COM_ATMOS_WMO_TMPL \
-    COMOUT_ATMOS_GEMPAK:COM_ATMOS_GEMPAK_TMPL
+declare -rx COMIN_ATMOS_HISTORY="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/atmos/history"
+declare -rx COMIN_ATMOS_BUFR="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/bufr"
+declare -rx COMOUT_ATMOS_BUFR="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/bufr"
+declare -rx COMOUT_ATMOS_WMO="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/wmo"
+declare -rx COMOUT_ATMOS_GEMPAK="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/gempak/"
 
 if [[ ! -d "${COMOUT_ATMOS_BUFR}" ]]; then
     mkdir -p "${COMOUT_ATMOS_BUFR}"

--- a/dev/jobs/JGFS_ATMOS_VERIFICATION
+++ b/dev/jobs/JGFS_ATMOS_VERIFICATION
@@ -22,7 +22,7 @@ export CDATE=${PDY}${cyc}
 # shellcheck disable=SC2041
 for grid in '1p00'; do
     prod_dir="COM_ATMOS_GRIB_${grid}"
-    GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "${prod_dir}:COM_ATMOS_GRIB_GRID_TMPL"
+    declare -rx "${prod_dir}"="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/grib2/${grid}"
 done
 
 # TODO: If none of these are on, why are we running this job?

--- a/dev/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
+++ b/dev/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
@@ -13,10 +13,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "aeroanlfinal" -c "base aeroanl aeroan
 ##############################################
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_CHEM_ANALYSIS:COM_CHEM_ANALYSIS_TMPL \
-    COMOUT_CONF:COM_CONF_TMPL \
-    COMOUT_ATMOS_RESTART:COM_ATMOS_RESTART_TMPL
+declare -rx COMOUT_CHEM_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/chem"
+declare -rx COMOUT_CONF="${ROTDIR}/${RUN}.${PDY}/${cyc}/conf"
+declare -rx COMOUT_ATMOS_RESTART="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/atmos/restart"
 
 mkdir -m 755 -p "${COMOUT_CHEM_ANALYSIS}"
 mkdir -m 755 -p "${COMOUT_ATMOS_RESTART}"

--- a/dev/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
+++ b/dev/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
@@ -22,14 +22,12 @@ GDUMP="${GDUMP/gcafs/gcdas}"
 ##############################################
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL \
-    COMOUT_CHEM_ANALYSIS:COM_CHEM_ANALYSIS_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
+declare -rx COMOUT_CHEM_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/chem"
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL \
-    COMIN_CHEM_BMAT_PREV:COM_CHEM_BMAT_TMPL \
-    COMIN_CHEM_ANALYSIS_PREV:COM_CHEM_ANALYSIS_TMPL
+declare -rx COMIN_ATMOS_RESTART_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/atmos/restart"
+declare -rx COMIN_CHEM_BMAT_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/analysis/chem/bmatrix"
+declare -rx COMIN_CHEM_ANALYSIS_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/analysis/chem"
 
 ###############################################################
 # Run relevant script

--- a/dev/jobs/JGLOBAL_ANALYSIS_STATS
+++ b/dev/jobs/JGLOBAL_ANALYSIS_STATS
@@ -11,20 +11,30 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "anlstat" -c "base anlstat"
 ##############################################
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMIN_OBS:COM_OBS_TMPL \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_OCEAN_ANALYSIS:COM_OCEAN_ANALYSIS_TMPL \
-    COMIN_AERO_ANALYSIS:COM_CHEM_ANALYSIS_TMPL \
-    COMIN_SNOW_ANALYSIS:COM_SNOW_ANALYSIS_TMPL \
-    COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMOUT_OCEAN_ANALYSIS:COM_OCEAN_ANALYSIS_TMPL \
-    COMOUT_AERO_ANALYSIS:COM_CHEM_ANALYSIS_TMPL \
-    COMOUT_SNOW_ANALYSIS:COM_SNOW_ANALYSIS_TMPL \
-    COMOUT_CONF:COM_CONF_TMPL \
-    COMOUT_ATMOS_ANLMON:COM_ATMOS_ANLMON_TMPL \
-    COMOUT_OCEAN_ANLMON:COM_OCEAN_ANLMON_TMPL \
-    COMOUT_AERO_ANLMON:COM_CHEM_ANLMON_TMPL \
-    COMOUT_SNOW_ANLMON:COM_SNOW_ANLMON_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
+declare -rx COMOUT_CONF="${ROTDIR}/${RUN}.${PDY}/${cyc}/conf"
+declare -rx COMIN_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMOUT_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMOUT_ATMOS_ANLMON="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/anlmon"
+mkdir -m 755 -p "${COMOUT_ATMOS_ANALYSIS}"
+mkdir -m 755 -p "${COMOUT_ATMOS_ANLMON}"
+mkdir -m 755 -p "${COMOUT_CONF}"
+
+if [[ "${DO_AERO_ANL:-NO}" == "YES" ]]; then
+    declare -rx COMIN_AERO_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/chem"
+    declare -rx COMOUT_AERO_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/chem"
+    declare -rx COMOUT_AERO_ANLMON="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/chem/anlmon"
+    mkdir -m 755 -p "${COMOUT_AERO_ANALYSIS}"
+    mkdir -m 755 -p "${COMOUT_AERO_ANLMON}"
+fi
+
+if [[ "${DO_JEDISNOWDA:-NO}" == "YES" ]]; then
+    declare -rx COMIN_SNOW_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/snow"
+    declare -rx COMOUT_SNOW_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/snow"
+    declare -rx COMOUT_SNOW_ANLMON="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/snow/anlmon"
+    mkdir -m 755 -p "${COMOUT_SNOW_ANALYSIS}"
+    mkdir -m 755 -p "${COMOUT_SNOW_ANLMON}"
+fi
 
 ###############################################################
 # Run relevant script

--- a/dev/jobs/JGLOBAL_ARCHIVE_TARS
+++ b/dev/jobs/JGLOBAL_ARCHIVE_TARS
@@ -9,54 +9,68 @@ fi
 ##############################################
 # Set variables used in the script
 ##############################################
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_ATMOS_ANLMON:COM_ATMOS_ANLMON_TMPL \
-    COMIN_ATMOS_BUFR:COM_ATMOS_BUFR_TMPL \
-    COMIN_ATMOS_GEMPAK:COM_ATMOS_GEMPAK_TMPL \
-    COMIN_ATMOS_GENESIS:COM_ATMOS_GENESIS_TMPL \
-    COMIN_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL \
-    COMIN_ATMOS_INPUT:COM_ATMOS_INPUT_TMPL \
-    COMIN_ATMOS_MASTER:COM_ATMOS_MASTER_TMPL \
-    COMIN_ATMOS_RESTART:COM_ATMOS_RESTART_TMPL \
-    COMIN_ATMOS_TRACK:COM_ATMOS_TRACK_TMPL \
-    COMIN_ATMOS_WMO:COM_ATMOS_WMO_TMPL \
-    COMIN_CHEM_HISTORY:COM_CHEM_HISTORY_TMPL \
-    COMIN_CHEM_ANALYSIS:COM_CHEM_ANALYSIS_TMPL \
-    COMIN_MED_RESTART:COM_MED_RESTART_TMPL \
-    COMIN_SNOW_ANALYSIS:COM_SNOW_ANALYSIS_TMPL \
-    COMIN_SNOW_ANLMON:COM_SNOW_ANLMON_TMPL \
-    COMIN_ICE_ANALYSIS:COM_ICE_ANALYSIS_TMPL \
-    COMIN_ICE_BMATRIX:COM_ICE_BMATRIX_TMPL \
-    COMIN_ICE_HISTORY:COM_ICE_HISTORY_TMPL \
-    COMIN_ICE_INPUT:COM_ICE_INPUT_TMPL \
-    COMIN_ICE_RESTART:COM_ICE_RESTART_TMPL \
-    COMIN_ICE_GRIB:COM_ICE_GRIB_TMPL \
-    COMIN_ICE_NETCDF:COM_ICE_NETCDF_TMPL \
-    COMIN_OBS:COM_OBS_TMPL \
-    COMIN_TOP:COM_TOP_TMPL \
-    COMIN_OCEAN_HISTORY:COM_OCEAN_HISTORY_TMPL \
-    COMIN_OCEAN_RESTART:COM_OCEAN_RESTART_TMPL \
-    COMIN_OCEAN_GRIB:COM_OCEAN_GRIB_TMPL \
-    COMIN_OCEAN_NETCDF:COM_OCEAN_NETCDF_TMPL \
-    COMIN_OCEAN_ANALYSIS:COM_OCEAN_ANALYSIS_TMPL \
-    COMIN_OCEAN_BMATRIX:COM_OCEAN_BMATRIX_TMPL \
-    COMIN_WAVE_GRID:COM_WAVE_GRID_TMPL \
-    COMIN_WAVE_HISTORY:COM_WAVE_HISTORY_TMPL \
-    COMIN_WAVE_STATION:COM_WAVE_STATION_TMPL \
-    COMIN_WAVE_RESTART:COM_WAVE_RESTART_TMPL \
-    COMIN_ATMOS_OZNMON:COM_ATMOS_OZNMON_TMPL \
-    COMIN_ATMOS_RADMON:COM_ATMOS_RADMON_TMPL \
-    COMIN_ATMOS_MINMON:COM_ATMOS_MINMON_TMPL \
-    COMIN_CONF:COM_CONF_TMPL \
-    COMOUT_CONF:COM_CONF_TMPL \
-    COMOUT_ATMOS_TRACK:COM_ATMOS_TRACK_TMPL
+# Setup Python path for pygfs
+PYTHONPATH="${HOMEgfs}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"
+export PYTHONPATH
 
-if [[ ! -d ${COMOUT_CONF} ]]; then mkdir -p "${COMOUT_CONF}"; fi
+# Construct COM paths
+# shellcheck disable=SC2309
+if [[ 10#${ENSMEM:--1} -ge 0 ]]; then
+    memdir=$(printf "mem%03d" $((10#${ENSMEM})))
+    COMIN="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}"
+    COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}"
+else
+    COMIN="${ROTDIR}/${RUN}.${PDY}/${cyc}"
+    COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}"
+fi
+
+declare -rx COMIN_ATMOS_ANALYSIS="${COMIN}/analysis/atmos"
+declare -rx COMIN_ATMOS_ANLMON="${COMIN}/products/atmos/anlmon"
+declare -rx COMIN_ATMOS_BUFR="${COMIN}/products/atmos/bufr"
+declare -rx COMIN_ATMOS_GEMPAK="${COMIN}/products/atmos/gempak/"
+declare -rx COMIN_ATMOS_GENESIS="${COMIN}/products/atmos/cyclone/genesis_vital"
+declare -rx COMIN_ATMOS_HISTORY="${COMIN}/model/atmos/history"
+declare -rx COMIN_ATMOS_INPUT="${COMIN}/model/atmos/input"
+declare -rx COMIN_ATMOS_MASTER="${COMIN}/model/atmos/master"
+declare -rx COMIN_ATMOS_RESTART="${COMIN}/model/atmos/restart"
+declare -rx COMIN_ATMOS_TRACK="${COMIN}/products/atmos/cyclone/tracks"
+declare -rx COMIN_ATMOS_WMO="${COMIN}/products/atmos/wmo"
+declare -rx COMIN_CHEM_HISTORY="${COMIN}/model/chem/history"
+declare -rx COMIN_CHEM_ANALYSIS="${COMIN}/analysis/chem"
+declare -rx COMIN_MED_RESTART="${COMIN}/model/med/restart"
+declare -rx COMIN_SNOW_ANALYSIS="${COMIN}/analysis/snow"
+declare -rx COMIN_SNOW_ANLMON="${COMIN}/products/snow/anlmon"
+declare -rx COMIN_ICE_ANALYSIS="${COMIN}/analysis/ice"
+declare -rx COMIN_ICE_BMATRIX="${COMIN}/bmatrix/ice"
+declare -rx COMIN_ICE_HISTORY="${COMIN}/model/ice/history"
+declare -rx COMIN_ICE_INPUT="${COMIN}/model/ice/input"
+declare -rx COMIN_ICE_RESTART="${COMIN}/model/ice/restart"
+declare -rx COMIN_ICE_GRIB="${COMIN}/products/ice/grib2"
+declare -rx COMIN_ICE_NETCDF="${COMIN}/products/ice/netcdf"
+declare -rx COMIN_OBS="${COMIN}/obs"
+declare -rx COMIN_TOP="${COMIN}"
+declare -rx COMIN_OCEAN_HISTORY="${COMIN}/model/ocean/history"
+declare -rx COMIN_OCEAN_RESTART="${COMIN}/model/ocean/restart"
+declare -rx COMIN_OCEAN_GRIB="${COMIN}/products/ocean/grib2"
+declare -rx COMIN_OCEAN_NETCDF="${COMIN}/products/ocean/netcdf"
+declare -rx COMIN_OCEAN_ANALYSIS="${COMIN}/analysis/ocean"
+declare -rx COMIN_OCEAN_BMATRIX="${COMIN}/bmatrix/ocean"
+declare -rx COMIN_WAVE_GRID="${COMIN}/products/wave/gridded"
+declare -rx COMIN_WAVE_HISTORY="${COMIN}/model/wave/history"
+declare -rx COMIN_WAVE_STATION="${COMIN}/products/wave/station"
+declare -rx COMIN_WAVE_RESTART="${COMIN}/model/wave/restart"
+declare -rx COMIN_ATMOS_OZNMON="${COMIN}/products/atmos/oznmon"
+declare -rx COMIN_ATMOS_RADMON="${COMIN}/products/atmos/radmon"
+declare -rx COMIN_ATMOS_MINMON="${COMIN}/products/atmos/minmon"
+declare -rx COMIN_CONF="${COMIN}/conf"
+declare -rx COMOUT_CONF="${COMOUT}/conf"
+declare -rx COMOUT_ATMOS_TRACK="${COMOUT}/products/atmos/cyclone/tracks"
+
+mkdir -p "${COMOUT_CONF}"
+mkdir -p "${COMOUT_ATMOS_TRACK}"
 
 for grid in "0p25" "0p50" "1p00"; do
-    YMD=${PDY} HH=${cyc} GRID=${grid} declare_from_tmpl -rx \
-        "COMIN_ATMOS_GRIB_${grid}:COM_ATMOS_GRIB_GRID_TMPL"
+    declare -rx "COMIN_ATMOS_GRIB_${grid}"="${COMIN}/products/atmos/grib2/${grid}"
 done
 
 ###############################################################
@@ -66,8 +80,7 @@ if [[ "${DO_WAVE}" == "YES" ]]; then
     if [[ -n "${wavepostGRD}" || -n "${waveinterpGRD}" ]]; then
         for grdID in ${wavepostGRD} ${waveinterpGRD}; do
             process_grdID "${grdID}"
-            YMD=${PDY} HH=${cyc} GRDRESNAME=${grdNAME} declare_from_tmpl -rx \
-                "COMIN_WAVE_GRID_${GRDREGION}_${GRDRES}:COM_WAVE_GRID_RES_TMPL"
+            declare -rx "COMIN_WAVE_GRID_${GRDREGION}_${GRDRES}"="${COMIN}/products/wave/gridded/${grdNAME}"
             grids_arr+=("${GRDREGION}.${GRDRES}")
         done
         export WAVE_OUT_GRIDS="${grids_arr[*]}"

--- a/dev/jobs/JGLOBAL_ARCHIVE_VRFY
+++ b/dev/jobs/JGLOBAL_ARCHIVE_VRFY
@@ -5,25 +5,38 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "arch_vrfy" -c "base arch_vrfy"
 ##############################################
 # Set variables used in the script
 ##############################################
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_ATMOS_GENESIS:COM_ATMOS_GENESIS_TMPL \
-    COMIN_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL \
-    COMIN_ATMOS_TRACK:COM_ATMOS_TRACK_TMPL \
-    COMIN_CHEM_ANALYSIS:COM_CHEM_ANALYSIS_TMPL \
-    COMIN_SNOW_ANALYSIS:COM_SNOW_ANALYSIS_TMPL \
-    COMIN_OBS:COM_OBS_TMPL \
-    COMOUT_ATMOS_TRACK:COM_ATMOS_TRACK_TMPL
+# Setup Python path for pygfs
+PYTHONPATH="${HOMEgfs}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"
+export PYTHONPATH
+
+# Construct COM paths
+# shellcheck disable=SC2309
+if [[ 10#${ENSMEM:--1} -ge 0 ]]; then
+    memdir=$(printf "mem%03d" $((10#${ENSMEM})))
+    COMIN="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}"
+    COMIN_ensstat="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat"
+    COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}"
+else
+    COMIN="${ROTDIR}/${RUN}.${PDY}/${cyc}"
+    COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}"
+fi
+
+declare -rx COMIN_ATMOS_ANALYSIS="${COMIN}/analysis/atmos"
+declare -rx COMIN_ATMOS_GENESIS="${COMIN}/products/atmos/cyclone/genesis_vital"
+declare -rx COMIN_ATMOS_HISTORY="${COMIN}/model/atmos/history"
+declare -rx COMIN_ATMOS_TRACK="${COMIN}/products/atmos/cyclone/tracks"
+declare -rx COMIN_CHEM_ANALYSIS="${COMIN}/analysis/chem"
+declare -rx COMIN_SNOW_ANALYSIS="${COMIN}/analysis/snow"
+declare -rx COMIN_OBS="${COMIN}/obs"
+declare -rx COMOUT_ATMOS_TRACK="${COMOUT}/products/atmos/cyclone/tracks"
 
 for grid in "0p25" "0p50" "1p00"; do
-    YMD=${PDY} HH=${cyc} GRID=${grid} declare_from_tmpl -rx \
-        "COMIN_ATMOS_GRIB_${grid}:COM_ATMOS_GRIB_GRID_TMPL"
+    declare -rx "COMIN_ATMOS_GRIB_${grid}"="${COMIN}/products/atmos/grib2/${grid}"
 done
 
 # GEFS-specific: Ensemble statistics path
 if [[ "${RUN}" == "gefs" ]]; then
-    MEMDIR="ensstat" YMD=${PDY} HH=${cyc} GRID="1p00" declare_from_tmpl -rx \
-        COMIN_ATMOS_ENSSTAT_1p00:COM_ATMOS_GRIB_GRID_TMPL
+    declare -rx COMIN_ATMOS_ENSSTAT_1p00="${COMIN_ensstat}/products/atmos/grib2/1p00"
 fi
 
 ###############################################################

--- a/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
+++ b/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
@@ -14,9 +14,8 @@ GDUMP_ENS="enkf${GDUMP}"
 # Begin JOB SPECIFIC work
 ##############################################
 # Generate COM variable from template
-MEMDIR='ensstat' RUN=${GDUMP_ENS} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_ATMOS_ANALYSIS_ENS:COM_ATMOS_ANALYSIS_TMPL \
-    COMOUT_CONF:COM_CONF_TMPL
+declare -rx COMOUT_ATMOS_ANALYSIS_ENS="${ROTDIR}/${GDUMP_ENS}.${PDY}/${cyc}/ensstat/analysis/atmos"
+declare -rx COMOUT_CONF="${ROTDIR}/${GDUMP_ENS}.${PDY}/${cyc}/ensstat/conf"
 
 mkdir -m 755 -p "${COMOUT_ATMOS_ANALYSIS_ENS}"
 mkdir -m 755 -p "${COMOUT_CONF}"

--- a/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
+++ b/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
@@ -16,11 +16,8 @@ GDUMP="gdas"
 # Begin JOB SPECIFIC work
 ##############################################
 # Generate COM variables from templates
-RUN=${GDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL
-
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${GDUMP}.${PDY}/${cyc}/obs"
+declare -rx COMIN_ATMOS_ANALYSIS_PREV="${ROTDIR}/enkf${GDUMP}.${gPDY}/${gcyc}/ensstat/analysis/atmos"
 
 ###############################################################
 # Run relevant script

--- a/dev/jobs/JGLOBAL_ATMOS_ANALYSIS
+++ b/dev/jobs/JGLOBAL_ATMOS_ANALYSIS
@@ -25,16 +25,13 @@ export APREFIX="${rCDUMP}.t${cyc}z."
 export GPREFIX_ENS="${GDUMP_ENS}.t${gcyc}z."
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL \
-    COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
+declare -rx COMOUT_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/analysis/atmos"
+declare -rx COMIN_ATMOS_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/atmos/history"
 
-MEMDIR='ensstat' RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_HISTORY_ENS_PREV:COM_ATMOS_HISTORY_TMPL
+declare -rx COMIN_ATMOS_HISTORY_ENS_PREV="${ROTDIR}/${GDUMP_ENS}.${gPDY}/${gcyc}/ensstat/model/atmos/history"
 
 # shellcheck disable=SC2153
 mkdir -p "${COMOUT_ATMOS_ANALYSIS}"

--- a/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
+++ b/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
@@ -23,17 +23,13 @@ export GPREFIX="${GDUMP}.t${gcyc}z."
 export APREFIX="${RUN}.t${cyc}z."
 export GPREFIX_ENS="${GDUMP_ENS}.t${gcyc}z."
 
-RUN=${rCDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${rCDUMP}.${PDY}/${cyc}/obs"
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_ATMOS_RESTART:COM_ATMOS_RESTART_TMPL
-
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_OBS_PREV:COM_OBS_TMPL \
-    COMIN_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
+declare -rx COMOUT_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMIN_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMIN_ATMOS_RESTART="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/atmos/restart"
+declare -rx COMIN_OBS_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/obs"
+declare -rx COMIN_ATMOS_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/atmos/history"
 
 export ATMGES="${COMIN_ATMOS_HISTORY_PREV}/${GPREFIX}atm.f006.nc"
 if [[ ! -f "${ATMGES}" ]]; then

--- a/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC_FV3JEDI
+++ b/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC_FV3JEDI
@@ -21,14 +21,10 @@ export rCDUMP="${RUN/enkf/}"
 ##############################################
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} RUN=${RUN} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
-YMD=${PDY} HH=${cyc} RUN=${RUN} declare_from_tmpl -rx \
-    COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_CONF:COM_CONF_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMOUT_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMIN_ATMOS_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/atmos/history"
+declare -rx COMOUT_CONF="${ROTDIR}/${RUN}.${PDY}/${cyc}/conf"
 
 mkdir -m 775 -p "${COMOUT_CONF}"
 

--- a/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_DIAG
+++ b/dev/jobs/JGLOBAL_ATMOS_ANALYSIS_DIAG
@@ -21,9 +21,8 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "analdiag" -c "base anal analdiag"
 #export GPREFIX="${GDUMP}.t${gcyc}z."
 #export APREFIX="${RUN}.t${cyc}z."
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMOUT_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
 mkdir -m 775 -p "${COMOUT_ATMOS_ANALYSIS}"
 
 # Create a DATAROOT directory variable where the gsidiags live

--- a/dev/jobs/JGLOBAL_ATMOS_CHGRES_GEN_CONTROL
+++ b/dev/jobs/JGLOBAL_ATMOS_CHGRES_GEN_CONTROL
@@ -11,8 +11,7 @@ export BDATE
 # Define COM directories
 # TODO: uncomment when testing for realtime
 #COMINgfs=$(compath.py "${envir}/gfs/${gfs_ver}")
-MEMDIR="mem000" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_ATMOS_INPUT_MEM:COM_ATMOS_INPUT_TMPL
+declare -rx COMOUT_ATMOS_INPUT_MEM="${ROTDIR}/${RUN}.${PDY}/${cyc}/mem000/model/atmos/input"
 ###############################################################
 # Create COMOUT_ATMOS_INPUT_MEM
 mkdir -p "${COMOUT_ATMOS_INPUT_MEM}"

--- a/dev/jobs/JGLOBAL_ATMOS_ENSSTAT
+++ b/dev/jobs/JGLOBAL_ATMOS_ENSSTAT
@@ -15,7 +15,7 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmos_ensstat" -c "base atmos_ensstat
 
 for grid in '0p25' '0p50' '1p00'; do
     prod_dir="COMOUT_ATMOS_GRIB_${grid}"
-    MEMDIR="ensstat" GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "${prod_dir}:COM_ATMOS_GRIB_GRID_TMPL"
+    declare -rx "${prod_dir}"="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/products/atmos/grib2/${grid}"
     mkdir -m 775 -p "${!prod_dir}"
 done
 

--- a/dev/jobs/JGLOBAL_ATMOS_POST_MANAGER
+++ b/dev/jobs/JGLOBAL_ATMOS_POST_MANAGER
@@ -15,7 +15,7 @@ export RUN=${RUN:-gfs}
 ###########################
 export EXT_FCST=NO
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMIN_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL
+declare -rx COMIN_ATMOS_HISTORY="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/atmos/history"
 
 ########################################################
 # Execute the script.

--- a/dev/jobs/JGLOBAL_ATMOS_PREP_SFC
+++ b/dev/jobs/JGLOBAL_ATMOS_PREP_SFC
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+#shellcheck disable=SC2155
 
 source "${HOMEgfs}/ush/jjob_header.sh" -e "prep_sfc" -c "base prep_sfc"
 
@@ -12,12 +13,14 @@ export gPDY=${GDATE:0:8}
 export gcyc=${GDATE:8:2}
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMINobsproc:COM_OBSPROC_TMPL
-YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMINobsproc_PREV:COM_OBSPROC_TMPL
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_OBS:COM_OBS_TMPL
+if [[ "${RUN_ENVIR:-emc}" == "nco" ]]; then
+    declare -rx COMINobsproc=$(compath.py "${envir}/obsproc/${obsproc_ver}")/"${RUN}.${PDY}/${cyc}/atmos"
+    declare -rx COMINobsproc_PREV=$(compath.py "${envir}/obsproc/${obsproc_ver}")/"${RUN}.${gPDY}/${gcyc}/atmos"
+else
+    declare -rx COMINobsproc="${DMPDIR}/${RUN}.${PDY}/${cyc}/atmos"
+    declare -rx COMINobsproc_PREV="${DMPDIR}/${RUN}.${gPDY}/${gcyc}/atmos"
+fi
+declare -rx COMOUT_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
 
 mkdir -p "${COMOUT_OBS}"
 

--- a/dev/jobs/JGLOBAL_ATMOS_PRODUCTS
+++ b/dev/jobs/JGLOBAL_ATMOS_PRODUCTS
@@ -6,15 +6,25 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmos_products" -c "base atmos_produc
 # Begin JOB SPECIFIC work
 ##############################################
 
+# Construct COM variables
+# shellcheck disable=SC2309
+if [[ 10#${ENSMEM:--1} -ge 0 ]]; then
+    memdir=$(printf "mem%03d" $((10#${ENSMEM})))
+    export COMIN="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}"
+    export COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}"
+else
+    export COMIN="${ROTDIR}/${RUN}.${PDY}/${cyc}"
+    export COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}"
+fi
+
 # Construct COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL \
-    COMIN_ATMOS_MASTER:COM_ATMOS_MASTER_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS="${COMIN}/analysis/atmos"
+declare -rx COMIN_ATMOS_HISTORY="${COMIN}/model/atmos/history"
+declare -rx COMIN_ATMOS_MASTER="${COMIN}/model/atmos/master"
 
 for grid in '0p25' '0p50' '1p00'; do
     prod_dir="COMOUT_ATMOS_GRIB_${grid}"
-    GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "${prod_dir}:COM_ATMOS_GRIB_GRID_TMPL"
+    declare -rx "COMOUT_ATMOS_GRIB_${grid}"="${COMOUT}/products/atmos/grib2/${grid}"
     mkdir -m 775 -p "${!prod_dir}"
 done
 

--- a/dev/jobs/JGLOBAL_ATMOS_SFCANL
+++ b/dev/jobs/JGLOBAL_ATMOS_SFCANL
@@ -15,20 +15,16 @@ if [[ "${RUN}" == "gcafs" || "${RUN}" == "gcdas" ]]; then
     BKG_RUN="gcdas"
 fi
 
-RUN=${BKG_RUN} YMD=${GDATE:0:8} HH=${GDATE:8:2} declare_from_tmpl -rx \
-    COMIN_OBS_PREV:COM_OBS_TMPL \
-    COMIN_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
+declare -rx COMIN_OBS_PREV="${ROTDIR}/${BKG_RUN}.${GDATE:0:8}/${GDATE:8:2}/obs"
+declare -rx COMIN_ATMOS_RESTART_PREV="${ROTDIR}/${BKG_RUN}.${GDATE:0:8}/${GDATE:8:2}/model/atmos/restart"
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_SNOW_ANALYSIS:COM_SNOW_ANALYSIS_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
+declare -rx COMIN_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMIN_SNOW_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/snow"
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_ATMOS_RESTART:COM_ATMOS_RESTART_TMPL
+declare -rx COMOUT_ATMOS_RESTART="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/atmos/restart"
 
-RUN="enkfgdas" MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ENKF_ANALYSIS_STAT:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMIN_ATMOS_ENKF_ANALYSIS_STAT="${ROTDIR}/enkfgdas.${PDY}/${cyc}/ensstat/analysis/atmos"
 
 mkdir -p "${COMOUT_ATMOS_RESTART}"
 

--- a/dev/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
+++ b/dev/jobs/JGLOBAL_ATMOS_TROPCY_QC_RELOC
@@ -20,7 +20,7 @@ export TANK_TROPCY=${TANK_TROPCY:-${DCOMROOT}} # path to tropical cyclone record
 ##############################################
 # Define COM directories
 ##############################################
-YMD=${PDY} HH=${cyc} declare_from_tmpl COMOUT_OBS:COM_OBS_TMPL
+declare -rx COMOUT_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
 mkdir -p "${COMOUT_OBS}"
 
 export CRES=${CASE_HIST:1}

--- a/dev/jobs/JGLOBAL_ATMOS_UPP
+++ b/dev/jobs/JGLOBAL_ATMOS_UPP
@@ -11,10 +11,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "upp" -c "base upp"
 ##############################################
 
 # Construct COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL \
-    COMOUT_ATMOS_MASTER:COM_ATMOS_MASTER_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMIN_ATMOS_HISTORY="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/atmos/history"
+declare -rx COMOUT_ATMOS_MASTER="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/atmos/master"
 mkdir -p "${COMOUT_ATMOS_MASTER}"
 
 ###############################################################

--- a/dev/jobs/JGLOBAL_ATMOS_VMINMON
+++ b/dev/jobs/JGLOBAL_ATMOS_VMINMON
@@ -16,12 +16,10 @@ export gcyc=${GDATE:8:2}
 #############################################
 # TANKverf - WHERE OUTPUT DATA WILL RESIDE
 #############################################
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMOUT_ATMOS_MINMON:COM_ATMOS_MINMON_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMOUT_ATMOS_MINMON="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/minmon"
 
-YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_MINMON_PREV:COM_ATMOS_MINMON_TMPL
+declare -rx COMIN_ATMOS_MINMON_PREV="${ROTDIR}/${RUN}.${gPDY}/${gcyc}/products/atmos/minmon"
 
 export gsistat="${COMIN_ATMOS_ANALYSIS}/${RUN}.t${cyc}z.gsistat.txt"
 export M_TANKverf=${M_TANKverf:-${COMOUT_ATMOS_MINMON}}

--- a/dev/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
+++ b/dev/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
@@ -13,9 +13,8 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "atmanlfinal" -c "base atmanl atmanlfi
 ##############################################
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMOUT_CONF:COM_CONF_TMPL
+declare -rx COMOUT_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMOUT_CONF="${ROTDIR}/${RUN}.${PDY}/${cyc}/conf"
 
 mkdir -m 775 -p "${COMOUT_ATMOS_ANALYSIS}"
 mkdir -m 775 -p "${COMOUT_CONF}"

--- a/dev/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
+++ b/dev/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
@@ -17,12 +17,10 @@ GDUMP="gdas"
 ##############################################
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/analysis/atmos"
+declare -rx COMIN_ATMOS_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/atmos/history"
 
 ###############################################################
 # Run relevant script

--- a/dev/jobs/JGLOBAL_ENKF_ARCHIVE_TARS
+++ b/dev/jobs/JGLOBAL_ENKF_ARCHIVE_TARS
@@ -5,16 +5,18 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "earc_tars" -c "base arch_tars earc_ta
 ##############################################
 # Set variables used in the script
 ##############################################
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS_ENSSTAT:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_ATMOS_HISTORY_ENSSTAT:COM_ATMOS_HISTORY_TMPL \
-    COMIN_ICE_ANALYSIS_ENSSTAT:COM_ICE_ANALYSIS_TMPL \
-    COMIN_OCEAN_ANALYSIS_ENSSTAT:COM_OCEAN_ANALYSIS_TMPL \
-    COMIN_SNOW_ANALYSIS_ENSSTAT:COM_SNOW_ANALYSIS_TMPL \
-    COMIN_CONF:COM_CONF_TMPL
+# Setup Python path for pygfs
+PYTHONPATH="${HOMEgfs}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"
+export PYTHONPATH
 
-RUN=${RUN/enkf/} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS_ENSSTAT="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/analysis/atmos"
+declare -rx COMIN_ATMOS_HISTORY_ENSSTAT="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/model/atmos/history"
+declare -rx COMIN_ICE_ANALYSIS_ENSSTAT="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/analysis/ice"
+declare -rx COMIN_OCEAN_ANALYSIS_ENSSTAT="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/analysis/ocean"
+declare -rx COMIN_SNOW_ANALYSIS_ENSSTAT="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/analysis/snow"
+declare -rx COMIN_CONF="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/conf"
+
+declare -rx COMIN_ATMOS_HISTORY="${ROTDIR}/${RUN/enkf/}.${PDY}/${cyc}/model/atmos/history"
 
 mkdir -p "${COMIN_CONF}"
 

--- a/dev/jobs/JGLOBAL_ENKF_ARCHIVE_VRFY
+++ b/dev/jobs/JGLOBAL_ENKF_ARCHIVE_VRFY
@@ -5,10 +5,13 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "earc_vrfy" -c "base earc_vrfy"
 ##############################################
 # Set variables used in the script
 ##############################################
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS_ENSSTAT:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_ATMOS_HISTORY_ENSSTAT:COM_ATMOS_HISTORY_TMPL \
-    COMIN_SNOW_ANALYSIS_ENSSTAT:COM_SNOW_ANALYSIS_TMPL
+# Setup Python path for pygfs
+PYTHONPATH="${HOMEgfs}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"
+export PYTHONPATH
+
+declare -rx COMIN_ATMOS_ANALYSIS_ENSSTAT="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/analysis/atmos"
+declare -rx COMIN_ATMOS_HISTORY_ENSSTAT="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/model/atmos/history"
+declare -rx COMIN_SNOW_ANALYSIS_ENSSTAT="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/analysis/snow"
 
 ###############################################################
 # Run archive script

--- a/dev/jobs/JGLOBAL_ENKF_DIAG
+++ b/dev/jobs/JGLOBAL_ENKF_DIAG
@@ -9,76 +9,24 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "ediag" -c "base anal eobs analdiag ed
 ##############################################
 # Begin JOB SPECIFIC work
 ##############################################
-# shellcheck disable=SC2153
-#GDATE=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} - ${assim_freq} hours")
-#export gPDY=${GDATE:0:8}
-#export gcyc=${GDATE:8:2}
-#export GDUMP="gdas"
-#export GDUMP_ENS="enkf${GDUMP}"
 
 export CASE=${CASE_ENS}
 
-#export OPREFIX="${RUN/enkf/}.t${cyc}z."
 export APREFIX="${RUN}.t${cyc}z."
-#export GPREFIX="${GDUMP_ENS}.t${gcyc}z."
-#GPREFIX_DET="${GDUMP}.t${gcyc}z."
 
-#RUN=${RUN/enkf/} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-#    COMIN_OBS:COM_OBS_TMPL
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/#${RUN/enkf/}.${PDY}/${cyc}/obs"
+declare -rx COMIN_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/analysis/atmos"
+declare -rx COMOUT_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/analysis/atmos"
 
 # Create a DATAROOT directory variable where the gsidiags live
 # shellcheck disable=SC2153,SC2311
 pCOMIN_ATMOS_ANALYSIS="$(dataroot_com_path "${COMIN_ATMOS_ANALYSIS}")"
 export pCOMIN_ATMOS_ANALYSIS
 
-#RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-#    COMIN_OBS_PREV:COM_OBS_TMPL \
-#    COMIN_ATMOS_ANALYSIS_DET_PREV:COM_ATMOS_ANALYSIS_TMPL
-
-#MEMDIR="ensstat" RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-#    COMIN_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
-
-#export ATMGES_ENSMEAN="${COMIN_ATMOS_HISTORY_PREV}/${GPREFIX}ensmean.atm.f006.nc"
-#if [[ ! -f "${ATMGES_ENSMEAN}" ]]; then
-#    export err=1
-#    err_exit "FILE MISSING: ATMGES_ENSMEAN == ${ATMGES_ENSMEAN}"
-#fi
-
-# Link observational data
-#export PREPQC="${COMIN_OBS}/${OPREFIX}prepbufr"
-#if [[ ! -f ${PREPQC} ]]; then
-#    echo "WARNING: Global PREPBUFR FILE ${PREPQC} MISSING"
-#fi
-#export TCVITL="${COMIN_OBS}/${OPREFIX}syndata.tcvitals.tm00"
-#if [[ ${DONST} == "YES" ]]; then
-#    export NSSTBF="${COMIN_OBS}/${OPREFIX}nsstbufr"
-#fi
-#export PREPQCPF="${COMIN_OBS}/${OPREFIX}prepbufr.acft_profiles"
-
-# Guess Bias correction coefficients related to control
-#export GBIAS=${COMIN_ATMOS_ANALYSIS_DET_PREV}/${GPREFIX_DET}abias.txt
-#export GBIASPC=${COMIN_ATMOS_ANALYSIS_DET_PREV}/${GPREFIX_DET}abias_pc.txt
-#export GBIASAIR=${COMIN_ATMOS_ANALYSIS_DET_PREV}/${GPREFIX_DET}abias_air.txt
-#export GRADSTAT=${COMIN_ATMOS_ANALYSIS_DET_PREV}/${GPREFIX_DET}radstat.tar
-
-# Bias correction coefficients related to ensemble mean
-#export ABIAS="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}abias.txt"
-#export ABIASPC="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}abias_pc.txt"
-#export ABIASAIR="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}abias_air.txt"
-#export ABIASe="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}abias_int.txt"
-
 # Diagnostics related to ensemble mean
 export CNVSTAT="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}cnvstat_ensmean.tar"
 export OZNSTAT="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}oznstat_ensmean.tar"
 export RADSTAT="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}radstat_ensmean.tar"
-
-# Select observations based on ensemble mean
-#export RUN_SELECT="YES"
-#export USE_SELECT="NO"
-#export SELECT_OBS="${COMOUT_ATMOS_ANALYSIS}/${APREFIX}obsinput.ensmean"
 
 export DIAG_SUFFIX="_ensmean"
 export DIAG_COMPRESS="NO"

--- a/dev/jobs/JGLOBAL_ENKF_ECEN
+++ b/dev/jobs/JGLOBAL_ENKF_ECEN
@@ -24,14 +24,11 @@ export APREFIX_ENS="${RUN}.t${cyc}z."
 export GPREFIX="${GDUMP}.t${gcyc}z."
 export GPREFIX_ENS="${GDUMP_ENS}.t${gcyc}z."
 
-RUN=${RUN/enkf/} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS_DET:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS_DET="${ROTDIR}/${RUN/enkf/}.${PDY}/${cyc}/analysis/atmos"
 
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_ATMOS_ANALYSIS_STAT:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMOUT_ATMOS_ANALYSIS_STAT="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/analysis/atmos"
 
-MEMDIR="ensstat" RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_HISTORY_STAT_PREV:COM_ATMOS_HISTORY_TMPL
+declare -rx COMIN_ATMOS_HISTORY_STAT_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/ensstat/model/atmos/history"
 
 ###############################################################
 # Run relevant script

--- a/dev/jobs/JGLOBAL_ENKF_ECEN_FV3JEDI
+++ b/dev/jobs/JGLOBAL_ENKF_ECEN_FV3JEDI
@@ -20,15 +20,12 @@ GDUMP_ENS="enkfgdas"
 ##############################################
 
 # Generate COM variables from templates
-RUN=${GDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
-MEMDIR='ensstat' RUN=${GDUMP_ENS} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS_ENSSTAT:COM_ATMOS_ANALYSIS_TMPL \
-    COMOUT_ATMOS_ANALYSIS_ENSSTAT:COM_ATMOS_ANALYSIS_TMPL \
-    COMOUT_CONF:COM_CONF_TMPL
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS="${ROTDIR}/${GDUMP}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMOUT_ATMOS_ANALYSIS="${ROTDIR}/${GDUMP}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMIN_ATMOS_ANALYSIS_ENSSTAT="${ROTDIR}/${GDUMP_ENS}.${PDY}/${cyc}/ensstat/analysis/atmos"
+declare -rx COMOUT_ATMOS_ANALYSIS_ENSSTAT="${ROTDIR}/${GDUMP_ENS}.${PDY}/${cyc}/ensstat/analysis/atmos"
+declare -rx COMOUT_CONF="${ROTDIR}/${GDUMP_ENS}.${PDY}/${cyc}/ensstat/conf"
+declare -rx COMIN_ATMOS_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/atmos/history"
 
 mkdir -m 755 -p "${COMOUT_CONF}"
 

--- a/dev/jobs/JGLOBAL_ENKF_SELECT_OBS
+++ b/dev/jobs/JGLOBAL_ENKF_SELECT_OBS
@@ -24,22 +24,17 @@ GPREFIX_DET="${GDUMP}.t${gcyc}z."
 export GSUFFIX="ensmean."
 
 # Generate COM variables from templates
-RUN=${RUN/enkf/} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL
-MEMDIR='ensstat' YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN/enkf/}.${PDY}/${cyc}/obs"
+declare -rx COMOUT_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/analysis/atmos"
 # shellcheck disable=SC2153
 declare -rx COMOUT_ATMOS_ANALYSIS_ENS="${COMOUT_ATMOS_ANALYSIS}"
 
-RUN=${RUN/enkf/} YMD=${PDY} HH=${cyc} declare_from_tmpl -r \
-    COMOUT_ATMOS_ANALYSIS_DET:COM_ATMOS_ANALYSIS_TMPL
+declare -r COMOUT_ATMOS_ANALYSIS_DET=${ROTDIR}/${RUN/enkf/}.${PDY}/${cyc}/analysis/atmos
 
-MEMDIR='ensstat' RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS_PREV="${ROTDIR}/${GDUMP_ENS}.${gPDY}/${gcyc}/ensstat/analysis/atmos"
+declare -rx COMIN_ATMOS_HISTORY_PREV="${ROTDIR}/${GDUMP_ENS}.${gPDY}/${gcyc}/ensstat/model/atmos/history"
 
-RUN="${GDUMP}" YMD=${gPDY} HH=${gcyc} declare_from_tmpl -r \
-    COMIN_ATMOS_ANALYSIS_DET_PREV:COM_ATMOS_ANALYSIS_TMPL
+declare -r COMIN_ATMOS_ANALYSIS_DET_PREV=${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/analysis/atmos
 
 # shellcheck disable=SC2153
 mkdir -p "${COMOUT_ATMOS_ANALYSIS}"

--- a/dev/jobs/JGLOBAL_ENKF_SFC
+++ b/dev/jobs/JGLOBAL_ENKF_SFC
@@ -28,13 +28,11 @@ export APREFIX_ENS="${RUN}.t${cyc}z."
 export GPREFIX="${GDUMP}.t${gcyc}z."
 export GPREFIX_ENS="${GDUMP_ENS}.t${gcyc}z."
 
-RUN=${RUN/enkf/} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL \
-    COMIN_ATMOS_ANALYSIS_DET:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN/enkf/}.${PDY}/${cyc}/obs"
+declare -rx COMIN_ATMOS_ANALYSIS_DET="${ROTDIR}/${RUN/enkf/}.${PDY}/${cyc}/analysis/atmos"
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_OBS_PREV:COM_OBS_TMPL \
-    COMIN_ATMOS_ANALYSIS_DET_PREV:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMIN_OBS_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/obs"
+declare -rx COMIN_ATMOS_ANALYSIS_DET_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/analysis/atmos"
 
 # Use CFP to stage and save files in parallel
 export USE_CFP=YES

--- a/dev/jobs/JGLOBAL_ENKF_UPDATE
+++ b/dev/jobs/JGLOBAL_ENKF_UPDATE
@@ -16,14 +16,11 @@ export GDUMP="enkfgdas" # EnKF ensemble always uses RUN=enkfgdas for prior membe
 export APREFIX="${RUN}.t${cyc}z."
 export GPREFIX="${GDUMP}.t${GDATE:8:2}z."
 
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS_STAT:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS_STAT="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/analysis/atmos"
 
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_ATMOS_ANALYSIS_STAT:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMOUT_ATMOS_ANALYSIS_STAT="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/analysis/atmos"
 
-MEMDIR="ensstat" RUN="enkfgdas" YMD=${GDATE:0:8} HH=${GDATE:8:2} declare_from_tmpl -rx \
-    COMIN_ATMOS_HISTORY_STAT_PREV:COM_ATMOS_HISTORY_TMPL
+declare -rx COMIN_ATMOS_HISTORY_STAT_PREV="${ROTDIR}/enkfgdas.${GDATE:0:8}/${GDATE:8:2}/ensstat/model/atmos/history"
 
 ###############################################################
 # Run relevant script

--- a/dev/jobs/JGLOBAL_ENS_GLOBUS_ARCH
+++ b/dev/jobs/JGLOBAL_ENS_GLOBUS_ARCH
@@ -5,8 +5,11 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "globus_earc" -c "base globus earc_gro
 ##############################################
 # Set variables used in the script
 ##############################################
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_CONF:COM_CONF_TMPL
+# Setup Python path for pygfs
+PYTHONPATH="${HOMEgfs}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"
+export PYTHONPATH
+
+declare -rx COMIN_CONF="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/conf"
 
 ###############################################################
 # Run globus script

--- a/dev/jobs/JGLOBAL_EXTRACTVARS
+++ b/dev/jobs/JGLOBAL_EXTRACTVARS
@@ -6,22 +6,20 @@ source "${USHgfs}/wave_domain_grid.sh"
 # Set COM Paths
 for grid in '0p25' '0p50' '1p00'; do
     prod_dir="COMIN_ATMOS_GRIB_${grid}"
-    GRID=${grid} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx "${prod_dir}:COM_ATMOS_GRIB_GRID_TMPL"
+    declare -rx "${prod_dir}"="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/atmos/grib2/${grid}"
     mkdir -p "${!prod_dir}"
 done
 
-YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx \
-    "COMIN_OCEAN_HISTORY:COM_OCEAN_HISTORY_TMPL" \
-    "COMIN_OCEAN_GRIB:COM_OCEAN_GRIB_TMPL" \
-    "COMIN_OCEAN_NETCDF:COM_OCEAN_NETCDF_TMPL" \
-    "COMIN_ICE_HISTORY:COM_ICE_HISTORY_TMPL" \
-    "COMIN_ICE_GRIB:COM_ICE_GRIB_TMPL" \
-    "COMIN_ICE_NETCDF:COM_ICE_NETCDF_TMPL" \
-    "COMIN_WAVE_GRID:COM_WAVE_GRID_TMPL"
+declare -rx COMIN_OCEAN_HISTORY="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/ocean/history"
+declare -rx COMIN_OCEAN_GRIB="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/ocean/grib2"
+declare -rx COMIN_OCEAN_NETCDF="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/ocean/netcdf"
+declare -rx COMIN_ICE_HISTORY="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/ice/history"
+declare -rx COMIN_ICE_GRIB="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/ice/grib2"
+declare -rx COMIN_ICE_NETCDF="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/ice/netcdf"
+declare -rx COMIN_WAVE_GRID="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/wave/gridded"
 
 process_grdID "${waveGRD}"
-YMD=${PDY} HH=${cyc} GRDRESNAME=${grdNAME} declare_from_tmpl -rx \
-    "COMIN_WAVE_GRID_${GRDREGION}_${GRDRES}:COM_WAVE_GRID_RES_TMPL"
+declare -rx "COMIN_WAVE_GRID_${GRDREGION}_${GRDRES}"="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/wave/gridded/${grdNAME}"
 
 if [[ "${DO_ATM}" == "YES" ]]; then
     mkdir -p "${ARC_RFCST_PROD_ATMOS_F2D}"

--- a/dev/jobs/JGLOBAL_FORECAST
+++ b/dev/jobs/JGLOBAL_FORECAST
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 
-if ((10#${ENSMEM:-0} > 0)); then
+# shellcheck disable=SC2309
+if [[ 10#${ENSMEM:--1} -ge 0 ]]; then
     export DATAjob="${DATAROOT}/${RUN}efcs${ENSMEM}.${PDY:-}${cyc}"
     export DATA="${DATAjob}/${jobid}"
     source "${HOMEgfs}/ush/jjob_header.sh" -e "efcs" -c "base fcst efcs"
@@ -20,8 +21,8 @@ if [[ ! -d "${DATAoutput}" ]]; then mkdir -p "${DATAoutput}"; fi
 # Begin JOB SPECIFIC work
 ##############################################
 
-# Restart conditions for GFS cycle come from GDAS
-# Restart conditions for GCAFS cycle come from GCDAS
+# Restart conditions for GFS cycle come from GDAS (except warm start surface analysis)
+# Similarly, restart conditions for GCAFS cycle come from GCDAS
 rCDUMP="${RUN/gfs/gdas}"
 export rCDUMP="${rCDUMP/gcafs/gcdas}"
 
@@ -33,66 +34,67 @@ declare -rx GDATE
 declare -rx gPDY="${GDATE:0:8}"
 declare -rx gcyc="${GDATE:8:2}"
 
-# Construct COM variables from templates (see config.com)
-YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx \
-    COMIN_ATMOS_INPUT:COM_ATMOS_INPUT_TMPL \
-    COMOUT_CONF:COM_CONF_TMPL \
-    COMOUT_ATMOS_RESTART:COM_ATMOS_RESTART_TMPL \
-    COMIN_ATMOS_RESTART:COM_ATMOS_RESTART_TMPL \
-    COMOUT_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL \
-    COMOUT_ATMOS_MASTER:COM_ATMOS_MASTER_TMPL
+# Construct COM variables
+# shellcheck disable=SC2309
+if [[ 10#${ENSMEM:--1} -ge 0 ]]; then
+    # Turn ensmem into 3-digit format with leading zeros
+    memdir=$(printf "mem%03i" $((10#${ENSMEM})))
+    declare -rx COMIN="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}"
+    declare -rx COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}"
+    declare -rx COMIN_RESTART="${ROTDIR}/${rCDUMP}.${PDY}/${cyc}/${memdir}"
+    declare -rx COMIN_RESTART_PREV="${ROTDIR}/${rCDUMP}.${gPDY}/${gcyc}/${memdir}"
+else
+    declare -rx COMIN="${ROTDIR}/${RUN}.${PDY}/${cyc}"
+    declare -rx COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}"
+    declare -rx COMIN_RESTART="${ROTDIR}/${rCDUMP}.${PDY}/${cyc}"
+    declare -rx COMIN_RESTART_PREV="${ROTDIR}/${rCDUMP}.${gPDY}/${gcyc}"
+fi
 
-RUN="${rCDUMP}" YMD="${gPDY}" HH="${gcyc}" declare_from_tmpl -rx \
-    COMIN_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
+declare -rx COMIN_ATMOS_INPUT="${COMIN}/model/atmos/input"
+declare -rx COMIN_ATMOS_RESTART_PREV="${COMIN_RESTART_PREV}/model/atmos/restart" # Used for most restarts
+declare -rx COMIN_ATMOS_RESTART="${COMIN}/model/atmos/restart"                   # Used for warm start surface analysis
+declare -rx COMOUT_CONF="${COMOUT}/conf"
+declare -rx COMOUT_ATMOS_RESTART="${COMOUT}/model/atmos/restart"
+declare -rx COMOUT_ATMOS_HISTORY="${COMOUT}/model/atmos/history"
+declare -rx COMOUT_ATMOS_MASTER="${COMOUT}/model/atmos/master"
 
 # GCAFS/GCDAS uses an offline atmospheric analysis
 if [[ "${RUN}" =~ "gcafs" ]] || [[ "${RUN}" =~ "gcdas" ]]; then
-    YMD="${PDY}" HH="${cyc}" RUN="${rCDUMP}" declare_from_tmpl -rx \
-        COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
+    declare -rx COMIN_ATMOS_ANALYSIS="${COMIN_RESTART}/analysis/atmos"
 else
     # other runs use their own atmospheric analysis
-    YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx \
-        COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
+    declare -rx COMIN_ATMOS_ANALYSIS="${COMIN}/analysis/atmos"
 fi
 
 if [[ "${DO_WAVE}" == "YES" ]]; then
-    YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx \
-        COMIN_WAVE_PREP:COM_WAVE_PREP_TMPL \
-        COMOUT_WAVE_RESTART:COM_WAVE_RESTART_TMPL \
-        COMOUT_WAVE_HISTORY:COM_WAVE_HISTORY_TMPL
-    RUN="${rCDUMP}" YMD="${gPDY}" HH="${gcyc}" declare_from_tmpl -rx \
-        COMIN_WAVE_RESTART_PREV:COM_WAVE_RESTART_TMPL
+    declare -rx COMIN_WAVE_PREP="${COMIN}/model/wave/prep"
+    declare -rx COMOUT_WAVE_RESTART="${COMOUT}/model/wave/restart"
+    declare -rx COMOUT_WAVE_HISTORY="${COMOUT}/model/wave/history"
+    declare -rx COMIN_WAVE_RESTART_PREV="${COMIN_RESTART_PREV}/model/wave/restart"
 fi
 
 if [[ "${DO_OCN}" == "YES" ]]; then
-    YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx \
-        COMIN_OCEAN_ANALYSIS:COM_OCEAN_ANALYSIS_TMPL \
-        COMIN_OCEAN_INPUT:COM_OCEAN_INPUT_TMPL \
-        COMOUT_MED_RESTART:COM_MED_RESTART_TMPL \
-        COMOUT_OCEAN_RESTART:COM_OCEAN_RESTART_TMPL \
-        COMOUT_OCEAN_HISTORY:COM_OCEAN_HISTORY_TMPL
-    RUN="${rCDUMP}" YMD="${gPDY}" HH="${gcyc}" declare_from_tmpl -rx \
-        COMIN_OCEAN_RESTART_PREV:COM_OCEAN_RESTART_TMPL \
-        COMIN_MED_RESTART_PREV:COM_MED_RESTART_TMPL
+    declare -rx COMIN_OCEAN_ANALYSIS="${COMIN}/analysis/ocean"
+    declare -rx COMIN_OCEAN_INPUT="${COMIN}/model/ocean/input"
+    declare -rx COMOUT_MED_RESTART="${COMOUT}/model/med/restart"
+    declare -rx COMOUT_OCEAN_RESTART="${COMOUT}/model/ocean/restart"
+    declare -rx COMOUT_OCEAN_HISTORY="${COMOUT}/model/ocean/history"
+    declare -rx COMIN_OCEAN_RESTART_PREV="${COMIN_RESTART_PREV}/model/ocean/restart"
+    declare -rx COMIN_MED_RESTART_PREV="${COMIN_RESTART_PREV}/model/med/restart"
 fi
 
 if [[ "${DO_ICE}" == "YES" ]]; then
-    YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx \
-        COMIN_ICE_INPUT:COM_ICE_INPUT_TMPL \
-        COMIN_ICE_ANALYSIS:COM_ICE_ANALYSIS_TMPL \
-        COMOUT_ICE_RESTART:COM_ICE_RESTART_TMPL \
-        COMOUT_ICE_HISTORY:COM_ICE_HISTORY_TMPL
-    RUN="${rCDUMP}" YMD="${gPDY}" HH="${gcyc}" declare_from_tmpl -rx \
-        COMIN_ICE_RESTART_PREV:COM_ICE_RESTART_TMPL
+    declare -rx COMIN_ICE_INPUT="${COMIN}/model/ice/input"
+    declare -rx COMIN_ICE_ANALYSIS="${COMIN}/analysis/ice"
+    declare -rx COMOUT_ICE_RESTART="${COMOUT}/model/ice/restart"
+    declare -rx COMOUT_ICE_HISTORY="${COMOUT}/model/ice/history"
+    declare -rx COMIN_ICE_RESTART_PREV="${COMIN_RESTART_PREV}/model/ice/restart"
 fi
 
 if [[ "${DO_AERO_FCST}" == "YES" ]]; then
-    YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx \
-        COMOUT_CHEM_HISTORY:COM_CHEM_HISTORY_TMPL
-    YMD="${PDY}" HH="${cyc}" RUN="${rCDUMP}" declare_from_tmpl -rx \
-        COMIN_TRACER_RESTART:COM_ATMOS_RESTART_TMPL
-    YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx \
-        COMIN_CHEM_INPUT:COM_CHEM_INPUT_TMPL
+    declare -rx COMOUT_CHEM_HISTORY="${COMOUT}/model/chem/history"
+    declare -rx COMIN_TRACER_RESTART="${COMIN_RESTART}/model/atmos/restart"
+    declare -rx COMIN_CHEM_INPUT="${COMIN}/model/chem/input"
 fi
 
 ###############################################################

--- a/dev/jobs/JGLOBAL_GLOBUS_ARCH
+++ b/dev/jobs/JGLOBAL_GLOBUS_ARCH
@@ -5,8 +5,11 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "globus_arch" -c "base globus"
 ##############################################
 # Set variables used in the script
 ##############################################
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_CONF:COM_CONF_TMPL
+# Setup Python path for pygfs
+PYTHONPATH="${HOMEgfs}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"
+export PYTHONPATH
+
+declare -rx COMIN_CONF="${ROTDIR}/${RUN}.${PDY}/${cyc}/conf"
 
 ###############################################################
 # Run globus script

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_ECEN
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_ECEN
@@ -16,18 +16,15 @@ export gPDY=${GDATE:0:8}
 export gcyc=${GDATE:8:2}
 export GDUMP="gdas"
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_OCEAN_HISTORY_PREV:COM_OCEAN_HISTORY_TMPL \
-    COMIN_ICE_HISTORY_PREV:COM_ICE_HISTORY_TMPL
+declare -rx COMIN_OCEAN_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/ocean/history"
+declare -rx COMIN_ICE_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/ice/history"
 
-YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_OCEAN_HISTORY_ENS_PREV:COM_OCEAN_HISTORY_TMPL \
-    COMIN_ICE_HISTORY_ENS_PREV:COM_ICE_HISTORY_TMPL
+declare -rx COMIN_OCEAN_HISTORY_ENS_PREV="${ROTDIR}/${RUN}.${gPDY}/${gcyc}/model/ocean/history"
+declare -rx COMIN_ICE_HISTORY_ENS_PREV="${ROTDIR}/${RUN}.${gPDY}/${gcyc}/model/ice/history"
 
-RUN=${GDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_OCEAN_ANALYSIS:COM_OCEAN_ANALYSIS_TMPL \
-    COMIN_ICE_RESTART:COM_ICE_RESTART_TMPL \
-    COMOUT_ICE_ANALYSIS:COM_ICE_ANALYSIS_TMPL
+declare -rx COMOUT_OCEAN_ANALYSIS="${ROTDIR}/${GDUMP}.${PDY}/${cyc}/analysis/ocean"
+declare -rx COMIN_ICE_RESTART="${ROTDIR}/${GDUMP}.${PDY}/${cyc}/model/ice/restart"
+declare -rx COMOUT_ICE_ANALYSIS="${ROTDIR}/${GDUMP}.${PDY}/${cyc}/analysis/ice"
 
 export NMEM_ENS_MAX=${NMEM_ENS}
 if [[ "${RUN}" == "enkfgfs" ]]; then

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_FINALIZE
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_FINALIZE
@@ -14,13 +14,12 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "marineanlfinal" -c "base marineanl ma
 ##############################################
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMIN_OBS:COM_OBS_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_OCEAN_ANALYSIS:COM_OCEAN_ANALYSIS_TMPL \
-    COMOUT_ICE_ANALYSIS:COM_ICE_ANALYSIS_TMPL \
-    COMOUT_ICE_RESTART:COM_ICE_RESTART_TMPL \
-    COMOUT_CONF:COM_CONF_TMPL
+declare -rx COMOUT_OCEAN_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/ocean"
+declare -rx COMOUT_ICE_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/ice"
+declare -rx COMOUT_ICE_RESTART="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/ice/restart"
+declare -rx COMOUT_CONF="${ROTDIR}/${RUN}.${PDY}/${cyc}/conf"
 
 mkdir -m 775 -p "${COMOUT_OCEAN_ANALYSIS}"
 mkdir -m 775 -p "${COMOUT_ICE_ANALYSIS}"

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_INITIALIZE
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_INITIALIZE
@@ -20,17 +20,14 @@ export GDUMP=${GDUMP:-"gdas"}
 ##############################################
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_OCEAN_HISTORY_PREV:COM_OCEAN_HISTORY_TMPL \
-    COMIN_ICE_HISTORY_PREV:COM_ICE_HISTORY_TMPL \
-    COMIN_ICE_RESTART_PREV:COM_ICE_RESTART_TMPL
+declare -rx COMIN_OCEAN_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/ocean/history"
+declare -rx COMIN_ICE_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/ice/history"
+declare -rx COMIN_ICE_RESTART_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/ice/restart"
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OCEAN_BMATRIX:COM_OCEAN_BMATRIX_TMPL \
-    COMIN_ICE_BMATRIX:COM_ICE_BMATRIX_TMPL
+declare -rx COMIN_OCEAN_BMATRIX="${ROTDIR}/${RUN}.${PDY}/${cyc}/bmatrix/ocean"
+declare -rx COMIN_ICE_BMATRIX="${ROTDIR}/${RUN}.${PDY}/${cyc}/bmatrix/ice"
 
 ###############################################################
 # Run relevant script

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_LETKF
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_LETKF
@@ -29,19 +29,15 @@ else
     export mem_offset=0
 fi
 
-RUN="${GDUMP}" YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_OCEAN_HISTORY_PREV:COM_OCEAN_HISTORY_TMPL \
-    COMIN_ICE_HISTORY_PREV:COM_ICE_HISTORY_TMPL
+declare -rx COMIN_OCEAN_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/ocean/history"
+declare -rx COMIN_ICE_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/ice/history"
 
-RUN="${GDUMP}" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${GDUMP}.${PDY}/${cyc}/obs"
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_OCEAN_LETKF:COM_OCEAN_LETKF_TMPL \
-    COMOUT_ICE_LETKF:COM_ICE_LETKF_TMPL
+declare -rx COMOUT_OCEAN_LETKF="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/ocean/letkf"
+declare -rx COMOUT_ICE_LETKF="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/ice/letkf"
 
-YMD=${PDY} HH=${cyc} MEMDIR="ensstat" declare_from_tmpl -rx \
-    COMOUT_CONF:COM_CONF_TMPL
+declare -rx COMOUT_CONF="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/conf"
 
 if [[ ! -d "${COMOUT_OCEAN_LETKF}" ]]; then mkdir -p "${COMOUT_OCEAN_LETKF}"; fi
 if [[ ! -d "${COMOUT_ICE_LETKF}" ]]; then mkdir -p "${COMOUT_ICE_LETKF}"; fi

--- a/dev/jobs/JGLOBAL_MARINE_BMAT
+++ b/dev/jobs/JGLOBAL_MARINE_BMAT
@@ -38,18 +38,15 @@ fi
 ##############################################
 
 # Generate COM variables from templates
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_OCEAN_HISTORY_PREV:COM_OCEAN_HISTORY_TMPL \
-    COMIN_ICE_HISTORY_PREV:COM_ICE_HISTORY_TMPL
+declare -rx COMIN_OCEAN_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/ocean/history"
+declare -rx COMIN_ICE_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/ice/history"
 
-RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_OCEAN_HISTORY_ENS_PREV:COM_OCEAN_HISTORY_TMPL \
-    COMIN_ICE_HISTORY_ENS_PREV:COM_ICE_HISTORY_TMPL
+declare -rx COMIN_OCEAN_HISTORY_ENS_PREV="${ROTDIR}/${GDUMP_ENS}.${gPDY}/${gcyc}/model/ocean/history"
+declare -rx COMIN_ICE_HISTORY_ENS_PREV="${ROTDIR}/${GDUMP_ENS}.${gPDY}/${gcyc}/model/ice/history"
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_OCEAN_BMATRIX:COM_OCEAN_BMATRIX_TMPL \
-    COMOUT_ICE_BMATRIX:COM_ICE_BMATRIX_TMPL \
-    COMOUT_CONF:COM_CONF_TMPL
+declare -rx COMOUT_OCEAN_BMATRIX="${ROTDIR}/${RUN}.${PDY}/${cyc}/bmatrix/ocean"
+declare -rx COMOUT_ICE_BMATRIX="${ROTDIR}/${RUN}.${PDY}/${cyc}/bmatrix/ice"
+declare -rx COMOUT_CONF="${ROTDIR}/${RUN}.${PDY}/${cyc}/conf"
 
 mkdir -m 775 -p "${COMOUT_OCEAN_BMATRIX}"
 mkdir -m 775 -p "${COMOUT_ICE_BMATRIX}"

--- a/dev/jobs/JGLOBAL_MARINE_BMAT_INITIALIZE
+++ b/dev/jobs/JGLOBAL_MARINE_BMAT_INITIALIZE
@@ -37,17 +37,14 @@ fi
 ##############################################
 
 # Generate COM variables from templates
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_OCEAN_HISTORY_PREV:COM_OCEAN_HISTORY_TMPL \
-    COMIN_ICE_HISTORY_PREV:COM_ICE_HISTORY_TMPL
+declare -rx COMIN_OCEAN_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/ocean/history"
+declare -rx COMIN_ICE_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/ice/history"
 
-RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_OCEAN_HISTORY_ENS_PREV:COM_OCEAN_HISTORY_TMPL \
-    COMIN_ICE_HISTORY_ENS_PREV:COM_ICE_HISTORY_TMPL
+declare -rx COMIN_OCEAN_HISTORY_ENS_PREV="${ROTDIR}/${GDUMP_ENS}.${gPDY}/${gcyc}/model/ocean/history"
+declare -rx COMIN_ICE_HISTORY_ENS_PREV="${ROTDIR}/${GDUMP_ENS}.${gPDY}/${gcyc}/model/ice/history"
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_OCEAN_BMATRIX:COM_OCEAN_BMATRIX_TMPL \
-    COMOUT_ICE_BMATRIX:COM_ICE_BMATRIX_TMPL
+declare -rx COMOUT_OCEAN_BMATRIX="${ROTDIR}/${RUN}.${PDY}/${cyc}/bmatrix/ocean"
+declare -rx COMOUT_ICE_BMATRIX="${ROTDIR}/${RUN}.${PDY}/${cyc}/bmatrix/ice"
 
 mkdir -p "${COMOUT_OCEAN_BMATRIX}"
 mkdir -p "${COMOUT_ICE_BMATRIX}"

--- a/dev/jobs/JGLOBAL_OCEANICE_PRODUCTS
+++ b/dev/jobs/JGLOBAL_OCEANICE_PRODUCTS
@@ -6,10 +6,28 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "oceanice_products" -c "base oceanice_
 # Begin JOB SPECIFIC work
 ##############################################
 
-# Construct COM variables from templates
-YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx "COMIN_${COMPONENT^^}_HISTORY":"COM_${COMPONENT^^}_HISTORY_TMPL"
-YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx "COMOUT_${COMPONENT^^}_GRIB":"COM_${COMPONENT^^}_GRIB_TMPL"
-YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx "COMOUT_${COMPONENT^^}_NETCDF":"COM_${COMPONENT^^}_NETCDF_TMPL"
+# Construct COM variables
+# shellcheck disable=SC2309
+if [[ 10#${ENSMEM:--1} -ge 0 ]]; then
+    memdir=$(printf "mem%03d" $((10#${ENSMEM})))
+    export COMIN="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}"
+    export COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}"
+else
+    export COMIN="${ROTDIR}/${RUN}.${PDY}/${cyc}"
+    export COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}"
+fi
+
+if [[ -z "${COMPONENT:-}" ]]; then
+    export err=1
+    err_exit "COMPONENT variable is not set."
+elif [[ "${COMPONENT}" == "ice" || "${COMPONENT}" == "ocean" ]]; then
+    declare -rx "COMIN_${COMPONENT^^}_HISTORY"="${COMIN}/model/${COMPONENT}/history"
+    declare -rx "COMOUT_${COMPONENT^^}_GRIB"="${COMOUT}/products/${COMPONENT}/grib2"
+    declare -rx "COMOUT_${COMPONENT^^}_NETCDF"="${COMOUT}/products/${COMPONENT}/netcdf"
+else
+    export err=1
+    err_exit "COMPONENT variable '${COMPONENT}' is invalid. Must be 'ice' or 'ocean'."
+fi
 
 ###############################################################
 # Run exglobal script

--- a/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS
+++ b/dev/jobs/JGLOBAL_OFFLINE_ATMOS_ANALYSIS
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+#shellcheck disable=SC2155
 
 source "${HOMEgfs}/ush/preamble.sh"
 source "${HOMEgfs}/ush/jjob_header.sh" -e "offlineanl" -c "base offlineanl"
@@ -20,16 +21,20 @@ export APREFIX_IN="gdas.t${cyc}z."
 export APREFIX="${RUN}.t${cyc}z."
 export GPREFIX="${GDUMP}.t${gcyc}z."
 
-RUN="gdas" DUMP="gdas" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBSPROC:COM_OBSPROC_TMPL \
-    COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
+if [[ "${RUN_ENVIR:-emc}" == "nco" ]]; then
+    declare -rx COMINobsproc=$(compath.py "${envir}/obsproc/${obsproc_ver}")/"gdas.${PDY}/${cyc}/atmos"
+    declare -rx COMINobsproc_PREV=$(compath.py "${envir}/obsproc/${obsproc_ver}")/"gdas.${gPDY}/${gcyc}/atmos"
+else
+    declare -rx COMINobsproc="${DMPDIR}/gdas.${PDY}/${cyc}/atmos"
+    declare -rx COMINobsproc_PREV="${DMPDIR}/gdas.${gPDY}/${gcyc}/atmos"
+fi
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_OBS:COM_OBS_TMPL \
-    COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
+declare -rx COMIN_ATMOS_ANALYSIS="${ROTDIR}/gdas.${PDY}/${cyc}/analysis/atmos"
 
-YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
+declare -rx COMOUT_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
+declare -rx COMOUT_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+
+declare -rx COMIN_ATMOS_HISTORY_PREV="${ROTDIR}/${RUN}.${gPDY}/${gcyc}/model/atmos/history"
 
 mkdir -p "${COMOUT_ATMOS_ANALYSIS}"
 mkdir -p "${COMOUT_OBS}"

--- a/dev/jobs/JGLOBAL_PREP_EMISSIONS
+++ b/dev/jobs/JGLOBAL_PREP_EMISSIONS
@@ -10,8 +10,18 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "prep_emissions" -c "base prep_emissio
 ##############################################
 # Begin JOB SPECIFIC work
 ##############################################
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMOUT_CHEM_INPUT:COM_CHEM_INPUT_TMPL
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMOUT_CHEM_RESTART:COM_CHEM_RESTART_TMPL
+# Construct COM variables
+# shellcheck disable=SC2309
+if [[ 10#${ENSMEM:--1} -ge 0 ]]; then
+    # Turn ensmem into 3-digit format with leading zeros
+    memdir=$(printf "mem%03i" $((10#${ENSMEM})))
+    declare -rx COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}"
+else
+    declare -rx COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}"
+fi
+
+declare -rx COMOUT_CHEM_INPUT="${COMOUT}/model/chem/input"
+declare -rx COMOUT_CHEM_RESTART="${COMOUT}/model/chem/restart"
 
 mkdir -p "${COMOUT_CHEM_INPUT}"
 

--- a/dev/jobs/JGLOBAL_PREP_OCEAN_OBS
+++ b/dev/jobs/JGLOBAL_PREP_OCEAN_OBS
@@ -5,7 +5,7 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "prepoceanobs" -c "base marineanl prep
 # Set variables used in the script
 ##############################################
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COMOUT_OBS:COM_OBS_TMPL
+declare -rx COMOUT_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
 
 ##############################################
 # Begin JOB SPECIFIC work

--- a/dev/jobs/JGLOBAL_SNOWENS_ANALYSIS
+++ b/dev/jobs/JGLOBAL_SNOWENS_ANALYSIS
@@ -23,20 +23,20 @@ fi
 # Begin JOB SPECIFIC work
 ##############################################
 # Generate COM variables from templates
-RUN=${CDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
-    COMOUT_CONF:COM_CONF_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${CDUMP}.${PDY}/${cyc}/obs"
+declare -rx COMOUT_ATMOS_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/atmos"
+declare -rx COMOUT_CONF="${ROTDIR}/${RUN}.${PDY}/${cyc}/conf"
 
 for imem in $(seq 1 "${NMEM_ENS}"); do
+    # Make the member COM directories. These will be declared in the script as we cycle through members.
     memchar="mem$(printf %03i "${imem}")"
-    MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl \
-        COMOUT_SNOW_ANALYSIS:COM_SNOW_ANALYSIS_TMPL
-    mkdir -p "${COMOUT_SNOW_ANALYSIS}"
+    product_dir="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memchar}/analysis/snow"
+    mkdir -p "${product_dir}"
 done
 
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -x COMOUT_SNOW_ANALYSIS:COM_SNOW_ANALYSIS_TMPL
+unset product_dir
+
+declare -rx COMOUT_SNOW_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/analysis/snow"
 
 mkdir -p "${COMOUT_SNOW_ANALYSIS}" "${COMOUT_CONF}"
 

--- a/dev/jobs/JGLOBAL_SNOW_ANALYSIS
+++ b/dev/jobs/JGLOBAL_SNOW_ANALYSIS
@@ -16,13 +16,11 @@ GDUMP="gdas"
 # Begin JOB SPECIFIC work
 ##############################################
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL \
-    COMOUT_SNOW_ANALYSIS:COM_SNOW_ANALYSIS_TMPL \
-    COMOUT_CONF:COM_CONF_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
+declare -rx COMOUT_SNOW_ANALYSIS="${ROTDIR}/${RUN}.${PDY}/${cyc}/analysis/snow"
+declare -rx COMOUT_CONF="${ROTDIR}/${RUN}.${PDY}/${cyc}/conf"
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
+declare -rx COMIN_ATMOS_RESTART_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/atmos/restart"
 
 mkdir -m 775 -p "${COMOUT_SNOW_ANALYSIS}" "${COMOUT_CONF}"
 

--- a/dev/jobs/JGLOBAL_WAVE_GEMPAK
+++ b/dev/jobs/JGLOBAL_WAVE_GEMPAK
@@ -8,14 +8,12 @@ source "${USHgfs}/wave_domain_grid.sh"
 ###################################
 export DBN_ALERT_TYPE=GFS_WAVE_GEMPAK
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_WAVE_GEMPAK:COM_WAVE_GEMPAK_TMPL
+declare -rx COMOUT_WAVE_GEMPAK="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/wave/gempak"
 
 if [[ -n "${GEMPAK_GRIDS}" ]]; then
     for grdID in ${GEMPAK_GRIDS}; do
         process_grdID "${grdID}"
-        YMD=${PDY} HH=${cyc} GRDRESNAME=${grdNAME} declare_from_tmpl -rx \
-            "COMIN_WAVE_GRID_${GRDREGION}_${GRDRES}:COM_WAVE_GRID_RES_TMPL"
+        declare -rx "COMIN_WAVE_GRID_${GRDREGION}_${GRDRES}"="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/wave/gridded/${grdNAME}"
     done
 else
     echo "'GEMPAK_GRIDS' is empty. No grids to process."

--- a/dev/jobs/JGLOBAL_WAVE_INIT
+++ b/dev/jobs/JGLOBAL_WAVE_INIT
@@ -5,10 +5,17 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "waveinit" -c "base wave waveinit"
 export MP_PULSE=0
 
 # Set COM Paths
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_WAVE_PREP:COM_WAVE_PREP_TMPL
+# shellcheck disable=SC2309
+if [[ 10#${ENSMEM:--1} -ge 0 ]]; then
+    # Turn ensmem into 3-digit format with leading zeros
+    memdir=$(printf "mem%03i" $((10#${ENSMEM})))
+    declare -rx COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}"
+else
+    declare -rx COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}"
+fi
+declare -rx COMOUT_WAVE_PREP="${COMOUT}/model/wave/prep"
 
-if [[ ! -d "${COMOUT_WAVE_PREP}" ]]; then mkdir -p "${COMOUT_WAVE_PREP}"; fi
+mkdir -p "${COMOUT_WAVE_PREP}"
 
 # Set mpi serial command
 export wavempexec=${wavempexec:-"mpirun -n"}

--- a/dev/jobs/JGLOBAL_WAVE_POST_BNDPNT
+++ b/dev/jobs/JGLOBAL_WAVE_POST_BNDPNT
@@ -5,10 +5,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "wavepostbndpnt" -c "base wave wavepos
 export MP_PULSE=0
 
 # Set COM Paths
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_WAVE_PREP:COM_WAVE_PREP_TMPL \
-    COMIN_WAVE_HISTORY:COM_WAVE_HISTORY_TMPL \
-    COMOUT_WAVE_STATION:COM_WAVE_STATION_TMPL
+declare -rx COMIN_WAVE_PREP="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/wave/prep"
+declare -rx COMIN_WAVE_HISTORY="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/wave/history"
+declare -rx COMOUT_WAVE_STATION="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/wave/station"
 
 mkdir -p "${COMOUT_WAVE_STATION}"
 

--- a/dev/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
+++ b/dev/jobs/JGLOBAL_WAVE_POST_BNDPNTBLL
@@ -7,10 +7,9 @@ export COMPONENT="wave"
 export MP_PULSE=0
 
 # Set COM Paths
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_WAVE_PREP:COM_WAVE_PREP_TMPL \
-    COMIN_WAVE_HISTORY:COM_WAVE_HISTORY_TMPL \
-    COMOUT_WAVE_STATION:COM_WAVE_STATION_TMPL
+declare -rx COMIN_WAVE_PREP="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/wave/prep"
+declare -rx COMIN_WAVE_HISTORY="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/wave/history"
+declare -rx COMOUT_WAVE_STATION="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/wave/station"
 
 mkdir -p "${COMOUT_WAVE_STATION}"
 

--- a/dev/jobs/JGLOBAL_WAVE_POST_PNT
+++ b/dev/jobs/JGLOBAL_WAVE_POST_PNT
@@ -5,10 +5,9 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "wavepostpnt" -c "base wave wavepostsb
 export MP_PULSE=0
 
 # Set COM Paths
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_WAVE_PREP:COM_WAVE_PREP_TMPL \
-    COMIN_WAVE_HISTORY:COM_WAVE_HISTORY_TMPL \
-    COMOUT_WAVE_STATION:COM_WAVE_STATION_TMPL
+declare -rx COMIN_WAVE_PREP="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/wave/prep"
+declare -rx COMIN_WAVE_HISTORY="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/wave/history"
+declare -rx COMOUT_WAVE_STATION="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/wave/station"
 
 mkdir -p "${COMOUT_WAVE_STATION}"
 

--- a/dev/jobs/JGLOBAL_WAVE_POST_SBS
+++ b/dev/jobs/JGLOBAL_WAVE_POST_SBS
@@ -4,18 +4,26 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "wavepostsbs" -c "base wave wavepostsb
 source "${USHgfs}/wave_domain_grid.sh"
 
 # Set COM Paths
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_WAVE_PREP:COM_WAVE_PREP_TMPL \
-    COMIN_WAVE_HISTORY:COM_WAVE_HISTORY_TMPL \
-    COMOUT_WAVE_GRID:COM_WAVE_GRID_TMPL
+# shellcheck disable=SC2309
+if [[ 10#${ENSMEM:--1} -ge 0 ]]; then
+    memdir=$(printf "mem%03i" $((10#${ENSMEM})))
+    declare -rx COMIN="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}"
+    declare -rx COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}"
+else
+    declare -rx COMIN="${ROTDIR}/${RUN}.${PDY}/${cyc}"
+    declare -rx COMOUT="${ROTDIR}/${RUN}.${PDY}/${cyc}"
+fi
+
+declare -rx COMIN_WAVE_PREP="${COMIN}/model/wave/prep"
+declare -rx COMIN_WAVE_HISTORY="${COMIN}/model/wave/history"
+declare -rx COMOUT_WAVE_GRID="${COMOUT}/products/wave/gridded"
 
 mkdir -p "${COMOUT_WAVE_GRID}"
 
 if [[ -n "${wavepostGRD}" || -n "${waveinterpGRD}" ]]; then
     for grdID in ${wavepostGRD} ${waveinterpGRD}; do
         process_grdID "${grdID}"
-        YMD=${PDY} HH=${cyc} GRDRESNAME=${grdNAME} declare_from_tmpl -rx \
-            "COMOUT_WAVE_GRID_${GRDREGION}_${GRDRES}:COM_WAVE_GRID_RES_TMPL"
+        declare -rx "COMOUT_WAVE_GRID_${GRDREGION}_${GRDRES}"="${COMOUT}/products/wave/gridded/${grdNAME}"
         out_dir_varname="COMOUT_WAVE_GRID_${GRDREGION}_${GRDRES}"
         out_dir=${!out_dir_varname}
         mkdir -p "${out_dir}"

--- a/dev/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
+++ b/dev/jobs/JGLOBAL_WAVE_PRDGEN_BULLS
@@ -6,9 +6,8 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "waveawipsbulls" -c "base wave waveawi
 # Set COM Paths
 ###################################
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_WAVE_STATION:COM_WAVE_STATION_TMPL \
-    COMOUT_WAVE_WMO:COM_WAVE_WMO_TMPL
+declare -rx COMIN_WAVE_STATION="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/wave/station"
+declare -rx COMOUT_WAVE_WMO="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/wave/wmo"
 
 mkdir -p "${COMOUT_WAVE_WMO}"
 

--- a/dev/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
+++ b/dev/jobs/JGLOBAL_WAVE_PRDGEN_GRIDDED
@@ -7,17 +7,15 @@ source "${USHgfs}/wave_domain_grid.sh"
 # Set COM Paths
 ###################################
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_WAVE_GRID:COM_WAVE_GRID_TMPL \
-    COMOUT_WAVE_WMO:COM_WAVE_WMO_TMPL
+declare -rx COMIN_WAVE_GRID="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/wave/gridded"
+declare -rx COMOUT_WAVE_WMO="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/wave/wmo"
 
 mkdir -p "${COMOUT_WAVE_WMO}"
 
 if [[ -n "${GEMPAK_GRIDS}" ]]; then
     for grdID in ${GEMPAK_GRIDS}; do
         process_grdID "${grdID}"
-        YMD=${PDY} HH=${cyc} GRDRESNAME=${grdNAME} declare_from_tmpl -rx \
-            "COMIN_WAVE_GRID_${GRDREGION}_${GRDRES}:COM_WAVE_GRID_RES_TMPL"
+        declare -rx "COMIN_WAVE_GRID_${GRDREGION}_${GRDRES}"="${ROTDIR}/${RUN}.${PDY}/${cyc}/products/wave/gridded/${grdNAME}"
     done
 else
     echo "GEMPAK_GRIDS are empty. No grids to process."

--- a/dev/jobs/JGLOBAL_WAVE_PREP
+++ b/dev/jobs/JGLOBAL_WAVE_PREP
@@ -12,12 +12,17 @@ export MP_PULSE=0
 export CDO=${CDO_ROOT}/bin/cdo
 
 # Set COM Paths
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL \
-    COMIN_WAVE_PREP:COM_WAVE_PREP_TMPL \
-    COMOUT_WAVE_PREP:COM_WAVE_PREP_TMPL \
-    COMINrtofs:COM_RTOFS_TMPL
-if [[ ! -d ${COMOUT_WAVE_PREP} ]]; then mkdir -p "${COMOUT_WAVE_PREP}"; fi
+declare -rx COMIN_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
+declare -rx COMIN_WAVE_PREP="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/wave/prep"
+declare -rx COMOUT_WAVE_PREP="${ROTDIR}/${RUN}.${PDY}/${cyc}/model/wave/prep"
+if [[ "${RUN_ENVIR:-emc}" == "nco" ]]; then
+    #shellcheck disable=SC2155
+    declare -rx COMINrtofs=$(compath.py "${envir}/rtofs/${rtofs_ver}")
+else
+    declare -rx COMINrtofs="${DMPDIR}"
+fi
+
+mkdir -p "${COMOUT_WAVE_PREP}"
 
 # Execute the Script
 "${SCRgfs}/exgfs_wave_prep.sh" && true

--- a/dev/parm/config/gfs/config.com
+++ b/dev/parm/config/gfs/config.com
@@ -3,6 +3,8 @@
 # shellcheck disable=SC2016
 echo "BEGIN: config.com"
 
+# TODO remove this config file. This will require removing all references to COM_*_TMPL variables in the workflow setup scripts.
+
 # These are just templates. All templates must use single quotations so variable
 #   expansion does not occur when this file is sourced. Substitution happens later
 #   during runtime. It is recommended to use the helper function `declare_from_tmpl()`,

--- a/dev/scripts/exgdas_atmos_nawips.sh
+++ b/dev/scripts/exgdas_atmos_nawips.sh
@@ -38,7 +38,7 @@ output=T
 pdsext=no
 
 GEMGRD="${RUN}_${grid}_${PDY}${cyc}f${fhr3}"
-source_dirvar="COMOUT_ATMOS_GRIB_${grid}"
+source_dirvar="COMIN_ATMOS_GRIB_${grid}"
 export GRIBIN="${!source_dirvar}/${RUN}.${cycle}.pres_a.${grid}.f${fhr3}.grib2"
 GRIBIN_chk="${GRIBIN}.idx"
 

--- a/dev/scripts/exgdas_enkf_post.sh
+++ b/dev/scripts/exgdas_enkf_post.sh
@@ -63,8 +63,7 @@ export OMP_NUM_THREADS=${NTHREADS_EPOS}
 # Forecast ensemble member files
 for imem in $(seq 1 "${NMEM_ENS}"); do
     memchar="mem"$(printf %03i "${imem}")
-    MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl -x \
-        COMIN_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL
+    declare -x COMIN_ATMOS_HISTORY=${ROTDIR}/${RUN}.${PDY}/${cyc}/${memchar}/model/atmos/history
 
     for fhr in $(seq "${FHMIN}" "${FHOUT}" "${FHMAX}"); do
         fhrchar=$(printf %03i "${fhr}")
@@ -74,8 +73,7 @@ for imem in $(seq 1 "${NMEM_ENS}"); do
 done
 
 # Forecast ensemble mean and smoothed files
-MEMDIR="ensstat" YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMOUT_ATMOS_HISTORY_STAT:COM_ATMOS_HISTORY_TMPL
+declare -rx COMOUT_ATMOS_HISTORY_STAT="${ROTDIR}/${RUN}.${PDY}/${cyc}/ensstat/model/atmos/history"
 if [[ ! -d "${COMOUT_ATMOS_HISTORY_STAT}" ]]; then
     mkdir -p "${COMOUT_ATMOS_HISTORY_STAT}"
 fi
@@ -87,8 +85,7 @@ for fhr in $(seq "${FHMIN}" "${FHOUT}" "${FHMAX}"); do
     if [[ "${SMOOTH_ENKF}" == "YES" ]]; then
         for imem in $(seq 1 "${NMEM_ENS}"); do
             memchar="mem"$(printf %03i "${imem}")
-            MEMDIR="${memchar}" YMD=${PDY} HH=${cyc} declare_from_tmpl -x \
-                COMIN_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL
+            declare -x COMIN_ATMOS_HISTORY=${ROTDIR}/${RUN}.${PDY}/${cyc}/${memchar}/model/atmos/history
             ${NLN} "${COMIN_ATMOS_HISTORY}/${PREFIX}atm.f${fhrchar}${ENKF_SUFFIX}.nc" "atmf${fhrchar}${ENKF_SUFFIX}_${memchar}"
         done
     fi

--- a/dev/scripts/exgfs_atmos_goes_nawips.sh
+++ b/dev/scripts/exgfs_atmos_goes_nawips.sh
@@ -46,7 +46,7 @@ fi
 pdsext=no
 
 GEMGRD="${RUN2}_${PDY}${cyc}f${fhr3}"
-GRIBIN="${COMOUT_ATMOS_GOES}/${RUN}.${cycle}.${GRIB}${fhr3}${EXT}"
+GRIBIN="${COMIN_ATMOS_GOES}/${RUN}.${cycle}.${GRIB}${fhr3}${EXT}"
 GRIBIN_chk="${GRIBIN}"
 
 if [[ ! -r "${GRIBIN_chk}" ]]; then

--- a/dev/scripts/exgfs_wave_init.sh
+++ b/dev/scripts/exgfs_wave_init.sh
@@ -74,7 +74,7 @@ done
 # Copy to other members if needed
 if [[ "${NET}" == "gefs" && ${NMEM_ENS} -gt 0 ]]; then
     for mem in $(seq -f "%03g" 1 "${NMEM_ENS}"); do
-        MEMDIR="mem${mem}" YMD="${PDY}" HH="${cyc}" declare_from_tmpl COMOUT_WAVE_PREP_MEM:COM_WAVE_PREP_TMPL
+        declare -x COMOUT_WAVE_PREP_MEM="${ROTDIR}/${RUN}.${PDY}/${cyc}/mem${mem}/model/wave/prep"
         mkdir -p "${COMOUT_WAVE_PREP_MEM}"
         for grdID in "${grdALL[@]}"; do
             cpfs "${COMOUT_WAVE_PREP}/${RUN}.t${cyc}z.mod_def.${grdID}.bin" "${COMOUT_WAVE_PREP_MEM}/${RUN}.t${cyc}z.mod_def.${grdID}.bin"

--- a/dev/scripts/exglobal_atmos_analysis.sh
+++ b/dev/scripts/exglobal_atmos_analysis.sh
@@ -599,8 +599,7 @@ if [[ "${DOHYBVAR}" == "YES" ]]; then
 
     for imem in $(seq 1 "${NMEM_ENS}"); do
         memchar="mem$(printf %03i "${imem}")"
-        MEMDIR=${memchar} RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl \
-            COMIN_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL
+        declare -x COMIN_ATMOS_HISTORY=${ROTDIR}/${GDUMP_ENS}.${gPDY}/${gcyc}/${memchar}/model/atmos/history
 
         for fhr in ${fhrs}; do
             ${NLN} "${COMIN_ATMOS_HISTORY}/${GPREFIX_ENS}${ENKF_SUFFIX}atm.f0${fhr}.nc" "./ensemble_data/sigf${fhr}_ens_${memchar}"

--- a/dev/scripts/exglobal_cleanup.sh
+++ b/dev/scripts/exglobal_cleanup.sh
@@ -113,8 +113,7 @@ current_date = $(date --utc +%Y%m%d%H -d "${current_date:0:8} ${current_date:8:2
         tail_log=$(tail -n 1 "${rocotolog}") || true
         # Test if the last line of rocotolog indicates success
         if [[ ${tail_log} =~ "This cycle is complete: Success" ]]; then
-            YMD="${current_PDY}" HH="${current_cyc}" declare_from_tmpl \
-                COMOUT_TOP:COM_TOP_TMPL
+            declare -x COMOUT_TOP=${ROTDIR}/${RUN}.${current_PDY}/${current_cyc}
             if [[ -d "${COMOUT_TOP}" ]]; then
                 IFS=", " read -r -a exclude_list <<< "${exclude_string}"
                 remove_files "${COMOUT_TOP}" "${exclude_list[@]:-}"

--- a/dev/scripts/exglobal_enkf_ecen.sh
+++ b/dev/scripts/exglobal_enkf_ecen.sh
@@ -106,11 +106,9 @@ for FHR in $(seq "${FHMIN}" "${FHOUT}" "${FHMAX}"); do
         gmemchar="mem"$(printf %03i "${smem}")
         memchar="mem"$(printf %03i "${imem}")
 
-        MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl -x \
-            COMOUT_ATMOS_ANALYSIS_MEM:COM_ATMOS_ANALYSIS_TMPL
+        declare -x COMOUT_ATMOS_ANALYSIS_MEM=${ROTDIR}/${RUN}.${PDY}/${cyc}/${memchar}/analysis/atmos
 
-        MEMDIR=${gmemchar} RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -x \
-            COMIN_ATMOS_HISTORY_MEM_PREV:COM_ATMOS_HISTORY_TMPL
+        declare -x COMIN_ATMOS_HISTORY_MEM_PREV=${ROTDIR}/${GDUMP_ENS}.${gPDY}/${gcyc}/${gmemchar}/model/atmos/history
 
         ${NLN} "${COMIN_ATMOS_HISTORY_MEM_PREV}/${GPREFIX_ENS}atm.f00${FHR}${ENKF_SUFFIX}.nc" "./atmges_${memchar}"
         if [[ "${DO_CALC_INCREMENT}" == "YES" ]]; then

--- a/dev/scripts/exglobal_enkf_sfc.sh
+++ b/dev/scripts/exglobal_enkf_sfc.sh
@@ -175,17 +175,13 @@ if [[ "${DOIAU}" == "YES" ]]; then
             cmem=$(printf %03i "${imem}")
             memchar="mem${cmem}"
 
-            MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl \
-                COMOUT_ATMOS_RESTART_MEM:COM_ATMOS_RESTART_TMPL
+            declare -x COMOUT_ATMOS_RESTART_MEM=${ROTDIR}/${RUN}.${PDY}/${cyc}/${memchar}/model/atmos/restart
 
-            MEMDIR=${gmemchar} RUN=${GDUMP_ENS} YMD=${gPDY} HH=${gcyc} declare_from_tmpl \
-                COMIN_ATMOS_RESTART_MEM_PREV:COM_ATMOS_RESTART_TMPL
+            declare -x COMIN_ATMOS_RESTART_MEM_PREV=${ROTDIR}/${GDUMP_ENS}.${gPDY}/${gcyc}/${gmemchar}/model/atmos/restart
 
-            MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl \
-                COMIN_ATMOS_ANALYSIS_MEM:COM_ATMOS_ANALYSIS_TMPL
+            declare -x COMIN_ATMOS_ANALYSIS_MEM=${ROTDIR}/${RUN}.${PDY}/${cyc}/${memchar}/analysis/atmos
 
-            MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl \
-                COMIN_SNOW_ANALYSIS_MEM:COM_SNOW_ANALYSIS_TMPL
+            declare -x COMIN_SNOW_ANALYSIS_MEM=${ROTDIR}/${RUN}.${PDY}/${cyc}/${memchar}/analysis/snow
 
             # determine where the input snow restart files come from
             snow_prefix=""
@@ -228,8 +224,7 @@ if [[ "${DOIAU}" == "YES" ]]; then
             cmem=$(printf %03i "${imem}")
             memchar="mem${cmem}"
 
-            MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl \
-                COMOUT_ATMOS_RESTART_MEM:COM_ATMOS_RESTART_TMPL
+            declare -x COMOUT_ATMOS_RESTART_MEM=${ROTDIR}/${RUN}.${PDY}/${cyc}/${memchar}/model/atmos/restart
 
             if [[ ${TILE_NUM} -eq 1 ]]; then
                 mkdir -p "${COMOUT_ATMOS_RESTART_MEM}"
@@ -258,14 +253,11 @@ if [[ "${DOSFCANL_ENKF}" == "YES" ]]; then
             cmem=$(printf %03i "${imem}")
             memchar="mem${cmem}"
 
-            RUN="${GDUMP_ENS}" MEMDIR=${gmemchar} YMD=${PDY} HH=${cyc} declare_from_tmpl \
-                COMIN_SNOW_ANALYSIS_MEM:COM_SNOW_ANALYSIS_TMPL
+            declare -x COMIN_SNOW_ANALYSIS_MEM=${ROTDIR}/${GDUMP_ENS}.${PDY}/${cyc}/${gmemchar}/analysis/snow
 
-            RUN="${GDUMP_ENS}" MEMDIR=${gmemchar} YMD=${gPDY} HH=${gcyc} declare_from_tmpl \
-                COMIN_ATMOS_RESTART_MEM_PREV:COM_ATMOS_RESTART_TMPL
+            declare -x COMIN_ATMOS_RESTART_MEM_PREV=${ROTDIR}/${GDUMP_ENS}.${gPDY}/${gcyc}/${gmemchar}/model/atmos/restart
 
-            MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl \
-                COMIN_ATMOS_ANALYSIS_MEM:COM_ATMOS_ANALYSIS_TMPL
+            declare -x COMIN_ATMOS_ANALYSIS_MEM=${ROTDIR}/${RUN}.${PDY}/${cyc}/${memchar}/analysis/atmos
 
             # determine where the input snow restart files come from
             snow_prefix=""
@@ -304,8 +296,7 @@ if [[ "${DOSFCANL_ENKF}" == "YES" ]]; then
             cmem=$(printf %03i "${imem}")
             memchar="mem${cmem}"
 
-            MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl \
-                COMOUT_ATMOS_RESTART_MEM:COM_ATMOS_RESTART_TMPL
+            declare -x COMOUT_ATMOS_RESTART_MEM=${ROTDIR}/${RUN}.${PDY}/${cyc}/${memchar}/model/atmos/restart
 
             if [[ ! -d "${COMOUT_ATMOS_RESTART_MEM}" ]]; then
                 mkdir -p "${COMOUT_ATMOS_RESTART_MEM}"

--- a/dev/scripts/exglobal_enkf_update.sh
+++ b/dev/scripts/exglobal_enkf_update.sh
@@ -131,11 +131,9 @@ for imem in $(seq 1 "${NMEM_ENS}"); do
     gmemchar="mem"$(printf "%03i" "${smem}")
     memchar="mem"$(printf "%03i" "${imem}")
 
-    MEMDIR=${gmemchar} RUN=${GDUMP} YMD=${GDATE:0:8} HH=${GDATE:8:2} declare_from_tmpl -x \
-        COMIN_ATMOS_HISTORY_MEM_PREV:COM_ATMOS_HISTORY_TMPL
+    declare -x COMIN_ATMOS_HISTORY_MEM_PREV=${ROTDIR}/${GDUMP}.${GDATE:0:8}/${GDATE:8:2}/${gmemchar}/model/atmos/history
 
-    MEMDIR=${memchar} YMD=${PDY} HH=${cyc} declare_from_tmpl -x \
-        COMOUT_ATMOS_ANALYSIS_MEM:COM_ATMOS_ANALYSIS_TMPL
+    declare -x COMOUT_ATMOS_ANALYSIS_MEM=${ROTDIR}/${RUN}.${PDY}/${cyc}/${memchar}/analysis/atmos
 
     mkdir -p "${COMOUT_ATMOS_ANALYSIS_MEM}"
 

--- a/dev/ush/de_template_com.sh
+++ b/dev/ush/de_template_com.sh
@@ -1,0 +1,111 @@
+#! /usr/bin/env bash
+# shellcheck disable=SC2016
+
+# The purpose of this script is to read a target config.com and apply the ush/bash_utils.sh declare_from_tmpl function to generate the COM variable.
+#
+# Here are two cases of COM variable generation in the current workflow:
+# YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx COMIN_ATMOS_INPUT:COM_ATMOS_INPUT_TMPL
+# YMD="${PDY}" HH="${cyc}" declare_from_tmpl -rx COMOUT_CONF:COM_CONF_TMPL
+#
+#
+# Here is the config.com for these TMPL variables:
+# COM_BASE='${ROTDIR}/${RUN}.${YMD}/${HH}/${MEMDIR}'
+# declare -rx COM_ATMOS_INPUT_TMPL=${COM_BASE}'/model/atmos/input'
+# declare -rx COM_CONF_TMPL=${COM_BASE}'/conf'
+#
+#
+# The output of this script will look like the following for non-member variables:
+# COMIN_ATMOS_INPUT=${ROTDIR}/${RUN}.${YMD}/${HH}/model/atmos/input
+# For member variables, it will look like this:
+# COMIN_ATMOS_INPUT=${ROTDIR}/${RUN}.${YMD}/${HH}/${MEMDIR}/model/atmos/input
+
+if [[ $# -ne 3 ]]; then
+    echo "Usage: $0 <path/to/config.com> <path/to/jjob> <path/to/bash_utils.sh>" >&2
+    exit 1
+fi
+
+set -eu -o pipefail
+
+config_com="${1}"
+jjob="${2}"
+bash_utils="${3}"
+
+if [[ ! -f "${config_com}" ]]; then
+    echo "Error: config.com file '${config_com}' not found!" >&2
+    exit 1
+fi
+
+if [[ ! -f "${jjob}" ]]; then
+    echo "Error: jjob file '${jjob}' not found!" >&2
+    exit 1
+fi
+
+# Source the config.com to get the TMPL variables
+source "${config_com}" > /dev/null
+# Source the bash_utils.sh to get the declare_from_tmpl function
+source "${bash_utils}" > /dev/null
+
+# Set static variable for use in templates
+export ROTDIR='${ROTDIR}'
+export DMPDIR='${DMPDIR}'
+export IODADIR='${IODADIR}'
+
+# Replace the declare_from_tmpl calls in the jjob with the generated COM variable declarations and replace them in the jjob
+line_num=0
+while IFS= read -r line; do
+    line_num=$((line_num + 1))
+    # Intialize RUN. This can be overridden by the prefix assignments.
+    export RUN='${RUN}'
+    if [[ "${line}" =~ declare_from_tmpl ]]; then
+        # Use awk to get the number of leading spaces
+        COUNT=$(awk '{print match($0, /[^ ]|$/)-1}' <<< "${line}")
+        spaces=""
+        for i in $(seq 1 "${COUNT}"); do
+            spaces="${spaces} "
+        done
+        # Extract the prefix assignments to declare_from_tmpl
+        prefix=$(echo "${line}" | sed -E 's/^(.*)declare_from_tmpl.*/\1/')
+        # Parse the prefix to get all of the variable assignments (e.g. YMD="${PDY}" HH="${cyc}")
+        IFS=' ' read -ra prefix_args <<< "${prefix}"
+        # Convert these into literal variable assignments (e.g. YMD='${PDY}' HH='${cyc}')
+        for i in "${!prefix_args[@]}"; do
+            # shellcheck disable=SC2004
+            prefix_args[${i}]=$(echo "${prefix_args[${i}]}" | sed -E 's/(.*)="*([a-zA-Z0-9_{}$]+)"*/\1='\''\2'\''/')
+        done
+        # Extract the arguments to declare_from_tmpl
+        args=$(echo "${line}" | sed -E 's/.*declare_from_tmpl (.*)/\1/')
+        # Extract the flags to declare_from_tmpl (e.g. -rx)
+        flags=$(echo "${args}" | grep -E -o -- '-[a-zA-Z]+')
+        # Generate the COM variable declaration using declare_from_tmpl
+        # The prefix arguments need to be in the form of VAR='${var}' (i.e. we want the template to render a literal string with the variable names, not their values)
+        # Use prefix_args to form these prefix assignments and pass them to declare_from_tmpl
+        # Valid prefix args are DUMP, YMD, HH, GRDRESNAME, MEMDIR, RUN, and GRID
+        for var in DUMP YMD HH GRDRESNAME MEMDIR RUN GRID; do
+            for arg in "${prefix_args[@]}"; do
+                if [[ "${arg}" =~ ${var} ]]; then
+                    # Get what the variable is assigned to
+                    assignment=$(echo "${arg}" | sed -E "s/${var}='(.*)'/\1/")
+                    declare -x "${var}"="${assignment}"
+                fi
+            done
+        done
+
+        # Now render the template
+        # shellcheck disable=SC2086
+        COM=$(declare_from_tmpl -rx ${args} | sed 's/declare_from_tmpl :: \(.*\)=\(.*\)/\1=\2/')
+        # Remove duplicate // in the COM path if it exists (e.g. if MEMDIR is empty, we don't want a double slash in the path)
+        COM=$(echo "${COM}" | sed 's/\/\//\//g')
+        # Prepend with declare ${flags} if flags are present
+        if [[ -n "${flags}" ]]; then
+            COM="declare ${flags} ${COM}"
+        fi
+        # And write it to stdout
+        echo "${spaces}${COM}"
+    else
+        # Not a declare_from_tmpl line, just print it as is
+        echo "${line}"
+    fi
+
+    # Unset any variables that may have been set in the prefix to avoid unintended consequences in later lines of the jjob
+    unset DUMP YMD HH GRDRESNAME MEMDIR RUN GRID flags args spaces
+done < "${jjob}"

--- a/gempak/ush/gdas_meta_loop.sh
+++ b/gempak/ush/gdas_meta_loop.sh
@@ -9,8 +9,7 @@ device="nc | gdasloop.meta"
 
 #
 # Link data into DATA to sidestep gempak path limits
-# TODO: Replace this
-#
+# TODO: Add only necessary files and remove unneeded ones to minimize data volume
 export COMIN="${RUN}.${PDY}${cyc}"
 if [[ ! -L "${COMIN}" ]]; then
     ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
@@ -39,7 +38,9 @@ for ((fhr = 24; fhr <= 144; fhr += 24)); do
     cycles=$(seq -s ' ' -f "%02g" 0 6 "${cyc}")
     for cycle in ${cycles}; do
         #  Test with GDAS in PROD
-        YMD=${day} HH=${cyc} GRID=1p00 declare_from_tmpl "COMIN_ATMOS_GEMPAK_1p00_past:COM_ATMOS_GEMPAK_TMPL"
+        COMIN_ATMOS_GEMPAK_1p00_past="${ROTDIR}/${RUN}.${day}/${cyc}/products/atmos/gempak/1p00"
+        # TODO: Add only necessary files and remove unneeded ones to minimize data volume
+        # TODO: remove live links and refer https://github.com/NOAA-EMC/global-workflow/issues/4406
         export COMIN="${RUN}.${day}${cycle}"
         if [[ ! -L "${COMIN}" ]]; then
             ${NLN} "${COMIN_ATMOS_GEMPAK_1p00_past}" "${COMIN}"

--- a/gempak/ush/gfs_meta_comp.sh
+++ b/gempak/ush/gfs_meta_comp.sh
@@ -25,7 +25,7 @@ device="nc | ${metaname}"
 export COMIN="gfs.multi"
 mkdir "${COMIN}"
 for cycle in $(seq -f "%02g" -s ' ' 0 "${INTERVAL_GFS}" "${cyc}"); do
-    YMD=${PDY} HH=${cycle} GRID="1p00" declare_from_tmpl gempak_dir:COM_ATMOS_GEMPAK_TMPL
+    gempak_dir="${ROTDIR}/${RUN}.${PDY}/${cycle}/products/atmos/gempak/1p00"
     for file_in in "${gempak_dir}/gfs_1p00_${PDY}${cycle}f"*; do
         file_out="${COMIN}/$(basename "${file_in}")"
         if [[ ! -L "${file_out}" ]]; then
@@ -100,7 +100,7 @@ for gareas in US NP; do
         # Create symlink in DATA to sidestep gempak path limits
         HPCGFS="${RUN}.${init_time}"
         if [[ ! -L ${HPCGFS} ]]; then
-            YMD="${init_PDY}" HH="${init_cyc}" GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
+            source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
             ${NLN} "${source_dir}" "${HPCGFS}"
         fi
 

--- a/gempak/ush/gfs_meta_mar_comp.sh
+++ b/gempak/ush/gfs_meta_mar_comp.sh
@@ -16,7 +16,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 export COMIN="gfs.multi"
 mkdir -p "${COMIN}"
 for cycle in $(seq -f "%02g" -s ' ' 0 "${INTERVAL_GFS}" "${cyc}"); do
-    YMD=${PDY} HH=${cycle} GRID="1p00" declare_from_tmpl gempak_dir:COM_ATMOS_GEMPAK_TMPL
+    gempak_dir="${ROTDIR}/${RUN}.${PDY}/${cycle}/products/atmos/gempak/1p00"
     for file_in in "${gempak_dir}/gfs_1p00_${PDY}${cycle}f"*; do
         file_out="${COMIN}/$(basename "${file_in}")"
         if [[ ! -L "${file_out}" ]]; then
@@ -77,7 +77,7 @@ for garea in NAtl NPac; do
         # Create symlink in DATA to sidestep gempak path limits
         HPCGFS="${RUN}.${init_time}"
         if [[ ! -L ${HPCGFS} ]]; then
-            YMD="${init_PDY}" HH="${init_cyc}" GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
+            source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
             ${NLN} "${source_dir}" "${HPCGFS}"
         fi
 

--- a/gempak/ush/gfs_meta_opc_na_ver.sh
+++ b/gempak/ush/gfs_meta_opc_na_ver.sh
@@ -63,7 +63,7 @@ for lookback in "${lookbacks[@]}"; do
     # Create symlink in DATA to sidestep gempak path limits
     HPCGFS="${RUN}.${init_time}"
     if [[ ! -L ${HPCGFS} ]]; then
-        YMD=${init_PDY} HH=${init_cyc} GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
+        source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
         ${NLN} "${source_dir}" "${HPCGFS}"
     fi
 

--- a/gempak/ush/gfs_meta_opc_np_ver.sh
+++ b/gempak/ush/gfs_meta_opc_np_ver.sh
@@ -63,7 +63,7 @@ for lookback in "${lookbacks[@]}"; do
     # Create symlink in DATA to sidestep gempak path limits
     HPCGFS="${RUN}.${init_time}"
     if [[ ! -L "${HPCGFS}" ]]; then
-        YMD=${init_PDY} HH=${init_cyc} GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
+        source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
         ${NLN} "${source_dir}" "${HPCGFS}"
     fi
 

--- a/gempak/ush/gfs_meta_ver.sh
+++ b/gempak/ush/gfs_meta_ver.sh
@@ -53,7 +53,7 @@ for lookback in "${lookbacks[@]}"; do
     # Create symlink in DATA to sidestep gempak path limits
     HPCGFS="${RUN}.${init_time}"
     if [[ ! -L "${HPCGFS}" ]]; then
-        YMD=${init_PDY} HH=${init_cyc} GRID="1p00" declare_from_tmpl source_dir:COM_ATMOS_GEMPAK_TMPL
+        source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
         ${NLN} "${source_dir}" "${HPCGFS}"
     fi
 

--- a/ush/atmos_ensstat.sh
+++ b/ush/atmos_ensstat.sh
@@ -11,7 +11,7 @@ cd "${grid}${grid_type}" || exit 2
 input_files=()
 for ((mem_num = 0; mem_num <= "${NMEM_ENS:-0}"; mem_num++)); do
     mem=$(printf "%03d" "${mem_num}")
-    MEMDIR="mem${mem}" GRID="${grid}" YMD="${PDY}" HH="${cyc}" declare_from_tmpl COMIN_ATMOS_GRIB:COM_ATMOS_GRIB_GRID_TMPL
+    COMIN_ATMOS_GRIB="${ROTDIR}/${RUN}.${PDY}/${cyc}/mem${mem}/products/atmos/grib2/${grid}"
     memfile_in="${COMIN_ATMOS_GRIB}/${RUN}.t${cyc}z.pres_a${grid_type}.${grid}.f${fhr3}.grib2"
 
     if [[ -r "${memfile_in}.idx" ]]; then

--- a/ush/bash_utils.sh
+++ b/ush/bash_utils.sh
@@ -1,74 +1,5 @@
 #! /usr/bin/env bash
 
-function declare_from_tmpl() {
-    #
-    # Define variables from corresponding templates by substituting in env variables.
-    #
-    # Each template must already be defined. Any variables in the template are replaced
-    #   with their values. Undefined variables are just removed WITHOUT raising an error.
-    #
-    # Template can be used implicitly, however, all declared COM variables must be
-    #   defined as either COMIN or COMOUT, therefore the template should be explicit
-    #
-    # Accepts as options `-r` and `-x`, which do the same thing as the same options in
-    #   `declare`. Variables are automatically marked as `-g` so the variable is visible
-    #   in the calling script.
-    #
-    # Syntax:
-    #   declare_from_tmpl [-rx] $var1[:$tmpl1] [$var2[:$tmpl2]] [...]]
-    #
-    #   options:
-    #       -r: Make variable read-only (same as `declare -r`)
-    #       -x: Mark variable for export (same as `declare -x`)
-    #   var1, var2, etc: Variable names whose values will be generated from a template
-    #                    and declared
-    #   tmpl1, tmpl2, etc: Specify the template to use (default is "${var}_TMPL")
-    #
-    #   Examples:
-    #       # Current cycle and RUN, implicitly using template COM_ATMOS_ANALYSIS_TMPL
-    #       YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_ATMOS_ANALYSIS
-    #
-    #       # Previous cycle and gdas using an explicit template
-    #       RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    #           COMIN_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
-    #
-    #       # Current cycle and COM for first member using an explicit template
-    #       MEMDIR='mem001' YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    #           COMOUT_ATMOS_HISTORY:COM_ATMOS_HISTORY_TMPL
-    #
-    if [[ ${DEBUG_WORKFLOW:-"NO"} == "NO" ]]; then
-        set +x
-    fi
-    local opts="-g"
-    local OPTIND=1
-    while getopts "rx" option; do
-        opts="${opts}${option}"
-    done
-    shift $((OPTIND - 1))
-
-    for input in "$@"; do
-        IFS=':' read -ra args <<< "${input}"
-        local com_var="${args[0]}"
-        local template
-        local value
-        if ((${#args[@]} > 1)); then
-            template="${args[1]}"
-        else
-            template="${com_var}_TMPL"
-        fi
-        if [[ ! -v "${template}" ]]; then
-            echo "FATAL ERROR in declare_from_tmpl: Requested template ${template} not defined!"
-            exit 2
-        fi
-        value=$(echo "${!template}" | envsubst)
-        # shellcheck disable=SC2086
-        declare ${opts} "${com_var}"="${value}"
-        # shellcheck disable=
-        echo "declare_from_tmpl :: ${com_var}=${value}"
-    done
-    set_trace
-}
-
 function wait_for_file() {
     #
     # Wait for a file to exist and return the status.
@@ -129,9 +60,7 @@ function dataroot_com_path() {
     #   original_com_path: The original COM path to be transformed.
     #
     # Example:
-    #   # Declare COMOUT_ATMOS_ANALYSIS using template
-    #   YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    #       COMOUT_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL
+    #   COMOUT_ATMOS_ANALYSIS="${COMIN}/analysis/atmos
     #   # Get the DATAROOT version of the COM path
     #   pCOMOUT_ATMOS_ANALYSIS=$(dataroot_com_path "${COMOUT_ATMOS_ANALYSIS}")
     #   echo "New COM path in DATAROOT: ${pCOMOUT_ATMOS_ANALYSIS}"
@@ -245,7 +174,6 @@ tock() {
 
 # shellcheck disable=
 
-declare -xf declare_from_tmpl
 declare -xf wait_for_file
 declare -xf dataroot_com_path
 declare -xf tick

--- a/ush/python/pygfs/task/offline_analysis.py
+++ b/ush/python/pygfs/task/offline_analysis.py
@@ -252,11 +252,11 @@ class OfflineAnalysis(Task):
         FileHandler({'copy': output_files}).sync()
         # these files are for the surface analysis
         transfer_files = []
-        transfer_files.append([os.path.join(self.task_config.COMIN_OBSPROC, f"{self.task_config.APREFIX_IN}rtgssthr.grb"),
+        transfer_files.append([os.path.join(self.task_config.COMINobsproc, f"{self.task_config.APREFIX_IN}rtgssthr.grb"),
                                os.path.join(self.task_config.COMOUT_OBS, f"{self.task_config.APREFIX}rtgssthr.grb")])
-        transfer_files.append([os.path.join(self.task_config.COMIN_OBSPROC, f"{self.task_config.APREFIX_IN}seaice.5min.blend.grb"),
+        transfer_files.append([os.path.join(self.task_config.COMINobsproc, f"{self.task_config.APREFIX_IN}seaice.5min.blend.grb"),
                                os.path.join(self.task_config.COMOUT_OBS, f"{self.task_config.APREFIX}seaice.5min.blend.grb")])
-        transfer_files.append([os.path.join(self.task_config.COMIN_OBSPROC, f"{self.task_config.APREFIX_IN}snogrb_t1534.3072.1536"),
+        transfer_files.append([os.path.join(self.task_config.COMINobsproc, f"{self.task_config.APREFIX_IN}snogrb_t1534.3072.1536"),
                                os.path.join(self.task_config.COMOUT_OBS, f"{self.task_config.APREFIX}snogrb_t1534.3072.1536")])
         # TODO: Re-stage the inputs for the GCDAS offline analysis on HPSS following EE2-compliant filenames, then update this line
         transfer_files.append([

--- a/ush/python/pygfs/utils/archive_vars.py
+++ b/ush/python/pygfs/utils/archive_vars.py
@@ -140,7 +140,6 @@ class ArchiveVrfyVars:
                 logger.warning(f"Config key '{key}' not found in config_dict; skipping.")
 
         # Import COM* directory and template variables created by job scripts
-        # Job scripts use declare_from_tmpl -rx which exports variables to environment
         for key in config_dict.keys():
             if key.startswith(("COM_", "COMIN_", "COMOUT_")):
                 general_dict[key] = config_dict.get(key)

--- a/ush/regrid_gsiSfcIncr_to_tile.sh
+++ b/ush/regrid_gsiSfcIncr_to_tile.sh
@@ -90,9 +90,8 @@ if [[ "${NMEM_REGRID}" -gt 1 ]]; then
 
         memdir=$(printf "mem%03i" "${imem}")
 
-        MEMDIR=${memdir} YMD=${PDY} HH=${cyc} declare_from_tmpl \
-            COMIN_SOIL_ANALYSIS_MEM:COM_ATMOS_ANALYSIS_TMPL \
-            COMOUT_ATMOS_ANALYSIS_MEM:COM_ATMOS_ANALYSIS_TMPL
+        COMIN_SOIL_ANALYSIS_MEM="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}/analysis/atmos"
+        COMOUT_ATMOS_ANALYSIS_MEM="${ROTDIR}/${RUN}.${PDY}/${cyc}/${memdir}/analysis/atmos"
 
         # Create MPMD command file for this member
         rm -f "cmdfile_in.${imem}" "cmdfile_out.${imem}"


### PR DESCRIPTION
# Description
This makes COM declarations explicit in GFS v17 and removes the use of `declare_from_tmpl`.

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Full tests running on C6 and WCOSS2.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners