### PR TITLE
HOTFIX outputs to see why wrong gh being used on Derecho

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,6 +101,10 @@ include:
       if [[ ! -x "${GH}" ]]; then
         echo "ERROR: GitHub CLI (gh) not found or not executable. Please install it."
         exit 1
+      else
+        echo "GitHub CLI (gh) binary resolved to: ${GH}"
+        echo "Found via PATH lookup (command -v): $(command -v gh 2>/dev/null || echo 'not in PATH')"
+        echo "And PATH has been set as: ${PATH}"
       fi
 
       # Configure GitLab native GitHub integration


### PR DESCRIPTION
# Fix debug output for GitHub CLI discovery in GitLab pipeline

## Description

Adds debug output to the `before_script` GitHub CLI setup block in `.gitlab-ci.yml` to aid troubleshooting when `gh` is found but pipeline behaviour is unexpected. Three issues were fixed in the initial implementation before merging:

1. **`which gh` missing `2>/dev/null`** — when `gh` is installed at `${HOME}/bin/gh` and that directory is not in `$PATH`, `which gh` writes a "not in PATH" error to stderr, polluting CI job output even on a successful setup.
2. **`which` instead of `command -v`** — ShellCheck SC2230 (`enable=all` in `.shellcheckrc`) flags `which` as non-standard. Replaced with `command -v` to match the established pattern already used on the adjacent line (`command -v gh 2>/dev/null`).
3. **Ambiguous echo label** — `"PATH to GitHub CLI (gh) is set to: ${GH}"` used the word `PATH` immediately above `"And PATH has been set as: ${PATH}"`, which could confuse readers scanning CI log output.

### Changes

**File:** `.gitlab-ci.yml`

```diff
- echo "PATH to GitHub CLI (gh) is set to: ${GH}"
- echo "Found in the following location with which: $(which gh)"
+ echo "GitHub CLI (gh) binary resolved to: ${GH}"
+ echo "Found via PATH lookup (command -v): $(command -v gh 2>/dev/null || echo 'not in PATH')"
  echo "And PATH has been set as: ${PATH}"
```

## Type of change
- [x] Bug fix (fixes something broken)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

## Change characteristics
- Is this change expected to change outputs? NO
- Is this a breaking change? NO
- Does this change require a documentation update? NO
- Does this change require a submodule update? NO

## Branch
`hotfix/debug_output_gh`