### PR TITLE
Copy CRTM coefficients at build time to FIXglobal and use from there at runtime

### DIFF
--- a/ecf/scripts/gcdas/chem/analysis/jgcdas_aerosol_analysis_initialize.ecf
+++ b/ecf/scripts/gcdas/chem/analysis/jgcdas_aerosol_analysis_initialize.ecf
@@ -95,10 +95,6 @@ export cyc=%CYC%
 export cycle=t%CYC%z
 export HOMEglobal=${HOMEgcafs}
 
-
-#TODO fix below line properly
-export CRTM_FIX="/lfs/h2/emc/da/noscrub/emc.da/GDASApp/fix/crtm/2.4.0"
-
 ############################################################
 # CALL executable job script here
 ############################################################

--- a/sorc/link_workflow_gcafs.sh
+++ b/sorc/link_workflow_gcafs.sh
@@ -124,6 +124,7 @@ done
 #--copy/link NoahMp table form ccpp-physics repository
 cd "${HOMEglobal}/parm/ufs" || exit 1
 ${LINK_OR_COPY} "${HOMEglobal}/sorc/ufs_model.fd/tests/parm/noahmptable.tbl" .
+${LINK_OR_COPY} "${HOMEglobal}/sorc/ufs_model.fd/tests/parm/fd_ufs.yaml" .
 
 cd "${HOMEglobal}/parm/post" || exit 1
 ${LINK_OR_COPY} "${HOMEglobal}/sorc/upp.fd/parm/params_grib2_tbl_new" .

--- a/sorc/link_workflow_gcafs.sh
+++ b/sorc/link_workflow_gcafs.sh
@@ -152,12 +152,33 @@ for file in "${ufs_templates[@]}"; do
     ${LINK_OR_COPY} "${HOMEglobal}/sorc/ufs_model.fd/tests/parm/${file}" .
 done
 
+# Link the CCPP suite XML files from ufs-weather-model
+if [[ -d "${HOMEglobal}/sorc/ufs_model.fd/UFSATM/ccpp/suites" ]]; then
+    for suite_file in "${HOMEglobal}/sorc/ufs_model.fd/UFSATM/ccpp/suites"/suite_*.xml; do
+        [[ -f "${suite_file}" ]] || continue
+        local_name=$(basename "${suite_file}")
+        if [[ -s "${local_name}" ]]; then
+            rm -f "${local_name}"
+        fi
+        ${LINK_OR_COPY} "${suite_file}" .
+    done
+fi
+
 # Link the script from ufs-weather-model that parses the templates
 cd "${HOMEglobal}/ush" || exit 1
 if [[ -s "atparse.bash" ]]; then
     rm -f "atparse.bash"
 fi
 ${LINK_OR_COPY} "${HOMEglobal}/sorc/ufs_model.fd/tests/atparse.bash" .
+
+# Link UPP modulefiles for module loading
+cd "${HOMEglobal}/modulefiles" || exit 1
+if [[ -d "${HOMEglobal}/sorc/ufs_model.fd/UFSATM/upp/modulefiles" ]]; then
+    if [[ -d "upp" ]]; then
+        rm -rf "upp"
+    fi
+    ${LINK_OR_COPY} "${HOMEglobal}/sorc/ufs_model.fd/UFSATM/upp/modulefiles" upp
+fi
 
 # add ufs_utils parm dir
 if [[ -d "${HOMEglobal}/sorc/ufs_utils.fd" ]]; then

--- a/sorc/link_workflow_gcafs.sh
+++ b/sorc/link_workflow_gcafs.sh
@@ -208,19 +208,19 @@ if [[ "${machine}" == "wcoss2" ]]; then
     cd crtm_aod || exit 1
     gdas_crtm_fix=/lfs/h2/emc/da/noscrub/emc.da/GDASApp/fix/crtm/2.4.0
     aod_file_list=(
-  "AerosolCoeff.bin"
-  "CloudCoeff.bin"
-  "v.viirs-m_npp.SpcCoeff.bin"
-  "v.viirs-m_npp.TauCoeff.bin"
-  "v.viirs-m_j1.SpcCoeff.bin"
-  "v.viirs-m_j1.TauCoeff.bin"
-  "v.viirs-m_j2.SpcCoeff.bin"
-  "v.viirs-m_j2.TauCoeff.bin"
-  "NPOESS.VISice.EmisCoeff.bin"
-  "NPOESS.VISland.EmisCoeff.bin"
-  "NPOESS.VISsnow.EmisCoeff.bin"
-  "NPOESS.VISwater.EmisCoeff.bin"
-)
+        "AerosolCoeff.bin"
+        "CloudCoeff.bin"
+        "v.viirs-m_npp.SpcCoeff.bin"
+        "v.viirs-m_npp.TauCoeff.bin"
+        "v.viirs-m_j1.SpcCoeff.bin"
+        "v.viirs-m_j1.TauCoeff.bin"
+        "v.viirs-m_j2.SpcCoeff.bin"
+        "v.viirs-m_j2.TauCoeff.bin"
+        "NPOESS.VISice.EmisCoeff.bin"
+        "NPOESS.VISland.EmisCoeff.bin"
+        "NPOESS.VISsnow.EmisCoeff.bin"
+        "NPOESS.VISwater.EmisCoeff.bin"
+    )
     for file in "${aod_file_list[@]}"; do
         if [[ -s "${file}" ]]; then
             rm -f "${file}"

--- a/sorc/link_workflow_gcafs.sh
+++ b/sorc/link_workflow_gcafs.sh
@@ -200,6 +200,36 @@ if [[ -d "${HOMEglobal}/sorc/gdas.cd" ]]; then
 fi
 
 #------------------------------
+#--add coefficient files needed for aerosol DA
+#------------------------------
+if [[ "${machine}" == "wcoss2" ]]; then
+    cd "${HOMEglobal}/fix/gdas" || exit 1
+    mkdir -p crtm_aod
+    cd crtm_aod || exit 1
+    gdas_crtm_fix=/lfs/h2/emc/da/noscrub/emc.da/GDASApp/fix/crtm/2.4.0
+    aod_file_list=(
+  "AerosolCoeff.bin"
+  "CloudCoeff.bin"
+  "v.viirs-m_npp.SpcCoeff.bin"
+  "v.viirs-m_npp.TauCoeff.bin"
+  "v.viirs-m_j1.SpcCoeff.bin"
+  "v.viirs-m_j1.TauCoeff.bin"
+  "v.viirs-m_j2.SpcCoeff.bin"
+  "v.viirs-m_j2.TauCoeff.bin"
+  "NPOESS.VISice.EmisCoeff.bin"
+  "NPOESS.VISland.EmisCoeff.bin"
+  "NPOESS.VISsnow.EmisCoeff.bin"
+  "NPOESS.VISwater.EmisCoeff.bin"
+)
+    for file in "${aod_file_list[@]}"; do
+        if [[ -s "${file}" ]]; then
+            rm -f "${file}"
+        fi
+        ${LINK_OR_COPY} "${gdas_crtm_fix}/${file}" .
+    done
+fi
+
+#------------------------------
 #--add NEXUS files
 #------------------------------
 if [[ -d "${HOMEglobal}/sorc/nexus.fd" ]]; then


### PR DESCRIPTION
# Description
This PR copies CRTM coefficients needed for the special JEDI-GCAFS version of CRTM to FIXglobal at build time and copies from there, not externally, at runtime.

Resolves https://github.com/NOAA-EMC/global-workflow/issues/4725