### PR TITLE
[develop] Update gitignore for additional sorc directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,10 +123,14 @@ sorc/logs
 sorc/calc_analysis.fd
 sorc/calc_increment_ens.fd
 sorc/calc_increment_ens_ncio.fd
+sorc/chgres_cube.fd
 sorc/emcsfc_ice_blend.fd
 sorc/emcsfc_snow2mdl.fd
 sorc/enkf.fd
 sorc/enkf_chgres_recenter_nc.fd
+sorc/ensadd.fd
+sorc/ensppf.fd
+sorc/ensstat.fd
 sorc/fbwndgfs.fd
 sorc/gaussian_sfcanl.fd
 sorc/getsfcensmeanp.fd
@@ -146,6 +150,7 @@ sorc/radmon_bcor.fd
 sorc/radmon_time.fd
 sorc/rdbfmsua.fd
 sorc/recentersigp.fd
+sorc/regridStates.fd
 sorc/supvit.fd
 sorc/syndat_getjtbul.fd
 sorc/syndat_maksynrc.fd
@@ -155,7 +160,9 @@ sorc/tocsbufr.fd
 sorc/tref_calc.fd
 sorc/upp.fd
 sorc/vint.fd
+sorc/wave_stat.fd
 sorc/webtitle.fd
+sorc/WW3.fd
 sorc/ocnicepost.fd
 
 # Ignore scripts from externals


### PR DESCRIPTION

# Description
PR #4916 introduced several new linked sorc directories via `link_workflow.sh`. These directories should not be included in any git pushes and therefore should have been added to the .gitignore file in that PR. This PR addresses this bug to ensure that these directories do not accidentally get added to any git commits. 

# Type of change
- [ ] Bug fix (fixes something broken)


# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
Tried a git add and saw it successfully ignores new sorc directories


# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
