### PR TITLE
Add a GCAFS bypass of SENDDBN in exglobal_atmos_products.sh (#4713)

### DIFF
--- a/dev/scripts/exglobal_atmos_products.sh
+++ b/dev/scripts/exglobal_atmos_products.sh
@@ -201,7 +201,7 @@ fi
 
 # Start sending DBN alerts
 # Everything below this line is for sending files to DBN (SENDDBN=YES)
-if [[ "${SENDDBN:-}" == "YES" ]]; then
+if [[ "${SENDDBN:-}" == "YES" && "${NET}" != "gcafs" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${RUN^^}_PGB2_0P25" "${job}" "${COMOUT_ATMOS_GRIB_0p25}/${PREFIX}pres_a.0p25.${fhr3}.grib2"
     "${DBNROOT}/bin/dbn_alert" MODEL "${RUN^^}_PGB2_0P25_WIDX" "${job}" "${COMOUT_ATMOS_GRIB_0p25}/${PREFIX}pres_a.0p25.${fhr3}.grib2.idx"
     if [[ "${RUN}" == "gfs" ]]; then


### PR DESCRIPTION
GCAFS utilizes exglobal_atmos_products.sh in their suite, but when `SENDDBN=YES` the atmos products job fails as the `SENDDBN` section is expecting either a gfs or gdas `${RUN} `variable instead of gcdas/gcafs. Since GCAFS is not currently expecting to send DBN alerts, this PR adds a condition to the SENDDBN section to bypass if the `${NET}` is GCAFS.
