### PR TITLE
[dev/gfs.v17] Add back bmat_init forecast dependencies

### DIFF
--- a/ecf/defs/gfs_prod.def
+++ b/ecf/defs/gfs_prod.def
@@ -1,4 +1,4 @@
-suite v17_bmat_triggers
+suite gfs_v17_nco
   family primary
     edit gfs_ver 'v17.0'
     edit PACKAGEHOME '/lfs/h3/emc/eib/noscrub/%EMC_USER%/gfs/para/packages/gfs.%gfs_ver%'
@@ -5397,7 +5397,6 @@ suite v17_bmat_triggers
             task jgdas_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
               trigger ../../prep/marine/jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs and ../../../../18/enkfgdas/forecast==complete and ../../../../18/gdas/forecast==complete
-
             task jgdas_marine_bmat
               trigger jgdas_marine_bmat_init==complete
             task jgdas_marine_anal_init
@@ -5966,7 +5965,6 @@ suite v17_bmat_triggers
             task jgfs_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
               trigger ../../prep/marine/jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs and ../../../../00/enkfgdas/forecast==complete and ../../../../00/gdas/forecast==complete
-
             task jgfs_marine_bmat
               trigger jgfs_marine_bmat_init==complete
             task jgfs_marine_anal_init

--- a/ecf/defs/gfs_prod.def
+++ b/ecf/defs/gfs_prod.def
@@ -1,4 +1,4 @@
-suite gfs_v17_nco
+suite v17_bmat_triggers
   family primary
     edit gfs_ver 'v17.0'
     edit PACKAGEHOME '/lfs/h3/emc/eib/noscrub/%EMC_USER%/gfs/para/packages/gfs.%gfs_ver%'
@@ -64,7 +64,7 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgfs_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs
+              trigger ../../prep/marine/jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs and ../../../../18/enkfgdas/forecast==complete and ../../../../18/gdas/forecast==complete
             task jgfs_marine_bmat
               trigger jgfs_marine_bmat_init==complete
             task jgfs_marine_anal_init
@@ -5396,7 +5396,8 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgdas_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs
+              trigger ../../prep/marine/jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs and ../../../../18/enkfgdas/forecast==complete and ../../../../18/gdas/forecast==complete
+
             task jgdas_marine_bmat
               trigger jgdas_marine_bmat_init==complete
             task jgdas_marine_anal_init
@@ -5964,7 +5965,8 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgfs_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs
+              trigger ../../prep/marine/jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs and ../../../../00/enkfgdas/forecast==complete and ../../../../00/gdas/forecast==complete
+
             task jgfs_marine_bmat
               trigger jgfs_marine_bmat_init==complete
             task jgfs_marine_anal_init
@@ -11293,7 +11295,7 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgdas_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs
+              trigger ../../prep/marine/jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs and ../../../../00/enkfgdas/forecast==complete and ../../../../00/gdas/forecast==complete
             task jgdas_marine_bmat
               trigger jgdas_marine_bmat_init==complete
             task jgdas_marine_anal_init
@@ -11861,7 +11863,7 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgfs_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs
+              trigger ../../prep/marine/jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs and ../../../../06/enkfgdas/forecast==complete and ../../../../06/gdas/forecast==complete
             task jgfs_marine_bmat
               trigger jgfs_marine_bmat_init==complete
             task jgfs_marine_anal_init
@@ -17191,7 +17193,7 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgdas_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs
+              trigger ../../prep/marine/jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs and ../../../../06/enkfgdas/forecast==complete and ../../../../06/gdas/forecast==complete
             task jgdas_marine_bmat
               trigger jgdas_marine_bmat_init==complete
             task jgdas_marine_anal_init
@@ -17759,7 +17761,7 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgfs_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs
+              trigger ../../prep/marine/jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs and ../../../../12/enkfgdas/forecast==complete and ../../../../12/gdas/forecast==complete
             task jgfs_marine_bmat
               trigger jgfs_marine_bmat_init==complete
             task jgfs_marine_anal_init
@@ -23089,7 +23091,7 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgdas_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs
+              trigger ../../prep/marine/jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs and ../../../../12/enkfgdas/forecast==complete and ../../../../12/gdas/forecast==complete
             task jgdas_marine_bmat
               trigger jgdas_marine_bmat_init==complete
             task jgdas_marine_anal_init


### PR DESCRIPTION

# Description
PR #5035 update the ecflow triggers for the bmat_init job to launch at the beginning of the forecast cycle by removing forecast dependencies and replacing them with a dependency on the marine prep job. However, when the parallel falls behind the marine prep job could launch/complete before the previous cycle's forecast completed. This would cause the bmat_init jobs to fail as the previous cycle's data was missing. This PR reinstates the bmat_init forecast dependencies alongside the marine prep job dependency  

# Type of change
- [ ] Bug fix (fixes something broken)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
ecf def file loads into ecf suite. should do a quick test here soon. 


# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
