### PR TITLE
[dev/gfs.v17] bugfix for fbwind ecf trigger

### DIFF
--- a/ecf/defs/gfs_prod.def
+++ b/ecf/defs/gfs_prod.def
@@ -1700,7 +1700,7 @@ suite gfs_v17_nco
             task jgfs_atmos_postsnd
               trigger ./product/jgfs_atmos_product_f180==complete
             task jgfs_atmos_fbwind
-              trigger ../product/jgfs_atmos_product_f006 == complete and ../../post/jgfs_atmos_product_f012 == complete and ../../post/jgfs_atmos_product_f024 == complete
+              trigger ./product/jgfs_atmos_product_f006 == complete and ./product/jgfs_atmos_product_f012 == complete and ./product/jgfs_atmos_product_f024 == complete
             family awips_20km_1p0
               task jgfs_atmos_awips_20km_1p0_f000
                 edit FHR '000'
@@ -7617,7 +7617,7 @@ suite gfs_v17_nco
             task jgfs_atmos_postsnd
               trigger ./product/jgfs_atmos_product_f180==complete
             task jgfs_atmos_fbwind
-              trigger ../product/jgfs_atmos_product_f006 == complete and ../../post/jgfs_atmos_product_f012 == complete and ../../post/jgfs_atmos_product_f024 == complete
+              trigger ./product/jgfs_atmos_product_f006 == complete and ./product/jgfs_atmos_product_f012 == complete and ./product/jgfs_atmos_product_f024 == complete
             family awips_20km_1p0
               task jgfs_atmos_awips_20km_1p0_f000
                 edit FHR '000'
@@ -13531,7 +13531,7 @@ suite gfs_v17_nco
             task jgfs_atmos_postsnd
               trigger ./product/jgfs_atmos_product_f180==complete
             task jgfs_atmos_fbwind
-              trigger ../product/jgfs_atmos_product_f006 == complete and ../../post/jgfs_atmos_product_f012 == complete and ../../post/jgfs_atmos_product_f024 == complete
+              trigger ./product/jgfs_atmos_product_f006 == complete and ./product/jgfs_atmos_product_f012 == complete and ./product/jgfs_atmos_product_f024 == complete
             family awips_20km_1p0
               task jgfs_atmos_awips_20km_1p0_f000
                 edit FHR '000'
@@ -19446,7 +19446,7 @@ suite gfs_v17_nco
             task jgfs_atmos_postsnd
               trigger ./product/jgfs_atmos_product_f180==complete
             task jgfs_atmos_fbwind
-              trigger ../product/jgfs_atmos_product_f006 == complete and ../../post/jgfs_atmos_product_f012 == complete and ../../post/jgfs_atmos_product_f024 == complete
+              trigger ./product/jgfs_atmos_product_f006 == complete and ./product/jgfs_atmos_product_f012 == complete and ./product/jgfs_atmos_product_f024 == complete
             family awips_20km_1p0
               task jgfs_atmos_awips_20km_1p0_f000
                 edit FHR '000'


### PR DESCRIPTION

# Description
Previous changes to the triggers for the `jgfs_atmos_fbwind` job got set incorrectly, which will cause the def file to not load into the ecflow server. This PR updates the ecf triggers for this job to allow the def file to load into the ecf server.


# Type of change
- [ ] Bug fix (fixes something broken)


# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
loaded ecf def file into ecflow server


# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
