### PR TITLE
Up the number of reattempts upon unknown state in CI

### DIFF
--- a/dev/ci/scripts/utils/rocotostat.py
+++ b/dev/ci/scripts/utils/rocotostat.py
@@ -21,7 +21,7 @@ ROCOTO_SUMMARY_SLEEP_DURATION = 120    # Sleep duration (seconds) between summar
 ROCOTO_STATCOUNT_MAX_ATTEMPTS = 4      # Maximum attempts for rocotostat --all
 ROCOTO_STATCOUNT_SLEEP_DURATION = 120  # Sleep duration (seconds) between statcount attempts
 
-ROCOTO_RETRY_MAX_ATTEMPTS = 2          # Maximum retry attempts for status checks
+ROCOTO_RETRY_MAX_ATTEMPTS = 4          # Maximum retry attempts for status checks
 ROCOTO_RETRY_SLEEP_DURATION = 120      # Sleep duration (seconds) between retry attempts
 
 # Telescoping delay configuration


### PR DESCRIPTION
# Description
Increases the number of tries the CI system will reattempt rocotostat when encountering an unknown job state. This is needed to handle the volatility of PBS Pro on Derecho and is similar to changes made to the build job.

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO

# How has this been tested?
Testing will be done as part of the PR process.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
