### PR TITLE
(dev/gfs.v17) Copy GSI/EnKF output files instead of linking

### DIFF
--- a/dev/scripts/exglobal_atmos_analysis.sh
+++ b/dev/scripts/exglobal_atmos_analysis.sh
@@ -627,29 +627,29 @@ fi
 
 ##############################################################
 # Output files
-${NLN} "${ATMANL}" siganl
-${NLN} "${ATMINC}" siginc.nc
-if [[ "${DOHYBVAR}" == "YES" && "${l4densvar}" == ".true." && "${lwrite4danl}" == ".true." ]]; then
-    ${NLN} "${ATMA03}" siga03
-    ${NLN} "${ATMI03}" sigi03.nc
-    ${NLN} "${ATMA04}" siga04
-    ${NLN} "${ATMI04}" sigi04.nc
-    ${NLN} "${ATMA05}" siga05
-    ${NLN} "${ATMI05}" sigi05.nc
-    ${NLN} "${ATMA07}" siga07
-    ${NLN} "${ATMI07}" sigi07.nc
-    ${NLN} "${ATMA08}" siga08
-    ${NLN} "${ATMI08}" sigi08.nc
-    ${NLN} "${ATMA09}" siga09
-    ${NLN} "${ATMI09}" sigi09.nc
-fi
-${NLN} "${ABIAS}" satbias_out
-${NLN} "${ABIASPC}" satbias_pc.out
-${NLN} "${ABIASAIR}" aircftbias_out
+#${NLN} "${ATMANL}" siganl
+#${NLN} "${ATMINC}" siginc.nc
+#if [[ "${DOHYBVAR}" == "YES" && "${l4densvar}" == ".true." && "${lwrite4danl}" == ".true." ]]; then
+#    ${NLN} "${ATMA03}" siga03
+#    ${NLN} "${ATMI03}" sigi03.nc
+#    ${NLN} "${ATMA04}" siga04
+#    ${NLN} "${ATMI04}" sigi04.nc
+#    ${NLN} "${ATMA05}" siga05
+#    ${NLN} "${ATMI05}" sigi05.nc
+#    ${NLN} "${ATMA07}" siga07
+#    ${NLN} "${ATMI07}" sigi07.nc
+#    ${NLN} "${ATMA08}" siga08
+#    ${NLN} "${ATMI08}" sigi08.nc
+#    ${NLN} "${ATMA09}" siga09
+#    ${NLN} "${ATMI09}" sigi09.nc
+#fi
+#${NLN} "${ABIAS}" satbias_out
+#${NLN} "${ABIASPC}" satbias_pc.out
+#${NLN} "${ABIASAIR}" aircftbias_out
 
-if [[ "${DONST}" == "YES" ]]; then
-    ${NLN} "${DTFINC}" dtfanl
-fi
+#if [[ "${DONST}" == "YES" ]]; then
+#    ${NLN} "${DTFINC}" dtfanl
+#fi
 
 # If requested, link (and if tarred, de-tar obsinput.tar) into obs_input.* files
 if [[ "${USE_SELECT}" == "YES" ]]; then
@@ -859,6 +859,36 @@ ${APRUN_GSI} "${DATA}/$(basename "${GSIEXEC}")" 1>&1 2>&2
 export err=$?
 if [[ ${err} -ne 0 ]]; then
     err_exit "Failed to run the GSI analysis!"
+fi
+
+#  Copy output
+
+if [[ ${RUN_SELECT} == "NO" ]]; then
+    if [[ ${DO_CALC_INCREMENT} == "NO" ]]; then
+        cpreq siginc.nc "${ATMINC}" 
+        if [[ "${DOHYBVAR}" == "YES" && "${l4densvar}" == ".true." && "${lwrite4danl}" == ".true." ]]; then
+            cpreq sigi03.nc "${ATMI03}" 
+            cpreq sigi09.nc "${ATMI09}" 
+        fi
+    else
+        cpreq siganl "${ATMANL}" 
+	if [[ "${DOHYBVAR}" == "YES" && "${l4densvar}" == ".true." && "${lwrite4danl}" == ".true." ]]; then
+            cpreq siga03 "${ATMA03}"
+            cpreq siga04 "${ATMA04}"
+            cpreq siga05 "${ATMA05}"
+            cpreq siga07 "${ATMA07}"
+            cpreq siga08 "${ATMA08}"
+            cpreq siga09 "${ATMA09}"
+        fi
+
+    fi	    
+    cpreq satbias_out     "${ABIAS}" 
+    cpreq satbias_pc.out  "${ABIASPC}" 
+    cpreq aircrftbias_out "${ABIASAIR}"
+
+    if [[ "${DONST}" == "YES" ]]; then
+        cpreq dtfanl "${DTFINC}"
+    fi
 fi
 
 ##############################################################

--- a/dev/scripts/exglobal_atmos_analysis.sh
+++ b/dev/scripts/exglobal_atmos_analysis.sh
@@ -840,7 +840,7 @@ fi
 
 if [[ "${RUN_SELECT}" == "NO" ]]; then
     if [[ "${DO_CALC_INCREMENT}" == "NO" ]]; then
-        cpreq siginc.nc "${ATMINC}" 
+        cpreq siginc.nc "${ATMINC}"
         if [[ "${DOHYBVAR}" == "YES" && "${l4densvar}" == ".true." && "${lwrite4danl}" == ".true." ]]; then
             cpreq sigi03.nc "${ATMI03}" 
             cpreq sigi09.nc "${ATMI09}" 

--- a/dev/scripts/exglobal_atmos_analysis.sh
+++ b/dev/scripts/exglobal_atmos_analysis.sh
@@ -859,7 +859,7 @@ if [[ ${RUN_SELECT} == "NO" ]]; then
     fi	    
     cpreq satbias_out     "${ABIAS}" 
     cpreq satbias_pc.out  "${ABIASPC}" 
-    cpreq aircrftbias_out "${ABIASAIR}"
+    cpreq aircftbias_out "${ABIASAIR}"
 
     if [[ "${DONST}" == "YES" ]]; then
         cpreq dtfanl "${DTFINC}"

--- a/dev/scripts/exglobal_atmos_analysis.sh
+++ b/dev/scripts/exglobal_atmos_analysis.sh
@@ -856,9 +856,9 @@ if [[ "${RUN_SELECT}" == "NO" ]]; then
             cpreq siga09 "${ATMA09}"
         fi
 
-    fi	    
-    cpreq satbias_out     "${ABIAS}" 
-    cpreq satbias_pc.out  "${ABIASPC}" 
+    fi
+    cpreq satbias_out "${ABIAS}"
+    cpreq satbias_pc.out "${ABIASPC}"
     cpreq aircftbias_out "${ABIASAIR}"
 
     if [[ "${DONST}" == "YES" ]]; then

--- a/dev/scripts/exglobal_atmos_analysis.sh
+++ b/dev/scripts/exglobal_atmos_analysis.sh
@@ -846,8 +846,8 @@ if [[ "${RUN_SELECT}" == "NO" ]]; then
             cpreq sigi09.nc "${ATMI09}"
         fi
     else
-        cpreq siganl "${ATMANL}" 
-	if [[ "${DOHYBVAR}" == "YES" && "${l4densvar}" == ".true." && "${lwrite4danl}" == ".true." ]]; then
+        cpreq siganl "${ATMANL}"
+        if [[ "${DOHYBVAR}" == "YES" && "${l4densvar}" == ".true." && "${lwrite4danl}" == ".true." ]]; then
             cpreq siga03 "${ATMA03}"
             cpreq siga04 "${ATMA04}"
             cpreq siga05 "${ATMA05}"

--- a/dev/scripts/exglobal_atmos_analysis.sh
+++ b/dev/scripts/exglobal_atmos_analysis.sh
@@ -842,8 +842,8 @@ if [[ "${RUN_SELECT}" == "NO" ]]; then
     if [[ "${DO_CALC_INCREMENT}" == "NO" ]]; then
         cpreq siginc.nc "${ATMINC}"
         if [[ "${DOHYBVAR}" == "YES" && "${l4densvar}" == ".true." && "${lwrite4danl}" == ".true." ]]; then
-            cpreq sigi03.nc "${ATMI03}" 
-            cpreq sigi09.nc "${ATMI09}" 
+            cpreq sigi03.nc "${ATMI03}"
+            cpreq sigi09.nc "${ATMI09}"
         fi
     else
         cpreq siganl "${ATMANL}" 

--- a/dev/scripts/exglobal_atmos_analysis.sh
+++ b/dev/scripts/exglobal_atmos_analysis.sh
@@ -626,31 +626,6 @@ if [[ "${JCAP}" -ne "${JCAP_A}" ]]; then
 fi
 
 ##############################################################
-# Output files
-#${NLN} "${ATMANL}" siganl
-#${NLN} "${ATMINC}" siginc.nc
-#if [[ "${DOHYBVAR}" == "YES" && "${l4densvar}" == ".true." && "${lwrite4danl}" == ".true." ]]; then
-#    ${NLN} "${ATMA03}" siga03
-#    ${NLN} "${ATMI03}" sigi03.nc
-#    ${NLN} "${ATMA04}" siga04
-#    ${NLN} "${ATMI04}" sigi04.nc
-#    ${NLN} "${ATMA05}" siga05
-#    ${NLN} "${ATMI05}" sigi05.nc
-#    ${NLN} "${ATMA07}" siga07
-#    ${NLN} "${ATMI07}" sigi07.nc
-#    ${NLN} "${ATMA08}" siga08
-#    ${NLN} "${ATMI08}" sigi08.nc
-#    ${NLN} "${ATMA09}" siga09
-#    ${NLN} "${ATMI09}" sigi09.nc
-#fi
-#${NLN} "${ABIAS}" satbias_out
-#${NLN} "${ABIASPC}" satbias_pc.out
-#${NLN} "${ABIASAIR}" aircftbias_out
-
-#if [[ "${DONST}" == "YES" ]]; then
-#    ${NLN} "${DTFINC}" dtfanl
-#fi
-
 # If requested, link (and if tarred, de-tar obsinput.tar) into obs_input.* files
 if [[ "${USE_SELECT}" == "YES" ]]; then
     rm -f obs_input.*

--- a/dev/scripts/exglobal_atmos_analysis.sh
+++ b/dev/scripts/exglobal_atmos_analysis.sh
@@ -838,8 +838,8 @@ fi
 
 #  Copy output
 
-if [[ ${RUN_SELECT} == "NO" ]]; then
-    if [[ ${DO_CALC_INCREMENT} == "NO" ]]; then
+if [[ "${RUN_SELECT}" == "NO" ]]; then
+    if [[ "${DO_CALC_INCREMENT}" == "NO" ]]; then
         cpreq siginc.nc "${ATMINC}" 
         if [[ "${DOHYBVAR}" == "YES" && "${l4densvar}" == ".true." && "${lwrite4danl}" == ".true." ]]; then
             cpreq sigi03.nc "${ATMI03}" 

--- a/dev/scripts/exglobal_enkf_update.sh
+++ b/dev/scripts/exglobal_enkf_update.sh
@@ -317,6 +317,9 @@ cpfs enkfstat.txt "${COMOUT_ATMOS_ANALYSIS_STAT}/${APREFIX}enkfstat.txt"
 
 # Copy output
 
+cmdfile="${DATA}/cmdfile_enkf_out"
+rm -f "${cmdfile}"
+
 for imem in $(seq 1 "${NMEM_ENS}"); do
     smem=$((imem + mem_offset))
     if [[ ${smem} -gt ${NMEM_ENS_MAX} ]]; then
@@ -331,19 +334,27 @@ for imem in $(seq 1 "${NMEM_ENS}"); do
 
     for FHR in ${nfhrs}; do
         if [[ "${DO_CALC_INCREMENT}" == "YES" ]]; then
-            cpreq "sanl_${PDY}${cyc}_fhr0${FHR}_${memchar}" \
-		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}analysis.atm.a00${FHR}.nc"
+            echo "cpreq "sanl_${PDY}${cyc}_fhr0${FHR}_${memchar}" \
+		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}analysis.atm.a00${FHR}.nc"" >> "${cmdfile}"
         else
-            cpreq "incr_${PDY}${cyc}_fhr0${FHR}_${memchar}" \
-		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}increment.atm.i00${FHR}.nc"    
+            echo "cpreq "incr_${PDY}${cyc}_fhr0${FHR}_${memchar}" \
+		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}increment.atm.i00${FHR}.nc"" >> "${cmdfile}"    
         fi
     
         if [[ "${DO_GSISOILDA}" == "YES" ]]; then
-            cpreq "sfcincr_${PDY}${cyc}_fhr0${FHR}_${memchar}" \
-		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}increment.sfc.i00${FHR}.nc" 
+            echo "cpreq "sfcincr_${PDY}${cyc}_fhr0${FHR}_${memchar}" \
+		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}increment.sfc.i00${FHR}.nc"" >> "${cmdfile}" 
         fi
     done
 done
+
+if [[ -s "${cmdfile}" ]]; then
+    "${USHglobal}/run_mpmd.sh" "${cmdfile}" && true
+    export err=$?
+    if [[ ${err} -ne 0 ]]; then
+        err_exit "run_mpmd.sh failed to copy enkf output files!"
+    fi
+fi
 
 ################################################################################
 #  Postprocessing

--- a/dev/scripts/exglobal_enkf_update.sh
+++ b/dev/scripts/exglobal_enkf_update.sh
@@ -135,10 +135,6 @@ for imem in $(seq 1 "${NMEM_ENS}"); do
 
     declare -x COMIN_ATMOS_HISTORY_MEM_PREV=${ROTDIR}/${GDUMP}.${GDATE:0:8}/${GDATE:8:2}/${gmemchar}/model/atmos/history
 
-    declare -x COMOUT_ATMOS_ANALYSIS_MEM=${ROTDIR}/${RUN}.${PDY}/${cyc}/${memchar}/analysis/atmos
-
-    mkdir -p "${COMOUT_ATMOS_ANALYSIS_MEM}"
-
     for FHR in ${nfhrs}; do
         ${NLN} "${COMIN_ATMOS_HISTORY_MEM_PREV}/${GPREFIX}atm.f00${FHR}${ENKF_SUFFIX}.nc" \
             "sfg_${PDY}${cyc}_fhr0${FHR}_${memchar}"
@@ -149,19 +145,6 @@ for imem in $(seq 1 "${NMEM_ENS}"); do
         if [[ "${cnvw_option}" == ".true." ]]; then
             ${NLN} "${COMIN_ATMOS_HISTORY_MEM_PREV}/${GPREFIX}sfc.f00${FHR}.nc" \
                 "sfgsfc_${PDY}${cyc}_fhr0${FHR}_${memchar}"
-        fi
-
-        if [[ "${DO_CALC_INCREMENT}" == "YES" ]]; then
-            ${NLN} "${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}analysis.atm.a00${FHR}.nc" \
-                "sanl_${PDY}${cyc}_fhr0${FHR}_${memchar}"
-        else
-            ${NLN} "${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}increment.atm.i00${FHR}.nc" \
-                "incr_${PDY}${cyc}_fhr0${FHR}_${memchar}"
-        fi
-
-        if [[ "${DO_GSISOILDA}" == "YES" ]]; then
-            ${NLN} "${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}increment.sfc.i00${FHR}.nc" \
-                "sfcincr_${PDY}${cyc}_fhr0${FHR}_${memchar}"
         fi
     done
 done
@@ -331,6 +314,36 @@ if [[ ${err} -ne 0 ]]; then
 fi
 
 cpfs enkfstat.txt "${COMOUT_ATMOS_ANALYSIS_STAT}/${APREFIX}enkfstat.txt"
+
+# Copy output
+
+for imem in $(seq 1 "${NMEM_ENS}"); do
+    smem=$((imem + mem_offset))
+    if [[ ${smem} -gt ${NMEM_ENS_MAX} ]]; then
+        smem=$((smem - NMEM_ENS_MAX))
+    fi
+    gmemchar="mem"$(printf "%03i" "${smem}")
+    memchar="mem"$(printf "%03i" "${imem}")
+
+    declare -x COMOUT_ATMOS_ANALYSIS_MEM=${ROTDIR}/${RUN}.${PDY}/${cyc}/${memchar}/analysis/atmos
+
+    mkdir -p "${COMOUT_ATMOS_ANALYSIS_MEM}"
+
+    for FHR in ${nfhrs}; do
+        if [[ "${DO_CALC_INCREMENT}" == "YES" ]]; then
+            cpreq "sanl_${PDY}${cyc}_fhr0${FHR}_${memchar}" \
+		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}analysis.atm.a00${FHR}.nc"
+        else
+            cpreq "incr_${PDY}${cyc}_fhr0${FHR}_${memchar}" \
+		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}increment.atm.i00${FHR}.nc"    
+        fi
+    
+        if [[ "${DO_GSISOILDA}" == "YES" ]]; then
+            cpreq "sfcincr_${PDY}${cyc}_fhr0${FHR}_${memchar}" \
+		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}increment.sfc.i00${FHR}.nc" 
+        fi
+    done
+done
 
 ################################################################################
 #  Postprocessing

--- a/dev/scripts/exglobal_enkf_update.sh
+++ b/dev/scripts/exglobal_enkf_update.sh
@@ -342,7 +342,7 @@ for imem in $(seq 1 "${NMEM_ENS}"); do
         fi
         if [[ "${DO_GSISOILDA}" == "YES" ]]; then
             echo "cpreq "sfcincr_${PDY}${cyc}_fhr0${FHR}_${memchar}" \
-		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}increment.sfc.i00${FHR}.nc"" >> "${cmdfile}" 
+		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}increment.sfc.i00${FHR}.nc"" >> "${cmdfile}"
         fi
     done
 done

--- a/dev/scripts/exglobal_enkf_update.sh
+++ b/dev/scripts/exglobal_enkf_update.sh
@@ -340,7 +340,6 @@ for imem in $(seq 1 "${NMEM_ENS}"); do
             echo "cpreq "incr_${PDY}${cyc}_fhr0${FHR}_${memchar}" \
 		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}increment.atm.i00${FHR}.nc"" >> "${cmdfile}"
         fi
-    
         if [[ "${DO_GSISOILDA}" == "YES" ]]; then
             echo "cpreq "sfcincr_${PDY}${cyc}_fhr0${FHR}_${memchar}" \
 		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}increment.sfc.i00${FHR}.nc"" >> "${cmdfile}" 

--- a/dev/scripts/exglobal_enkf_update.sh
+++ b/dev/scripts/exglobal_enkf_update.sh
@@ -338,7 +338,7 @@ for imem in $(seq 1 "${NMEM_ENS}"); do
 		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}analysis.atm.a00${FHR}.nc"" >> "${cmdfile}"
         else
             echo "cpreq "incr_${PDY}${cyc}_fhr0${FHR}_${memchar}" \
-		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}increment.atm.i00${FHR}.nc"" >> "${cmdfile}"    
+		"${COMOUT_ATMOS_ANALYSIS_MEM}/${APREFIX}increment.atm.i00${FHR}.nc"" >> "${cmdfile}"
         fi
     
         if [[ "${DO_GSISOILDA}" == "YES" ]]; then


### PR DESCRIPTION
Not for merging yet

# Description
For EE2 compliance, it was determined that linking can be used for reading input data in $DATA, but copying must be used to write output $DATA to $COM.

Refs #4406 


# Type of change
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Full resolution single analysis rocoto tests on WCOSS2

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
