### PR TITLE
Turn off surface sensitive channels for Metop-C AMSU-A

### DIFF
--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -57,7 +57,7 @@ VERSION FILE CHANGES
 SORC CHANGES
 ------------
 
-* No changes from GFS v16.3.32
+* Update GSI checkout tag to `gfsda.v16.3.33` (was `gfsda.v16.3.32`).
 
 JOBS CHANGES
 ------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -126,5 +126,5 @@ DOCUMENTATION
 PREPARED BY
 -----------
 Andrew.Collard@noaa.gov
-Travis.Elless@noaa.gov
+Travis.J.Elless@noaa.gov
 David.Huber@noaa.gov

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -1,4 +1,4 @@
-GFS V16.3.32 RELEASE NOTES
+GFS V16.3.33 RELEASE NOTES
 
 -------
 PRELUDE
@@ -57,7 +57,8 @@ VERSION FILE CHANGES
 SORC CHANGES
 ------------
 
-* Update GSI checkout tag to `gfsda.v16.3.33` (was `gfsda.v16.3.32`).
+* No source code changes from GFS v16.3.32
+* Update GSI checkout tag to `gfsda.v16.3.33` (was `gfsda.v16.3.32`) due to fix file change.
 
 JOBS CHANGES
 ------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -3,7 +3,7 @@ GFS V16.3.33 RELEASE NOTES
 -------
 PRELUDE
 -------
-Turn off Metop-C AMSU-A channel 4 which has become unusable.
+Turn off Metop-C AMSU-A channels 1-6 and 15 as channel 4 has become unusable and affects the QC of the other channels.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -78,7 +78,7 @@ SCRIPT CHANGES
 FIX CHANGES
 -----------
 
-* Turn off Metop-C AMSU-A channel 4 in global_satinfo.txt which has become unusable.
+* Turn off Metop-C AMSU-A channels 1-6 and 15.
 
 MODULE CHANGES
 --------------

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -3,7 +3,7 @@ GFS V16.3.32 RELEASE NOTES
 -------
 PRELUDE
 -------
-Bug fixes to the GSI.  Addition of two new GNSSRO instruments. Turn off Metop-B AMSU-A channel 8 which has become unusable.
+Turn off Metop-C AMSU-A channel 4 which has become unusable.
 
 IMPLEMENTATION INSTRUCTIONS
 ---------------------------
@@ -13,9 +13,9 @@ The NOAA VLab and the NOAA-EMC and NCAR organization spaces on GitHub are used t
 ```bash
 cd $PACKAGEROOT
 
-mkdir gfs.v16.3.32
-cd gfs.v16.3.32
-git clone -b OMD-gfs.v16.3.32 https://github.com/NOAA-EMC/global-workflow.git .
+mkdir gfs.v16.3.33
+cd gfs.v16.3.33
+git clone -b OMD-gfs.v16.3.33 https://github.com/NOAA-EMC/global-workflow.git .
 
 cd sorc
 ./checkout.sh -o
@@ -27,7 +27,7 @@ The checkout script extracts the following GFS components:
 | ---------- | ---------------------------- | ----------------------- |
 | MODEL      | GFS.v16.3.26                 | Jun.Wang@noaa.gov       |
 | GLDAS      | gldas_gfsv16_release.v.2.1.0 | Helin.Wei@noaa.gov      |
-| GSI        | gfsda.v16.3.32               | Andrew.Collard@noaa.gov |
+| GSI        | gfsda.v16.3.33               | Andrew.Collard@noaa.gov |
 | UFS_UTILS  | ops-gfsv16.3.20              | George.Gayno@noaa.gov   |
 | POST       | upp_v8.3.0                   | Wen.Meng@noaa.gov       |
 | GSI-Utils  | gsiutil.v16.3.26             | Andrew.Collard@noaa.gov |
@@ -52,56 +52,47 @@ cd ../ecf
 VERSION FILE CHANGES
 --------------------
 
-* in `versions/run.ver` change `version=v16.3.32` and `gfs_ver=v16.3.32`
+* in `versions/run.ver` change `version=v16.3.33` and `gfs_ver=v16.3.33`
 
 SORC CHANGES
 ------------
 
-* Bug fixes in GSI sorc code (https://github.com/NOAA-EMC/GSI/issues/1006):
-* Safeguard to prevent NaNs from CRTM affecting minimisation
-* Add PlanetiQ YAM-8 data with SAID 768 
-* Revert PR #837 changes to dev-v16 radinfo.f90 (Improves minimization)
-* Fix bug in calculation of Windborne and Saildrone Obs Errors
-* Additional variables in diag files for WDQMS
-* Correct additional windborne and saildrone bugs
-* Allow saildrone to assimilate either relative humidity or dew point.
+* No changes from GFS v16.3.32
 
 JOBS CHANGES
 ------------
 
-* No changes from GFS v16.3.31
+* No changes from GFS v16.3.32
 
 PARM/CONFIG CHANGES
 -------------------
 
-* No changes from GFS v16.3.31
+* No changes from GFS v16.3.32
 
 SCRIPT CHANGES
 --------------
 
-* Corrects the index in the exgdas_enkf_update.sh script for the satellite observation's namelist entry of abi_q19.
-* Adds gmi_option=4 to exglobal_atmos_analysis.sh script.
+* No changes from GFS v16.3.32
 
 FIX CHANGES
 -----------
 
-* Addition of Sentinal-6 and PlanetIQ YAM-8 GNSSRO active assimilation.
-* Turn off Metop-B AMSU-A channel 8 which has become unusable.
+* Turn off Metop-C AMSU-A channel 4 in global_satinfo.txt which has become unusable.
 
 MODULE CHANGES
 --------------
 
-* No changes from GFS v16.3.31.
+* No changes from GFS v16.3.32.
 
 CHANGES TO FILE AND FILE SIZES
 ------------------------------
 
-* No significant changes from GFS v16.3.31.
+* No changes from GFS v16.3.32.
 
 ENVIRONMENT AND RESOURCE CHANGES
 --------------------------------
 
-* No changes from GFS v16.3.31.
+* No changes from GFS v16.3.32.
 
 PRE-IMPLEMENTATION TESTING REQUIREMENTS
 ---------------------------------------
@@ -114,25 +105,25 @@ PRE-IMPLEMENTATION TESTING REQUIREMENTS
 DISSEMINATION INFORMATION
 -------------------------
 
-* No changes from GFS v16.3.31
+* No changes from GFS v16.3.32
 
 HPSS ARCHIVE
 ------------
 
-* No changes from GFS v16.3.31
+* No changes from GFS v16.3.32
 
 JOB DEPENDENCIES AND FLOW DIAGRAM
 ---------------------------------
 
-* No changes from GFS v16.3.31
+* No changes from GFS v16.3.32
 
 DOCUMENTATION
 -------------
 
-* No changes from GFS v16.3.31
+* No changes from GFS v16.3.32
 
 PREPARED BY
 -----------
-David.Huber@noaa.gov
 Andrew.Collard@noaa.gov
-Russ.Treadon@noaa.gov
+Travis.Elless@noaa.gov
+David.Huber@noaa.gov

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -32,7 +32,7 @@ fi
 echo gsi checkout ...
 if [[ ! -d gsi.fd ]] ; then
     rm -f ${topdir}/checkout-gsi.log
-    git clone --recursive --branch gfsda.v16.3.32 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
+    git clone --recursive --branch gfsda.v16.3.33 https://github.com/NOAA-EMC/GSI.git gsi.fd >> ${topdir}/checkout-gsi.log 2>&1
     cd gsi.fd
     git submodule update --init
     cd ${topdir}

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,5 +1,5 @@
-export version=v16.3.32
-export gfs_ver=v16.3.32
+export version=v16.3.33
+export gfs_ver=v16.3.33
 export nam_ver=v4.2
 export rtofs_ver=v2.5
 export radarl2_ver=v1.2


### PR DESCRIPTION
# Description

Turn off surface sensitive channels for Metop-C AMSU-A.  

This is required due to Ch 4 becoming unusable and the dependence of surface channel QC on this channel.

  Resolves #5140
  Refs [GSI #1022](https://github.com/NOAA-EMC/GSI/pull/1022)
-->
<!-- For more on writing good commit messages, see https://cbea.ms/git-commit/ -->

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? YES/NO (If YES, please indicate to which system(s))
  - [x] GFS
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? YES (If YES, please add a link to any PRs that are pending.)
  - [x] GSI [GSI #1021](https://github.com/NOAA-EMC/GSI/pull/1021) and  [GSI #1022](https://github.com/NOAA-EMC/GSI/pull/1022)
 

# How has this been tested?
Standalone run and compare to operations on WCOSS2

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
