### PR TITLE
Only check if HOMEglobal is defined when loading modules

### DIFF
--- a/modulefiles/gw_run.gaeac6.lua
+++ b/modulefiles/gw_run.gaeac6.lua
@@ -5,7 +5,7 @@ Load environment to run GFS on Gaea C6
 -- Test that HOMEglobal is set.
 -- If not, load_modules.sh was not sourced to load this module.
 local homegfssdir=os.getenv("HOMEglobal") or "None"
-if (homegfssdir == "None") then
+if (homegfssdir == "None" and mode() == "load") then
     LmodError("FATAL ERROR HOMEglobal variable is unset.\n" ..
               "Please \"source dev/ush/load_modules.sh\" rather than loading this module directly.\n")
 end

--- a/modulefiles/gw_run.hera.lua
+++ b/modulefiles/gw_run.hera.lua
@@ -5,7 +5,7 @@ Load environment to run GFS on Hera
 -- Test that HOMEglobal is set.
 -- If not, load_modules.sh was not sourced to load this module.
 local homegfssdir=os.getenv("HOMEglobal") or "None"
-if (homegfssdir == "None") then
+if (homegfssdir == "None" and mode() == "load") then
     LmodError("FATAL ERROR HOMEglobal variable is unset.\n" ..
               "Please \"source dev/ush/load_modules.sh\" rather than loading this module directly.\n")
 end

--- a/modulefiles/gw_run.hercules.lua
+++ b/modulefiles/gw_run.hercules.lua
@@ -5,7 +5,7 @@ Load environment to run GFS on Hercules
 -- Test that HOMEglobal is set.
 -- If not, load_modules.sh was not sourced to load this module.
 local homegfssdir=os.getenv("HOMEglobal") or "None"
-if (homegfssdir == "None") then
+if (homegfssdir == "None" and mode() == "load") then
     LmodError("FATAL ERROR HOMEglobal variable is unset.\n" ..
               "Please \"source dev/ush/load_modules.sh\" rather than loading this module directly.\n")
 end

--- a/modulefiles/gw_run.noaacloud.lua
+++ b/modulefiles/gw_run.noaacloud.lua
@@ -5,7 +5,7 @@ Load environment to run GFS on NOAA cloud
 -- Test that HOMEglobal is set.
 -- If not, load_modules.sh was not sourced to load this module.
 local homegfssdir=os.getenv("HOMEglobal") or "None"
-if (homegfssdir == "None") then
+if (homegfssdir == "None" and mode() == "load") then
     LmodError("FATAL ERROR HOMEglobal variable is unset.\n" ..
               "Please \"source dev/ush/load_modules.sh\" rather than loading this module directly.\n")
 end

--- a/modulefiles/gw_run.orion.lua
+++ b/modulefiles/gw_run.orion.lua
@@ -5,7 +5,7 @@ Load environment to run GFS on Orion
 -- Test that HOMEglobal is set.
 -- If not, load_modules.sh was not sourced to load this module.
 local homegfssdir=os.getenv("HOMEglobal") or "None"
-if (homegfssdir == "None") then
+if (homegfssdir == "None" and mode() == "load") then
     LmodError("FATAL ERROR HOMEglobal variable is unset.\n" ..
               "Please \"source dev/ush/load_modules.sh\" rather than loading this module directly.\n")
 end

--- a/modulefiles/gw_run.ursa.lua
+++ b/modulefiles/gw_run.ursa.lua
@@ -5,7 +5,7 @@ Load environment to run GFS on Ursa
 -- Test that HOMEglobal is set.
 -- If not, load_modules.sh was not sourced to load this module.
 local homegfssdir=os.getenv("HOMEglobal") or "None"
-if (homegfssdir == "None") then
+if (homegfssdir == "None" and mode() == "load") then
     LmodError("FATAL ERROR HOMEglobal variable is unset.\n" ..
               "Please \"source dev/ush/load_modules.sh\" rather than loading this module directly.\n")
 end


### PR DESCRIPTION
# Description
This prevents `module purge` or `module reset` from returning errors if `HOMEglobal` is not defined. This is only useful for debugging and has no impact on running jobs.

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
On Ursa:
```console
> . dev/ush/load_modules.sh run
Currently Loaded Modules:
  1) lmod                             11) tar/1.34                21) jasper/2.0.32              31) c-blosc/1.21.5          41) antlr/2.7.7      51) gsi-ncdiag/1.1.2        61) py-pyyaml/6.0.2           71) py-xarray/2024.7.0
  2) intel-oneapi-compilers/2024.2.1  12) gettext/0.22.5          22) libpng/1.6.37              32) netcdf-c/4.9.2          42) gsl/2.8          52) crtm-fix/2.4.0.1_emc    62) py-markupsafe/2.1.3       72) gw_run.common
  3) stack-oneapi/2024.2.1            13) sqlite/3.46.0           23) openjpeg/2.3.1             33) netcdf-fortran/4.6.1    43) nco/5.2.4        53) git-lfs/3.5.1           63) py-jinja2/3.1.4           73) g2c/2.1.0
  4) intel-oneapi-mpi/2021.13.1       14) util-linux-uuid/2.40.2  24) eccodes/2.33.0             34) parallel-netcdf/1.12.3  44) bacio/2.4.1      54) crtm/2.4.0.1            64) py-pytz/2023.3            74) wgrib2/3.6.0
  5) stack-intel-oneapi-mpi/2021.13   15) python/3.11.7           25) intel-oneapi-mkl/2024.2.1  35) parallelio/2.6.2        45) w3emc/2.10.0     55) bufr/12.1.0             65) py-tzdata/2023.3          75) prepobs/1.1.3
  6) glibc/2.34                       16) stack-python/3.11.7     26) proj/9.4.1                 36) python-venv/1.0         46) prod_util/2.1.1  56) py-f90nml/1.4.3         66) py-pandas/2.2.3           76) fit2obs/1.1.10
  7) intel-oneapi-runtime/2024.2.1    17) nghttp2/1.63.0          27) udunits/2.2.28             37) py-mpi4py/4.0.1         47) g2/3.5.1         57) py-certifi/2023.7.22    67) py-six/1.16.0             77) imagemagick/7.1.1-29
  8) zlib/1.2.13                      18) curl/8.10.1             28) cdo/2.4.4                  38) py-numpy/1.26.4         48) ip/5.1.0         58) py-cftime/1.0.3.4       68) py-python-dateutil/2.8.2  78) gw_run.ursa
  9) pigz/2.8                         19) cmake/3.27.9            29) hdf5/1.14.3                39) py-pip/23.1.2           49) grib-util/1.4.0  59) py-netcdf4/1.7.1.post2  69) py-packaging/24.1
 10) zstd/1.5.6                       20) libjpeg/2.1.0           30) snappy/1.2.1               40) esmf/8.8.0              50) g2tmpl/1.13.0    60) libyaml/0.2.5           70) py-setuptools/69.2.0
> module reset
>
```

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added