### PR TITLE
Add Forecast Manager Configs to `parm/config/gfs`

### DIFF
--- a/parm/config/gfs/config.fcst_manager
+++ b/parm/config/gfs/config.fcst_manager
@@ -1,0 +1,38 @@
+#! /usr/bin/env bash
+
+########## config.fcst_manager ##########
+# Forecast manager specific configuration
+
+echo "BEGIN: config.fcst_manager"
+
+# Number of parallel ATM instance groups. Each group has 4 product copy ranks
+# (atmf, sfcf, grib, flux) plus 1 barrier rank = 5 ranks per instance.
+# Forecast hours are distributed round-robin across instances so all groups
+# copy in parallel. Total ATM ranks = MGR_NATM_INST * 5.
+# Must match the ntasks calculation in config.resources "fcst_manager".
+export MGR_NATM_INST=${MGR_NATM_INST:-2}
+
+# WW3/OCN/ICE: product table split into n sub-tables; one rank per sub-table.
+export MGR_NTASKS_WW3=${MGR_NTASKS_WW3:-2}
+export MGR_NTASKS_OCN=${MGR_NTASKS_OCN:-1}
+export MGR_NTASKS_ICE=${MGR_NTASKS_ICE:-1}
+
+# Maximum time (seconds) to wait for product tables to appear in COMOUT_CONF.
+# Must be less than the batch walltime of the fcst_manager job.
+export FCST_MGR_INIT_TIMEOUT=7200
+
+# Maximum time (seconds) to wait for the model to finish before the manager
+# declares a timeout and exits with an error (0 = no timeout).
+export FCST_MGR_TIMEOUT=0
+
+# Polling interval (seconds) between sentinel checks.
+export FCST_MGR_SLEEP=5
+
+# Seconds between the two size samples used to verify a data file is no longer
+# being written before copying it (size-stability guard). Set to 0 to disable.
+export FCST_MGR_STABILITY_WAIT=5
+
+# Get task specific resources
+. "${EXPDIR}/config.resources" "fcst_manager"
+
+echo "END: config.fcst_manager"

--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -1000,6 +1000,31 @@ case ${step} in
     unset NTASKS_TOT
     ;;
 
+  "fcst_manager")
+    # Forecast manager: ATM always uses 5 fixed ranks (4 per-product + 1 barrier).
+    # WW3/OCN/ICE use MGR_NTASKS_<component> round-robin ranks each.
+    # Walltime must be long enough to cover the full forecast run.
+    is_exclusive=False
+    prepost=True
+    (( ntasks = MGR_NATM_INST * 5 ))  # ATM: MGR_NATM_INST x (4 product + 1 barrier)
+    if [[ "${DO_WAVE}" == "YES" ]]; then
+        (( ntasks += ${MGR_NTASKS_WW3:-2} ))
+    fi
+    if [[ "${DO_OCN:-NO}" == "YES" ]]; then
+        (( ntasks += ${MGR_NTASKS_OCN:-1} ))
+    fi
+    if [[ "${DO_ICE:-NO}" == "YES" ]]; then
+        (( ntasks += ${MGR_NTASKS_ICE:-1} ))
+    fi
+    if [[ "${DO_AERO_FCST:-NO}" == "YES" ]]; then
+        (( ntasks += 1 ))
+    fi
+    tasks_per_node=${ntasks}
+    threads_per_task=1
+    memory="20GB"
+    walltime="06:00:00"
+    ;;
+
   "oceanice_products")
     # Walltime is per forecast hour; will be multipled by group size
     walltime="00:15:00"


### PR DESCRIPTION
# Description
Follow-up to #4907. The forecast manager PR added its config under `dev/parm/config/gfs/` (the v17-rendered config tracking path), but the legacy `parm/config/gfs/` tree was not updated. This PR mirrors those two edits into `parm/config/gfs/` so both config locations stay in sync for the operational configuration tracking on `dev/gfs.v17`.

  Refs #4822 
  Refs #4907

<!-- For more on writing good commit messages, see https://cbea.ms/git-commit/ -->

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO (If YES, please indicate to which system(s))
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Include the output of `gw_cistat -r /path/to/RUNTESTS/directory` for the tests you ran.
`gw_cistat` is available after sourcing the `gw_setup.sh` script in `dev/ush/`.

Example:
- Clone and build on WCOSS
- Cycled test on Orion
- Forecast-only on Hera
-->


# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
