### PR TITLE
(dev/gfs.v17) Add a cleanup script for ecflow

### DIFF
--- a/dev/ush/gfsv17_ecflow_rt_cleanup.sh
+++ b/dev/ush/gfsv17_ecflow_rt_cleanup.sh
@@ -8,39 +8,38 @@ DATA=/lfs/h2/emc/ptmp/emc.global/gfs_v17_cleanup.$$
 COMROOT=/lfs/h2/emc/gfstemp/emc.global/ecflow/comroot/ops/para/com/gfs/v17.0
 DATAROOT=/lfs/h2/emc/gfstemp/emc.global/ecflow/rundirs
 
-mkdir -p ${DATA} ${DATAROOT}
-export PDY=$($NDATE| cut -c1-8)
+mkdir -p "${DATA}" "${DATAROOT}"
+export PDY=$("${NDATE}" | cut -c1-8)
 export cycle=t00z
 
-cd $DATA
+cd "${DATA}"
 setpdy.sh
 source PDY
 # PDYm1 PDY PDYp1
 
 # Exception handling - if the realtime state is delay
-if [ ! -d ${COMROOT}/enkfgdas.${PDY}/06 ]; then
-  echo "FATAL ERROR: The ${COMROOT}/enkfgdas.${PDY}/06 is not found"
-  exit 9
+if [[ ! -d "${COMROOT}/enkfgdas.${PDY}/06" ]]; then
+    echo "FATAL ERROR: The ${COMROOT}/enkfgdas.${PDY}/06 is not found"
+    exit 9
 fi
 
 # Clean DATA
 # DATA retain current PDY   ~   60TB
-cd $DATAROOT
-excluded_pdy=$PDY
+cd "${DATAROOT}"
+excluded_pdy=${PDY}
 excluded_cdate_m1=${PDYm1}18
-for dir_to_remove in $(ls -d */ | grep -v ${excluded_pdy} | grep -v ${excluded_cdate_m1} | grep -v "DBNLOG" | grep -v "ecflow"); do
-  dir_to_remove="${dir_to_remove%/}"
-  echo "Removing directory ${DATAROOT}/${dir_to_remove}"
-  rm -rf ${DATAROOT}/${dir_to_remove}
+for dir_to_remove in $(ls -d */ | grep -v "${excluded_pdy}" | grep -v "${excluded_cdate_m1}" | grep -v "DBNLOG" | grep -v "ecflow"); do
+    dir_to_remove="${dir_to_remove%/}"
+    echo "Removing directory ${DATAROOT}/${dir_to_remove}"
+    rm -rf "${DATAROOT}/${dir_to_remove}"
 done
 
 
 # Clean COM
 # COM retain 3 full days - 195TB (65T /day on production frequency)
-cd $COMROOT
-for dir_to_remove in $(ls -d */ | grep -v ${PDY} | grep -v ${PDYm1} | grep -v ${PDYm2} | grep -v ${PDYm3} | grep -v "fix"); do
-#### for dir_to_remove in $(ls -d */ | grep -v ${PDY} | grep -v ${PDYm1} | grep -v ${PDYm2} | grep -v "fix"); do
-  dir_to_remove="${dir_to_remove%/}"
-  echo "Removing directory ${COMROOT}/${dir_to_remove}"
-  rm -rf ${COMROOT}/${dir_to_remove}
+cd "${COMROOT}"
+for dir_to_remove in $(ls -d */ | grep -v "${PDY}" | grep -v "${PDYm1}" | grep -v "${PDYm2}" | grep -v "${PDYm3}" | grep -v "fix"); do
+    dir_to_remove="${dir_to_remove%/}"
+    echo "Removing directory ${COMROOT}/${dir_to_remove}"
+    rm -rf "${COMROOT}/${dir_to_remove}"
 done

--- a/dev/ush/gfsv17_ecflow_rt_cleanup.sh
+++ b/dev/ush/gfsv17_ecflow_rt_cleanup.sh
@@ -34,7 +34,8 @@ fi
 # Clean DATA
 # DATA retain current PDY   ~   60TB
 cd "${DATAROOT}"
-for dir_to_remove in $(find ./* -maxdepth 0 -type d -mtime +1 | grep -v "DBNLOG" | grep -v "ecflow"); do
+# Delete any directories older than 48 hours
+for dir_to_remove in $(find ./* -maxdepth 0 -type d -mmin +2880 | grep -v "DBNLOG" | grep -v "ecflow"); do
     echo "Removing directory ${DATAROOT}/${dir_to_remove}"
     rm -rf "${dir_to_remove}"
 done

--- a/dev/ush/gfsv17_ecflow_rt_cleanup.sh
+++ b/dev/ush/gfsv17_ecflow_rt_cleanup.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -eux
+
+module reset
+module load prod_envir prod_util
+
+DATA=/lfs/h2/emc/ptmp/emc.global/gfs_v17_cleanup.$$
+COMROOT=/lfs/h2/emc/gfstemp/emc.global/ecflow/comroot/ops/para/com/gfs/v17.0
+DATAROOT=/lfs/h2/emc/gfstemp/emc.global/ecflow/rundirs
+
+mkdir -p ${DATA} ${DATAROOT}
+export PDY=$($NDATE| cut -c1-8)
+export cycle=t00z
+
+cd $DATA
+setpdy.sh
+source PDY
+# PDYm1 PDY PDYp1
+
+# Exception handling - if the realtime state is delay
+if [ ! -d ${COMROOT}/enkfgdas.${PDY}/06 ]; then
+  echo "FATAL ERROR: The ${COMROOT}/enkfgdas.${PDY}/06 is not found"
+  exit 9
+fi
+
+# Clean DATA
+# DATA retain current PDY   ~   60TB
+cd $DATAROOT
+excluded_pdy=$PDY
+excluded_cdate_m1=${PDYm1}18
+for dir_to_remove in $(ls -d */ | grep -v ${excluded_pdy} | grep -v ${excluded_cdate_m1} | grep -v "DBNLOG" | grep -v "ecflow"); do
+  dir_to_remove="${dir_to_remove%/}"
+  echo "Removing directory ${DATAROOT}/${dir_to_remove}"
+  rm -rf ${DATAROOT}/${dir_to_remove}
+done
+
+
+# Clean COM
+# COM retain 3 full days - 195TB (65T /day on production frequency)
+cd $COMROOT
+for dir_to_remove in $(ls -d */ | grep -v ${PDY} | grep -v ${PDYm1} | grep -v ${PDYm2} | grep -v ${PDYm3} | grep -v "fix"); do
+#### for dir_to_remove in $(ls -d */ | grep -v ${PDY} | grep -v ${PDYm1} | grep -v ${PDYm2} | grep -v "fix"); do
+  dir_to_remove="${dir_to_remove%/}"
+  echo "Removing directory ${COMROOT}/${dir_to_remove}"
+  rm -rf ${COMROOT}/${dir_to_remove}
+done

--- a/dev/ush/gfsv17_ecflow_rt_cleanup.sh
+++ b/dev/ush/gfsv17_ecflow_rt_cleanup.sh
@@ -36,19 +36,17 @@ fi
 cd "${DATAROOT}"
 excluded_pdy=${PDY}
 excluded_cdate_m1=${PDYm1}18
-for dir_to_remove in $(find * -maxdepth 0 -type d | grep -v "${excluded_pdy}" | grep -v "${excluded_cdate_m1}" | grep -v "DBNLOG" | grep -v "ecflow"); do
-    dir_to_remove="${dir_to_remove%/}"
+for dir_to_remove in $(find ./* -maxdepth 0 -type d | grep -v "${excluded_pdy}" | grep -v "${excluded_cdate_m1}" | grep -v "DBNLOG" | grep -v "ecflow"); do
     echo "Removing directory ${DATAROOT}/${dir_to_remove}"
-    rm -rf "${DATAROOT}/${dir_to_remove}"
+    rm -rf "${dir_to_remove}"
 done
 
 # Clean COM
 # COM retain 3 full days - 195TB (65T /day on production frequency)
 cd "${COMROOT}"
-for dir_to_remove in $(find * -maxdepth 0 -type d | grep -v "${PDY}" | grep -v "${PDYm1}" | grep -v "${PDYm2}" | grep -v "${PDYm3}" | grep -v "fix"); do
-    dir_to_remove="${dir_to_remove%/}"
+for dir_to_remove in $(find ./* -maxdepth 0 -type d | grep -v "${PDY}" | grep -v "${PDYm1}" | grep -v "${PDYm2}" | grep -v "${PDYm3}" | grep -v "fix"); do
     echo "Removing directory ${COMROOT}/${dir_to_remove}"
-    rm -rf "${COMROOT}/${dir_to_remove}"
+    rm -rf "${dir_to_remove}"
 done
 
 echo "Finished cleaning up at $(date)"

--- a/dev/ush/gfsv17_ecflow_rt_cleanup.sh
+++ b/dev/ush/gfsv17_ecflow_rt_cleanup.sh
@@ -34,17 +34,15 @@ fi
 # Clean DATA
 # DATA retain current PDY   ~   60TB
 cd "${DATAROOT}"
-excluded_pdy=${PDY}
-excluded_cdate_m1=${PDYm1}18
-for dir_to_remove in $(find ./* -maxdepth 0 -type d | grep -v "${excluded_pdy}" | grep -v "${excluded_cdate_m1}" | grep -v "DBNLOG" | grep -v "ecflow"); do
+for dir_to_remove in $(find ./* -maxdepth 0 -type d -mtime +1 | grep -v "DBNLOG" | grep -v "ecflow"); do
     echo "Removing directory ${DATAROOT}/${dir_to_remove}"
     rm -rf "${dir_to_remove}"
 done
 
 # Clean COM
-# COM retain 3 full days - 195TB (65T /day on production frequency)
+# COM retain 2 full days - 195TB (65T /day on production frequency)
 cd "${COMROOT}"
-for dir_to_remove in $(find ./* -maxdepth 0 -type d | grep -v "${PDY}" | grep -v "${PDYm1}" | grep -v "${PDYm2}" | grep -v "${PDYm3}" | grep -v "fix"); do
+for dir_to_remove in $(find ./* -maxdepth 0 -type d | grep -v "${PDY}" | grep -v "${PDYm1}" | grep -v "fix"); do
     echo "Removing directory ${COMROOT}/${dir_to_remove}"
     rm -rf "${dir_to_remove}"
 done

--- a/dev/ush/gfsv17_ecflow_rt_cleanup.sh
+++ b/dev/ush/gfsv17_ecflow_rt_cleanup.sh
@@ -42,7 +42,6 @@ for dir_to_remove in $(find * -maxdepth 0 -type d | grep -v "${excluded_pdy}" | 
     rm -rf "${DATAROOT}/${dir_to_remove}"
 done
 
-
 # Clean COM
 # COM retain 3 full days - 195TB (65T /day on production frequency)
 cd "${COMROOT}"

--- a/dev/ush/gfsv17_ecflow_rt_cleanup.sh
+++ b/dev/ush/gfsv17_ecflow_rt_cleanup.sh
@@ -1,21 +1,29 @@
 #!/bin/bash
-set -eux
+set -eu
+declare -x PS4='+ $(basename ${BASH_SOURCE[0]:-${FUNCNAME[0]:-"Unknown"}})[${LINENO}]'
 
 module reset
 module load prod_envir prod_util
 
-DATA=/lfs/h2/emc/ptmp/emc.global/gfs_v17_cleanup.$$
+module list
+
+set -x
+
+DATA=/lfs/h2/emc/ptmp/${USER}/gfs_v17_cleanup.$$
 COMROOT=/lfs/h2/emc/gfstemp/emc.global/ecflow/comroot/ops/para/com/gfs/v17.0
 DATAROOT=/lfs/h2/emc/gfstemp/emc.global/ecflow/rundirs
 
 mkdir -p "${DATA}" "${DATAROOT}"
-export PDY=$("${NDATE}" | cut -c1-8)
+PDY=$("${NDATE}" | cut -c1-8)
+export PDY
 export cycle=t00z
 
 cd "${DATA}"
 setpdy.sh
 source PDY
 # PDYm1 PDY PDYp1
+
+echo "Start cleanup at $(date)"
 
 # Exception handling - if the realtime state is delay
 if [[ ! -d "${COMROOT}/enkfgdas.${PDY}/06" ]]; then
@@ -28,7 +36,7 @@ fi
 cd "${DATAROOT}"
 excluded_pdy=${PDY}
 excluded_cdate_m1=${PDYm1}18
-for dir_to_remove in $(ls -d */ | grep -v "${excluded_pdy}" | grep -v "${excluded_cdate_m1}" | grep -v "DBNLOG" | grep -v "ecflow"); do
+for dir_to_remove in $(find * -maxdepth 0 -type d | grep -v "${excluded_pdy}" | grep -v "${excluded_cdate_m1}" | grep -v "DBNLOG" | grep -v "ecflow"); do
     dir_to_remove="${dir_to_remove%/}"
     echo "Removing directory ${DATAROOT}/${dir_to_remove}"
     rm -rf "${DATAROOT}/${dir_to_remove}"
@@ -38,8 +46,10 @@ done
 # Clean COM
 # COM retain 3 full days - 195TB (65T /day on production frequency)
 cd "${COMROOT}"
-for dir_to_remove in $(ls -d */ | grep -v "${PDY}" | grep -v "${PDYm1}" | grep -v "${PDYm2}" | grep -v "${PDYm3}" | grep -v "fix"); do
+for dir_to_remove in $(find * -maxdepth 0 -type d | grep -v "${PDY}" | grep -v "${PDYm1}" | grep -v "${PDYm2}" | grep -v "${PDYm3}" | grep -v "fix"); do
     dir_to_remove="${dir_to_remove%/}"
     echo "Removing directory ${COMROOT}/${dir_to_remove}"
     rm -rf "${COMROOT}/${dir_to_remove}"
 done
+
+echo "Finished cleaning up at $(date)"

--- a/dev/ush/gfsv17_ecflow_rt_cleanup.sh
+++ b/dev/ush/gfsv17_ecflow_rt_cleanup.sh
@@ -44,7 +44,7 @@ done
 # Clean COM
 # COM retain 3 full days - 195TB (65T /day on production frequency)
 cd "${COMROOT}"
-for dir_to_remove in $(find ./* -maxdepth 0 -type d | grep -v "${PDY}" | grep -v "${PDYm1}" | grep -v "${PDYm2}" | grep -v "${PDYm3}" | grep -v "fix"); do
+for dir_to_remove in $(find ./* -maxdepth 0 -type d | grep -v "${PDY}" | grep -v "${PDYm1}" | grep -v "fix"); do
     echo "Removing directory ${COMROOT}/${dir_to_remove}"
     rm -rf "${dir_to_remove}"
 done


### PR DESCRIPTION
# Description
This introduces a cleanup script for ecflow. The script should be added to the crontab and executed once per day when running an ecflow experiment AFTER updating the `DATA`, `DATAROOT`, and `COMROOT` directories.

# Type of change
- [ ] Bug fix (fixes something broken)
- [x] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO
 
# How has this been tested?
Already used in an ecflow test.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings