### PR TITLE
[dev/gfs.v17] Remove marine prep fsm from ecflow def

### DIFF
--- a/dev/scripts/exglobal_fsm.sh
+++ b/dev/scripts/exglobal_fsm.sh
@@ -109,12 +109,12 @@ while [[ "${proceed_trigger_scan}" == "YES" ]]; do
         # TODO remove/change this and look at obsproc for the bufr files
         for ty_md in adt icec sst; do
             # Check for the existence of files for each type of marine observation; if any type is missing, skip the rest and wait for the next scan
-	    if [[ ${ty_md} == "adt" && ${cyc} != "00" ]]; then
-		echo "adt files are only produced at 00z...skipping check for ${cyc}z"
-		continue
-	    else
+            if [[ ${ty_md} == "adt" && ${cyc} != "00" ]]; then
+                echo "adt files are only produced at 00z...skipping check for ${cyc}z"
+                continue
+            else
                 tty_files=("${COMIN_OCEAN_OBS_gfs}/"*"${ty_md}"*)
-	    fi
+            fi
             count_tty=${#tty_files[@]}
             if [[ ${count_tty} -eq 0 ]]; then
                 skip_this_scan="NO"
@@ -292,8 +292,8 @@ while [[ "${proceed_trigger_scan}" == "YES" ]]; do
             else
                 tty_files=("${COMIN_OCEAN_OBS_gfs}/"*"${ty_md}"*)
             fi
-	    # Check for the existence of files for each type of marine observation; if any type is missing, skip the rest and wait for the next scan
-	    count_tty=${#tty_files[@]}
+            # Check for the existence of files for each type of marine observation; if any type is missing, skip the rest and wait for the next scan
+            count_tty=${#tty_files[@]}
             if [[ ${count_tty} -eq 0 ]]; then
                 skip_this_scan="NO"
                 proceed_trigger_scan="YES"

--- a/dev/scripts/exglobal_fsm.sh
+++ b/dev/scripts/exglobal_fsm.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -x
+set -u -o pipefail
+shopt -s nullglob
 
 # File Service Manager (FSM) for Global Workfow
 # WGF (Workflow Group Family Assignment) - atmos, ocean
@@ -77,8 +79,11 @@ if [[ "${RJN}" == "forecast" ]]; then
     fi
 fi
 
-#### COMINobsproc=${COMINobsproc:-${DMPDIR}/gfs.${PDY}/${cyc}/atmos}
-COMINgdasobs="${COMINgdasobs:-${DMPDIR}/gdas.${previous_cycle_PDY}/${previous_cycle_cyc}/atmos}"
+COMIN_ATMOS_OBS_gfs=${COMIN_ATMOS_OBS_gfs:-$(compath.py "${envir}/obsproc/${obsproc_ver}")/"gfs.${PDY}/${cyc}/atmos"}
+COMIN_ATMOS_OBS_gdas=${COMIN_ATMOS_OBS_gdas:-$(compath.py "${envir}/obsproc/${obsproc_ver}")/"gdas.${PDY}/${cyc}/atmos"}
+COMIN_ATMOS_OBS_PREV_gdas=${COMIN_ATMOS_OBS_PREV_gdas:-$(compath.py "${envir}/obsproc/${obsproc_ver}")/"gdas.${previous_cycle_PDY}/${previous_cycle_cyc}/atmos"}
+COMIN_OCEAN_OBS_gfs=${COMIN_OCEAN_OBS_gfs:-"${ROTDIR}/gfs.${PDY}/${cyc}/obs"}
+COMIN_OCEAN_OBS_gdas=${COMIN_OCEAN_OBS_gdas:-"${ROTDIR}/gdas.${PDY}/${cyc}/obs"}
 
 proceed_trigger_scan="YES"
 while [[ "${proceed_trigger_scan}" == "YES" ]]; do
@@ -87,10 +92,9 @@ while [[ "${proceed_trigger_scan}" == "YES" ]]; do
     #### release_gfs_atmos_prep
     if [[ "${scan_release_gfs_atmos_prep}" == "YES" ]]; then
         echo "Proceeding with scan_release_gfs_atmos_prep"
-        COMINobsproc=${DMPDIR}/gfs.${PDY}/${cyc}/atmos
         # TODO: try to remove the use of ls.
         # shellcheck disable=SC2012
-        if [[ -s "${COMINgdasobs}/gdas.t${previous_cycle_cyc}z.updated.status.tm00.bufr_d" ]] && [[ -s "${COMINobsproc}/gfs.t${cyc}z.prepbufr" ]] && [[ $(ls "${COMINobsproc}"/gfs.t*z.*.bufr_d | wc -l) -ge 60 ]]; then
+        if [[ -s "${COMIN_ATMOS_OBS_PREV_gdas}/gdas.t${previous_cycle_cyc}z.updated.status.tm00.bufr_d" ]] && [[ -s "${COMIN_ATMOS_OBS_gfs}/gfs.t${cyc}z.prepbufr" ]] && [[ $(ls "${COMIN_ATMOS_OBS_gfs}"/gfs.t*z.*.bufr_d | wc -l) -ge 60 ]]; then
             ecflow_client --event release_gfs_atmos_prep
             scan_release_gfs_atmos_prep="NO"
         else
@@ -103,10 +107,9 @@ while [[ "${proceed_trigger_scan}" == "YES" ]]; do
         skip_this_scan="YES"
         echo "Proceeding with scan_release_gfs_marine_prepoceanobs"
         # TODO remove/change this and look at obsproc for the bufr files
-        COMIN_prep_ocean_obs=${DMPDIR_ocean}/gfs.${PDY}/${cyc}/ocean
         for ty_md in adt icec sst insitu; do
             # Check for the existence of files for each type of marine observation; if any type is missing, skip the rest and wait for the next scan
-            tty_files=("${COMIN_prep_ocean_obs}/${ty_md}"/*"${ty_md}"*)
+            tty_files=("${COMIN_OCEAN_OBS_gfs}/"*"${ty_md}"*)
             count_tty=${#tty_files[@]}
             if [[ ${count_tty} -eq 0 ]]; then
                 skip_this_scan="NO"
@@ -264,8 +267,7 @@ while [[ "${proceed_trigger_scan}" == "YES" ]]; do
     #### release_gdas_atmos_prep
     if [[ "${scan_release_gdas_atmos_prep}" == "YES" ]]; then
         echo "Proceeding with scan_release_gdas_atmos_prep"
-        COMINobsproc=${DMPDIR}/gdas.${PDY}/${cyc}/atmos
-        if [[ -s ${COMINgdasobs}/gdas.t${previous_cycle_cyc}z.updated.status.tm00.bufr_d ]] && [[ -s ${COMINobsproc}/gdas.t${cyc}z.prepbufr ]] && [[ -s ${COMINobsproc}/gdas.t${cyc}z.updated.status.tm00.bufr_d ]]; then
+        if [[ -s ${COMIN_ATMOS_OBS_PREV_gdas}/gdas.t${previous_cycle_cyc}z.updated.status.tm00.bufr_d ]] && [[ -s ${COMIN_ATMOS_OBS_gdas}/gdas.t${cyc}z.prepbufr ]] && [[ -s ${COMIN_ATMOS_OBS_gdas}/gdas.t${cyc}z.updated.status.tm00.bufr_d ]]; then
             ecflow_client --event release_gdas_atmos_prep
             scan_release_gdas_atmos_prep="NO"
         else
@@ -278,11 +280,10 @@ while [[ "${proceed_trigger_scan}" == "YES" ]]; do
         skip_this_scan="YES"
         echo "Proceeding with scan_release_gdas_marine_prepoceanobs"
         # TODO remove/change this and look at obsproc for the bufr files
-        COMIN_prep_ocean_obs=${DMPDIR_ocean}/gdas.${PDY}/${cyc}/ocean
         for ty_md in adt icec sst insitu; do
             # TODO: try to remove the use of ls.
             # shellcheck disable=SC2012
-            if [[ $(ls "${COMIN_prep_ocean_obs}"/"${ty_md}"/*"${ty_md}"* | wc -l) -eq 0 ]]; then
+            if [[ $(ls "${COMIN_OCEAN_OBS_gdas}"/*"${ty_md}"* | wc -l) -eq 0 ]]; then
                 skip_this_scan="NO"
                 proceed_trigger_scan="YES"
             fi

--- a/dev/scripts/exglobal_fsm.sh
+++ b/dev/scripts/exglobal_fsm.sh
@@ -107,7 +107,7 @@ while [[ "${proceed_trigger_scan}" == "YES" ]]; do
         skip_this_scan="YES"
         echo "Proceeding with scan_release_gfs_marine_prepoceanobs"
         # TODO remove/change this and look at obsproc for the bufr files
-        for ty_md in adt icec sst insitu; do
+        for ty_md in adt icec sst; do
             # Check for the existence of files for each type of marine observation; if any type is missing, skip the rest and wait for the next scan
             tty_files=("${COMIN_OCEAN_OBS_gfs}/"*"${ty_md}"*)
             count_tty=${#tty_files[@]}
@@ -280,7 +280,7 @@ while [[ "${proceed_trigger_scan}" == "YES" ]]; do
         skip_this_scan="YES"
         echo "Proceeding with scan_release_gdas_marine_prepoceanobs"
         # TODO remove/change this and look at obsproc for the bufr files
-        for ty_md in adt icec sst insitu; do
+        for ty_md in adt icec sst; do
             # TODO: try to remove the use of ls.
             # shellcheck disable=SC2012
             if [[ $(ls "${COMIN_OCEAN_OBS_gdas}"/*"${ty_md}"* | wc -l) -eq 0 ]]; then

--- a/dev/scripts/exglobal_fsm.sh
+++ b/dev/scripts/exglobal_fsm.sh
@@ -109,7 +109,12 @@ while [[ "${proceed_trigger_scan}" == "YES" ]]; do
         # TODO remove/change this and look at obsproc for the bufr files
         for ty_md in adt icec sst; do
             # Check for the existence of files for each type of marine observation; if any type is missing, skip the rest and wait for the next scan
-            tty_files=("${COMIN_OCEAN_OBS_gfs}/"*"${ty_md}"*)
+	    if [[ ${ty_md} == "adt" && ${cyc} != "00" ]]; then
+		echo "adt files are only produced at 00z...skipping check for ${cyc}z"
+		continue
+	    else
+                tty_files=("${COMIN_OCEAN_OBS_gfs}/"*"${ty_md}"*)
+	    fi
             count_tty=${#tty_files[@]}
             if [[ ${count_tty} -eq 0 ]]; then
                 skip_this_scan="NO"
@@ -281,13 +286,20 @@ while [[ "${proceed_trigger_scan}" == "YES" ]]; do
         echo "Proceeding with scan_release_gdas_marine_prepoceanobs"
         # TODO remove/change this and look at obsproc for the bufr files
         for ty_md in adt icec sst; do
-            # TODO: try to remove the use of ls.
-            # shellcheck disable=SC2012
-            if [[ $(ls "${COMIN_OCEAN_OBS_gdas}"/*"${ty_md}"* | wc -l) -eq 0 ]]; then
+            if [[ ${ty_md} == "adt" && ${cyc} != "00" ]]; then
+                echo "adt files are only produced at 00z...skipping check for ${cyc}z"
+                continue
+            else
+                tty_files=("${COMIN_OCEAN_OBS_gfs}/"*"${ty_md}"*)
+            fi
+	    # Check for the existence of files for each type of marine observation; if any type is missing, skip the rest and wait for the next scan
+	    count_tty=${#tty_files[@]}
+            if [[ ${count_tty} -eq 0 ]]; then
                 skip_this_scan="NO"
                 proceed_trigger_scan="YES"
             fi
         done
+
         if [[ "${skip_this_scan}" == "YES" ]]; then
             ecflow_client --event release_gdas_marine_prepoceanobs
             scan_release_gdas_marine_prepoceanobs="NO"

--- a/ecf/defs/gfs_prod.def
+++ b/ecf/defs/gfs_prod.def
@@ -30,13 +30,9 @@ suite gfs_v17_nco
           endfamily		//atmos
           family marine
             edit WGF 'marine'
-            task jgfs_marine_prep_fsm
-              edit RJN 'prep'
-              trigger :TIME >= 0300 and :TIME < 0630
-              event 1 release_gfs_marine_prepoceanobs
             task jgfs_marine_obs_bufr_dump
               # TODO make this trigger off of obsproc dump job completion
-              trigger jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs
+              trigger :TIME >= 0307 and :TIME < 0312
             task jgfs_marine_obs_dump
               # this should start when the obsproc job starts
               trigger :TIME >= 0245 and :TIME < 0630
@@ -69,7 +65,7 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgfs_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs and ../../../../18/enkfgdas/forecast==complete and ../../../../18/gdas/forecast==complete
+              trigger ../../prep/marine/jgfs_marine_obs_dump==complete and ../../../../18/enkfgdas/forecast==complete and ../../../../18/gdas/forecast==complete
             task jgfs_marine_bmat
               trigger jgfs_marine_bmat_init==complete
             task jgfs_marine_anal_init
@@ -5362,14 +5358,9 @@ suite gfs_v17_nco
           endfamily		//atmos
           family marine
             edit WGF 'marine'
-            task jgdas_marine_prep_fsm
-              edit RJN 'prep'
-              # TODO change these times to match the GDAS cycle
-              trigger :TIME >= 0300 and :TIME < 0630
-              event 1 release_gdas_marine_prepoceanobs
             task jgdas_marine_obs_bufr_dump
               # TODO make this trigger off of obsproc dump job completion
-              trigger jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs
+              trigger :TIME >= 0610 and :TIME < 0615 
             task jgdas_marine_obs_dump
               # this should start when the obsproc job starts
               trigger :TIME >= 0545 and :TIME < 0630
@@ -5407,7 +5398,7 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgdas_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs and ../../../../18/enkfgdas/forecast==complete and ../../../../18/gdas/forecast==complete
+              trigger ../../prep/marine/jgdas_marine_obs_dump==complete and ../../../../18/enkfgdas/forecast==complete and ../../../../18/gdas/forecast==complete
             task jgdas_marine_bmat
               trigger jgdas_marine_bmat_init==complete
             task jgdas_marine_anal_init
@@ -5947,13 +5938,9 @@ suite gfs_v17_nco
           endfamily		//atmos
           family marine
             edit WGF 'marine'
-            task jgfs_marine_prep_fsm
-              edit RJN 'prep'
-              trigger :TIME >= 0900 and :TIME < 1230
-              event 1 release_gfs_marine_prepoceanobs
             task jgfs_marine_obs_bufr_dump
               # TODO make this trigger off of obsproc dump job completion
-              trigger jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs
+              trigger :TIME >= 0907 and :TIME < 0912 
             task jgfs_marine_obs_dump
               # this should start when the obsproc job starts
               trigger :TIME >= 0845 and :TIME < 1230
@@ -5986,7 +5973,7 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgfs_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs and ../../../../00/enkfgdas/forecast==complete and ../../../../00/gdas/forecast==complete
+              trigger ../../prep/marine/jgfs_marine_obs_dump==complete and ../../../../00/enkfgdas/forecast==complete and ../../../../00/gdas/forecast==complete
             task jgfs_marine_bmat
               trigger jgfs_marine_bmat_init==complete
             task jgfs_marine_anal_init
@@ -11279,12 +11266,9 @@ suite gfs_v17_nco
           endfamily  		//atmos
           family marine
             edit WGF 'marine'
-            task jgdas_marine_prep_fsm
-              edit RJN 'prep'
-              trigger :TIME >= 0900 and :TIME < 1230
-              event 1 release_gdas_marine_prepoceanobs
             task jgdas_marine_obs_bufr_dump
-              trigger jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs
+              #NCO/Ops should use obsproc trigger.  Time trigger is a workaround for development
+              trigger :TIME >= 1210 and :TIME < 1215 
             task jgdas_marine_obs_dump
               trigger :TIME >= 1145 and :TIME < 1230
           endfamily  		//marine
@@ -11321,7 +11305,7 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgdas_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs and ../../../../00/enkfgdas/forecast==complete and ../../../../00/gdas/forecast==complete
+              trigger ../../prep/marine/jgdas_marine_obs_dump==complete and ../../../../00/enkfgdas/forecast==complete and ../../../../00/gdas/forecast==complete
             task jgdas_marine_bmat
               trigger jgdas_marine_bmat_init==complete
             task jgdas_marine_anal_init
@@ -11861,13 +11845,9 @@ suite gfs_v17_nco
           endfamily		//atmos
           family marine
             edit WGF 'marine'
-            task jgfs_marine_prep_fsm
-              edit RJN 'prep'
-              trigger :TIME >= 1500 and :TIME < 1830
-              event 1 release_gfs_marine_prepoceanobs
             task jgfs_marine_obs_bufr_dump
               # TODO make this trigger off of obsproc dump job completion
-              trigger jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs
+              trigger :TIME >= 1507 and :TIME < 1512 
             task jgfs_marine_obs_dump
               # this should start when the obsproc job starts
               trigger :TIME >= 1445 and :TIME < 1830
@@ -11900,7 +11880,7 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgfs_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs and ../../../../06/enkfgdas/forecast==complete and ../../../../06/gdas/forecast==complete
+              trigger ../../prep/marine/jgfs_marine_obs_dump==complete and ../../../../06/enkfgdas/forecast==complete and ../../../../06/gdas/forecast==complete
             task jgfs_marine_bmat
               trigger jgfs_marine_bmat_init==complete
             task jgfs_marine_anal_init
@@ -17193,13 +17173,9 @@ suite gfs_v17_nco
           endfamily  		//atmos
           family marine
             edit WGF 'marine'
-            task jgdas_marine_prep_fsm
-              edit RJN 'prep'
-              trigger :TIME >= 1500 and :TIME < 1830
-              event 1 release_gdas_marine_prepoceanobs
             task jgdas_marine_obs_bufr_dump
             # TODO make this trigger off of obsproc dump job completion
-              trigger jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs
+              trigger :TIME >= 1810 and :TIME < 1815 
             task jgdas_marine_obs_dump
               trigger :TIME >= 1745 and :TIME < 1830
           endfamily  		//marine
@@ -17236,7 +17212,7 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgdas_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs and ../../../../06/enkfgdas/forecast==complete and ../../../../06/gdas/forecast==complete
+              trigger ../../prep/marine/jgdas_marine_obs_dump==complete and ../../../../06/enkfgdas/forecast==complete and ../../../../06/gdas/forecast==complete
             task jgdas_marine_bmat
               trigger jgdas_marine_bmat_init==complete
             task jgdas_marine_anal_init
@@ -17776,13 +17752,9 @@ suite gfs_v17_nco
           endfamily		//atmos
           family marine
             edit WGF 'marine'
-            task jgfs_marine_prep_fsm
-              edit RJN 'prep'
-              trigger :TIME >= 2100 and :TIME < 2359
-              event 1 release_gfs_marine_prepoceanobs
             task jgfs_marine_obs_bufr_dump
               # TODO make this trigger off of obsproc dump job completion
-              trigger jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs
+              trigger :TIME >= 2107 and :TIME < 2112 
             task jgfs_marine_obs_dump
               # this should start when the obsproc job starts
               trigger :TIME >= 2045 or :TIME < 0030
@@ -17815,7 +17787,7 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgfs_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgfs_marine_prep_fsm:release_gfs_marine_prepoceanobs and ../../../../12/enkfgdas/forecast==complete and ../../../../12/gdas/forecast==complete
+              trigger ../../prep/marine/jgfs_marine_obs_dump==complete and ../../../../12/enkfgdas/forecast==complete and ../../../../12/gdas/forecast==complete
             task jgfs_marine_bmat
               trigger jgfs_marine_bmat_init==complete
             task jgfs_marine_anal_init
@@ -23108,12 +23080,9 @@ suite gfs_v17_nco
           endfamily  		//atmos
           family marine
             edit WGF 'marine'
-            task jgdas_marine_prep_fsm
-              edit RJN 'prep'
-              trigger :TIME >= 2100 and :TIME < 2359
-              event 1 release_gdas_marine_prepoceanobs
             task jgdas_marine_obs_bufr_dump
-              trigger jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs
+              #TODO NCO/OPS should use obsproc completion trigger
+              trigger :TIME >= 0010 and :TIME < 0015 
             task jgdas_marine_obs_dump
               # this should start when the obsproc job starts
               trigger :TIME >= 2345 or :TIME < 0030
@@ -23151,7 +23120,7 @@ suite gfs_v17_nco
             edit WGF 'marine'
             task jgdas_marine_bmat_init
               # TODO make this trigger off of obsproc dump job completion
-              trigger ../../prep/marine/jgdas_marine_prep_fsm:release_gdas_marine_prepoceanobs and ../../../../12/enkfgdas/forecast==complete and ../../../../12/gdas/forecast==complete
+              trigger ../../prep/marine/jgdas_marine_obs_dump==complete and ../../../../12/enkfgdas/forecast==complete and ../../../../12/gdas/forecast==complete
             task jgdas_marine_bmat
               trigger jgdas_marine_bmat_init==complete
             task jgdas_marine_anal_init


### PR DESCRIPTION

# Description
This PR removes the dependency of the marine prep fsm job from the ecflow definition file. Triggers are updated to use time triggers for marine prep job as a substitute from the obsproc completion trigger needed during operations. The bmat_init job trigger is also updated to remove the dependency on the fsm job.  

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
def file successfully loads into ecflow server


# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
