### PR TITLE
(develop) Split sfc analysis job on Derecho

### DIFF
--- a/env/DERECHO.env
+++ b/env/DERECHO.env
@@ -191,13 +191,14 @@ case ${step} in
         fi
         export APRUN_CALCINC="${APRUN_default}"
         ;;
-    "sfcanl")
+    "sfcanl_gcycle")
         export NTHREADS_CYCLE=${threads_per_task:-14}
         if [[ ${NTHREADS_CYCLE} -gt ${max_tasks_per_node} ]]; then
             export NTHREADS_CYCLE=${max_tasks_per_node}
         fi
         export APRUN_CYCLE="${APRUN_default}"
-
+        ;;
+    "sfcanl_regrid")
         # REGRID requires 6 tasks for reproducibility
         ntasks_regrid=6
         export APRUN_REGRID="${launcher} -n ${ntasks_regrid} "
@@ -268,7 +269,7 @@ case ${step} in
         export APRUN_CALCINC="${APRUN_default}"
 
         ;;
-    "esfc")
+    "esfc_gcycle")
         export NTHREADS_ESFC=${NTHREADSmax}
         export APRUN_ESFC="${APRUN_default}"
 
@@ -277,7 +278,8 @@ case ${step} in
             export NTHREADS_CYCLE=${max_tasks_per_node}
         fi
         export APRUN_CYCLE="${APRUN_default}"
-
+        ;;
+    "esfc_regrid")
         # REGRID requires 6*NMEM_ENS tasks for reproducibility
         export APRUN_REGRID="${launcher} -n ${ntasks}"
         ;;

--- a/sorc/build_all.sh
+++ b/sorc/build_all.sh
@@ -79,7 +79,7 @@ export HOMEglobal
 
 echo "Sourcing global-workflow modules ..."
 source "${HOMEglobal}/dev/ush/gw_setup.sh"
-if [[ ${MACHINE_ID} == "derecho" ]]; then
+if [[ "${MACHINE_ID}" == "derecho" && "${compute_build}" == "NO" ]]; then
     # Derecho has stricter limits on head node usage
     cat << 'EOF'
 WARNING: Interactive build on Derecho is limited to four cores to comply


### PR DESCRIPTION
# Description
A recent update (#4745) that split the sfc analysis into two jobs inadvertently left out Derecho. This repeats those changes for Derecho.

Also, build_all.sh is updated so it only warns about building on the head node on Derecho when *not* using compute build.

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
- PR tests on Derecho

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
