### PR TITLE
Change postamble to be an executable script rather than a function

### DIFF
--- a/ush/jjob_shell_setup.sh
+++ b/ush/jjob_shell_setup.sh
@@ -26,7 +26,7 @@
 # (e.g. preamble.sh callers such as run_mpmd.sh)
 export USHglobal="${USHglobal:-${HOMEglobal}/ush}"
 export start_time=${start_time:-$(date +%s)}
-_calling_script=${_calling_script:-$(basename "${BASH_SOURCE[1]}")}
+export _calling_script=${_calling_script:-$(basename "${BASH_SOURCE[1]}")}
 
 ##############################################
 # Utility functions

--- a/ush/jjob_shell_setup.sh
+++ b/ush/jjob_shell_setup.sh
@@ -7,7 +7,7 @@
 #
 # Handles:
 #   - Sourcing utility functions (wait_for_file, dataroot_com_path, timer,
-#       err_exit, postamble)
+#       err_exit)
 #   - Setting shell options (nullglob)
 #   - Each utility script exports its own functions via declare -xf
 #   - Activating strict mode (set -eu) and tracing (set -x)
@@ -52,9 +52,8 @@ set -x
 ##############################################
 # Exit trap: run postamble on exit to report elapsed time and clean up
 ##############################################
-source "${USHglobal}/postamble.sh"
 # shellcheck disable=SC2064
-trap "postamble ${start_time}" EXIT
+trap "${USHglobal}/postamble.sh ${start_time}" EXIT
 
 ##############################################
 # Temporal variables: PDY, PDYm#, PDYp# (via setpdy.sh)

--- a/ush/postamble.sh
+++ b/ush/postamble.sh
@@ -1,53 +1,46 @@
 #! /usr/bin/env bash
 
 #######
-# Defines the postamble function for use in J-jobs and ex-scripts.
+# A postamble for use in J-jobs and ex-scripts.
+# This is intended to be used in a trap to execute commands when a script ends,
+# regardless of how it ends (normal exit, error, etc.).
 #
-# Source this file to load the function into the current shell:
-#   source "${USHglobal}/postamble.sh"
-#
-# Then register with trap:
-#   trap "postamble ${start_time}" EXIT
+# To use, register with trap:
+#   trap "${USHglobal}/postamble.sh ${start_time}" EXIT
 #######
 
-postamble() {
-    #
-    # Commands to execute when a script ends.
-    #
-    # Syntax:
-    #   postamble start_time [rc]
-    #
-    #   Arguments:
-    #     start_time: start time of script (in seconds since epoch)
-    #     rc:         exit code of the script [default: $?]
-    #
+# Commands to execute when a script ends.
+#
+# Syntax:
+#   postamble.sh start_time [rc]
+#
+#   Arguments:
+#     start_time: start time of script (in seconds since epoch)
+#     rc:         exit code of the script [default: $?]
+#
 
-    set +x
-    local start_time="${1}"
-    local rc="${2:-$?}"
+set +x
+start_time="${start_time:-${1}}"
+rc="${rc:-${2:-$?}}"
 
-    # Execute any commands registered in POSTAMBLE_CMD
-    #
-    # Commands can be added to the postamble by appending them to $POSTAMBLE_CMD:
-    #    POSTAMBLE_CMD="new_thing; ${POSTAMBLE_CMD:-}" # (before existing commands)
-    #    POSTAMBLE_CMD="${POSTAMBLE_CMD:-}; new_thing" # (after existing commands)
-    #
-    # These commands will be called when EACH SCRIPT terminates, so be mindful.
-    # Please consult with global-workflow CMs about permanent changes to
-    # $POSTAMBLE_CMD or this postamble function.
-    if [[ -v 'POSTAMBLE_CMD' ]]; then
-        ${POSTAMBLE_CMD}
-    fi
+# Execute any commands registered in POSTAMBLE_CMD
+#
+# Commands can be added to the postamble by appending them to $POSTAMBLE_CMD:
+#    POSTAMBLE_CMD="new_thing; ${POSTAMBLE_CMD:-}" # (before existing commands)
+#    POSTAMBLE_CMD="${POSTAMBLE_CMD:-}; new_thing" # (after existing commands)
+#
+# These commands will be called when EACH SCRIPT terminates, so be mindful.
+# Please consult with global-workflow CMs about permanent changes to
+# $POSTAMBLE_CMD or this postamble function.
+if [[ -v 'POSTAMBLE_CMD' ]]; then
+    ${POSTAMBLE_CMD}
+fi
 
-    # Calculate the elapsed time
-    local end_time end_time_human elapsed_sec elapsed
-    end_time=$(date +%s)
-    end_time_human=$(date -d@"${end_time}" -u +%H:%M:%S)
-    elapsed_sec=$((end_time - start_time))
-    elapsed=$(date -d@"${elapsed_sec}" -u +%H:%M:%S)
+# Calculate the elapsed time
+_end_time=$(date +%s)
+_end_time_human=$(date -d@"${_end_time}" -u +%H:%M:%S)
+_elapsed_sec=$((_end_time - start_time))
+_elapsed=$(date -d@"${_elapsed_sec}" -u +%H:%M:%S)
 
-    echo "End ${_calling_script:-script} at ${end_time_human} with error code ${rc} (time elapsed: ${elapsed})"
-    exit "${rc}"
-}
-
-declare -xf postamble
+echo "End ${_calling_script:-script} at ${_end_time_human} with error code ${rc} (time elapsed: ${_elapsed})"
+exit "${rc}"


### PR DESCRIPTION
# Description
This pull request changes the postamble bash function into an executable script and also calls it with trap as part of the `jjob_shell_setup.sh` script. This is the next step towards making the global workflow compliant for NWS operations.

  Resolves #4686 

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
