### PR TITLE
[dev/gfs.v17] Fix gempak meta job so it can run in production mode

### DIFF
--- a/dev/jobs/JGFS_ATMOS_GEMPAK_META
+++ b/dev/jobs/JGFS_ATMOS_GEMPAK_META
@@ -6,7 +6,7 @@ set -x
 ############################################
 # GFS GEMPAK META PRODUCT GENERATION
 ############################################
-source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak_meta" -c "base gempak"
+source "${HOMEgfs}/ush/jjob_header.sh" -e "gempak_meta" -c "base gempakmeta"
 
 #{% if false %}
 source "${HOMEgfs}/ush/jjob_standard_vars.sh"
@@ -29,17 +29,6 @@ export MP_PULSE=0
 export MP_DEBUG_NOTIMEOUT=yes
 
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
-
-#############################################
-#set the fcst hrs for all the cycles
-#############################################
-export fhbeg=0
-export fhend=384
-export fhinc=12
-
-if [[ "${fhend}" -gt "${FHMAX_GFS}" ]]; then
-    export fhend="${FHMAX_GFS}"
-fi
 
 export COMPONENT="atmos"
 

--- a/dev/parm/config/gfs/config.gempakmeta
+++ b/dev/parm/config/gfs/config.gempakmeta
@@ -1,0 +1,27 @@
+#! /usr/bin/env bash
+
+########## config.gempakmeta ##########
+# GFS gempakmeta step specific
+
+echo "BEGIN: config.gempakmeta"
+
+#############################################
+#set the fcst hrs for all the cycles
+#############################################
+# The meta task has a maximum forecast hour to process of 384.
+fhend_max=384
+
+if [[ ${FHMAX_GFS} -lt ${fhend_max} ]]; then
+  fhend=${FHMAX_GFS}
+else
+  fhend=${fhend_max}
+fi
+
+export fhend
+export fhbeg=0
+export fhinc=12
+
+# Get task specific resources
+source "${EXPDIR}/config.resources" gempakmeta
+
+echo "END: config.gempakmeta"

--- a/dev/parm/config/gfs/config.resources
+++ b/dev/parm/config/gfs/config.resources
@@ -1392,6 +1392,15 @@ case ${step} in
     fi
     ;;
 
+  "gempakmeta")
+    walltime="00:15:00"
+    threads_per_task=1
+    ntasks=28
+    tasks_per_node=28
+    memory="40GB"
+    prepost=True
+    ;;
+
   "fbwind")
     walltime="00:05:00"
     ntasks=1

--- a/dev/scripts/exgfs_atmos_gempak_meta.sh
+++ b/dev/scripts/exgfs_atmos_gempak_meta.sh
@@ -4,6 +4,8 @@ GEMGRD1="${RUN}_1p00_${PDY}${cyc}f"
 
 export numproc=23
 
+# fhend, fhbeg, and fhinc come from config.gempakmeta
+
 # Find the last hour available
 for ((fhr = fhend; fhr >= fhbeg; fhr = fhr - fhinc)); do
     fhr3=$(printf "%03d" "${fhr}")
@@ -12,10 +14,17 @@ for ((fhr = fhend; fhr >= fhbeg; fhr = fhr - fhinc)); do
     fi
 done
 
+# If none were found, start at fhbeg
+if [[ ${fhr} -lt ${fhbeg} ]]; then
+    fhr=${fhbeg}
+fi
+
 sleep_interval=20
 max_tries=180
 first_time=0
 do_all=0
+
+fhr3=$(printf "%03d" "${fhr}")
 
 #loop through and process needed forecast hours
 while [[ ${fhr} -le ${fhend} ]]; do
@@ -49,32 +58,37 @@ while [[ ${fhr} -le ${fhend} ]]; do
 
     if [[ ${do_all} -eq 1 ]]; then
         do_all=0
-        awk '{print $1}' "${HOMEgfs}/gempak/fix/gfs_meta" | envsubst > "poescript"
+        awk '{print $1}' "${HOMEgfs}/gempak/fix/gfs_meta" | envsubst > "poescript" || true
     else
         #
         #    Do not try to grep out 12, it will grab the 12 from 126.
         #    This will work as long as we don't need 12 fhr metafiles
         #
         if [[ ${fhr} -ne 12 ]]; then
-            grep "${fhr}" "${HOMEgfs}/gempak/fix/gfs_meta" | awk -F" [0-9]" '{print $1}' | envsubst > "poescript"
+            grep "${fhr}" "${HOMEgfs}/gempak/fix/gfs_meta" | awk -F" [0-9]" '{print $1}' | envsubst > "poescript" || true
         fi
     fi
 
-    #  If this is the final fcst hour, alert the
-    #  file to all centers.
-    #
-    if [[ ${fhr} -ge ${fhend} ]]; then
-        export DBN_ALERT_TYPE=GFS_METAFILE_LAST
-    fi
+    # Do not try to run the poescript if it doesn't exist.
+    # This means that there are no jobs to run for this fhr
+    if [[ -f "poescript" ]]; then
 
-    export fend=${fhr}
+        # Declare fend for the various gempak/ush scripts
+        export fend=${fhr}
 
-    cat poescript
+        #  If this is the final fcst hour, alert the
+        #  file to all centers.
+        #
+        if [[ ${fhr} -ge ${fhend} ]]; then
+            export DBN_ALERT_TYPE=GFS_METAFILE_LAST
+        fi
 
-    "${HOMEgfs}/ush/run_mpmd.sh" poescript && true
-    export err=$?
-    if [[ ${err} -ne 0 ]]; then
-        err_exit "Failed to generate one or more gempak meta plots!"
+        "${HOMEgfs}/ush/run_mpmd.sh" poescript && true
+        export err=$?
+        if [[ ${err} -ne 0 ]]; then
+            err_exit "Failed to generate one or more gempak meta plots!"
+        fi
+
     fi
 
     if [[ ${fhr} -eq 126 ]]; then

--- a/dev/scripts/exgfs_atmos_nawips.sh
+++ b/dev/scripts/exgfs_atmos_nawips.sh
@@ -115,7 +115,11 @@ EOF
 
 export err=$?
 if [[ ${err} -ne 0 ]]; then
+<<<<<<< HEAD
     err_exit
+=======
+    err_exit "Failed to convert ${grid} grid from GRIB to GEMPAK for forecast hour ${fhr3}"
+>>>>>>> 28297944e ([develop] Fix the meta gempak job so it can run in production mode (#4711))
 fi
 
 cpfs "${GEMGRD}" "${destination}/${GEMGRD}"

--- a/dev/scripts/exgfs_atmos_nawips.sh
+++ b/dev/scripts/exgfs_atmos_nawips.sh
@@ -115,11 +115,7 @@ EOF
 
 export err=$?
 if [[ ${err} -ne 0 ]]; then
-<<<<<<< HEAD
-    err_exit
-=======
     err_exit "Failed to convert ${grid} grid from GRIB to GEMPAK for forecast hour ${fhr3}"
->>>>>>> 28297944e ([develop] Fix the meta gempak job so it can run in production mode (#4711))
 fi
 
 cpfs "${GEMGRD}" "${destination}/${GEMGRD}"

--- a/dev/workflow/applications/gfs_cycled.py
+++ b/dev/workflow/applications/gfs_cycled.py
@@ -175,7 +175,7 @@ class GFSCycledAppConfig(AppConfig):
             configs += ['metp']
 
         if options['do_gempak']:
-            configs += ['gempak']
+            configs += ['gempak', 'gempakmeta']
             if options['do_goes']:
                 configs += ['npoess']
 

--- a/dev/workflow/applications/gfs_forecast_only.py
+++ b/dev/workflow/applications/gfs_forecast_only.py
@@ -106,7 +106,7 @@ class GFSForecastOnlyAppConfig(AppConfig):
                 configs += ['postsnd']
 
             if options['do_gempak']:
-                configs += ['gempak']
+                configs += ['gempak', 'gempakmeta']
 
             if options['do_awips']:
                 configs += ['awips', 'fbwind']

--- a/dev/workflow/rocoto/gfs_tasks.py
+++ b/dev/workflow/rocoto/gfs_tasks.py
@@ -1697,7 +1697,7 @@ class GFSTasks(Tasks):
         deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep=deps)
 
-        resources = self.get_resource('gempak')
+        resources = self.get_resource('gempakmeta')
         task_name = f'{self.run}_gempakmeta'
         task_dict = {'task_name': task_name,
                      'resources': resources,

--- a/ecf/scripts/gfs/gempak/atmos/jgfs_atmos_gempak_meta.ecf
+++ b/ecf/scripts/gfs/gempak/atmos/jgfs_atmos_gempak_meta.ecf
@@ -3,8 +3,8 @@
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:05:00
-#PBS -l select=1:mpiprocs=28:ompthreads=1:ncpus=28:mem=6GB
+#PBS -l walltime=06:00:00
+#PBS -l select=1:mpiprocs=28:ompthreads=1:ncpus=28:mem=40GB
 #PBS -l place=vscatter:shared
 #PBS -l debug=true
 

--- a/gempak/ush/gdas_ecmwf_meta_ver.sh
+++ b/gempak/ush/gdas_ecmwf_meta_ver.sh
@@ -17,9 +17,8 @@ device="nc | ecmwfver.meta"
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 
 export COMIN="gdas.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+rm -f "${COMIN}"
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 vergrid="F-GDAS | ${PDY:2}/0600"
 fcsthr="0600f006"
 
@@ -42,9 +41,8 @@ for area in ${areas}; do
         dgdattim=$(printf "f%03d" "${fhr}")
         sdatenum=$(date --utc +%y%m%d -d "${PDY} ${cyc2} - ${fhr} hours")
 
-        if [[ ! -L "ecmwf.20${sdatenum}" ]]; then
-            ${NLN} "${COMINecmwf}/ecmwf.20${sdatenum}/gempak" "ecmwf.20${sdatenum}"
-        fi
+        rm -f "ecmwf.20${sdatenum}"
+        ${NLN} "${COMINecmwf}/ecmwf.20${sdatenum}/gempak" "ecmwf.20${sdatenum}"
         gdfile="ecmwf.20${sdatenum}/ecmwf_glob_20${sdatenum}12"
 
         # 500 MB HEIGHT METAFILE
@@ -146,7 +144,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s ecmwfver.meta ]]; then
     exit "${err}"
 fi
 
-mv ecmwfver.meta "${COMOUT_ATMOS_GEMPAK_META}/ecmwfver_${PDY}_${cyc2}"
+cpfs ecmwfver.meta "${COMOUT_ATMOS_GEMPAK_META}/ecmwfver_${PDY}_${cyc2}"
 export err=$?
 if [[ "${err}" -ne 0 ]]; then
     echo "FATAL ERROR: Failed to move meta file to ${COMOUT_ATMOS_GEMPAK_META}/ecmwfver_${PDY}_${cyc2}"

--- a/gempak/ush/gdas_meta_loop.sh
+++ b/gempak/ush/gdas_meta_loop.sh
@@ -9,9 +9,8 @@ device="nc | gdasloop.meta"
 # Link data into DATA to sidestep gempak path limits
 # TODO: Add only necessary files and remove unneeded ones to minimize data volume
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L "${COMIN}" ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+rm -f "${COMIN}"
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 if [[ "${envir}" == "para" ]]; then
     export m_title="GDASP"
@@ -40,9 +39,8 @@ for ((fhr = 24; fhr <= 144; fhr += 24)); do
         # TODO: Add only necessary files and remove unneeded ones to minimize data volume
         # TODO: remove live links and refer https://github.com/NOAA-EMC/global-workflow/issues/4406
         export COMIN="${RUN}.${day}${cycle}"
-        if [[ ! -L "${COMIN}" ]]; then
-            ${NLN} "${COMIN_ATMOS_GEMPAK_1p00_past}" "${COMIN}"
-        fi
+        rm -f "${COMIN}"
+        ${NLN} "${COMIN_ATMOS_GEMPAK_1p00_past}" "${COMIN}"
         gdfile="${COMIN}/gdas_1p00_${day}${cycle}f000"
 
         "${GEMEXE}/gdplot2_nc" << EOF
@@ -228,7 +226,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s gdasloop.meta ]]; then
     exit "${err}"
 fi
 
-mv gdasloop.meta "${COMOUT_ATMOS_GEMPAK_META}/gdas_${PDY}_${cyc}_loop"
+cpfs gdasloop.meta "${COMOUT_ATMOS_GEMPAK_META}/gdas_${PDY}_${cyc}_loop"
 export err=$?
 if [[ "${err}" -ne 0 ]]; then
     echo "FATAL ERROR: Failed to move meta file to ${COMOUT_ATMOS_GEMPAK_META}/gdas_${PDY}_${cyc}_loop"

--- a/gempak/ush/gdas_meta_na.sh
+++ b/gempak/ush/gdas_meta_na.sh
@@ -10,9 +10,8 @@ device="nc | gdas.meta"
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L "${COMIN}" ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+rm -f "${COMIN}"
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 if [[ "${envir}" == "para" ]]; then
     export m_title="GDASP"
@@ -98,7 +97,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s gdas.meta ]] &> /dev/null; then
     exit "${err}"
 fi
 
-mv gdas.meta "${COMOUT_ATMOS_GEMPAK_META}/gdas_${PDY}_${cyc}_na"
+cpfs gdas.meta "${COMOUT_ATMOS_GEMPAK_META}/gdas_${PDY}_${cyc}_na"
 export err=$?
 if [[ "${err}" -ne 0 ]]; then
     echo "FATAL ERROR: Failed to move meta file to ${COMOUT_ATMOS_GEMPAK_META}/gdas_${PDY}_${cyc}_na"

--- a/gempak/ush/gdas_ukmet_meta_ver.sh
+++ b/gempak/ush/gdas_ukmet_meta_ver.sh
@@ -21,9 +21,8 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 
 # SET CURRENT CYCLE AS THE VERIFICATION GRIDDED FILE.
 export COMIN="gdas.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+rm -f "${COMIN}"
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 vergrid="F-GDAS | ${PDY:2}/0600"
 fcsthr="0600f006"
 
@@ -52,9 +51,9 @@ for area in ${areas}; do
         sdatenum=${stime:0:6}
         cyclenum=${stime:6}
 
-        if [[ ! -L "ukmet.20${sdatenum}" ]]; then
-            ${NLN} "${COMINukmet}/ukmet.20${sdatenum}/gempak" "ukmet.20${sdatenum}"
-        fi
+        rm -f "ukmet.20${sdatenum}"
+        # TODO: remove live links and refer https://github.com/NOAA-EMC/global-workflow/issues/4406
+        ${NLN} "${COMINukmet}/ukmet.20${sdatenum}/gempak" "ukmet.20${sdatenum}"
         gdfile="ukmet.20${sdatenum}/ukmet_20${sdatenum}${cyclenum}${dgdattim}"
 
         # 500 MB HEIGHT METAFILE
@@ -154,7 +153,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s ukmetver_12.meta ]]; then
     exit "${err}"
 fi
 
-mv ukmetver_12.meta "${COMOUT_ATMOS_GEMPAK_META}/ukmetver_${PDY}_12"
+cpfs ukmetver_12.meta "${COMOUT_ATMOS_GEMPAK_META}/ukmetver_${PDY}_12"
 export err=$?
 if [[ "${err}" -ne 0 ]]; then
     echo "FATAL ERROR: Failed to move meta file to ${COMOUT_ATMOS_GEMPAK_META}/ukmetver_${PDY}_12"

--- a/gempak/ush/gfs_meta_ak.sh
+++ b/gempak/ush/gfs_meta_ak.sh
@@ -17,9 +17,7 @@ device="nc | gfs.meta.ak"
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 fend=F216
 
@@ -218,7 +216,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s gfs.meta.ak ]]; then
     exit "${err}"
 fi
 
-mv gfs.meta.ak "${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_ak"
+cpfs gfs.meta.ak "${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_ak"
 export err=$?
 if [[ "${err}" -ne 0 ]]; then
     echo "FATAL ERROR: Failed to move meta file to ${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_ak"

--- a/gempak/ush/gfs_meta_bwx.sh
+++ b/gempak/ush/gfs_meta_bwx.sh
@@ -5,6 +5,7 @@
 # Set up Local Variables
 #
 
+rm -rf "${DATA}/BWX"
 mkdir -p -m 775 "${DATA}/BWX"
 cd "${DATA}/BWX" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -18,9 +19,7 @@ device="nc | ${metaname}"
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 fend=F180
 
@@ -346,7 +345,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]]; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${metaname}"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${metaname}"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${metaname}"

--- a/gempak/ush/gfs_meta_comp.sh
+++ b/gempak/ush/gfs_meta_comp.sh
@@ -41,9 +41,8 @@ for cycle in $(seq -f "%02g" -s ' ' 0 "${INTERVAL_GFS}" "${cyc}"); do
 done
 
 export HPCNAM="nam.${PDY}"
-if [[ ! -L ${HPCNAM} ]]; then
-    ${NLN} "${COMINnam}/nam.${PDY}/gempak" "${HPCNAM}"
-fi
+# TODO: remove live links and refer https://github.com/NOAA-EMC/global-workflow/issues/4406
+${NLN} "${COMINnam}/nam.${PDY}/gempak" "${HPCNAM}"
 
 #
 # DEFINE YESTERDAY
@@ -105,10 +104,10 @@ for gareas in US NP; do
 
         # Create symlink in DATA to sidestep gempak path limits
         HPCGFS="${RUN}.${init_time}"
-        if [[ ! -L ${HPCGFS} ]]; then
-            source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
-            ${NLN} "${source_dir}" "${HPCGFS}"
-        fi
+        # TODO: Add only necessary files and remove unneeded ones to minimize data volume
+        # TODO: remove live links and refer https://github.com/NOAA-EMC/global-workflow/issues/4406
+        source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
+        ${NLN} "${source_dir}" "${HPCGFS}"
 
         if [[ ${init_PDY} == "${PDY}" ]]; then
             desc="T"
@@ -238,9 +237,8 @@ EOF
         ukmet_PDY=${ukmet_date:0:8}
         ukmet_cyc=${ukmet_date:8:2}
         export HPCUKMET=ukmet.${ukmet_PDY}
-        if [[ ! -L "${HPCUKMET}" ]]; then
-            ${NLN} "${COMINukmet}/ukmet.${ukmet_PDY}/gempak" "${HPCUKMET}"
-        fi
+        rm -f "${HPCUKMET}"
+        ${NLN} "${COMINukmet}/ukmet.${ukmet_PDY}/gempak" "${HPCUKMET}"
         grid2="F-UKMETHPC | ${ukmet_PDY:2}/${ukmet_date}"
 
         for fhr in 0 12 24 84 108; do
@@ -501,7 +499,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_us_${metatype}"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_us_${metatype}"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_us_${metatype}"

--- a/gempak/ush/gfs_meta_crb.sh
+++ b/gempak/ush/gfs_meta_crb.sh
@@ -5,6 +5,7 @@
 # Set Up Local Variables
 #
 
+rm -rf "${DATA}/crb"
 mkdir -p -m 775 "${DATA}/crb"
 cd "${DATA}/crb" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -20,9 +21,7 @@ device="nc | ${metaname}"
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 # DEFINE YESTERDAY
 PDYm1=$(date --utc +%Y%m%d -d "${PDY} 00 - 24 hours")
@@ -252,15 +251,13 @@ if [[ ${cyc} == 00 ]]; then
     export HPCECMWF=ecmwf.${PDY}
     HPCECMWF_m1=ecmwf.${PDY}
     export HPCUKMET=ukmet.${PDYm1}
-    if [[ ! -L "${HPCECMWF}" ]]; then
-        ${NLN} "${COMINecmwf}/ecmwf.${PDY}/gempak" "${HPCECMWF}"
-    fi
-    if [[ ! -L "${HPCECMWF_m1}" ]]; then
-        ${NLN} "${COMINecmwf}/ecmwf.${PDYm1}/gempak" "${HPCECMWF_m1}"
-    fi
-    if [[ ! -L "${HPCUKMET}" ]]; then
-        ${NLN} "${COMINukmet}/ukmet.${PDYm1}/gempak" "${HPCUKMET}"
-    fi
+    rm -f "${HPCECMWF}"
+    # TODO: remove live links and refer https://github.com/NOAA-EMC/global-workflow/issues/4406
+    ${NLN} "${COMINecmwf}/ecmwf.${PDY}/gempak" "${HPCECMWF}"
+    rm -f "${HPCECMWF_m1}"
+    ${NLN} "${COMINecmwf}/ecmwf.${PDYm1}/gempak" "${HPCECMWF_m1}"
+    rm -f "${HPCUKMET}"
+    ${NLN} "${COMINukmet}/ukmet.${PDYm1}/gempak" "${HPCUKMET}"
 
     grid1="F-${MDL} | ${PDY:2}/${cyc}00"
     grid2="${HPCECMWF_m1}/ecmwf_glob_${PDYm1}12"
@@ -407,7 +404,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"

--- a/gempak/ush/gfs_meta_hi.sh
+++ b/gempak/ush/gfs_meta_hi.sh
@@ -3,6 +3,7 @@
 # Metafile Script : gfs_meta_hi.sh
 #
 
+rm -rf "${DATA}/mrfhi"
 mkdir -p -m 775 "${DATA}/mrfhi"
 cd "${DATA}/mrfhi" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -14,9 +15,7 @@ device="nc | mrfhi.meta"
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 if [[ "${envir}" = "prod" ]]; then
     export m_title="GFS"
@@ -180,7 +179,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s mrfhi.meta ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv mrfhi.meta "${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_hi"
+cpfs mrfhi.meta "${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_hi"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_hi"

--- a/gempak/ush/gfs_meta_hur.sh
+++ b/gempak/ush/gfs_meta_hur.sh
@@ -5,6 +5,7 @@
 # Set up Local Variables
 #
 
+rm -rf "${DATA}/hur"
 mkdir -p -m 775 "${DATA}/hur"
 cd "${DATA}/hur" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -20,9 +21,7 @@ device="nc | ${metaname}"
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 #
 # DEFINE YESTERDAY
@@ -306,15 +305,12 @@ if [[ ${cyc} -eq 00 ]]; then
     export HPCECMWF=ecmwf.${PDY}
     HPCECMWF_m1=ecmwf.${PDY}
     export HPCUKMET=ukmet.${PDYm1}
-    if [[ ! -L "${HPCECMWF}" ]]; then
-        ${NLN} "${COMINecmwf}/ecmwf.${PDY}/gempak" "${HPCECMWF}"
-    fi
-    if [[ ! -L "${HPCECMWF_m1}" ]]; then
-        Ln -sf "${COMINecmwf}/ecmwf.${PDYm1}/gempak" "${HPCECMWF_m1}"
-    fi
-    if [[ ! -L "${HPCUKMET}" ]]; then
-        ${NLN} "${COMINukmet}/ukmet.${PDYm1}/gempak" "${HPCUKMET}"
-    fi
+    # TODO: remove live links and refer https://github.com/NOAA-EMC/global-workflow/issues/4406
+    ${NLN} "${COMINecmwf}/ecmwf.${PDY}/gempak" "${HPCECMWF}"
+    rm -f "${HPCECMWF_m1}"
+    ${NLN} "${COMINecmwf}/ecmwf.${PDYm1}/gempak" "${HPCECMWF_m1}"
+    rm -f "${HPCUKMET}"
+    ${NLN} "${COMINukmet}/ukmet.${PDYm1}/gempak" "${HPCUKMET}"
     grid1="F-${MDL} | ${PDY:2}/${cyc}00"
     grid2="${HPCECMWF_m1}/ecmwf_glob_${PDYm1}12"
     grid3="F-UKMETHPC | ${PDY:2}/${cyc}00"
@@ -460,7 +456,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"

--- a/gempak/ush/gfs_meta_mar_atl.sh
+++ b/gempak/ush/gfs_meta_mar_atl.sh
@@ -5,6 +5,7 @@
 # Set up Local Variables
 #
 
+rm -rf "${DATA}/MAR_ATL"
 mkdir -p -m 775 "${DATA}/MAR_ATL"
 cd "${DATA}/MAR_ATL" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -14,9 +15,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 mdl=gfs
 MDL="GFS"
@@ -272,7 +271,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_atl"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_atl"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_atl"

--- a/gempak/ush/gfs_meta_mar_comp.sh
+++ b/gempak/ush/gfs_meta_mar_comp.sh
@@ -36,9 +36,8 @@ done
 # TODO: Replace this
 #
 export HPCNAM="nam.${PDY}"
-if [[ ! -L ${HPCNAM} ]]; then
-    ${NLN} "${COMINnam}/nam.${PDY}/gempak" "${HPCNAM}"
-fi
+# TODO: remove live links and refer https://github.com/NOAA-EMC/global-workflow/issues/4406
+${NLN} "${COMINnam}/nam.${PDY}/gempak" "${HPCNAM}"
 
 mdl=gfs
 MDL="GFS"
@@ -82,10 +81,9 @@ for garea in NAtl NPac; do
 
         # Create symlink in DATA to sidestep gempak path limits
         HPCGFS="${RUN}.${init_time}"
-        if [[ ! -L ${HPCGFS} ]]; then
-            source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
-            ${NLN} "${source_dir}" "${HPCGFS}"
-        fi
+        rm -f "${HPCGFS}"
+        source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
+        ${NLN} "${source_dir}" "${HPCGFS}"
 
         case ${cyc} in
             00 | 12)
@@ -491,7 +489,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_comp"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_comp"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert MODEL" "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_comp"

--- a/gempak/ush/gfs_meta_mar_pac.sh
+++ b/gempak/ush/gfs_meta_mar_pac.sh
@@ -5,6 +5,7 @@
 # Set up Local Variables
 #
 
+rm -rf "${DATA}/MAR_PAC"
 mkdir -p -m 775 "${DATA}/MAR_PAC"
 cd "${DATA}/MAR_PAC" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -14,9 +15,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 mdl=gfs
 MDL="GFS"
@@ -271,7 +270,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_pac"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_pac"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_pac"

--- a/gempak/ush/gfs_meta_mar_ql.sh
+++ b/gempak/ush/gfs_meta_mar_ql.sh
@@ -5,6 +5,7 @@
 # Set up Local Variables
 #
 
+rm -rf "${DATA}/MAR_QL"
 mkdir -p -m 775 "${DATA}/MAR_QL"
 cd "${DATA}/MAR_QL" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -14,9 +15,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 mdl=gfs
 MDL="GFS"
@@ -180,7 +179,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_ql"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_ql"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_ql"

--- a/gempak/ush/gfs_meta_mar_skewt.sh
+++ b/gempak/ush/gfs_meta_mar_skewt.sh
@@ -5,6 +5,7 @@
 # Set up Local Variables
 #
 
+rm -rf "${DATA}/MAR_SKEWT"
 mkdir -p -m 775 "${DATA}/MAR_SKEWT"
 cd "${DATA}/MAR_SKEWT" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -14,9 +15,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 mdl=gfs
 MDL="GFS"
@@ -292,7 +291,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_skewt"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_skewt"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_skewt"

--- a/gempak/ush/gfs_meta_mar_ver.sh
+++ b/gempak/ush/gfs_meta_mar_ver.sh
@@ -5,6 +5,7 @@
 # Set up Local Variables
 #
 
+rm -rf "${DATA}/MAR_VER"
 mkdir -p -m 775 "${DATA}/MAR_VER"
 cd "${DATA}/MAR_VER" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -14,9 +15,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 mdl=gfs
 MDL="GFS"
@@ -102,7 +101,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_ver"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_ver"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_mar_ver"

--- a/gempak/ush/gfs_meta_nhsh.sh
+++ b/gempak/ush/gfs_meta_nhsh.sh
@@ -3,6 +3,7 @@
 # Metafile Script : mrf_meta_nhsh
 #
 
+rm -rf "${DATA}/mrfnhsh"
 mkdir -p -m 775 "${DATA}/mrfnhsh"
 cd "${DATA}/mrfnhsh" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -12,9 +13,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 if [[ "${envir}" == "para" ]]; then
     export m_title="GFSP"
@@ -113,7 +112,7 @@ for metaname in Nmeta_nh Nmeta_sh; do
         exit $((err + 100))
     fi
 
-    mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_${metaname/Nmeta_/}"
+    cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_${metaname/Nmeta_/}"
     if [[ "${SENDDBN}" == "YES" ]]; then
         "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
             "${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_${metaname/Nmeta_/}"

--- a/gempak/ush/gfs_meta_opc_na_ver.sh
+++ b/gempak/ush/gfs_meta_opc_na_ver.sh
@@ -5,6 +5,7 @@
 # Set up Local Variables
 #
 
+rm -rf "${DATA}/OPC_NA_VER_F${fend}"
 mkdir -p -m 775 "${DATA}/OPC_NA_VER_F${fend}"
 cd "${DATA}/OPC_NA_VER_F${fend}" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -14,9 +15,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 mdl=gfs
 MDL="GFS"
@@ -60,10 +59,9 @@ for lookback in "${lookbacks[@]}"; do
 
     # Create symlink in DATA to sidestep gempak path limits
     HPCGFS="${RUN}.${init_time}"
-    if [[ ! -L ${HPCGFS} ]]; then
-        source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
-        ${NLN} "${source_dir}" "${HPCGFS}"
-    fi
+    rm -f "${HPCGFS}"
+    source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
+    ${NLN} "${source_dir}" "${HPCGFS}"
 
     grid="F-${MDL2} | ${init_PDY}/${init_cyc}00"
 
@@ -163,7 +161,7 @@ if [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit 100
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}ver_${PDY}_${cyc}_na_mar"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}ver_${PDY}_${cyc}_na_mar"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}ver_${PDY}_${cyc}_na_mar"

--- a/gempak/ush/gfs_meta_opc_np_ver.sh
+++ b/gempak/ush/gfs_meta_opc_np_ver.sh
@@ -5,6 +5,7 @@
 # Set up Local Variables
 #
 
+rm -rf "${DATA}/OPC_NP_VER_F${fend}"
 mkdir -p -m 775 "${DATA}/OPC_NP_VER_F${fend}"
 cd "${DATA}/OPC_NP_VER_F${fend}" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -14,10 +15,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
-
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 mdl=gfs
 MDL="GFS"
 metaname="gfsver_mpc_np_${cyc}.meta"
@@ -60,10 +58,9 @@ for lookback in "${lookbacks[@]}"; do
 
     # Create symlink in DATA to sidestep gempak path limits
     HPCGFS="${RUN}.${init_time}"
-    if [[ ! -L "${HPCGFS}" ]]; then
-        source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
-        ${NLN} "${source_dir}" "${HPCGFS}"
-    fi
+    rm -f "${HPCGFS}"
+    source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
+    ${NLN} "${source_dir}" "${HPCGFS}"
 
     grid="F-${MDL2} | ${init_PDY}/${init_cyc}00"
 
@@ -162,7 +159,7 @@ if [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit 100
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}ver_${PDY}_${cyc}_np_mar"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}ver_${PDY}_${cyc}_np_mar"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}ver_${PDY}_${cyc}_np_mar"

--- a/gempak/ush/gfs_meta_precip.sh
+++ b/gempak/ush/gfs_meta_precip.sh
@@ -5,6 +5,7 @@
 # Set up Local Variables
 #
 
+rm -rf "${DATA}/precip"
 mkdir -p -m 775 "${DATA}/precip"
 cd "${DATA}/precip" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -14,10 +15,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
-
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 #
 # Set model and metafile naming conventions
 #
@@ -260,7 +258,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_us_${metatype}"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_us_${metatype}"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_us_${metatype}"

--- a/gempak/ush/gfs_meta_qpf.sh
+++ b/gempak/ush/gfs_meta_qpf.sh
@@ -5,6 +5,7 @@
 # Set up Local Variables
 #
 
+rm -rf "${DATA}/qpf"
 mkdir -p -m 775 "${DATA}/qpf"
 cd "${DATA}/qpf" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -14,9 +15,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 mdl=gfs
 MDL=GFS
@@ -398,7 +397,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_us_${metatype}"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_us_${metatype}"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_us_${metatype}"

--- a/gempak/ush/gfs_meta_sa.sh
+++ b/gempak/ush/gfs_meta_sa.sh
@@ -5,6 +5,7 @@
 # Set Up Local Variables
 #
 
+rm -rf "${DATA}/SA"
 mkdir -p -m 775 "${DATA}/SA"
 cd "${DATA}/SA" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -14,9 +15,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 mdl=gfs
 MDL=GFS
@@ -411,7 +410,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"

--- a/gempak/ush/gfs_meta_sa2.sh
+++ b/gempak/ush/gfs_meta_sa2.sh
@@ -6,8 +6,9 @@
 # comparisons to the ecmwf and ukmet
 #
 
-mkdir SA2
-cd SA2 || exit 1
+rm -rf "${DATA}/SA2"
+mkdir -p -m 775 "${DATA}/SA2"
+cd "${DATA}/SA2" || exit 1
 
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 
@@ -16,9 +17,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # TODO: Replace this
 #
 export HPCGFS="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${HPCGFS} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${HPCGFS}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${HPCGFS}"
 
 mdl=gfs
 MDL=GFS
@@ -34,12 +33,9 @@ PDYm1="$(date --utc +%Y%m%d -d "${PDY} ${cyc} - 24 hours")"
 
 HPCECMWF="ecmwf.${PDYm1}"
 HPCUKMET="ukmet.${PDY}"
-if [[ ! -L "${HPCECMWF}" ]]; then
-    ${NLN} "${COMINecmwf}/ecmwf.${PDYm1}/gempak" "${HPCECMWF}"
-fi
-if [[ ! -L "${HPCUKMET}" ]]; then
-    ${NLN} "${COMINukmet}/ukmet.${PDY}/gempak" "${HPCUKMET}"
-fi
+# TODO: remove live links and refer https://github.com/NOAA-EMC/global-workflow/issues/4406
+${NLN} "${COMINecmwf}/ecmwf.${PDYm1}/gempak" "${HPCECMWF}"
+${NLN} "${COMINukmet}/ukmet.${PDY}/gempak" "${HPCUKMET}"
 
 "${GEMEXE}/gdplot2_nc" << EOF
 \$MAPFIL= mepowo.gsf
@@ -341,7 +337,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"

--- a/gempak/ush/gfs_meta_trop.sh
+++ b/gempak/ush/gfs_meta_trop.sh
@@ -5,6 +5,7 @@
 # Set Up Local Variables
 #
 
+rm -rf "${DATA}/TROP"
 mkdir -p -m 775 "${DATA}/TROP"
 cd "${DATA}/TROP" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -14,9 +15,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 mdl=gfs
 MDL=GFS
@@ -238,7 +237,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s "${metaname}" ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/${mdl}_${PDY}_${cyc}_${metatype}"

--- a/gempak/ush/gfs_meta_us.sh
+++ b/gempak/ush/gfs_meta_us.sh
@@ -14,9 +14,7 @@ cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 device="nc | gfs.meta"
 
@@ -159,7 +157,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s gfs.meta ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv gfs.meta "${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_us"
+cpfs gfs.meta "${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_us"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_us"

--- a/gempak/ush/gfs_meta_usext.sh
+++ b/gempak/ush/gfs_meta_usext.sh
@@ -3,6 +3,7 @@
 # Metafile Script : gfs_meta_usext.sh
 #
 
+rm -rf "${DATA}/mrfus"
 mkdir -p -m 775 "${DATA}/mrfus"
 cd "${DATA}/mrfus" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -13,9 +14,7 @@ cpreq "${HOMEgfs}/gempak/fix/ak_sfstns.tbl" alaska.tbl
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 device="nc | mrf.meta"
 
@@ -230,7 +229,7 @@ if [[ "${err}" -ne 0 ]] || [[ ! -s mrf.meta ]] &> /dev/null; then
     exit $((err + 100))
 fi
 
-mv mrf.meta "${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_usext"
+cpfs mrf.meta "${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_usext"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/gfs_${PDY}_${cyc}_usext"

--- a/gempak/ush/gfs_meta_ver.sh
+++ b/gempak/ush/gfs_meta_ver.sh
@@ -5,6 +5,7 @@
 # Set up Local Variables
 #
 
+rm -rf "${DATA}/VER"
 mkdir -p -m 775 "${DATA}/VER"
 cd "${DATA}/VER" || exit 2
 cpreq "${HOMEgfs}/gempak/fix/datatype.tbl" datatype.tbl
@@ -18,9 +19,7 @@ device="nc | ${metaname}"
 # TODO: Replace this
 #
 export COMIN="${RUN}.${PDY}${cyc}"
-if [[ ! -L ${COMIN} ]]; then
-    ${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
-fi
+${NLN} "${COMIN_ATMOS_GEMPAK_1p00}" "${COMIN}"
 
 # SET CURRENT CYCLE AS THE VERIFICATION GRIDDED FILE.
 vergrid="F-${MDL} | ${PDY:2}/${cyc}00"
@@ -50,10 +49,9 @@ for lookback in "${lookbacks[@]}"; do
 
     # Create symlink in DATA to sidestep gempak path limits
     HPCGFS="${RUN}.${init_time}"
-    if [[ ! -L "${HPCGFS}" ]]; then
-        source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
-        ${NLN} "${source_dir}" "${HPCGFS}"
-    fi
+    rm -f "${HPCGFS}"
+    source_dir="${ROTDIR}/${RUN}.${init_PDY}/${init_cyc}/products/atmos/gempak/1p00"
+    ${NLN} "${source_dir}" "${HPCGFS}"
 
     grid="F-${MDL2} | ${init_PDY}/${init_cyc}00"
 
@@ -208,7 +206,7 @@ EOFplt
 
 done
 
-mv "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/gfsver_${PDY}_${cyc}"
+cpfs "${metaname}" "${COMOUT_ATMOS_GEMPAK_META}/gfsver_${PDY}_${cyc}"
 if [[ "${SENDDBN}" == "YES" ]]; then
     "${DBNROOT}/bin/dbn_alert" MODEL "${DBN_ALERT_TYPE}" "${job}" \
         "${COMOUT_ATMOS_GEMPAK_META}/gfsver_${PDY}_${cyc}"


### PR DESCRIPTION
# Description
This allows the gfs_gempakmeta job to run in either production mode (alongside the forecast) or development mode (after the forecast) in dev/gfs.v17. It also increases the memory request as production mode is more memory intensive.

Note, to test this in production mode via rocoto, the XML must be updated to trigger the `gfs_gempakmeta` job when the forecast starts.

Resolves #4436 
Resolves #4087 

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
C96_atm3DVar_extended case on WCOSS2 in production and development modes.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added