### PR TITLE
(dev/gfs.v17) Updates/fixes for ecflow

### DIFF
--- a/parm/config/gfs/config.ufs
+++ b/parm/config/gfs/config.ufs
@@ -657,26 +657,26 @@ fi
 # WW3 restart field variable is different for slow vs fast loop.  Add  WW3_RSTFLDS="ice" for slow loop variables based on coupling scheme.
 case "${model_list}" in
   atm)
-    default_template="${PARMgfs}/ufs/ufs.configure.atm${tmpl_suffix:-}.IN"
+    default_template="${PARMglobal}/ufs/ufs.configure.atm${tmpl_suffix:-}.IN"
     ;;
   atm.aero)
-    default_template="${PARMgfs}/ufs/ufs.configure.atmaero${tmpl_suffix:-}.IN"
+    default_template="${PARMglobal}/ufs/ufs.configure.atmaero${tmpl_suffix:-}.IN"
     ;;
   atm.wave)
-    default_template="${PARMgfs}/ufs/ufs.configure.leapfrog_atm_wav${tmpl_suffix:-}.IN"
+    default_template="${PARMglobal}/ufs/ufs.configure.leapfrog_atm_wav${tmpl_suffix:-}.IN"
     ;;
   atm.ocean.ice)
-    default_template="${PARMgfs}/ufs/ufs.configure.s2s${tmpl_suffix:-}.IN"
+    default_template="${PARMglobal}/ufs/ufs.configure.s2s${tmpl_suffix:-}.IN"
     ;;
   atm.ocean.ice.aero)
-    default_template="${PARMgfs}/ufs/ufs.configure.s2sa${tmpl_suffix:-}.IN"
+    default_template="${PARMglobal}/ufs/ufs.configure.s2sa${tmpl_suffix:-}.IN"
     ;;
   atm.ocean.ice.wave)
-    default_template="${PARMgfs}/ufs/ufs.configure.s2sw${tmpl_suffix:-}.IN"
+    default_template="${PARMglobal}/ufs/ufs.configure.s2sw${tmpl_suffix:-}.IN"
     WW3_RSTFLDS="ice"
     ;;
   atm.ocean.ice.wave.aero)
-    default_template="${PARMgfs}/ufs/ufs.configure.s2swa${tmpl_suffix:-}.IN"
+    default_template="${PARMglobal}/ufs/ufs.configure.s2swa${tmpl_suffix:-}.IN"
     WW3_RSTFLDS="ice"
     ;;
   *)

--- a/parm/config/gfs/config.upp
+++ b/parm/config/gfs/config.upp
@@ -8,7 +8,7 @@ echo "BEGIN: config.upp"
 # Get task specific resources
 . "${EXPDIR}/config.resources" upp
 
-export UPP_CONFIG="${PARMgfs}/post/upp.yaml"
+export UPP_CONFIG="${PARMglobal}/post/upp.yaml"
 
 # No. of forecast hours to process in a single job
 export NFHRS_PER_GROUP=3


### PR DESCRIPTION
The ecflow case is failing due to a PARMgfs variable in config.upp. This changes that variable to PARMglobal.