### PR TITLE
(dev/gfs.v17) Remove GOES simulated imagery DBN alerts; enable DBN alerts in ecflow

### DIFF
--- a/dev/scripts/exgfs_atmos_grib2_special_npoess.sh
+++ b/dev/scripts/exgfs_atmos_grib2_special_npoess.sh
@@ -184,15 +184,6 @@ for ((fhr = SHOUR; fhr <= FHOUR; fhr = fhr + FHINC)); do
     cpfs pgb2ifile "${COMOUT_ATMOS_GOES}/${RUN}.${cycle}.goessimpgrb2.0p25.f${fhr3}.idx"
     cpfs pgb2file2 "${COMOUT_ATMOS_GOES}/${RUN}.${cycle}.goessimpgrb2f${fhr3}.grd221"
 
-    if [[ "${SENDDBN}" == "YES" ]]; then
-        "${DBNROOT}/bin/dbn_alert" MODEL GFS_GOESSIMPGB2_0P25 "${job}" \
-            "${COMOUT_ATMOS_GOES}/${RUN}.${cycle}.goessimpgrb2.0p25.f${fhr3}"
-        "${DBNROOT}/bin/dbn_alert" MODEL GFS_GOESSIMPGB2_0P25_WIDX "${job}" \
-            "${COMOUT_ATMOS_GOES}/${RUN}.${cycle}.goessimpgrb2.0p25.f${fhr3}.idx"
-        "${DBNROOT}/bin/dbn_alert" MODEL GFS_GOESSIMGRD221_PGB2 "${job}" \
-            "${COMOUT_ATMOS_GOES}/${RUN}.${cycle}.goessimpgrb2f${fhr3}.grd221"
-    fi
-
     echo "${PDY}${cyc}${fhr}" > "${COMOUT_ATMOS_GOES}/${RUN}.t${cyc}z.control.goessimpgrb"
     rm -f pgb2file2 pgb2ifile
 

--- a/ecf/include/head.h
+++ b/ecf/include/head.h
@@ -51,12 +51,7 @@ if [ -n "%COMPATH:%" ]; then export COMPATH=${COMPATH:-%COMPATH:%}; fi
 if [ -n "%MAILTO:%" ]; then export MAILTO=${MAILTO:-%MAILTO:%}; fi
 if [ -n "%DBNLOG:%" ]; then export DBNLOG=${DBNLOG:-%DBNLOG:%}; fi
 export KEEPDATA=NO
-#### enkfgdas fcst job failure with SENDDBN="YES" as of 20260306 with expdir:
-####   -rw-r--r-- 1 emc.global global 17K Mar  4 15:57 /lfs/h2/emc/gfstemp/emc.global/expdir/retrov17_01_realtime/config.base
-####   GFS code hash with this issue caab01
-#### Therefore, set the SENDDBN to NO for now
-#### export SENDDBN=${SENDDBN:-%SENDDBN:YES%}
-export SENDDBN="NO"
+export SENDDBN=${SENDDBN:-%SENDDBN:YES%}
 export DBNLOG="NO"
 export SENDDBN_NTC=${SENDDBN_NTC:-%SENDDBN_NTC:YES%}
 

--- a/ecf/include/head.h
+++ b/ecf/include/head.h
@@ -52,7 +52,7 @@ if [ -n "%MAILTO:%" ]; then export MAILTO=${MAILTO:-%MAILTO:%}; fi
 if [ -n "%DBNLOG:%" ]; then export DBNLOG=${DBNLOG:-%DBNLOG:%}; fi
 export KEEPDATA=NO
 export SENDDBN=${SENDDBN:-%SENDDBN:YES%}
-export DBNLOG="NO"
+export DBNLOG=${DBNLOG:-%DBNLOG:YES%}
 export SENDDBN_NTC=${SENDDBN_NTC:-%SENDDBN_NTC:YES%}
 
 if [ -n "%DATAROOT:%" ]; then export DATAROOT="%DATAROOT:%"; fi


### PR DESCRIPTION
# Description
This removes the last of the DBN alerts for retired products and enables DBN alerts when running in ecflow.
Resolves #4785 
Resolves #4962 

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs YES
  - [x] GFS
      - Updates file alerts for NOMADS
  - [ ] GEFS
  - [ ] SFS
  - [ ] GCAFS
- Is this a breaking change (a change in existing functionality)? YES - removes retired DBN alerts
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Testing in rocoto

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added