### PR TITLE
(develop) Reduce debug output from logit decorator

### DIFF
--- a/ush/python/pygfs/jedi/jedi.py
+++ b/ush/python/pygfs/jedi/jedi.py
@@ -121,7 +121,6 @@ class Jedi:
         self._jcb_config = self.jcb_config.deepcopy()
 
     @staticmethod
-    @logit(logger)
     def get_jedi_dict(jedi_config_dict: dict, task_config: AttrDict, expected_block_names: Optional[list] = None):
         """Get dictionary of Jedi objects from YAML specifying their configuration dictionaries
 

--- a/ush/python/pygfs/jedi/jedi.py
+++ b/ush/python/pygfs/jedi/jedi.py
@@ -25,7 +25,6 @@ class Jedi:
     Class for initializing and executing JEDI applications
     """
 
-    @logit(logger, name="Jedi")
     def __init__(self, config: Dict[str, Any], task_config: AttrDict) -> None:
         """Constructor for JEDI objects
 

--- a/ush/python/pygfs/task/aero_analysis.py
+++ b/ush/python/pygfs/task/aero_analysis.py
@@ -22,7 +22,6 @@ class AerosolAnalysis(Analysis):
     """
     Class for JEDI-based global aerosol analysis tasks
     """
-    @logit(logger, name="AerosolAnalysis")
     def __init__(self, config):
         """Constructor global aero analysis task
 

--- a/ush/python/pygfs/task/aero_bmatrix.py
+++ b/ush/python/pygfs/task/aero_bmatrix.py
@@ -12,7 +12,6 @@ class AerosolBMatrix(Analysis):
     """
     Class for global aerosol BMatrix tasks
     """
-    @logit(logger, name="AerosolBMatrix")
     def __init__(self, config):
         """Constructor global aero analysis bmatrix task
 

--- a/ush/python/pygfs/task/analysis.py
+++ b/ush/python/pygfs/task/analysis.py
@@ -15,7 +15,6 @@ class Analysis(Task):
     """
     General class for JEDI-based global analysis tasks
     """
-    @logit(logger, name="Analysis")
     def __init__(self, config: Dict[str, Any]):
         """Constructor global analysis task
 

--- a/ush/python/pygfs/task/analysis_stats.py
+++ b/ush/python/pygfs/task/analysis_stats.py
@@ -24,7 +24,6 @@ class AnalysisStats(Analysis):
     """
     Class for JEDI-based global analysis stats tasks
     """
-    @logit(logger, name="AnalysisStats")
     def __init__(self, config: Dict[str, Any]):
         """
         Constructor global analysis stats task

--- a/ush/python/pygfs/task/archive.py
+++ b/ush/python/pygfs/task/archive.py
@@ -19,7 +19,6 @@ class Archive(Task):
     """Task to archive ROTDIR data to HPSS (or locally)
     """
 
-    @logit(logger, name="Archive")
     def __init__(self, config: AttrDict) -> None:
         """Constructor for the Archive task
 

--- a/ush/python/pygfs/task/atm_analysis.py
+++ b/ush/python/pygfs/task/atm_analysis.py
@@ -13,7 +13,6 @@ class AtmAnalysis(Analysis):
     """
     Class for JEDI-based global atm deterministic analysis tasks
     """
-    @logit(logger, name="AtmAnalysis")
     def __init__(self, config: Dict[str, Any]):
         """Constructor global atm analysis task
 

--- a/ush/python/pygfs/task/atmens_analysis.py
+++ b/ush/python/pygfs/task/atmens_analysis.py
@@ -13,7 +13,6 @@ class AtmEnsAnalysis(Analysis):
     """
     Class for JEDI-based global atmens analysis tasks
     """
-    @logit(logger, name="AtmEnsAnalysis")
     def __init__(self, config: Dict[str, Any]):
         """Constructor global atmens analysis task
 

--- a/ush/python/pygfs/task/chem_fire_emission.py
+++ b/ush/python/pygfs/task/chem_fire_emission.py
@@ -23,7 +23,6 @@ class ChemFireEmissions(Task):
     """Chemistry Emissions pre-processing Task
     """
 
-    @logit(logger, name="ChemFireEmissions")
     def __init__(self, config: Dict[str, Any]) -> None:
         """Constructor for the Chemistry Fire Emissions task
 

--- a/ush/python/pygfs/task/ensemble_recenter.py
+++ b/ush/python/pygfs/task/ensemble_recenter.py
@@ -13,7 +13,6 @@ class EnsembleRecenter(Analysis):
     """
     Class for JEDI-based ensemble increment recentering
     """
-    @logit(logger, name="EnsembleRecenter")
     def __init__(self, config: Dict[str, Any]):
         """Constructor for atmospheric ensemble increment recentering task
 

--- a/ush/python/pygfs/task/fetch.py
+++ b/ush/python/pygfs/task/fetch.py
@@ -17,7 +17,6 @@ class Fetch(Task):
     """Task to pull ROTDIR data from HPSS (or locally)
     """
 
-    @logit(logger, name="Fetch")
     def __init__(self, config: Dict[str, Any]) -> None:
         """Constructor for the Fetch task
         The constructor is responsible for collecting necessary yamls based on

--- a/ush/python/pygfs/task/fv3_analysis_calc.py
+++ b/ush/python/pygfs/task/fv3_analysis_calc.py
@@ -16,7 +16,6 @@ class FV3AnalysisCalc(Analysis):
     """
     Class for analysis calculation
     """
-    @logit(logger, name="FV3AnalysisCalc")
     def __init__(self, config: Dict[str, Any]):
         """Constructor for analysis calculation task
 

--- a/ush/python/pygfs/task/gfs_forecast.py
+++ b/ush/python/pygfs/task/gfs_forecast.py
@@ -13,7 +13,6 @@ class GFSForecast(Task):
     UFS-weather-model forecast task for the GFS
     """
 
-    @logit(logger, name="GFSForecast")
     def __init__(self, config: Dict[str, Any], *args, **kwargs):
         """
         Parameters

--- a/ush/python/pygfs/task/globus_hpss.py
+++ b/ush/python/pygfs/task/globus_hpss.py
@@ -20,7 +20,6 @@ class GlobusHpss(Task):
     """Task to send tarballs (created by the archive task) to HPSS via Globus
     """
 
-    @logit(logger, name="GlobusHpss")
     def __init__(self, config: Dict[str, Any]) -> None:
         """Constructor for the GlobusHpss task
 

--- a/ush/python/pygfs/task/marine_analysis.py
+++ b/ush/python/pygfs/task/marine_analysis.py
@@ -19,7 +19,6 @@ class MarineAnalysis(Analysis):
     """
     Class for global marine analysis tasks
     """
-    @logit(logger, name="MarineAnalysis")
     def __init__(self, config):
         """Constructor for global marine analysis
 

--- a/ush/python/pygfs/task/marine_bmat.py
+++ b/ush/python/pygfs/task/marine_bmat.py
@@ -19,7 +19,6 @@ class MarineBMat(Analysis):
     """
     Class for global marine B-matrix tasks.
     """
-    @logit(logger, name="MarineBMat")
     def __init__(self, config):
         """Constructor for marine B-matrix task
 

--- a/ush/python/pygfs/task/marine_letkf.py
+++ b/ush/python/pygfs/task/marine_letkf.py
@@ -18,7 +18,6 @@ class MarineLETKF(Analysis):
     Class for global ocean and sea ice analysis LETKF task
     """
 
-    @logit(logger, name="MarineLETKF")
     def __init__(self, config: Dict) -> None:
         """Constructor for ocean and sea ice LETKF task
 

--- a/ush/python/pygfs/task/marine_recenter.py
+++ b/ush/python/pygfs/task/marine_recenter.py
@@ -18,7 +18,6 @@ class MarineRecenter(Analysis):
     Class for global ocean analysis recentering task
     """
 
-    @logit(logger, name="MarineRecenter")
     def __init__(self, config: Dict) -> None:
         """Constructor for ocean recentering task
 

--- a/ush/python/pygfs/task/nexus_emission.py
+++ b/ush/python/pygfs/task/nexus_emission.py
@@ -40,7 +40,6 @@ class NEXUSEmissions(Task):
     """NEXUS Emissions pre-processing Task
     """
 
-    @logit(logger, name="NEXUSEmissions")
     def __init__(self, config: Dict[str, Any]) -> None:
         """Constructor for the NEXUS Emissions task
 

--- a/ush/python/pygfs/task/oceanice_products.py
+++ b/ush/python/pygfs/task/oceanice_products.py
@@ -34,7 +34,6 @@ class OceanIceProducts(Task):
     TRIPOLE_DIMS_MAP = {'mx025': [1440, 1080], 'mx050': [720, 526], 'mx100': [360, 320], 'mx500': [72, 35]}
     LATLON_DIMS_MAP = {'0p25': [1440, 721], '0p50': [720, 361], '1p00': [360, 181], '5p00': [72, 36]}
 
-    @logit(logger, name="OceanIceProducts")
     def __init__(self, config: Dict[str, Any]) -> None:
         """Constructor for the Ocean/Ice Productstask
 

--- a/ush/python/pygfs/task/offline_analysis.py
+++ b/ush/python/pygfs/task/offline_analysis.py
@@ -20,7 +20,6 @@ class OfflineAnalysis(Task):
     Class for tasks to compute analysis increments from
     an offline analysis and previous forecast
     """
-    @logit(logger, name="SnowAnalysis")
     def __init__(self, config: Dict[str, Any]):
         """Constructor global offline analysis task
 

--- a/ush/python/pygfs/task/snow_analysis.py
+++ b/ush/python/pygfs/task/snow_analysis.py
@@ -27,7 +27,6 @@ class SnowAnalysis(Analysis):
     Class for JEDI-based global snow analysis tasks
     """
 
-    @logit(logger, name="Analysis")
     def __init__(self, config: Dict[str, Any]):
         """Constructor global snow analysis task
 

--- a/ush/python/pygfs/task/snowens_analysis.py
+++ b/ush/python/pygfs/task/snowens_analysis.py
@@ -30,7 +30,6 @@ class SnowEnsAnalysis(Analysis):
     Class for JEDI-based global snow ensemble analysis tasks
     """
 
-    @logit(logger, name="SnowEnsAnalysis")
     def __init__(self, config: Dict[str, Any]):
         """Constructor global snow ensemble analysis task
 

--- a/ush/python/pygfs/task/stage_ic.py
+++ b/ush/python/pygfs/task/stage_ic.py
@@ -18,7 +18,6 @@ logger = getLogger(__name__.split('.')[-1])
 class Stage(Task):
     """Task to stage initial conditions"""
 
-    @logit(logger, name="Stage")
     def __init__(self, config: Dict[str, Any]) -> None:
         """Constructor for the Stage task
 

--- a/ush/python/pygfs/task/upp.py
+++ b/ush/python/pygfs/task/upp.py
@@ -24,7 +24,6 @@ class UPP(Task):
 
     VALID_UPP_RUN = ['analysis', 'forecast', 'goes']
 
-    @logit(logger, name="UPP")
     def __init__(self, config: Dict[str, Any]) -> None:
         """Constructor for the UPP task
         The constructor is responsible for resolving the "UPP_CONFIG" based in the run-type "upp_run"

--- a/ush/python/pygfs/ufswm/gfs.py
+++ b/ush/python/pygfs/ufswm/gfs.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__.split('.')[-1])
 
 class GFS(UFS):
 
-    @logit(logger, name="GFS")
     def __init__(self, config):
 
         super().__init__("GFS", config)

--- a/ush/python/pygfs/ufswm/ufs.py
+++ b/ush/python/pygfs/ufswm/ufs.py
@@ -12,7 +12,6 @@ UFS_VARIANTS = ['GFS']
 
 class UFS:
 
-    @logit(logger, name="UFS")
     def __init__(self, model_name: str, config: Dict[str, Any]):
         """Initialize the UFS-weather-model generic class and check if the model_name is a valid variant
 

--- a/ush/python/pygfs/utils/archive_tar_vars.py
+++ b/ush/python/pygfs/utils/archive_tar_vars.py
@@ -39,11 +39,12 @@ config_dict dictionaries.
 
 Logging
 -------
-All public operational functions are decorated with @logit(logger).
+All public operational functions are decorated with @logit (TODO) to log entry, exit, and return values.
 """
 import os
 from logging import getLogger
-from wxflow import AttrDict, logit, to_YMD, to_YMDH, add_to_datetime, to_timedelta, to_fv3time
+from wxflow import AttrDict, to_YMD, to_YMDH, add_to_datetime, to_timedelta, to_fv3time
+# from wxflow import logit  # Uncomment when logit decorator is implemented
 
 logger = getLogger(__name__.split('.')[-1])
 
@@ -64,8 +65,11 @@ class ArchiveTarVars:
     generation logic. This class only provides the variables they need.
     """
 
+    # TODO: Convert these to instance methods so we aren't passing config_dict around.
+    #       Add an __init__ method to accept and store config_dict.
+    #       Then add logit decorators to the instance methods and remove debug prints of
+    #       return dicts (since the logit decorator will log the return values).
     @staticmethod
-    @logit(logger)
     def get_all_yaml_vars(config_dict: AttrDict) -> AttrDict:
         """
         Collect all variables needed for YAML templates.
@@ -141,7 +145,6 @@ class ArchiveTarVars:
         return arch_dict
 
     @staticmethod
-    @logit(logger)
     def add_config_vars(config_dict: AttrDict) -> AttrDict:
 
         """
@@ -260,7 +263,6 @@ class ArchiveTarVars:
         return config_vars
 
     @staticmethod
-    @logit(logger)
     def _get_all_cyc_vars(config_dict: AttrDict) -> AttrDict:
         """Compute common cycle variables for all archive YAML templates.
 
@@ -307,10 +309,11 @@ class ArchiveTarVars:
         if config_dict.get('RUN', '') == 'gcdas':
             vars_out.update(ArchiveTarVars._get_gcdas_specific_cyc_vars(config_dict, current_cycle))
 
+        logger.debug(f"Cycle variables: {list(vars_out.keys())}")
+
         return vars_out
 
     @staticmethod
-    @logit(logger)
     def _get_enkf_specific_cyc_vars(config_dict: AttrDict, current_cycle) -> AttrDict:
         """Compute EnKF-specific cycle variables.
 
@@ -473,10 +476,11 @@ class ArchiveTarVars:
         enkf_vars['save_warm_start_forecast'] = False
         enkf_vars['save_warm_start_cycled'] = False
 
+        logger.debug(f"EnKF variables: {list(enkf_vars.keys())}")
+
         return enkf_vars
 
     @staticmethod
-    @logit(logger)
     def _get_gcdas_specific_cyc_vars(config_dict: AttrDict, current_cycle) -> AttrDict:
         """Compute GCDAS-specific cycle variables.
 
@@ -512,7 +516,6 @@ class ArchiveTarVars:
         return gcdas_vars
 
     @staticmethod
-    @logit(logger)
     def get_enkf_com_paths(config_dict: AttrDict) -> AttrDict:
         """Extract absolute COMIN paths for EnKF ensemble mean/spread (ENSGRP=0).
 
@@ -564,10 +567,10 @@ class ArchiveTarVars:
                 com_paths[var_name] = abs_path
                 logger.debug(f"Extracted {var_name}: {abs_path}")
         logger.info(f"Extracted {len(com_paths)} absolute ensemble statistics COM paths (will convert to relative after YAML rendering)")
+        logger.debug(f"Ensemble COM paths: {com_paths}")
         return com_paths
 
     @staticmethod
-    @logit(logger)
     def get_enkf_member_com_paths(config_dict: AttrDict, member: int) -> AttrDict:
         """Generate absolute COM paths for a single ensemble member.
 
@@ -650,10 +653,10 @@ class ArchiveTarVars:
                 member_vars[var_key] = abs_path
 
         logger.debug(f"Generated {len(member_vars)} absolute COM paths for member {member} (will convert to relative after YAML rendering)")
+        logger.debug(f"Ensemble member {member} COM paths: {member_vars}")
         return member_vars
 
     @staticmethod
-    @logit(logger)
     def _create_enkf_mem_com_sets(config_dict: AttrDict, first_group_mem: int, last_group_mem: int) -> AttrDict:
         """Generate COM path sets for a group of ensemble members.
 
@@ -674,10 +677,10 @@ class ArchiveTarVars:
         mem_var_set = {}
         for member in range(first_group_mem, last_group_mem + 1):
             mem_var_set[f"com_set_{member:02d}"] = ArchiveTarVars.get_enkf_member_com_paths(config_dict, member)
+        logger.debug(f"Ensemble member COM sets for members {first_group_mem}-{last_group_mem}: {list(mem_var_set.keys())}")
         return mem_var_set
 
     @staticmethod
-    @logit(logger)
     def _create_cycle_dicts(config_dict: AttrDict) -> AttrDict:
         """Create cycle directories for template substitution
 
@@ -693,15 +696,17 @@ class ArchiveTarVars:
         AttrDict
             Dictionary containing current_cycle_dict and previous_cycle_dict
         """
-        return {
+        cycle_dict = {
             '${ROTDIR}': config_dict['ROTDIR'],
             '${RUN}': config_dict['RUN'],
             '${YMD}': to_YMD(config_dict['current_cycle']),
             '${HH}': config_dict['current_cycle'].strftime("%H"),
         }
 
+        logger.debug(f"Created cycle dictionary for template substitution: {cycle_dict}")
+        return cycle_dict
+
     @staticmethod
-    @logit(logger)
     def get_tarball_specific_vars(config_dict: AttrDict, tarball_type: str) -> AttrDict:
         """
         Calculate tarball-specific template variables.
@@ -852,10 +857,11 @@ class ArchiveTarVars:
         else:
             logger.warning(f"Tarball type '{tarball_type}' does not have specific variable calculations")
 
+        logger.debug(f"Tarball-specific variables for {tarball_type}: {tarball_vars}")
+
         return tarball_vars
 
     @staticmethod
-    @logit(logger)
     def _calculate_restart_prefixes(current_cycle: 'datetime', restart_interval: int, fhmax: int) -> list:
         """Calculate restart time prefixes for a given interval and forecast max.
 
@@ -891,4 +897,5 @@ class ArchiveTarVars:
 
         logger.debug(f"Calculated {len(restart_prefixes)} restart prefixes "
                      f"(interval={restart_interval}H, FHMAX={fhmax}H)")
+        logger.debug(f"Restart prefixes: {restart_prefixes}")
         return restart_prefixes

--- a/ush/python/pygfs/utils/archive_vrfy_vars.py
+++ b/ush/python/pygfs/utils/archive_vrfy_vars.py
@@ -37,11 +37,12 @@ _get_cycle_vars(config_dict):
 
 Logging
 -------
-All public operational functions are decorated with @logit(logger).
+All public operational functions are decorated with @logit (TODO) to log entry, exit, and return values.
 """
 import os
 from logging import getLogger
-from wxflow import AttrDict, logit, to_YMD, to_YMDH
+from wxflow import AttrDict, to_YMD, to_YMDH
+# from wxflow import logit  # Uncomment if logit decorator is available
 
 logger = getLogger(__name__.split('.')[-1])
 
@@ -60,8 +61,11 @@ class ArchiveVrfyVars:
     generation logic. This class only provides the variables they need.
     """
 
+    # TODO: Convert these to instance methods so we aren't passing config_dict around.
+    #       Add an __init__ method to accept and store config_dict.
+    #       Then add logit decorators to the instance methods and remove debug prints of
+    #       return dicts (since the logit decorator will log the return values).
     @staticmethod
-    @logit(logger)
     def get_all_yaml_vars(config_dict: AttrDict) -> AttrDict:
         """Collect all variables needed for YAML templates.
 
@@ -91,12 +95,11 @@ class ArchiveVrfyVars:
         arch_dict.update(ArchiveVrfyVars._get_cycle_vars(config_dict))
 
         logger.info(f"Collected {len(arch_dict)} variables for YAML templates")
-        logger.debug(f"arch_dict keys: {list(arch_dict.keys())}")
+        logger.debug(f"Returning dictionary {arch_dict}")
 
         return arch_dict
 
     @staticmethod
-    @logit(logger)
     def add_config_vars(config_dict: AttrDict) -> AttrDict:
         """Collect configuration keys and COM* variables for archive operations.
 
@@ -144,12 +147,11 @@ class ArchiveVrfyVars:
                 general_dict[key] = config_dict.get(key)
 
         logger.info(f"Collected {len(general_dict)} general archive variables")
-        logger.debug(f"General variables: {list(general_dict.keys())}")
+        logger.debug(f"General dictionary: {general_dict}")
 
         return general_dict
 
     @staticmethod
-    @logit(logger)
     def _get_cycle_vars(config_dict: AttrDict) -> AttrDict:
         """Calculate cycle-specific variables.
 
@@ -176,9 +178,12 @@ class ArchiveVrfyVars:
         # Archive directory (used by all systems)
         VFYARC = os.path.join(config_dict.ROTDIR, "vrfyarch")
 
-        return {
+        cycle_vars = {
             'cycle_HH': cycle_HH,
             'cycle_YMDH': cycle_YMDH,
             'cycle_YMD': cycle_YMD,
             'VFYARC': VFYARC
         }
+
+        logger.debug(f"Calculated cycle variables: {cycle_vars}")
+        return cycle_vars


### PR DESCRIPTION
# Description
This reduces the amount of debug output written by `Task` methods and Python ex-scripts by
1. Modifying the wxflow `logit` method to avoid printing `self`
2. No longer decorating `__init__` methods with `logit`

Refs #4721 

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? YES
  - [x] wxflow https://github.com/NOAA-EMC/wxflow/pull/73
  - [x] GDASApp https://github.com/NOAA-EMC/GDASApp/pull/2129

# How has this been tested?
Testing is in progress on C6 and WCOSS2.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added