### PR TITLE
(develop) Increase Hera's wallclock for the prep_emissions jobs

### DIFF
--- a/dev/parm/config/gcafs/config.resources.HERA
+++ b/dev/parm/config/gcafs/config.resources.HERA
@@ -5,7 +5,7 @@
 
 case ${step} in
   "prep_emissions")
-    export walltime="00:45:00"
+    export walltime="01:45:00"
     ;;
 
   "prep")

--- a/dev/parm/config/gefs/config.resources.HERA
+++ b/dev/parm/config/gefs/config.resources.HERA
@@ -5,7 +5,7 @@
 
 case ${step} in
   "prep_emissions")
-    export walltime="00:45:00"
+    export walltime="01:45:00"
     ;;
 
   *)


### PR DESCRIPTION
# Description
This increases the wallclock for the GCAFS and GEFS prep_emissions jobs on Hera, which are currently timing out.

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Will test with CI

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added