### PR TITLE
[dev/gfs.v17] Replace nagrib2 with nagrib2_nc and negate gpend calls

### DIFF
--- a/dev/scripts/exgdas_atmos_nawips.sh
+++ b/dev/scripts/exgdas_atmos_nawips.sh
@@ -25,7 +25,7 @@ for table in g2varswmo2.tbl g2vcrdwmo2.tbl g2varsncep1.tbl g2vcrdncep1.tbl; do
     cpreq "${source_table}" "${table}"
 done
 
-NAGRIB="${GEMEXE}/nagrib2"
+NAGRIB="${GEMEXE}/nagrib2_nc"
 
 cpyfil=gds
 garea=dset
@@ -48,7 +48,7 @@ fi
 
 cpreq "${GRIBIN}" "grib${fhr3}"
 
-export pgm="nagrib2 F${fhr3}"
+export pgm="nagrib2_nc F${fhr3}"
 startmsg
 
 ${NAGRIB} << EOF
@@ -79,7 +79,5 @@ if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${destination}/${GEMGRD}"
 fi
-
-"${GEMEXE}/gpend"
 
 ############################### END OF SCRIPT #######################

--- a/dev/scripts/exgfs_atmos_goes_nawips.sh
+++ b/dev/scripts/exgfs_atmos_goes_nawips.sh
@@ -19,7 +19,7 @@ for table in g2varswmo2.tbl g2vcrdwmo2.tbl g2varsncep1.tbl g2vcrdncep1.tbl; do
 done
 
 NAGRIB_TABLE="${HOMEgfs}/gempak/fix/nagrib.tbl"
-NAGRIB="${GEMEXE}/nagrib2"
+NAGRIB="${GEMEXE}/nagrib2_nc"
 
 # shellcheck disable=SC2312
 entry=$(grep "^${RUN2} " "${NAGRIB_TABLE}" | awk 'index($1,"#") != 1 {print $0}')
@@ -56,7 +56,7 @@ fi
 
 cpreq "${GRIBIN}" "grib${fhr3}"
 
-export pgm="nagrib_nc F${fhr3}"
+export pgm="nagrib2_nc F${fhr3}"
 startmsg
 
 ${NAGRIB} << EOF
@@ -87,7 +87,5 @@ if [[ ${SENDDBN} == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_0p25}/${GEMGRD}"
 fi
-
-"${GEMEXE}/gpend"
 
 ############################### END OF SCRIPT #######################

--- a/dev/scripts/exgfs_atmos_nawips.sh
+++ b/dev/scripts/exgfs_atmos_nawips.sh
@@ -22,7 +22,7 @@ cd "${DATA_RUN}" || exit 1
 # "Import" functions used in this script
 source "${USHgfs}/product_functions.sh"
 
-NAGRIB="${GEMEXE}/nagrib2"
+NAGRIB="${GEMEXE}/nagrib2_nc"
 
 cpyfil=gds
 garea=dset
@@ -92,7 +92,7 @@ else
     cpreq "${GRIBIN}" "grib${fhr3}"
 fi
 
-export pgm="nagrib2 F${fhr3}"
+export pgm="nagrib2_nc F${fhr3}"
 startmsg
 
 ${NAGRIB} << EOF
@@ -116,12 +116,6 @@ EOF
 export err=$?
 if [[ ${err} -ne 0 ]]; then
     err_exit
-fi
-
-"${GEMEXE}/gpend"
-export err=$?
-if [[ ${err} -ne 0 ]]; then
-    err_exit "${GEMEXE}/gpend failed!"
 fi
 
 cpfs "${GEMGRD}" "${destination}/${GEMGRD}"

--- a/dev/scripts/exgfs_wave_nawips.sh
+++ b/dev/scripts/exgfs_wave_nawips.sh
@@ -13,7 +13,7 @@
 source "${USHgfs}/wave_domain_grid.sh"
 source "${USHgfs}/atparse.bash"
 
-NAGRIB="nagrib2"
+NAGRIB="nagrib2_nc"
 fhr3=$(printf "%03d" "${FORECAST_HOUR}")
 
 cpreq "${HOMEgfs}/gempak/fix/g2varswmo2.tbl" "${DATA}/"


### PR DESCRIPTION
# Description
After analysis of previous CI tests of the GFSv17 workflow was performed with assistance of GDIT's Daniel Kokron (@dkokron) and with input from NCO-SDB's Bruce Hebbard and Shucai Guan, the message queues generated and used by multiple, simultaneous executions of the GEMPAK program 'nagrib2' in the WCOSS environment were determined to be the likely source of the errors central to issue #3630.  The alternative GEMPAK program 'nagrib2_nc' does not use message queues, and this PR incorporates its utility in place of 'nagrib2' for relevant GEMPAK jobs.  Without the use of message queues, calls to 'gpend' are not needed with 'nagrib2_nc', and are removed or otherwise negated in this PR. 

The effort leading to this PR initially targeted `exgdas_atmos_nawips.sh` and `exgfs_atmos_nawips.sh`, as each was known to use 'nagrib2' and had experienced errors.  However, each of `exgfs_atmos_goes_nawips.sh` and `exgfs_wave_nawips.sh` were found to also use 'nagrib2'.  It was previously noted that GEMPAK errors affected the execution of both `exgfs_atmos_nawips.sh` and `exgfs_wave_nawips.sh` with cycle [2026011600](https://github.com/NOAA-EMC/global-workflow/issues/3630#issuecomment-3856542918) of the _retrov17_01_realtime_ run.  Therefore, all (four) product scripts using 'nagrib2' are proposed to be modified with this PR. 

This PR is intended to resolve #3630.


# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? YES/NO (If YES, please indicate to which system(s))
  - [x] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
After cloning and building the workflow on WCOSS, two CI tests of case _C96_atm3DVar_extended_ were performed that included modifications to `exgdas_atmos_nawips.sh` and `exgfs_atmos_nawips.sh`.  No differences to the GEMPAK products were noted between the use of 'nagrib2' and 'nagrib2_nc'.

A third CI test that includes modifications to `exgfs_atmos_goes_nawips.sh` and `exgfs_wave_nawips.sh` is <ins>in progress</ins> as of the initiation of this PR.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
