### PR TITLE
[dev/gfs.v17] Add Less-Strict Error Handling

### DIFF
--- a/ush/preamble.sh
+++ b/ush/preamble.sh
@@ -32,7 +32,7 @@ echo "Begin ${_calling_script} at ${start_time_human}"
 declare -x PS4='+ $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LINENO}]'
 
 set_strict() {
-    if [[ ${STRICT:-"YES"} == "YES" ]]; then
+    if [[ ${STRICT:-"NO"} == "YES" ]]; then
         # Exit on error or undefined variable
         set -eu
         # Exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)

--- a/ush/preamble.sh
+++ b/ush/preamble.sh
@@ -34,8 +34,14 @@ declare -x PS4='+ $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LIN
 set_strict() {
     if [[ ${STRICT:-"YES"} == "YES" ]]; then
         # Exit on error or undefined variable
-        # TODO: Also error in a pipeline (e.g. if and command in "cmd | cmd2" fails)
-        set -eu # -o pipefail
+        set -eu
+        # Exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
+        set -o pipefail
+    else
+        # Ensure pipeline exit status reflects any failed component
+        set -o pipefail
+        # Log a warning when any command or pipeline returns non-zero but continue
+        trap 'echo "WARNING: command exited with status $? at line ${LINENO} of ${BASH_SOURCE[0]:-${0}}" >&2' ERR
     fi
 }
 

--- a/ush/preamble.sh
+++ b/ush/preamble.sh
@@ -35,8 +35,6 @@ set_strict() {
     if [[ ${STRICT:-"NO"} == "YES" ]]; then
         # Exit on error or undefined variable
         set -eu
-        # Exit on error in a pipeline (e.g. if a command in "cmd | cmd2" fails)
-        set -o pipefail
     else
         # Ensure pipeline exit status reflects any failed component
         set -o pipefail


### PR DESCRIPTION
<!--
  *** PLEASE READ ***

  Any PRs not following this template will be closed.

  Please delete all these comments before submitting the PR.

  Please use a short (<60 char), descriptive title for the PR title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

  No content should appear above the "Description" header.

  If this PR is not merge-ready (e.g. it depends on other PRs not yet merged), please mark it as draft until it is ready.

  PRs should meet these guidelines:
  - Each PR should address ONE topic and have an associated issue.
  - No hard-coded paths or personal directories.
  - No temporary or backup files should be committed (including logs).
  - Any code that you disabled by being commented out should be removed or reenabled.
-->
# Description
- Currently, `set_strict()` enforces strict Bash error handling (set -eu) when STRICT=YES, causing scripts to exit on undefined variables or any command failure. This PR adds the ability to only log these errors (without exiting) when STRICT=NO, allowing scripts to continue running while still reporting issues for debugging and monitoring.
  Resolves #4692 


# Type of change
- [ ] Bug fix (fixes something broken)
- [x] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO (If YES, please indicate to which system(s))
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
- test script run and check



# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
