### PR TITLE
Do not assign anyone to issues by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/NCO_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/NCO_bug_report.yml
@@ -1,11 +1,8 @@
 name: NCO Bug Report
 description: Report something that is incorrect or broken
-labels: ["nco-bug", "triage"]
+labels: ["nco-bug"]
 type: "bug"
 projects: ["NOAA-EMC/41"]
-assignees:
-  - DavidHuber-NOAA
-  - TravisElless-NOAA
 
 body:
   - type: markdown


### PR DESCRIPTION
# Description
This updates the NCO bug report issue template so that 1. the defunct `triage` label is not added by default and 2. no one is assigned by default. This will make it clearer when someone picks an issue up.

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
Issue template update.

# How has this been tested?
Rendered the template.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings