### PR TITLE
(develop) Update marineanalysis rundirs to include $RUN  (#4992)

### DIFF
--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_CHECKPOINT
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_CHECKPOINT
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 export WIPE_DATA="NO"
-export DATAjob="${DATAROOT}/marineanalysis.${PDY:-}${cyc}"
+export DATAjob="${DATAROOT}/${RUN}_marineanalysis.${PDY:-}${cyc}"
 export DATAens="${DATAjob}/ensdata"
 export DATA="${DATAjob}/marineanlvar"
 source "${HOMEglobal}/ush/jjob_header.sh" -e "marineanlchkpt" -c "base marineanl marineanlchkpt"

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_ECEN
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_ECEN
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-export DATAjob="${DATAROOT/enkf/}/marineanalysis.${PDY:-}${cyc}"
+export DATAjob="${DATAROOT/enkf/}/${RUN/enkf/}_marineanalysis.${PDY:-}${cyc}"
 export DATA="${DATAjob}/marineanlecen"
 export DATAens="${DATAjob}/ensdata"
 

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_FINALIZE
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_FINALIZE
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 export WIPE_DATA="NO"
-export DATAjob="${DATAROOT}/marineanalysis.${PDY:-}${cyc}"
+export DATAjob="${DATAROOT}/${RUN}_marineanalysis.${PDY:-}${cyc}"
 export DATAens="${DATAjob}/ensdata"
 export DATA="${DATAjob}/marineanlvar"
 source "${HOMEglobal}/ush/jjob_header.sh" -e "marineanlfinal" -c "base marineanl marineanlfinal"

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_INITIALIZE
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_INITIALIZE
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -x
-export DATAjob="${DATAROOT}/marineanalysis.${PDY:-}${cyc}"
+
+export DATAjob="${DATAROOT}/${RUN}_marineanalysis.${PDY:-}${cyc}"
 export DATAens="${DATAjob}/ensdata"
 export DATA="${DATAjob}/marineanlvar"
 source "${HOMEglobal}/ush/jjob_header.sh" -e "marineanlinit" -c "base marineanl marineanlinit"

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_LETKF
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_LETKF
@@ -2,7 +2,7 @@
 set -x
 
 # Use ${DATAROOT/enkf} because DATAjob is created by a gdas_marineanlinit job
-export DATAjob="${DATAROOT/enkf/}/marineanalysis.${PDY:-}${cyc}"
+export DATAjob="${DATAROOT/enkf/}/${RUN/enkf/}_marineanalysis.${PDY:-}${cyc}"
 export DATA="${DATAjob}/marineanlletkf"
 export DATAens="${DATAjob}/ensdata"
 if [[ ! -d "${DATAens}" ]]; then mkdir -p "${DATAens}"; fi

--- a/dev/jobs/JGLOBAL_MARINE_ANALYSIS_VARIATIONAL
+++ b/dev/jobs/JGLOBAL_MARINE_ANALYSIS_VARIATIONAL
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 set -x
 export WIPE_DATA="NO"
-export DATAjob="${DATAROOT}/marineanalysis.${PDY:-}${cyc}"
+export DATAjob="${DATAROOT}/${RUN}_marineanalysis.${PDY:-}${cyc}"
 export DATAens="${DATAjob}/ensdata"
 export DATA="${DATAjob}/marineanlvar"
 source "${HOMEglobal}/ush/jjob_header.sh" -e "marineanlvar" -c "base marineanl marineanlvar"

--- a/dev/jobs/JGLOBAL_MARINE_BMAT
+++ b/dev/jobs/JGLOBAL_MARINE_BMAT
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 export WIPE_DATA="NO"
-export DATAjob="${DATAROOT}/marineanalysis.${PDY:-}${cyc}"
+export DATAjob="${DATAROOT}/${RUN}_marineanalysis.${PDY:-}${cyc}"
 # DATA is pre-populated by the MARINE_BMAT_INIT job
 export DATA="${DATAjob}/marinebmat"
 # Create the directory to hold ensemble perturbations

--- a/dev/jobs/JGLOBAL_MARINE_BMAT_INITIALIZE
+++ b/dev/jobs/JGLOBAL_MARINE_BMAT_INITIALIZE
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-export DATAjob="${DATAROOT}/marineanalysis.${PDY:-}${cyc}"
+export DATAjob="${DATAROOT}/${RUN}_marineanalysis.${PDY:-}${cyc}"
 # Create the directory to hold the BMAT initialization data
 export DATA="${DATAjob}/marinebmat"
 # Create the directory to hold ensemble perturbations


### PR DESCRIPTION
# Description
Companion to PR #4991 for the develop branch

This PR adds $RUN to the marine analysis rundir path so that the gfs and gdas directories don't step on each other in ecflow. This is not needed in rocoto, but the rundir format is changed in both to be consistent as it is defined at the JJOB level.

Resolves #4992

 
# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Testing ongoing -- will post results and take out of draft when complete.


# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary