### PR TITLE
(dev/gfs.v17) Use fhr3 for atmos product DBN alerts

### DIFF
--- a/dev/scripts/exglobal_atmos_products.sh
+++ b/dev/scripts/exglobal_atmos_products.sh
@@ -253,7 +253,7 @@ if [[ "${SENDDBN:-}" == "YES" ]]; then
                 ;;
             gfs)
                 "${DBNROOT}/bin/dbn_alert" MODEL "${RUN^^}_SF" "${job}" "${COMIN_ATMOS_HISTORY}/${PREFIX}atm.${fhr3}.nc"
-                if [[ ${fhr} -gt 0 && ${fhr} -le 84 || ${fhr} -eq 120 ]]; then
+                if [[ ${fhr} -gt 0 && 10#${fhr3} -le 84 || 10#${fhr3} -eq 120 ]]; then
                     "${DBNROOT}/bin/dbn_alert" MODEL "${RUN^^}_BF" "${job}" "${COMIN_ATMOS_HISTORY}/${PREFIX}sfc.${fhr3}.nc"
                 fi
 

--- a/dev/scripts/exglobal_atmos_products.sh
+++ b/dev/scripts/exglobal_atmos_products.sh
@@ -253,7 +253,7 @@ if [[ "${SENDDBN:-}" == "YES" ]]; then
                 ;;
             gfs)
                 "${DBNROOT}/bin/dbn_alert" MODEL "${RUN^^}_SF" "${job}" "${COMIN_ATMOS_HISTORY}/${PREFIX}atm.${fhr3}.nc"
-                if [[ $((10#${fhr})) -gt 0 && $((10#${fhr3})) -le 84 || $((10#${fhr3})) -eq 120 ]]; then
+                if [[ $((10#${fhr3})) -gt 0 && $((10#${fhr3})) -le 84 || $((10#${fhr3})) -eq 120 ]]; then
                     "${DBNROOT}/bin/dbn_alert" MODEL "${RUN^^}_BF" "${job}" "${COMIN_ATMOS_HISTORY}/${PREFIX}sfc.${fhr3}.nc"
                 fi
 

--- a/dev/scripts/exglobal_atmos_products.sh
+++ b/dev/scripts/exglobal_atmos_products.sh
@@ -253,7 +253,7 @@ if [[ "${SENDDBN:-}" == "YES" ]]; then
                 ;;
             gfs)
                 "${DBNROOT}/bin/dbn_alert" MODEL "${RUN^^}_SF" "${job}" "${COMIN_ATMOS_HISTORY}/${PREFIX}atm.${fhr3}.nc"
-                if [[ ${fhr} -gt 0 && 10#${fhr3} -le 84 || 10#${fhr3} -eq 120 ]]; then
+                if [[ $((10#${fhr})) -gt 0 && $((10#${fhr3})) -le 84 || $((10#${fhr3})) -eq 120 ]]; then
                     "${DBNROOT}/bin/dbn_alert" MODEL "${RUN^^}_BF" "${job}" "${COMIN_ATMOS_HISTORY}/${PREFIX}sfc.${fhr3}.nc"
                 fi
 

--- a/ecf/include/head.h
+++ b/ecf/include/head.h
@@ -57,6 +57,7 @@ export KEEPDATA=NO
 #### Therefore, set the SENDDBN to NO for now
 #### export SENDDBN=${SENDDBN:-%SENDDBN:YES%}
 export SENDDBN="NO"
+export DBNLOG="NO"
 export SENDDBN_NTC=${SENDDBN_NTC:-%SENDDBN_NTC:YES%}
 
 if [ -n "%DATAROOT:%" ]; then export DATAROOT="%DATAROOT:%"; fi


### PR DESCRIPTION
# Description
This replaces the undefined `fhr` with `fhr3` in `exglobal_atmos_products.sh` for DBN alerts. It also sets a default value for `DBNLOG`, which was previously undefined.

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
ecflow testing in progress

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings