### PR TITLE
[hotfix] Reverse the order of discovery for gh in pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,7 +93,7 @@ include:
       fi
 
       # Setup GitHub CLI for use throughout the pipeline
-      export GH=$(which gh 2>/dev/null || echo "${HOME}/bin/gh")
+      export GH=$(echo "${HOME}/bin/gh" || which gh 2>/dev/null)
       if [[ ! -x "${GH}" ]]; then
         echo "ERROR: GitHub CLI (gh) not found or not executable. Please install it."
         exit 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,7 +93,11 @@ include:
       fi
 
       # Setup GitHub CLI for use throughout the pipeline
-      export GH=$(echo "${HOME}/bin/gh" || which gh 2>/dev/null)
+      if [[ -x "${HOME}/bin/gh" ]]; then
+        export GH="${HOME}/bin/gh"
+      else
+        export GH="$(command -v gh 2>/dev/null)"
+      fi
       if [[ ! -x "${GH}" ]]; then
         echo "ERROR: GitHub CLI (gh) not found or not executable. Please install it."
         exit 1


### PR DESCRIPTION
# [hotfix] gitlab-ci: prefer user-local gh binary over system PATH

## Summary
Reverses the discovery order for the GitHub CLI (`gh`) binary used throughout
the GitLab CI pipeline. Previously the pipeline preferred whatever `gh` was
first on `PATH` and only fell back to `~/bin/gh`. With this change, the
user-local install at `${HOME}/bin/gh` is checked first.

## Motivation
On some HPC runners (notably Hera/WCOSS2), the system-wide `gh` discovered via
`which` is either stale, missing required scopes, or not the version we
provision through the runner setup. The provisioned binary at `${HOME}/bin/gh`
is the version we control and test against, so it should win when both exist.

## Changes
- `.gitlab-ci.yml`: Reorder `gh` discovery — try `${HOME}/bin/gh` first, fall
  back to `which gh`.

## Testing
- [ ] CI pipeline runs successfully on Hera with `~/bin/gh` present
- [ ] CI pipeline runs successfully on a runner where only system `gh` exists
      (fallback path)
- [ ] `gh` version logged in pipeline output matches the provisioned version

## Type
- [x] Bug fix (CI hotfix)
- [ ] New feature
- [ ] Breaking change

## Related
- Branch: `hotfox/gh_pipeline_discover_order`
