### PR TITLE
Change postamble to be an executable script rather than a function (#4719)

### DIFF
--- a/ush/jjob_shell_setup.sh
+++ b/ush/jjob_shell_setup.sh
@@ -7,7 +7,7 @@
 #
 # Handles:
 #   - Sourcing utility functions (wait_for_file, dataroot_com_path, timer,
-#       err_exit, postamble)
+#       err_exit)
 #   - Setting shell options (nullglob)
 #   - Each utility script exports its own functions via declare -xf
 #   - Activating strict mode (set -eu) and tracing (set -x)
@@ -26,7 +26,7 @@
 # (e.g. preamble.sh callers such as run_mpmd.sh)
 export USHglobal="${USHglobal:-${HOMEglobal}/ush}"
 export start_time=${start_time:-$(date +%s)}
-_calling_script=${_calling_script:-$(basename "${BASH_SOURCE[1]}")}
+export _calling_script=${_calling_script:-$(basename "${BASH_SOURCE[1]}")}
 
 ##############################################
 # Utility functions
@@ -52,9 +52,8 @@ set -x
 ##############################################
 # Exit trap: run postamble on exit to report elapsed time and clean up
 ##############################################
-source "${USHglobal}/postamble.sh"
 # shellcheck disable=SC2064
-trap "postamble ${start_time}" EXIT
+trap "${USHglobal}/postamble.sh ${start_time}" EXIT
 
 ##############################################
 # Temporal variables: PDY, PDYm#, PDYp# (via setpdy.sh)

--- a/ush/postamble.sh
+++ b/ush/postamble.sh
@@ -1,53 +1,46 @@
 #! /usr/bin/env bash
 
 #######
-# Defines the postamble function for use in J-jobs and ex-scripts.
+# A postamble for use in J-jobs and ex-scripts.
+# This is intended to be used in a trap to execute commands when a script ends,
+# regardless of how it ends (normal exit, error, etc.).
 #
-# Source this file to load the function into the current shell:
-#   source "${USHglobal}/postamble.sh"
-#
-# Then register with trap:
-#   trap "postamble ${start_time}" EXIT
+# To use, register with trap:
+#   trap "${USHglobal}/postamble.sh ${start_time}" EXIT
 #######
 
-postamble() {
-    #
-    # Commands to execute when a script ends.
-    #
-    # Syntax:
-    #   postamble start_time [rc]
-    #
-    #   Arguments:
-    #     start_time: start time of script (in seconds since epoch)
-    #     rc:         exit code of the script [default: $?]
-    #
+# Commands to execute when a script ends.
+#
+# Syntax:
+#   postamble.sh start_time [rc]
+#
+#   Arguments:
+#     start_time: start time of script (in seconds since epoch)
+#     rc:         exit code of the script [default: $?]
+#
 
-    set +x
-    local start_time="${1}"
-    local rc="${2:-$?}"
+set +x
+start_time="${start_time:-${1}}"
+rc="${rc:-${2:-$?}}"
 
-    # Execute any commands registered in POSTAMBLE_CMD
-    #
-    # Commands can be added to the postamble by appending them to $POSTAMBLE_CMD:
-    #    POSTAMBLE_CMD="new_thing; ${POSTAMBLE_CMD:-}" # (before existing commands)
-    #    POSTAMBLE_CMD="${POSTAMBLE_CMD:-}; new_thing" # (after existing commands)
-    #
-    # These commands will be called when EACH SCRIPT terminates, so be mindful.
-    # Please consult with global-workflow CMs about permanent changes to
-    # $POSTAMBLE_CMD or this postamble function.
-    if [[ -v 'POSTAMBLE_CMD' ]]; then
-        ${POSTAMBLE_CMD}
-    fi
+# Execute any commands registered in POSTAMBLE_CMD
+#
+# Commands can be added to the postamble by appending them to $POSTAMBLE_CMD:
+#    POSTAMBLE_CMD="new_thing; ${POSTAMBLE_CMD:-}" # (before existing commands)
+#    POSTAMBLE_CMD="${POSTAMBLE_CMD:-}; new_thing" # (after existing commands)
+#
+# These commands will be called when EACH SCRIPT terminates, so be mindful.
+# Please consult with global-workflow CMs about permanent changes to
+# $POSTAMBLE_CMD or this postamble function.
+if [[ -v 'POSTAMBLE_CMD' ]]; then
+    ${POSTAMBLE_CMD}
+fi
 
-    # Calculate the elapsed time
-    local end_time end_time_human elapsed_sec elapsed
-    end_time=$(date +%s)
-    end_time_human=$(date -d@"${end_time}" -u +%H:%M:%S)
-    elapsed_sec=$((end_time - start_time))
-    elapsed=$(date -d@"${elapsed_sec}" -u +%H:%M:%S)
+# Calculate the elapsed time
+_end_time=$(date +%s)
+_end_time_human=$(date -d@"${_end_time}" -u +%H:%M:%S)
+_elapsed_sec=$((_end_time - start_time))
+_elapsed=$(date -d@"${_elapsed_sec}" -u +%H:%M:%S)
 
-    echo "End ${_calling_script:-script} at ${end_time_human} with error code ${rc} (time elapsed: ${elapsed})"
-    exit "${rc}"
-}
-
-declare -xf postamble
+echo "End ${_calling_script:-script} at ${_end_time_human} with error code ${rc} (time elapsed: ${_elapsed})"
+exit "${rc}"


### PR DESCRIPTION
This pull request changes the postamble bash function into an executable script and also calls it with trap as part of the `jjob_shell_setup.sh` script. This is the next step towards making the global workflow compliant for NWS operations.

