### PR TITLE
(dev/gfs.v17) Update change_res_ens dependency for enkf forecast manager (#5169)

### DIFF
--- a/ecf/.gitignore
+++ b/ecf/.gitignore
@@ -487,6 +487,7 @@ scripts/enkfgdas/forecast/jenkfgdas_fcst_mem077.ecf
 scripts/enkfgdas/forecast/jenkfgdas_fcst_mem078.ecf
 scripts/enkfgdas/forecast/jenkfgdas_fcst_mem079.ecf
 scripts/enkfgdas/forecast/jenkfgdas_fcst_mem080.ecf
+scripts/enkfgdas/forecast/jenkfgdas_fcst_manager_mem*.ecf
 scripts/enkfgdas/post/jenkfgdas_epos000.ecf
 scripts/enkfgdas/post/jenkfgdas_epos001.ecf
 scripts/enkfgdas/post/jenkfgdas_epos002.ecf

--- a/ecf/defs/gfs_prod.def
+++ b/ecf/defs/gfs_prod.def
@@ -5621,7 +5621,7 @@ suite gfs_v17_nco
             task jenkfgdas_atmos_ens_update
               trigger jenkfgdas_atmos_diag_ens==complete
             task jenkfgdas_change_res_ens
-              trigger ../../../gdas/forecast/jgdas_fcst==complete and ../../forecast/jenkfgdas_fcst_mem001==complete
+              trigger ../../../gdas/forecast/jgdas_fcst==complete and ../../forecast/jenkfgdas_fcst_manager_mem001==complete
             task jenkfgdas_atmos_ens_anal_sfc_regrid
               trigger jenkfgdas_atmos_ens_update==complete
             task jenkfgdas_atmos_ens_anal_sfc_gcycle
@@ -11851,7 +11851,7 @@ suite gfs_v17_nco
             task jenkfgdas_atmos_ens_update
               trigger jenkfgdas_atmos_diag_ens==complete
             task jenkfgdas_change_res_ens
-              trigger ../../../gdas/forecast/jgdas_fcst==complete and ../../forecast/jenkfgdas_fcst_mem001==complete
+              trigger ../../../gdas/forecast/jgdas_fcst==complete and ../../forecast/jenkfgdas_fcst_manager_mem001==complete
             task jenkfgdas_atmos_ens_anal_sfc_regrid
               trigger jenkfgdas_atmos_ens_update==complete
             task jenkfgdas_atmos_ens_anal_sfc_gcycle
@@ -18081,7 +18081,7 @@ suite gfs_v17_nco
             task jenkfgdas_atmos_ens_update
               trigger jenkfgdas_atmos_diag_ens==complete
             task jenkfgdas_change_res_ens
-              trigger ../../../gdas/forecast/jgdas_fcst==complete and ../../forecast/jenkfgdas_fcst_mem001==complete
+              trigger ../../../gdas/forecast/jgdas_fcst==complete and ../../forecast/jenkfgdas_fcst_manager_mem001==complete
             task jenkfgdas_atmos_ens_anal_sfc_regrid
               trigger jenkfgdas_atmos_ens_update==complete
             task jenkfgdas_atmos_ens_anal_sfc_gcycle
@@ -24312,7 +24312,7 @@ suite gfs_v17_nco
             task jenkfgdas_atmos_ens_update
               trigger jenkfgdas_atmos_diag_ens==complete
             task jenkfgdas_change_res_ens
-              trigger ../../../gdas/forecast/jgdas_fcst==complete and ../../forecast/jenkfgdas_fcst_mem001==complete
+              trigger ../../../gdas/forecast/jgdas_fcst==complete and ../../forecast/jenkfgdas_fcst_manager_mem001==complete
             task jenkfgdas_atmos_ens_anal_sfc_regrid
               trigger jenkfgdas_atmos_ens_update==complete
             task jenkfgdas_atmos_ens_anal_sfc_gcycle

--- a/ecf/defs/gfs_prod.def
+++ b/ecf/defs/gfs_prod.def
@@ -5621,7 +5621,7 @@ suite gfs_v17_nco
             task jenkfgdas_atmos_ens_update
               trigger jenkfgdas_atmos_diag_ens==complete
             task jenkfgdas_change_res_ens
-              trigger ../../../gdas/forecast/jgdas_fcst==complete and ../../forecast/jenkfgdas_fcst_manager_mem001==complete
+              trigger ../../../gdas/forecast/jgdas_fcst_manager==complete and ../../forecast/jenkfgdas_fcst_manager_mem001==complete
             task jenkfgdas_atmos_ens_anal_sfc_regrid
               trigger jenkfgdas_atmos_ens_update==complete
             task jenkfgdas_atmos_ens_anal_sfc_gcycle
@@ -11851,7 +11851,7 @@ suite gfs_v17_nco
             task jenkfgdas_atmos_ens_update
               trigger jenkfgdas_atmos_diag_ens==complete
             task jenkfgdas_change_res_ens
-              trigger ../../../gdas/forecast/jgdas_fcst==complete and ../../forecast/jenkfgdas_fcst_manager_mem001==complete
+              trigger ../../../gdas/forecast/jgdas_fcst_manager==complete and ../../forecast/jenkfgdas_fcst_manager_mem001==complete
             task jenkfgdas_atmos_ens_anal_sfc_regrid
               trigger jenkfgdas_atmos_ens_update==complete
             task jenkfgdas_atmos_ens_anal_sfc_gcycle
@@ -18081,7 +18081,7 @@ suite gfs_v17_nco
             task jenkfgdas_atmos_ens_update
               trigger jenkfgdas_atmos_diag_ens==complete
             task jenkfgdas_change_res_ens
-              trigger ../../../gdas/forecast/jgdas_fcst==complete and ../../forecast/jenkfgdas_fcst_manager_mem001==complete
+              trigger ../../../gdas/forecast/jgdas_fcst_manager==complete and ../../forecast/jenkfgdas_fcst_manager_mem001==complete
             task jenkfgdas_atmos_ens_anal_sfc_regrid
               trigger jenkfgdas_atmos_ens_update==complete
             task jenkfgdas_atmos_ens_anal_sfc_gcycle
@@ -24312,7 +24312,7 @@ suite gfs_v17_nco
             task jenkfgdas_atmos_ens_update
               trigger jenkfgdas_atmos_diag_ens==complete
             task jenkfgdas_change_res_ens
-              trigger ../../../gdas/forecast/jgdas_fcst==complete and ../../forecast/jenkfgdas_fcst_manager_mem001==complete
+              trigger ../../../gdas/forecast/jgdas_fcst_manager==complete and ../../forecast/jenkfgdas_fcst_manager_mem001==complete
             task jenkfgdas_atmos_ens_anal_sfc_regrid
               trigger jenkfgdas_atmos_ens_update==complete
             task jenkfgdas_atmos_ens_anal_sfc_gcycle


### PR DESCRIPTION
# Description
In ecflow, the jenkfgdas_change_res_ens job depends on the gdas forecast and the mem001 enkfgdas forecast. With the introduction of the forecast manager for the ensemble, this dependency should be updated to the mem001 enkfgdas forecast manager rather than the ensemble forecast itself since it needs to read a history file.

The dependency is correct in rocoto.

Resolves #5169 

# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
This fix is being exercised in the ecflow realtime parallel.


# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
