### PR TITLE
(dev/gfs.v17) Hotfix for ozone archiving

### DIFF
--- a/parm/archive/gdas.yaml.j2
+++ b/parm/archive/gdas.yaml.j2
@@ -118,16 +118,6 @@ gdas:
         - "{{ COMIN_SNOW_ANLMON | relpath(ROTDIR) }}/{{ head }}snow_analysis.ioda_hofx_stats.tar.gz"
             {% endif %}
 
-        # Ozone verification
-            {% if DO_VERFOZN %}
-        - "{{ COMIN_ATMOS_OZNMON | relpath(ROTDIR) }}/time/bad_cnt.{{ cycle_YMDH }}"
-        - "{{ COMIN_ATMOS_OZNMON | relpath(ROTDIR) }}/time/bad_diag.{{ cycle_YMDH }}"
-        - "{{ COMIN_ATMOS_OZNMON | relpath(ROTDIR) }}/time/bad_pen.{{ cycle_YMDH }}"
-        - "{{ COMIN_ATMOS_OZNMON | relpath(ROTDIR) }}/time/stdout.time.tar.gz"
-        - "{{ COMIN_ATMOS_OZNMON | relpath(ROTDIR) }}/horiz/stdout.horiz.tar.gz"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}_verfozn.log"
-            {% endif %}
-
         # Radiance verification
             {% if DO_VERFRAD %}
         - "{{ COMIN_ATMOS_RADMON | relpath(ROTDIR) }}/radmon_angle.tar.gz"
@@ -194,6 +184,12 @@ gdas:
             {% endif %}
 
             {% if DO_VERFOZN %}
+        - "{{ COMIN_ATMOS_OZNMON | relpath(ROTDIR) }}/time/bad_cnt.{{ cycle_YMDH }}"
+        - "{{ COMIN_ATMOS_OZNMON | relpath(ROTDIR) }}/time/bad_diag.{{ cycle_YMDH }}"
+        - "{{ COMIN_ATMOS_OZNMON | relpath(ROTDIR) }}/time/bad_pen.{{ cycle_YMDH }}"
+        - "{{ COMIN_ATMOS_OZNMON | relpath(ROTDIR) }}/time/stdout.time.tar.gz"
+        - "{{ COMIN_ATMOS_OZNMON | relpath(ROTDIR) }}/horiz/stdout.horiz.tar.gz"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_verfozn.log"
                 # Not all of these ozone instruments always produce data
                 {% set oznmon_types = [
                    "gome_metop-b", "omi_aura", "ompslp_npp", "ompsnp_n20",


### PR DESCRIPTION
# Description
Hotfix for #4883.  Files produced by the verfozn step were still marked as `required` in the gdas_arch_tar_gdas step.  In this PR, these files are now moved to `optional`.

Refs #4881 

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
ATM only CI on WCOSS2.  The test itself fails due to an HPSS outage.  The previous failure in gdas_arch_tar_gdas.log has been removed:
`FileNotFoundError: FATAL ERROR: Required file, directory, or glob gdas.20211221/00/products/atmos/oznmon/time/bad_cnt.2021122100 not found!`

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
