### PR TITLE
(dev/gfsv.17) Add utility script to check for dead links (#4799)

### DIFF
--- a/dev/parm/config/gcafs/config.base.j2
+++ b/dev/parm/config/gcafs/config.base.j2
@@ -110,6 +110,7 @@ export HOMEobsproc="${BASE_GIT:-}/obsproc/v${obsproc_run_ver:-}"
 export NMV="/bin/mv"
 export NLN="/bin/ln -sf"
 export VERBOSE="YES"
+export CHECK_DEAD_LINKS="NO"
 export DEBUG_POSTSCRIPT="NO" # PBS only; sets debug=true
 export CHGRP_RSTPROD="{{ CHGRP_RSTPROD }}"
 export CHGRP_CMD="{{ CHGRP_CMD }}"

--- a/dev/parm/config/gefs/config.base.j2
+++ b/dev/parm/config/gefs/config.base.j2
@@ -78,6 +78,7 @@ export HOMEpost="${HOMEglobal}"
 export NMV="/bin/mv"
 export NLN="/bin/ln -sf"
 export VERBOSE="YES"
+export CHECK_DEAD_LINKS="NO"
 export DEBUG_POSTSCRIPT="NO" # PBS only; sets debug=true
 export CHGRP_RSTPROD="{{ CHGRP_RSTPROD }}"
 export CHGRP_CMD="{{ CHGRP_CMD }}"

--- a/dev/parm/config/gfs/config.base.j2
+++ b/dev/parm/config/gfs/config.base.j2
@@ -108,6 +108,7 @@ export HOMEobsproc="${BASE_GIT:-}/obsproc/v${obsproc_run_ver:-}"
 export NMV="/bin/mv"
 export NLN="/bin/ln -sf"
 export VERBOSE="YES"
+export CHECK_DEAD_LINKS="NO"
 export DEBUG_POSTSCRIPT="NO" # PBS only; sets debug=true
 export CHGRP_RSTPROD="{{ CHGRP_RSTPROD }}"
 export CHGRP_CMD="{{ CHGRP_CMD }}"

--- a/dev/parm/config/sfs/config.base.j2
+++ b/dev/parm/config/sfs/config.base.j2
@@ -78,6 +78,7 @@ export HOMEpost="${HOMEglobal}"
 export NMV="/bin/mv"
 export NLN="/bin/ln -sf"
 export VERBOSE="YES"
+export CHECK_DEAD_LINKS="NO"
 export KEEPDATA="{{ KEEPDATA }}"
 export DEBUG_POSTSCRIPT="NO" # PBS only; sets debug=true
 export CHGRP_RSTPROD="{{ CHGRP_RSTPROD }}"

--- a/dev/scripts/exglobal_forecast.sh
+++ b/dev/scripts/exglobal_forecast.sh
@@ -176,6 +176,11 @@ fi
 UFS_configure
 echo "MAIN: Name lists and model configuration written"
 
+# check for and log dead links in ${DATA} before running executables
+if [[ ${CHECK_DEAD_LINKS} == "YES" ]]; then
+    "${HOMEglobal}/dev/ush/check_dead_links.sh" "${DATA}"
+fi
+
 #------------------------------------------------------------------
 # run the executable
 

--- a/dev/ush/check_dead_links.sh
+++ b/dev/ush/check_dead_links.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+#######################################
+# Check a directory for dead links
+# Usage:
+#   ./check_dead_links.sh <target_directory>
+# Outputs:
+#   number and list of dead links only if found
+# Returns:
+#   0 if check completes, 1 for invalid usage
+#######################################
+
+# Check if exactly one argument was provided
+if [[ $# -ne 1 ]]; then
+    echo "Error: $0 accepts a single argument."
+    echo "Usage: $0 <target_directory>"
+    exit 1
+fi
+
+# Check that the argument is an existing directory
+if [[ ! -d "$1" ]]; then
+    echo "Error: '$1' is not a directory or does not exist."
+    echo "Usage: $0 <target_directory>"
+    exit 1
+fi
+
+# Find dead links in the target directory
+dead_links=$(find "$1" -xtype l)
+
+# Check if the dead_links variable is non-empty
+if [[ -n "${dead_links}" ]]; then
+    # count dead links
+    count_dead_links=$(echo "${dead_links}" | wc -l)
+
+    echo "Found ${count_dead_links} dead links in $1:"
+    echo "${dead_links}"
+fi
+
+# Success if script completes
+exit 0


### PR DESCRIPTION
# Description
This PR adds a toggleable utility to check for dead links in shell scripts, and it adds a check to `${DATA}` in `exglobal_forcast.sh` as a usage example. The controlling environment variable `CHECK_DEAD_LINKS` (in each `config.base.j2`) defaults to `NO`. If `YES`, the check runs. The utility script logs dead links if it finds them, but the ex-script will only exit if the utility is improperly called.

Resolves #4799

# Type of change
- [ ] Bug fix (fixes something broken)
- [x] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
1. Clone, build, and link the global workflow
2. Change the default behavior to `CHECK_DEAD_LINKS=YES`
3. Add some dead links to `${DATA}`
4. Run a workflow that includes `exglobal_forecast.sh`
5. Verify the dead links are correctly logged
6. Verify improper usage of the utility script leads to the ex-script exiting.

# Checklist
- [ ] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
