### PR TITLE
Multi Branch Support in GitLab Pipelines

### DIFF
--- a/.github/workflows/trigger-gitlab-pipelines.yml
+++ b/.github/workflows/trigger-gitlab-pipelines.yml
@@ -156,7 +156,7 @@ jobs:
           # Pass GitHub commit SHA to GitLab for native GitHub integration
           curl --verbose --request POST \
             --form "token=${{ secrets.GITLAB_TRIGGER_TOKEN }}" \
-            --form "ref=develop" \
+            --form "ref=${{ github.ref_name }}" \
             --form "variables[PR_NUMBER]=${{ env.PR_NUM }}" \
             --form "variables[GITHUB_COMMIT_SHA]=${{ env.PR_HEAD_SHA }}" \
             --form "variables[GW_REPO_URL]=${{ vars.GW_REPO_URL }}" \

--- a/.github/workflows/trigger-gitlab-pipelines.yml
+++ b/.github/workflows/trigger-gitlab-pipelines.yml
@@ -156,7 +156,7 @@ jobs:
           # Pass GitHub commit SHA to GitLab for native GitHub integration
           curl --verbose --request POST \
             --form "token=${{ secrets.GITLAB_TRIGGER_TOKEN }}" \
-            --form "ref=${{ github.ref_name }}" \
+            --form "ref=${{ github.ref }}" \
             --form "variables[PR_NUMBER]=${{ env.PR_NUM }}" \
             --form "variables[GITHUB_COMMIT_SHA]=${{ env.PR_HEAD_SHA }}" \
             --form "variables[GW_REPO_URL]=${{ vars.GW_REPO_URL }}" \

--- a/.github/workflows/trigger-gitlab-pipelines.yml
+++ b/.github/workflows/trigger-gitlab-pipelines.yml
@@ -156,7 +156,7 @@ jobs:
           # Pass GitHub commit SHA to GitLab for native GitHub integration
           curl --verbose --request POST \
             --form "token=${{ secrets.GITLAB_TRIGGER_TOKEN }}" \
-            --form "ref=${{ github.ref }}" \
+            --form "ref=${{ github.ref_name }}" \
             --form "variables[PR_NUMBER]=${{ env.PR_NUM }}" \
             --form "variables[GITHUB_COMMIT_SHA]=${{ env.PR_HEAD_SHA }}" \
             --form "variables[GW_REPO_URL]=${{ vars.GW_REPO_URL }}" \

--- a/dev/ci/gitlab-ci-hosts.yml
+++ b/dev/ci/gitlab-ci-hosts.yml
@@ -459,7 +459,7 @@ build-gaeac6:
   variables:
     machine: gaeac6
   tags:
-    - hera2
+    - gaeac6
   rules:
     - if: ($CI_PIPELINE_SOURCE == "schedule" || $CI_PIPELINE_SOURCE == "trigger") && ($RUN_ON_MACHINES =~ /\bgaeac6\b|all/)
     - when: never  # Prevent pipeline from running on any other event (e.g., merges to develop)

--- a/dev/ci/gitlab-ci-hosts.yml
+++ b/dev/ci/gitlab-ci-hosts.yml
@@ -460,6 +460,7 @@ build-gaeac6:
     machine: gaeac6
   tags:
     - gaeac6
+    - licenced
   rules:
     - if: ($CI_PIPELINE_SOURCE == "schedule" || $CI_PIPELINE_SOURCE == "trigger") && ($RUN_ON_MACHINES =~ /\bgaeac6\b|all/)
     - when: never  # Prevent pipeline from running on any other event (e.g., merges to develop)

--- a/dev/ci/gitlab-ci-hosts.yml
+++ b/dev/ci/gitlab-ci-hosts.yml
@@ -459,7 +459,7 @@ build-gaeac6:
   variables:
     machine: gaeac6
   tags:
-    - hera
+    - hera2
     - licensed
   rules:
     - if: ($CI_PIPELINE_SOURCE == "schedule" || $CI_PIPELINE_SOURCE == "trigger") && ($RUN_ON_MACHINES =~ /\bgaeac6\b|all/)

--- a/dev/ci/gitlab-ci-hosts.yml
+++ b/dev/ci/gitlab-ci-hosts.yml
@@ -460,7 +460,6 @@ build-gaeac6:
     machine: gaeac6
   tags:
     - hera2
-    - licensed
   rules:
     - if: ($CI_PIPELINE_SOURCE == "schedule" || $CI_PIPELINE_SOURCE == "trigger") && ($RUN_ON_MACHINES =~ /\bgaeac6\b|all/)
     - when: never  # Prevent pipeline from running on any other event (e.g., merges to develop)

--- a/dev/ci/gitlab-ci-hosts.yml
+++ b/dev/ci/gitlab-ci-hosts.yml
@@ -459,8 +459,8 @@ build-gaeac6:
   variables:
     machine: gaeac6
   tags:
-    - gaeac6
-    - licenced
+    - hera
+    - licensed
   rules:
     - if: ($CI_PIPELINE_SOURCE == "schedule" || $CI_PIPELINE_SOURCE == "trigger") && ($RUN_ON_MACHINES =~ /\bgaeac6\b|all/)
     - when: never  # Prevent pipeline from running on any other event (e.g., merges to develop)


### PR DESCRIPTION
# Dynamic Branch Ref in GitLab Pipeline Trigger

## Summary

The `trigger-gitlab-pipelines.yml` GitHub Actions workflow was hardcoding
`ref=develop` when posting to the GitLab pipeline trigger API. This prevented
the workflow from running CI against branches other than `develop` — even when a
user explicitly selected a different branch (e.g., `dev/gfs.v17`) from the
"Use workflow from" dropdown in the GitHub Actions dispatch UI.

Refs #5121

## Problem

When triggering the GitLab pipeline manually via **Run workflow**, GitHub Actions
presents a branch selector. The selected branch determines which branch of the
repository the workflow YAML is loaded from. However, the `curl` call that fires
the downstream GitLab pipeline was always sending `ref=develop` regardless of
that selection:

```yaml
# Before — hardcoded
--form "ref=develop" \
```

This meant:

- Testing a PR against `dev/gfs.v17` (or any non-`develop` branch) would
  silently run the GitLab pipeline against `develop` instead.
- Any branch-specific CI configuration, variables, or test matrices defined on
  that branch would be bypassed.

## Fix

Replace the hardcoded value with `${{ github.ref_name }}`, which GitHub Actions
automatically resolves to the short branch name selected at dispatch time
(e.g., `develop`, `dev/gfs.v17`):

```yaml
# After — dynamic
--form "ref=${{ github.ref_name }}" \
```

`github.ref_name` is the branch (or tag) name without the `refs/heads/` prefix,
which is exactly the format the GitLab pipeline trigger API expects for its `ref`
parameter.

## Files Changed

| File | Change |
|------|--------|
| `.github/workflows/trigger-gitlab-pipelines.yml` | `ref=develop` → `ref=${{ github.ref_name }}` |

## Behavior After This Change

| Dispatch branch selected | GitLab pipeline `ref` |
|--------------------------|-----------------------|
| `develop` (default) | `develop` — no change from previous behavior |
| `dev/gfs.v17` | `dev/gfs.v17` |
| `feature/my-branch` | `feature/my-branch` |

## Testing

1. Trigger the workflow from `develop` with a PR number — pipeline targets
   `develop` as before.
2. Trigger the workflow from `dev/gfs.v17` with a PR number — GitLab pipeline
   now correctly targets the `dev/gfs.v17` branch.

<img width="416" height="559" alt="image" src="https://github.com/user-attachments/assets/04948d8a-f81b-46dc-9f33-9b670f609c0e" />

<img width="500" height="163" alt="image" src="https://github.com/user-attachments/assets/db5df351-fac0-4522-8016-1b3426674358" />

## Notes

- This is a non-breaking change for all existing `develop`-branch workflows;
  the default branch in the dispatch UI remains `develop`.
- No secrets, variables, or environment settings were modified.
