### PR TITLE
[dev/gcafs.v1] Update global cycle output path

### DIFF
--- a/ush/global_cycle.sh
+++ b/ush/global_cycle.sh
@@ -338,7 +338,7 @@ cat << EOF > fort.37
  /
 EOF
 
-${APRUNCY} "${CYCLEXEC}" 1>> "${PGMOUT}" 2>> "${PGMERR}"
+${APRUNCY} "${CYCLEXEC}" 1>&1 2>&2
 
 export err=$?
 


### PR DESCRIPTION

# Description
It was found during debugging for a GCAFS failure that the output from the global cycle executable was being written to the Data directory and was not being included in the full job log file that gets written to the output directory. This PR updates where output from the global cycle gets directed so it is included in the job log file.
 
  Refs #4850 

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 
# How has this been tested?
The gcdas_surface_initialize job completed with expected output in the job logfile


# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
