### PR TITLE
HOTFIX: (develop) Adjust walltime settings for GAEAC6

### DIFF
--- a/sorc/build_opts.yaml
+++ b/sorc/build_opts.yaml
@@ -2,13 +2,13 @@ host_override:  # over-ride options for host
   # Gaea must use the login nodes for builds
   GAEAC6:
     max_cores: 8
-    walltime_ratio: 1.5  # Uniformly adjust the wallclock by this factor (builds are slower on head nodes)
+    walltime_ratio: 2  # Uniformly adjust the wallclock by this factor (builds are slower on head nodes)
 #    exclude_nodes: "gaea61"  # Use this field to black-list out any malfunctioning nodes.
     build:
       gdas:
         cores: 8
         memory: "60G"
-        walltime: "02:30:00"
+        walltime: "03:00:00"
 systems:
   common:
     - "ufs_utils"


### PR DESCRIPTION
# Description
This hotfix increases the wallclock requests for Gaea C6 so CI builds can complete while Gaea SAs work on the head node issue. This should be reverted when Gaea returns to nominal operating status.

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)