### PR TITLE
(dev/gfs.v17) Track changes in /jobs and /scripts via linking

### DIFF
--- a/dev/ush/setup_gfs_for_nco.py
+++ b/dev/ush/setup_gfs_for_nco.py
@@ -326,8 +326,8 @@ def setup_gfs_for_nco(link_or_copy='copy'):
 
 if __name__ == "__main__":
     # Get command line argument for whether to copy or link files, default to 'copy'
-    parser = argparse.ArgumentParser(description="Set up GFS workflow for NCO by copying or linking necessary files from dev to the global workflow directory.")
-    parser.add_argument('--link', action='store_true', )
+    parser = argparse.ArgumentParser(description="Set up GFS workflow for NCO by linking or copying necessary files from dev to the global workflow directory.")
+    parser.add_argument('--copy', action='store_true', )
     args = parser.parse_args()
-    link_or_copy = 'link' if args.link else 'copy'
+    link_or_copy = 'copy' if args.copy else 'link'
     setup_gfs_for_nco(link_or_copy=link_or_copy)


### PR DESCRIPTION
# Description
This PR allows change tracking in the `/jobs` and `/scripts` directories created by `setup_gfs_for_nco.py` utility. The utility already supports linking and copying, with copying as the default behavior. This PR changes the default behavior to linking, so that changes made in either of these directories are made to the tracked files in `/dev`. See #4779 for further discussion. Note that using the `--copy` flag will defeat the purpose of this PR. This should probably be documented when docs on this script are added.

Resolves #4779 

# Type of change
- [ ] Bug fix (fixes something broken)
- [x] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
1. Cloned, built, and linked global workflow on gaea
2. ran `setup_gfs_for_nco.py`
3. made changes to `/jobs` and `/scripts`
4. verified the changes were reflected in a `git diff`

# Checklist
- [ ] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
