### PR TITLE
Hotfix pipeline clone pr

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,6 +157,17 @@ include:
         git remote add github "${GW_REPO_URL}"
         git fetch github
         ${GH} pr checkout "${PR_NUMBER}"
+        # Workaround for git <= 2.45 (e.g. Gaea Spack git 2.43.x):
+        # `gh pr checkout` repoints branch.<name>.remote to the PR author's fork.
+        # git submodule--helper then builds an unadvertised-SHA fallback fetch URL
+        # from that upstream, producing "<author-fork>.git <gdas-sha>" -> "not our ref".
+        # Re-pin the current branch upstream to NOAA-EMC/global-workflow so the
+        # fallback URL is correct. Remove once Gaea ships git >= 2.47.
+        git remote set-url origin "${GW_REPO_URL}"
+        _br=$(git branch --show-current)
+        git config "branch.${_br}.remote"     origin
+        git config "branch.${_br}.pushRemote" origin
+        unset _br
         git submodule update --init --recursive -j 8
       fi
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,12 +157,9 @@ include:
         git remote add github "${GW_REPO_URL}"
         git fetch github
         ${GH} pr checkout "${PR_NUMBER}"
-        # Workaround for git <= 2.45 (e.g. Gaea Spack git 2.43.x):
-        # `gh pr checkout` repoints branch.<name>.remote to the PR author's fork.
-        # git submodule--helper then builds an unadvertised-SHA fallback fetch URL
-        # from that upstream, producing "<author-fork>.git <gdas-sha>" -> "not our ref".
-        # Re-pin the current branch upstream to NOAA-EMC/global-workflow so the
-        # fallback URL is correct. Remove once Gaea ships git >= 2.47.
+        # Re-pin branch upstream to NOAA-EMC after `gh pr checkout` (which points it
+        # at the author's fork). Fixes submodule "not our ref" on git <= 2.45.
+        # Remove once Gaea ships git >= 2.47.
         git remote set-url origin "${GW_REPO_URL}"
         _br=$(git branch --show-current)
         git config "branch.${_br}.remote"     origin


### PR DESCRIPTION
## Discription

Fixes intermittent GitLab CI build failures on Gaea where `git submodule update --init --recursive` fails with:

```
fatal: remote error: upload-pack: not our ref e454a2324fc0bd8e7561725912138cafa7a1a741
```

…even though the pinned `sorc/gdas.cd` SHA is valid and reachable.

## Root Cause

A git client-side bug in versions **≤ 2.45** (Gaea's Spack stack currently ships **git 2.43.x**), interacting with `gh pr checkout`:

1. `gh pr checkout <PR>` sets `branch.<name>.remote` to the **PR author's fork** \
(e.g. `https://github.com/<author>/global-workflow`).
2. When a submodule is pinned to a SHA that isn't on any advertised branch (common for cross-repo PRs like gdas.cd against `refs/pull/*/head`), `git submodule--helper` falls back to fetching that bare SHA.
3. To build the fallback fetch URL, older git uses the parent repo's **branch upstream URL** as the base — i.e. the author's fork — instead of the submodule's own `.gitmodules` URL.
4. The author's fork doesn't contain the gdas.cd SHA, so the server replies `not our ref` and the build fails.

git **≥ 2.47** computes the fallback URL correctly and is unaffected.

## Fix

Three config operations added to `.build_template` in `.gitlab-ci.yml`, immediately after `gh pr checkout`:

```bash
git remote set-url origin "${GW_REPO_URL}"
_br=$(git branch --show-current)
git config "branch.${_br}.remote"     origin
git config "branch.${_br}.pushRemote" origin
```

This re-pins the checked-out PR branch's upstream to `NOAA-EMC/global-workflow`, so the submodule helper's fallback URL is correct.

## Scope / Risk

- Touches only `.gitlab-ci.yml` `.build_template`. No build/runtime code affected.
- Behavior unchanged on git ≥ 2.47 (the re-pin has no effect on submodule fetching there).
- No impact on `gh pr` operations — `origin` already pointed at NOAA-EMC; this just re-asserts it after `gh` mutated it.

## Validation

- Test scripts using (git 2.43.6) **without** patch → fails identically to Gaea (`not our ref e454a2324f…`).
- Test scripts **with** patch → `[OK] all submodules resolved`, `==> DONE`.
- Tested against PR #4856 (`feature/no_self`) which exposes the bug via gdas.cd pinned to `refs/pull/2129/head`.

## Follow-up

Remove this workaround once Gaea's Spack stack ships git ≥ 2.47.