### PR TITLE
[dev/gfsv17] Fix coupled restart issue

### DIFF
--- a/ush/forecast_det.sh
+++ b/ush/forecast_det.sh
@@ -58,7 +58,7 @@ UFS_det() {
     local ii filepath filename
     local rdate seconds
     local fv3_rst_ok cmeps_rst_ok mom6_rst_ok cice6_rst_ok ww3_rst_ok
-    local ihour
+    local hdate hdatep1 fhout_ocn_by_2
     for ((ii = nrestarts - 1; ii >= 0; ii--)); do
 
         filepath="${file_array[ii]}"
@@ -88,13 +88,20 @@ UFS_det() {
             if [[ ! -f "${DATArestart}/MOM6_RESTART/${rdate:0:8}.${rdate:8:2}0000.MOM.res.nc" ]]; then
                 mom6_rst_ok="NO"
             else
-                # Also check for MOM6 history file availability by checking for log file 
+                # Also check for MOM6 history file availability
                 # TODO: SFS runs with 24-hr averaging of ocean output, which causes issues with restart checks,
                 # TODO: so we will skip them for now, and revisit this logic later
                 if [[ "${FHOUT_OCN}" -le 6 ]]; then
-                    ihour=$(printf %02i "${FHOUT_OCN}")
-                    if [[ ! -f "${DATA}/${rdate:0:8}.${rdate:8:2}0000.mom6.${ihour}h" ]]; then
+                    fhout_ocn_by_2=$((FHOUT_OCN / 2))
+                    hdate=$(date -u -d "${rdate:0:8} ${rdate:8:2} + ${fhout_ocn_by_2} hours" +"%Y%m%d%H")
+                    if [[ ! -f "${DATAoutput}/MOM6_OUTPUT/ocn_${hdate:0:4}_${hdate:4:2}_${hdate:6:2}_${hdate:8:2}_00.nc" ]]; then
                         mom6_rst_ok="NO"
+                    else
+                        # Also check for the next MOM6 history file (hdate + FHOUT_OCN hours)
+                        hdatep1=$(date -u -d "${hdate:0:8} ${hdate:8:2} + ${FHOUT_OCN} hours" +"%Y%m%d%H")
+                        if [[ ! -f "${DATAoutput}/MOM6_OUTPUT/ocn_${hdatep1:0:4}_${hdatep1:4:2}_${hdatep1:6:2}_${hdatep1:8:2}_00.nc" ]]; then
+                            mom6_rst_ok="NO"
+                        fi
                     fi
                 fi
             fi

--- a/ush/forecast_det.sh
+++ b/ush/forecast_det.sh
@@ -94,12 +94,12 @@ UFS_det() {
                 if [[ "${FHOUT_OCN}" -le 6 ]]; then
                     fhout_ocn_by_2=$((FHOUT_OCN / 2))
                     hdate=$(date -u -d "${rdate:0:8} ${rdate:8:2} + ${fhout_ocn_by_2} hours" +"%Y%m%d%H")
-                    if [[ ! -f "${DATAoutput}/MOM6_OUTPUT/ocn_${hdate:0:4}_${hdate:4:2}_${hdate:6:2}_${hdate:8:2}.nc" ]]; then
+                    if [[ ! -f "${DATAoutput}/MOM6_OUTPUT/ocn_${hdate:0:4}_${hdate:4:2}_${hdate:6:2}_${hdate:8:2}_00.nc" ]]; then
                         mom6_rst_ok="NO"
                     else
                         # Also check for the next MOM6 history file (hdate + FHOUT_OCN hours)
                         hdatep1=$(date -u -d "${hdate:0:8} ${hdate:8:2} + ${FHOUT_OCN} hours" +"%Y%m%d%H")
-                        if [[ ! -f "${DATAoutput}/MOM6_OUTPUT/ocn_${hdatep1:0:4}_${hdatep1:4:2}_${hdatep1:6:2}_${hdatep1:8:2}.nc" ]]; then
+                        if [[ ! -f "${DATAoutput}/MOM6_OUTPUT/ocn_${hdatep1:0:4}_${hdatep1:4:2}_${hdatep1:6:2}_${hdatep1:8:2}_00.nc" ]]; then
                             mom6_rst_ok="NO"
                         fi
                     fi

--- a/ush/forecast_det.sh
+++ b/ush/forecast_det.sh
@@ -89,6 +89,9 @@ UFS_det() {
                 mom6_rst_ok="NO"
             else
                 # Also check for MOM6 history file availability
+		# This is done because MOM6 output and restart files are asynchronous 
+		# TODO: We now have MOM6 log files, and so this logic can be updated to only check that 1 time level is written
+		# and confirm that the file is fully written via the log file. 
                 # TODO: SFS runs with 24-hr averaging of ocean output, which causes issues with restart checks,
                 # TODO: so we will skip them for now, and revisit this logic later
                 if [[ "${FHOUT_OCN}" -le 6 ]]; then

--- a/ush/forecast_det.sh
+++ b/ush/forecast_det.sh
@@ -58,7 +58,7 @@ UFS_det() {
     local ii filepath filename
     local rdate seconds
     local fv3_rst_ok cmeps_rst_ok mom6_rst_ok cice6_rst_ok ww3_rst_ok
-    local hdate hdatep1 fhout_ocn_by_2
+    local ihour
     for ((ii = nrestarts - 1; ii >= 0; ii--)); do
 
         filepath="${file_array[ii]}"
@@ -88,20 +88,13 @@ UFS_det() {
             if [[ ! -f "${DATArestart}/MOM6_RESTART/${rdate:0:8}.${rdate:8:2}0000.MOM.res.nc" ]]; then
                 mom6_rst_ok="NO"
             else
-                # Also check for MOM6 history file availability
+                # Also check for MOM6 history file availability by checking for log file 
                 # TODO: SFS runs with 24-hr averaging of ocean output, which causes issues with restart checks,
                 # TODO: so we will skip them for now, and revisit this logic later
                 if [[ "${FHOUT_OCN}" -le 6 ]]; then
-                    fhout_ocn_by_2=$((FHOUT_OCN / 2))
-                    hdate=$(date -u -d "${rdate:0:8} ${rdate:8:2} + ${fhout_ocn_by_2} hours" +"%Y%m%d%H")
-                    if [[ ! -f "${DATAoutput}/MOM6_OUTPUT/ocn_${hdate:0:4}_${hdate:4:2}_${hdate:6:2}_${hdate:8:2}_00.nc" ]]; then
+                    ihour=$(printf %02i "${FHOUT_OCN}")
+                    if [[ ! -f "${DATA}/${rdate:0:8}.${rdate:8:2}0000.mom6.${ihour}h" ]]; then
                         mom6_rst_ok="NO"
-                    else
-                        # Also check for the next MOM6 history file (hdate + FHOUT_OCN hours)
-                        hdatep1=$(date -u -d "${hdate:0:8} ${hdate:8:2} + ${FHOUT_OCN} hours" +"%Y%m%d%H")
-                        if [[ ! -f "${DATAoutput}/MOM6_OUTPUT/ocn_${hdatep1:0:4}_${hdatep1:4:2}_${hdatep1:6:2}_${hdatep1:8:2}_00.nc" ]]; then
-                            mom6_rst_ok="NO"
-                        fi
                     fi
                 fi
             fi

--- a/ush/forecast_det.sh
+++ b/ush/forecast_det.sh
@@ -89,9 +89,9 @@ UFS_det() {
                 mom6_rst_ok="NO"
             else
                 # Also check for MOM6 history file availability
-		# This is done because MOM6 output and restart files are asynchronous 
-		# TODO: We now have MOM6 log files, and so this logic can be updated to only check that 1 time level is written
-		# and confirm that the file is fully written via the log file. 
+                # This is done because MOM6 output and restart files are asynchronous
+                # TODO: We now have MOM6 log files, and so this logic can be updated to only check that 1 time level is written
+                # and confirm that the file is fully written via the log file.
                 # TODO: SFS runs with 24-hr averaging of ocean output, which causes issues with restart checks,
                 # TODO: so we will skip them for now, and revisit this logic later
                 if [[ "${FHOUT_OCN}" -le 6 ]]; then


### PR DESCRIPTION
<!--
  *** PLEASE READ ***

  Any PRs not following this template will be closed.

  Please delete all these comments before submitting the PR.

  Please use a short (<60 char), descriptive title for the PR title above. It should complete the sentence "If merged, this PR will _____". Capitalize the first word and do not end with a period.

  No content should appear above the "Description" header.

  If this PR is not merge-ready (e.g. it depends on other PRs not yet merged), please mark it as draft until it is ready.

  PRs should meet these guidelines:
  - Each PR should address ONE topic and have an associated issue.
  - No hard-coded paths or personal directories.
  - No temporary or backup files should be committed (including logs).
  - Any code that you disabled by being commented out should be removed or reenabled.
-->
# Description
<!-- This description will become the commit message for the PR. -->
<!--
  Solely pointing to an issue is not an adequate description!

  Please use this format for your description:

  Describe your changes. Focus on the *what* and *why*. The *how* will be evident from the changes. In particular, be sure to note any interface changes, such as command line syntax, that will need to be communicated to users.

  At the end of your description, please be sure to add the issue this PR solves using the word "Resolves". If there are any issues that are related but not yet resolved (including in other repos), you may use "Refs".

  Resolves #1234
  Refs #4321
  Refs NOAA-EMC/repo#5678
-->

After PR https://github.com/NOAA-EMC/global-workflow/pull/4688 the coupled restart feature was broken.  This PR fixes this by correctly naming the MOM6 output files.  

Future work, once linking/copying is sorted out for the forecast will be to change how we check to ensure the MOM6 output file is fully written.  A TODO was added to note this. 

Resolves  #4817
<!-- For more on writing good commit messages, see https://cbea.ms/git-commit/ -->

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? YES/NO (If YES, please indicate to which system(s))
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? YES/NO
- Does this change require a documentation update? YES/NO
- Does this change require an update to any of the following submodules? YES/NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
generate workflows -G on gaea and wcoss2. 



# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
