### PR TITLE
(dev/gfs.v17) Archive MPMD logs in DATA instead of piping back to the parent log

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ Department of Commerce seal and logo, or the seal and logo of a DOC bureau,
 shall not be used in any manner to imply endorsement of any commercial product
 or activity by DOC or the United States Government.
 
+Generative AI has been used to assist with the development of this code.
+The code has been reviewed, edited, and validated by NWS staff or affiliates.

--- a/dev/parm/config/gcafs/config.base.j2
+++ b/dev/parm/config/gcafs/config.base.j2
@@ -109,13 +109,16 @@ export HOMEobsproc="${BASE_GIT:-}/obsproc/v${obsproc_run_ver:-}"
 # CONVENIENT utility scripts and other environment parameters
 export NMV="/bin/mv"
 export NLN="/bin/ln -sf"
-export VERBOSE="YES"
-export CHECK_DEAD_LINKS="NO"
-export DEBUG_POSTSCRIPT="NO" # PBS only; sets debug=true
 export CHGRP_RSTPROD="{{ CHGRP_RSTPROD }}"
 export CHGRP_CMD="{{ CHGRP_CMD }}"
 export NCDUMP="${NETCDF:-${netcdf_c_ROOT:-}}/bin/ncdump"
 export NCLEN="${HOMEglobal}/ush/getncdimlen"
+
+# Log control
+export VERBOSE="YES"
+export CAT_MPMD_LOGS="YES"  # Copy MPMD logs to the parent log. Remove or set to NO when delivering to NCO.
+export DEBUG_POSTSCRIPT="NO" # PBS only; sets debug=true
+export CHECK_DEAD_LINKS="NO"
 
 # Machine environment, jobs, and other utility scripts
 export BASE_ENV="${HOMEglobal}/env"

--- a/dev/parm/config/gefs/config.base.j2
+++ b/dev/parm/config/gefs/config.base.j2
@@ -77,13 +77,16 @@ export HOMEpost="${HOMEglobal}"
 # CONVENIENT utility scripts and other environment parameters
 export NMV="/bin/mv"
 export NLN="/bin/ln -sf"
-export VERBOSE="YES"
-export CHECK_DEAD_LINKS="NO"
-export DEBUG_POSTSCRIPT="NO" # PBS only; sets debug=true
 export CHGRP_RSTPROD="{{ CHGRP_RSTPROD }}"
 export CHGRP_CMD="{{ CHGRP_CMD }}"
 export NCDUMP="${NETCDF:-${netcdf_c_ROOT:-}}/bin/ncdump"
 export NCLEN="${HOMEglobal}/ush/getncdimlen"
+
+# Log control
+export VERBOSE="YES"
+export CHECK_DEAD_LINKS="NO"
+export CAT_MPMD_LOGS="YES"  # Copy MPMD logs to the parent log. Remove or set to NO when delivering to NCO.
+export DEBUG_POSTSCRIPT="NO" # PBS only; sets debug=true
 
 # Machine environment, jobs, and other utility scripts
 export BASE_ENV="${HOMEglobal}/env"

--- a/dev/parm/config/gfs/config.base.j2
+++ b/dev/parm/config/gfs/config.base.j2
@@ -1,18 +1,4 @@
-#-if [ -n "%PDY:%" ]; then
--  export PDY=${PDY:-%PDY:%}
--else
--  export PDY=$($NDATE | cut -c1-8)
--fi
-+# if [ -n "%PDY:%" ]; then
-+#   export PDY=${PDY:-%PDY:%}
-+# else
-+#   export PDY=$($NDATE | cut -c1-8)
-+# fi
-+if [[ %CYC% == 00 || || %CYC% == 06 || %CYC% == 12 ]]; then
-+    export PDY=20260613
-+ else
-+    export PDY=20260612
-+ fi! /usr/bin/env bash
+#! /usr/bin/env bash
 
 ########## config.base ##########
 # Common to all steps

--- a/dev/parm/config/gfs/config.base.j2
+++ b/dev/parm/config/gfs/config.base.j2
@@ -1,4 +1,18 @@
-#! /usr/bin/env bash
+#-if [ -n "%PDY:%" ]; then
+-  export PDY=${PDY:-%PDY:%}
+-else
+-  export PDY=$($NDATE | cut -c1-8)
+-fi
++# if [ -n "%PDY:%" ]; then
++#   export PDY=${PDY:-%PDY:%}
++# else
++#   export PDY=$($NDATE | cut -c1-8)
++# fi
++if [[ %CYC% == 00 || || %CYC% == 06 || %CYC% == 12 ]]; then
++    export PDY=20260613
++ else
++    export PDY=20260612
++ fi! /usr/bin/env bash
 
 ########## config.base ##########
 # Common to all steps
@@ -107,13 +121,16 @@ export HOMEobsproc="${BASE_GIT:-}/obsproc/v${obsproc_run_ver:-}"
 # CONVENIENT utility scripts and other environment parameters
 export NMV="/bin/mv"
 export NLN="/bin/ln -sf"
-export VERBOSE="YES"
-export CHECK_DEAD_LINKS="NO"
-export DEBUG_POSTSCRIPT="NO" # PBS only; sets debug=true
 export CHGRP_RSTPROD="{{ CHGRP_RSTPROD }}"
 export CHGRP_CMD="{{ CHGRP_CMD }}"
 export NCDUMP="${NETCDF:-${netcdf_c_ROOT:-}}/bin/ncdump"
 export NCLEN="${HOMEglobal}/ush/getncdimlen"
+
+# Log control
+export VERBOSE="YES"
+export CAT_MPMD_LOGS="YES"  # Copy MPMD logs to the parent log. Remove or set to NO when delivering to NCO.
+export DEBUG_POSTSCRIPT="NO" # PBS only; sets debug=true
+export CHECK_DEAD_LINKS="NO"
 
 # Machine environment, jobs, and other utility scripts
 export BASE_ENV="${HOMEglobal}/env"

--- a/dev/parm/config/sfs/config.base.j2
+++ b/dev/parm/config/sfs/config.base.j2
@@ -77,14 +77,17 @@ export HOMEpost="${HOMEglobal}"
 # CONVENIENT utility scripts and other environment parameters
 export NMV="/bin/mv"
 export NLN="/bin/ln -sf"
-export VERBOSE="YES"
-export CHECK_DEAD_LINKS="NO"
 export KEEPDATA="{{ KEEPDATA }}"
-export DEBUG_POSTSCRIPT="NO" # PBS only; sets debug=true
 export CHGRP_RSTPROD="{{ CHGRP_RSTPROD }}"
 export CHGRP_CMD="{{ CHGRP_CMD }}"
 export NCDUMP="${NETCDF:-${netcdf_c_ROOT:-}}/bin/ncdump"
 export NCLEN="${HOMEglobal}/ush/getncdimlen"
+
+# Log control
+export VERBOSE="YES"
+export CAT_MPMD_LOGS="YES"  # Copy MPMD logs to the parent log. Remove or set to NO when delivering to NCO.
+export DEBUG_POSTSCRIPT="NO" # PBS only; sets debug=true
+export CHECK_DEAD_LINKS="NO"
 
 # Machine environment, jobs, and other utility scripts
 export BASE_ENV="${HOMEglobal}/env"

--- a/dev/scripts/exglobal_atmos_products.sh
+++ b/dev/scripts/exglobal_atmos_products.sh
@@ -130,9 +130,6 @@ for ((nset = 1; nset <= downset; nset++)); do
         err_exit "FATAL ERROR: Some or all interpolations of the master grib file failed during MPMD execution!"
     fi
 
-    # We are in a loop over downset, save output from mpmd into nset specific output
-    mv mpmd.out "mpmd_${nset}.out"
-
     # Concatenate grib files from each processor into a single one
     # and clean-up as you go
     echo "INFO: Concatenating processor-specific grib2 files into a single product file"

--- a/docs/source/configure.rst
+++ b/docs/source/configure.rst
@@ -67,6 +67,9 @@ The global-workflow configs contain switches that change how the system runs. Ma
 | QUILTING         | Use I/O quilting                 | .true.        | NO          | If .true. choose OUTPUT_GRID as cubed_sphere_grid |
 |                  |                                  |               |             | in netcdf or gaussian_grid                        |
 +------------------+----------------------------------+---------------+-------------+---------------------------------------------------+
+| CAT_MPMD_LOGS    | Write MPMD logs back to the      | YES           | NO          | If YES, the contents of the MPMD logs will be     |
+|                  | parent log.                      |               |             | written to the parent log file.                   |
++------------------+----------------------------------+---------------+-------------+---------------------------------------------------+
 | WRITE_DOPOST     | Run inline post                  | .true.        | NO          | If .true. produces master post output in forecast |
 |                  |                                  |               |             | job                                               |
 +------------------+----------------------------------+---------------+-------------+---------------------------------------------------+

--- a/parm/config/gfs/config.base
+++ b/parm/config/gfs/config.base
@@ -83,12 +83,15 @@ export HOMEobsproc="${BASE_GIT:-}/obsproc/v${obsproc_run_ver:-}"
 # CONVENIENT utility scripts and other environment parameters
 export NMV="/bin/mv"
 export NLN="/bin/ln -sf"
-export VERBOSE="YES"
-export DEBUG_POSTSCRIPT="NO" # PBS only; sets debug=true
 export CHGRP_RSTPROD="YES"
 export CHGRP_CMD="chgrp rstprod"
 export NCDUMP="${NETCDF:-${netcdf_c_ROOT:-}}/bin/ncdump"
 export NCLEN="${HOMEglobal}/ush/getncdimlen"
+
+export VERBOSE="YES"
+export DEBUG_POSTSCRIPT="NO" # PBS only; sets debug=true
+export CAT_MPMD_LOGS="NO"  # Copy MPMD logs to the parent log. Useful for debugging.
+export CHECK_DEAD_LINKS="NO" # Whether to check for dead links in DATA directories before execution
 
 # Machine environment, jobs, and other utility scripts
 export BASE_ENV="${HOMEglobal}/env"

--- a/ush/regrid_gsiSfcIncr_to_tile.sh
+++ b/ush/regrid_gsiSfcIncr_to_tile.sh
@@ -224,7 +224,6 @@ export err=$?
 if [[ ${err} -ne 0 ]]; then
     err_exit "run_mpmd.sh failed to copy input and fix data!"
 fi
-mv mpmd.out mpmd_in.out
 
 # Finish defining input/output directory list
 export out_dir="${in_dir}"
@@ -279,6 +278,5 @@ export err=$?
 if [[ ${err} -ne 0 ]]; then
     err_exit "run_mpmd.sh failed to copy output files to COMOUT, ABORT!"
 fi
-mv mpmd.out mpmd_out.out
 
 exit 0

--- a/ush/run_mpmd.sh
+++ b/ush/run_mpmd.sh
@@ -76,6 +76,9 @@ export OMP_NUM_THREADS=1
 mpmd_cmdfile="${DATA:-}/mpmd_cmdfile"
 rm -f "${mpmd_cmdfile}"*
 
+# Get the starting timestamp for the log/command output directory.
+timestamp=$(date +%Y%m%d_%H%M%S)
+
 # Functions to support MPMD execution
 chunk_mpmd() {
     # Usage chunk_mpmd cmdfile chunk_size chunk_num chunk_file
@@ -132,30 +135,37 @@ chunk_mpmd() {
     return 0
 }
 
-cat_outputs() {
-    # This function concatenates the output files from the MPMD job and prints them to stdout.
-    # It also removes the individual output files after concatenation.
+move_outputs() {
+    # This function makes an after-run directory (mpmd_<timestamp>) and moves the run scripts
+    # and outputs to this directory.
+    # Usage: move_outputs chunk_num
 
-    # Optional argument to issue error if no output files are found.
-    _err_on_empty="${1:-false}"
-    out_files=$(find . -name 'mpmd.*.out')
-    if [[ -z "${out_files}" ]]; then
-        if [[ "${_err_on_empty}" == "true" ]]; then
-            echo "ERROR: No output files found for MPMD job"
-            return 1
-        else
-            # Nothing to do, return success.
-            return 0
-        fi
+    if [[ $# -ne 1 ]]; then
+        echo "ERROR: move_outputs function requires 1 argument: the chunk number."
+        return 1
     fi
-    for file in ${out_files}; do
-        {
-            echo "BEGIN OUTPUT FROM ${file}"
-            cat "${file}"
-            echo "END OUTPUT FROM ${file}"
-        } >> mpmd.out
-        rm -f "${file}"
-    done
+
+    local chunk_num="${1}"
+
+    # Only find the output files for this chunk, which should be named mpmd.*.out
+    out_files=$(find "${DATA:-}" -maxdepth 1 -type f -name "mpmd.*.out" -print)
+    if [[ -z "${out_files}" ]]; then
+        # Nothing to do, raise a warning and exit successfully
+        echo "WARNING: No output files found from MPMD jobs."
+        return 0
+    fi
+
+    echo "INFO: Moving MPMD output files for chunk ${chunk_num} to after-run directory."
+
+    after_run_dir="mpmd_${timestamp}_chunk${chunk_num}"
+    mkdir -p "${after_run_dir}"
+
+    # shellcheck disable=SC2086
+    mv -f ${out_files} "${after_run_dir}/"
+    mv -f "${mpmd_cmdfile}.chunk${chunk_num}" "${after_run_dir}/"
+
+    # Always copy the cmdfile to the after_run_dir for reference.
+    cp "${cmdfile}" "${after_run_dir}/"
 }
 
 cat << EOF
@@ -176,6 +186,7 @@ if [[ ${nm} -gt ${max_tasks_per_node:-1} ]]; then
     echo "INFO: Number of MPMD tasks (${nm}) is greater than the maximum tasks per node (${max_tasks_per_node:-1})."
     echo "      Running MPMD job in chunks of ${max_tasks_per_node:-1} tasks per node."
     chunk_size=${max_tasks_per_node:-1}
+    # Calculate the number of chunks needed (ceil (nm / chunk_size))
 else
     # Otherwise, we can run all MPMD tasks in one chunk.
     chunk_size=${nm}
@@ -209,27 +220,9 @@ for ((i = 0; i < nm; i += chunk_size)); do
         echo "ERROR: MPMD job failed for ${chunk_file}"
         break
     fi
-    # Call cat_outputs and error if no outputs are found.
-    cat_outputs "true"
-    err=$?
-    if [[ ${err} -ne 0 ]]; then
-        echo "ERROR: No output files found for MPMD job for chunk file '${chunk_file}'"
-        break
-    fi
+    # Move just the log files for this chunk.
+    move_outputs "${chunk_num}"
     ((chunk_num = chunk_num + 1))
 done
-
-# On success remove the command file and any chunk files.
-if [[ ${err} -eq 0 ]]; then
-    rm -f "${mpmd_cmdfile}.chunk"*
-fi
-
-# Concatenate any remaining output files if they exist
-cat_outputs
-if [[ -s mpmd.out ]]; then
-    cat mpmd.out
-else
-    echo "WARNING: No output files found for MPMD job"
-fi
 
 exit "${err}"

--- a/ush/run_mpmd.sh
+++ b/ush/run_mpmd.sh
@@ -161,7 +161,7 @@ move_outputs() {
     mkdir -p "${after_run_dir}"
 
     # Write logs back to stdout if requested.
-    if [[ "${CAT_MPMD_LOGS:NO}" == "YES" ]]; then
+    if [[ "${CAT_MPMD_LOGS:-NO}" == "YES" ]]; then
         for out_file in ${out_files}; do
             echo "INFO: Contents of ${out_file}:"
             cat "${out_file}"

--- a/ush/run_mpmd.sh
+++ b/ush/run_mpmd.sh
@@ -160,8 +160,17 @@ move_outputs() {
     after_run_dir="mpmd_${timestamp}_chunk${chunk_num}"
     mkdir -p "${after_run_dir}"
 
+    # Write logs back to stdout if requested.
+    if [[ "${CAT_MPMD_LOGS:NO}" == "YES" ]]; then
+        for out_file in ${out_files}; do
+            echo "INFO: Contents of ${out_file}:"
+            cat "${out_file}"
+        done
+    fi
+
     # shellcheck disable=SC2086
     mv -f ${out_files} "${after_run_dir}/"
+
     mv -f "${mpmd_cmdfile}.chunk${chunk_num}" "${after_run_dir}/"
 
     # Always copy the cmdfile to the after_run_dir for reference.


### PR DESCRIPTION
# Description
Per NCO, MPMD logs will no longer be piped back to the parent log (by default). Instead, those logs should be archived within the ${DATA} directory until the job completes, then deleted (if KEEPDATA=NO).

When running the workflow in debug mode, these logs will still be piped back to the parent log.

Relatedly, the MPMD command files will no longer be deleted at the end of the MPMD task suite. Instead, they will also be archived in DATA.

Resolves #4854

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs YES (logs only)
  - [x] GFS
  - [x] GEFS
  - [x] SFS
  - [x] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? YES
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
CI tests on Gaea

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary