### PR TITLE
HOTFIX Create RESTART directory to prevent FMS from doing it

### DIFF
--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_ECEN
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_ECEN
@@ -26,7 +26,7 @@ PYTHONPATH="${HOMEgfs}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"
 export PYTHONPATH
 
 ## HOTFIX
-# TODO Move this to the GDASApp config. Better yet, fix this in the model so RESTART doesn't get created.
+# TODO Fix this in the input.nml template so RESTART doesn't get created in the first place.
 mkdir -p "${DATA}/RESTART"
 
 # Ignore possible spelling error (nothing is misspelled)

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_ECEN
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_ECEN
@@ -25,6 +25,10 @@ source "${USHgfs}/set_strict.sh"
 PYTHONPATH="${HOMEgfs}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"
 export PYTHONPATH
 
+## HOTFIX
+# TODO Move this to the GDASApp config. Better yet, fix this in the model so RESTART doesn't get created.
+mkdir -p "${DATA}/RESTART"
+
 # Ignore possible spelling error (nothing is misspelled)
 # shellcheck disable=SC2153
 GDATE=$(date --utc +%Y%m%d%H -d "${PDY} ${cyc} - ${assim_freq} hours")


### PR DESCRIPTION
# Description
This fixes a crash seen at high resolution where FMS fails to create the RESTART directory in parallel.

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Ran the marine recentering job showing that both the directory and it's permissions were correct.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added