### PR TITLE
(dev/gfs.v17) Update verfozn and analdiag scripts to handle missing ozone data

### DIFF
--- a/dev/scripts/exgdas_atmos_verfozn.sh
+++ b/dev/scripts/exgdas_atmos_verfozn.sh
@@ -36,8 +36,7 @@ if [[ -s "${oznstat}" ]]; then
     fi
 
 else
-    # oznstat file not found
-    export err=1
-    err_exit "${oznstat} does not exist!"
+    echo "Warning: Oznstat file not found"
+    echo "Warning: Exiting without performing ozone verification"
 fi
 exit 0

--- a/dev/scripts/exgdas_atmos_verfozn.sh
+++ b/dev/scripts/exgdas_atmos_verfozn.sh
@@ -36,7 +36,7 @@ if [[ -s "${oznstat}" ]]; then
     fi
 
 else
-    echo "Warning: Oznstat file not found"
-    echo "Warning: Exiting without performing ozone verification"
+    echo "WARNING: Oznstat file not found"
+    echo "WARNING: Exiting without performing ozone verification"
 fi
 exit 0

--- a/dev/scripts/exglobal_diag.sh
+++ b/dev/scripts/exglobal_diag.sh
@@ -230,7 +230,7 @@ if [[ "${DIAG_TARBALL}" == "YES" ]]; then
                 err_exit "Unable to create ${diagfile[n]}!"
             fi
         else
-	    echo "WARNING: No diagnostic files found for type ${n} = ${diaglist[n]#list}"
+            echo "WARNING: No diagnostic files found for type ${n} = ${diaglist[n]#list}"
             echo "WARNING: Unable to create ${diagfile[n]}"
         fi
     done

--- a/dev/scripts/exglobal_diag.sh
+++ b/dev/scripts/exglobal_diag.sh
@@ -229,6 +229,9 @@ if [[ "${DIAG_TARBALL}" == "YES" ]]; then
             if [[ ${err} -ne 0 ]]; then
                 err_exit "Unable to create ${diagfile[n]}!"
             fi
+        else
+	    echo "No diagnostic files found for ntype=${n}"	
+	    echo "Unable to create ${diagfile[n]}"	
         fi
     done
     echo "END tar diagnostic files"

--- a/dev/scripts/exglobal_diag.sh
+++ b/dev/scripts/exglobal_diag.sh
@@ -230,8 +230,8 @@ if [[ "${DIAG_TARBALL}" == "YES" ]]; then
                 err_exit "Unable to create ${diagfile[n]}!"
             fi
         else
-	    echo "No diagnostic files found for ntype=${n}"	
-	    echo "Unable to create ${diagfile[n]}"	
+	    echo "WARNING: No diagnostic files found for ntype=${n}"	
+	    echo "WARNING: Unable to create ${diagfile[n]}"	
         fi
     done
     echo "END tar diagnostic files"

--- a/dev/scripts/exglobal_diag.sh
+++ b/dev/scripts/exglobal_diag.sh
@@ -230,7 +230,7 @@ if [[ "${DIAG_TARBALL}" == "YES" ]]; then
                 err_exit "Unable to create ${diagfile[n]}!"
             fi
         else
-            echo "WARNING: No diagnostic files found for ntype=${n}"
+	    echo "WARNING: No diagnostic files found for type ${n} = ${diaglist[n]#list}"
             echo "WARNING: Unable to create ${diagfile[n]}"
         fi
     done

--- a/dev/scripts/exglobal_diag.sh
+++ b/dev/scripts/exglobal_diag.sh
@@ -230,8 +230,8 @@ if [[ "${DIAG_TARBALL}" == "YES" ]]; then
                 err_exit "Unable to create ${diagfile[n]}!"
             fi
         else
-	    echo "WARNING: No diagnostic files found for ntype=${n}"	
-	    echo "WARNING: Unable to create ${diagfile[n]}"	
+            echo "WARNING: No diagnostic files found for ntype=${n}"
+            echo "WARNING: Unable to create ${diagfile[n]}"
         fi
     done
     echo "END tar diagnostic files"

--- a/dev/scripts/exglobal_enkf_update.sh
+++ b/dev/scripts/exglobal_enkf_update.sh
@@ -119,7 +119,9 @@ cpreq "${COMIN_ATMOS_ANALYSIS_STAT}/${ABIASe}" "satbias_in"
 flist="${CNVSTAT} ${OZNSTAT} ${RADSTAT}"
 for ftype in ${flist}; do
     fname="${COMIN_ATMOS_ANALYSIS_STAT}/${ftype}"
-    tar -xvf "${fname}"
+    if [[ -s "${fname}" ]]; then
+        tar -xvf "${fname}"
+    fi
 done
 
 nfhrs="${IAUFHRS_ENKF//,/ }"

--- a/parm/archive/enkf.yaml.j2
+++ b/parm/archive/enkf.yaml.j2
@@ -74,7 +74,6 @@ enkf:
             {% set da_stat_files = ["enkfstat.txt",
                                     "gsistat_ensmean.txt",
                                     "cnvstat_ensmean.tar",
-                                    "oznstat_ensmean.tar",
                                     "radstat_ensmean.tar"] %}
             {% set da_conf_files = [] %}
         {% else %}
@@ -140,3 +139,8 @@ enkf:
         - "{{ COMIN_OCEAN_ANALYSIS_ENSSTAT | relpath(ROTDIR) }}/{{ head }}bg_ensvar.nc"
         - "{{ COMIN_ICE_ANALYSIS_ENSSTAT | relpath(ROTDIR) }}/{{ head }}bg_ensvar.nc"
         {% endif %}
+    optional:
+        {% if not DO_JEDIATMENS %}
+        - "{{ COMIN_ATMOS_ANALYSIS_ENSSTAT | relpath(ROTDIR) }}/{{ head }}oznstat_ensmean.tar"
+        {% endif %}
+


### PR DESCRIPTION
# Description
This PR adds warnings to the verfozn and analdiag/ediag scripts to handle missing ozone data, allowing the verfozn step to not fail when there is no oznstat file.

Refs #4881 

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?



# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
