### PR TITLE
(develop) Save previous cycle bias correction if observation is missing.

### DIFF
--- a/ush/python/pygfs/jedi/jedi.py
+++ b/ush/python/pygfs/jedi/jedi.py
@@ -464,32 +464,38 @@ class Jedi:
         satlist = []
         satcovlist = []
         tlaplist = []
+        obsbiasin_path = self.jcb_config[f"{self.component}_obsbiasin_path"]
+        obsbiasout_path = self.jcb_config[f"{self.component}_obsbiasout_path"]
         for ob in self.jcb_config['observations']:
-            # Sat bias file
-            satfile = os.path.join(self.jcb_config[f"{self.component}_obsbiasout_path"],
-                                   self.jcb_config[f"{self.component}_obsbiasout_prefix"] + ob + self.jcb_config[f"{self.component}_obsbiasout_suffix"])
-            if os.path.exists(satfile):
-                satlist.append(satfile)
-
-            # Sat bias cov file
-            satcovfile = os.path.join(self.jcb_config[f"{self.component}_obsbiasout_path"],
-                                      self.jcb_config[f"{self.component}_obsbiasout_prefix"] + ob + self.jcb_config[f"{self.component}_obsbiascovout_suffix"])
-            if os.path.exists(satcovfile):
-                satcovlist.append(satcovfile)
+            # Sat bias and sat bias cov files
+            for obsbiasout_suffix in [self.jcb_config[f"{self.component}_obsbiasout_suffix"],
+                                      self.jcb_config[f"{self.component}_obsbiascovout_suffix"]]:
+                satfile_name = os.path.join(self.jcb_config[f"{self.component}_obsbiasout_prefix"] + ob + obsbiasout_suffix)
+                obsbiasin_file = os.path.join(obsbiasin_path, satfile_name)
+                obsbiasout_file = os.path.join(obsbiasout_path, satfile_name)
+                if os.path.exists(obsbiasout_file):
+                    satlist.append(obsbiasout_file)
+                elif os.path.exists(obsbiasin_file):
+                    logger.warning(f"{satfile_name} does not exist in {obsbiasout_path} and will be taken from {obsbiasin_path}")
+                    satlist.append(obsbiasin_file)
+                else:
+                    logger.warning(f"{satfile_name} does not exist in {obsbiasout_path} or {obsbiasin_path}!")
 
             # Temperature lapse rate file
-            tlapfile = os.path.join(self.jcb_config[f"{self.component}_obsbiasin_path"],
+            tlapfile = os.path.join(obsbiasin_path,
                                     self.jcb_config[f"{self.component}_obsbiasin_prefix"] + ob + self.jcb_config[f"{self.component}_obstlapsein_suffix"])
             if os.path.exists(tlapfile):
                 tlaplist.append(tlapfile)
+            else:
+                logger.warning(f"{tlapfile} does not exist in {obsbiasin_path}!")
 
         # Create tarball of bias correction files
         logger.info(f"Creating bias correction tarball {tarball}")
         with tarfile.open(tarball, 'w') as bcor:
             logger.info(f"Adding {bcor.getnames()}")
-            for satfile in satlist + satcovlist:
-                logger.info(f"Adding satellite bias correction file {satfile} to {tarball}")
-                bcor.add(satfile, arcname=os.path.basename(satfile))
+            for satfile_name in satlist:
+                logger.info(f"Adding satellite bias correction file {satfile_name} to {tarball}")
+                bcor.add(satfile_name, arcname=os.path.basename(satfile_name))
             for tlapfile in tlaplist:
                 # Change GPREFIX to APREFIX in tlapse file name when adding to tarball
                 tlapfile_rename = tlapfile.replace(self.jcb_config[f"{self.component}_obsbiasin_prefix"],

--- a/ush/python/pygfs/jedi/jedi.py
+++ b/ush/python/pygfs/jedi/jedi.py
@@ -493,9 +493,9 @@ class Jedi:
         logger.info(f"Creating bias correction tarball {tarball}")
         with tarfile.open(tarball, 'w') as bcor:
             logger.info(f"Adding {bcor.getnames()}")
-            for satfile_name in satlist:
-                logger.info(f"Adding satellite bias correction file {satfile_name} to {tarball}")
-                bcor.add(satfile_name, arcname=os.path.basename(satfile_name))
+            for satfile in satlist:
+                logger.info(f"Adding satellite bias correction file {satfile} to {tarball}")
+                bcor.add(satfile, arcname=os.path.basename(satfile))
             for tlapfile in tlaplist:
                 # Change GPREFIX to APREFIX in tlapse file name when adding to tarball
                 tlapfile_rename = tlapfile.replace(self.jcb_config[f"{self.component}_obsbiasin_prefix"],


### PR DESCRIPTION
# Description

This PR fixes a bug in JEDI atmospheric DA whereby if an observation is missing on one cycle, and thus a bias correction is not generated for that observation, the DA job will break on the following cycle since the bias correction will now be missing.

This PR modifies the method in `jedi.py` that saves the bias correction for each observation. If an observation is missing, it will now save the bias correction from the previous cycle for the next cycle.

Resolved #5099 

# Type of change
- [X] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO (If YES, please indicate to which system(s))
  - [ ] GFS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO (If YES, please add a link to any PRs that are pending.)
  - [ ] EMC verif-global <!-- NOAA-EMC/EMC_verif-global#1234 -->
  - [ ] GDAS <!-- NOAA-EMC/GDASApp#1234 -->
  - [ ] GFS-utils <!-- NOAA-EMC/gfs-utils#1234 -->
  - [ ] GSI <!-- NOAA-EMC/GSI#1234 -->
  - [ ] GSI-monitor <!-- NOAA-EMC/GSI-Monitor#1234 -->
  - [ ] GSI-utils <!-- NOAA-EMC/GSI-Utils#1234 -->
  - [ ] UFS-utils <!-- ufs-community/UFS_UTILS#1234 -->
  - [ ] UFS-weather-model <!-- ufs-community/ufs-weather-model#1234 -->
  - [ ] wxflow <!-- NOAA-EMC/wxflow#1234 -->

# How has this been tested?
<!-- Please list any test you conducted, including the machine.

Clone and build on Ursa
Run and pass C96C48_ufs_hybatmDA

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [X] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
