### PR TITLE
(dev/gfs.v17) Shorten ecflow RUNDIR cleanup retention time

### DIFF
--- a/dev/ush/gfsv17_ecflow_rt_cleanup.sh
+++ b/dev/ush/gfsv17_ecflow_rt_cleanup.sh
@@ -61,9 +61,9 @@ source PDY
 
 echo "Start cleanup at $(date)"
 
-# Clean DATA directories older than 48 hours
+# Clean DATA directories older than 24 hours
 cd "${DATAROOT}"
-for dir_to_remove in $(find ./* -maxdepth 0 -type d -mmin +2880 | grep -v "DBNLOG" | grep -v "ecflow"); do
+for dir_to_remove in $(find ./* -maxdepth 0 -type d -mmin +1440 | grep -v "DBNLOG" | grep -v "ecflow"); do
     echo "Removing directory ${DATAROOT}/${dir_to_remove}"
     if [[ "${DRY_RUN}" == false ]]; then
         rm -rf "${dir_to_remove}"


### PR DESCRIPTION
# Description
The ecflow cleanup script is currently set to clean up RUNDIRS older than 48 hours old.  This was selected so we didn't accidentally scrub over the weekends if there was a failure.  Due to the forecast rundirs not being fully scrubbed on their own (will be addressed in PR #4984), the retention time is being shortened to save more disk space in the short term.

Resolves #5147

# Type of change
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
Currently exercised in ecflow real time parallel


# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
