### PR TITLE
Update HPC Account for CI/CI from fv3-cpu to hfv3gfs for Ursa

### DIFF
--- a/dev/ci/platforms/config.ursa
+++ b/dev/ci/platforms/config.ursa
@@ -71,7 +71,7 @@ export GW_BASH_CI_ROOT=${GFS_CI_ROOT}/GFS_BASH_CI
 export max_concurrent_cases=5
 export max_concurrent_pr=4
 
-# HPC account which overides the default account
+# HPC account which overrides the default account
 export HPC_ACCOUNT=${HPC_ACCOUNT:-hfv3gfs}
 
 #########################################################################

--- a/dev/ci/platforms/config.ursa
+++ b/dev/ci/platforms/config.ursa
@@ -72,7 +72,7 @@ export max_concurrent_cases=5
 export max_concurrent_pr=4
 
 # HPC account which overides the default account
-export HPC_ACCOUNT=${HPC_ACCOUNT:-fv3-cpu}
+export HPC_ACCOUNT=${HPC_ACCOUNT:-hfv3gfs}
 
 #########################################################################
 # System-specific settings


### PR DESCRIPTION
## Summary

Changes the default `HPC_ACCOUNT` for Ursa CI/CD from `fv3-cpu` to `hfv3gfs` in the platform configuration
by simply updating the default in `config.ursa` from `fv3-cpu` to `hfv3gfs`.
Resolves #4790 

## Changed Files

| File | Change |
|------|--------|
| `dev/ci/platforms/config.ursa` | `HPC_ACCOUNT` default: `fv3-cpu` → `hfv3gfs` |

## Testing

Used `ctest -R test_C48_ATM-gfs_stage_ic_setup` to make sure HPC_ACCOUNT propagated to XML on Ursa role account.