### PR TITLE
GFSv16.3.31 - Tropical storm name updates for 2026-2027 hurricane seasons

### DIFF
--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -1,9 +1,9 @@
-GFS V16.3.30 RELEASE NOTES
+GFS V16.3.31 RELEASE NOTES
 
 -------
 PRELUDE
 -------
-This removes an extraneous module path from the build script.
+Tropical storm name updates for the 2026-2027 hurricane seasons are made in the GFS syndat_stmnames fix file.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -13,9 +13,9 @@ The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub are used t
 ```bash
 cd $PACKAGEROOT
 
-mkdir gfs.v16.3.30
-cd gfs.v16.3.30
-git clone -b EMC-v16.3.30 https://github.com/NOAA-EMC/global-workflow.git .
+mkdir gfs.v16.3.31
+cd gfs.v16.3.31
+git clone -b EMC-v16.3.31 https://github.com/NOAA-EMC/global-workflow.git .
 cd sorc
 ./checkout.sh -o
 ```
@@ -51,47 +51,47 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* in `versions/run.ver` change `version=v16.3.30` and `gfs_ver=v16.3.30`
+* in `versions/run.ver` change `version=v16.3.31` and `gfs_ver=v16.3.31`
 
 SORC CHANGES
 ------------
 
-* No changes from GFS v16.3.29
+* No changes from GFS v16.3.30
 
 JOBS CHANGES
 ------------
 
-* No changes from GFS v16.3.29
+* No changes from GFS v16.3.30
 
 PARM/CONFIG CHANGES
 -------------------
 
-* No changes from GFS v16.3.29
+* No changes from GFS v16.3.30
 
 SCRIPT CHANGES
 --------------
 
-* No changes from GFS v16.3.29.
+* No changes from GFS v16.3.30.
 
 FIX CHANGES
 -----------
 
-* No changes from GFS v16.3.29.
+* The `fix_am/syndat_stmnames` file is updated to adjust some hurricane names for 2026/2027 seasons.
 
 MODULE CHANGES
 --------------
 
-* An extraneous ``module use`` was removed from ``build_fv3.sh``.  This module path was required when building GFS v16.3.25, but is no longer required.
+* No changes from GFS v16.3.30.
 
 CHANGES TO FILE AND FILE SIZES
 ------------------------------
 
-* No significant changes from GFS v16.3.29.
+* No changes from GFS v16.3.30.
 
 ENVIRONMENT AND RESOURCE CHANGES
 --------------------------------
 
-* No changes from GFS v16.3.29.
+* No changes from GFS v16.3.30.
 
 PRE-IMPLEMENTATION TESTING REQUIREMENTS
 ---------------------------------------
@@ -104,22 +104,22 @@ PRE-IMPLEMENTATION TESTING REQUIREMENTS
 DISSEMINATION INFORMATION
 -------------------------
 
-* No changes from GFS v16.3.29
+* No changes from GFS v16.3.30
 
 HPSS ARCHIVE
 ------------
 
-* No changes from GFS v16.3.29
+* No changes from GFS v16.3.30
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
 
-* No changes from GFS v16.3.29
+* No changes from GFS v16.3.30
 
 DOCUMENTATION
 -------------
 
-* No changes from GFS v16.3.29
+* No changes from GFS v16.3.30
 
 PREPARED BY
 -----------

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.30
-export gfs_ver=v16.3.30
+export version=v16.3.31
+export gfs_ver=v16.3.31
 export nam_ver=v4.2
 export rtofs_ver=v2.5
 export radarl2_ver=v1.2


### PR DESCRIPTION
# Description
This non-code update just increments the version to 16.3.31 to accompany an updated tropical storm name list.

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)