### PR TITLE
[dev/gfs.v17] Add documentation block to parse-storm-type.pl

### DIFF
--- a/ush/parse-storm-type.pl
+++ b/ush/parse-storm-type.pl
@@ -1,5 +1,22 @@
 #! /usr/bin/env perl
 
+# DESCRIPTION: Parses lines of tropical cyclone data found in the tcvitals file.
+#              It specifically looks for records from NHC (National Hurricane
+#              Center) or JTWC (Joint Typhoon Warning Center).
+#
+# FUNCTIONALITY:
+# 1. Validation: Matches lines against a specific pattern to ensure they contain
+#    the required identifiers, storm name, and date/time group. Invalid lines
+#    are ignored with a warning.
+# 2. Reformatting: Truncates the storm name/identifier to 9 characters and
+#    reformats the output line, left-justifying the name.
+# 3. Filtering: Checks the 2-character tropical cyclone type field (expected at
+#    character 150) and ignores any records classified as non-tropical/unclassified:
+#    DB (Disturbance), EX (Extra-tropical), LO (Low), WV (Wave), or XX (Unknown).
+# 4. Output: Prints/returns only the reformatted lines that represent a classified
+#    tropical cyclone.
+
+
 use warnings;
 use strict;
 


### PR DESCRIPTION

# Description
This PR brings in a change to `dev/gfs.v17` that was made to develop via #4744. A documentation block is being added to the script `ush/parse-storm-type.pl` which is an EE2 requirement for GFS. 

Resolve #299 

# Type of change
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
No test has been performed since only comment statements are being added 


# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
