### PR TITLE
[dev/gfs.v17] Add missing file error handling to getncdimlen

### DIFF
--- a/ush/getncdimlen
+++ b/ush/getncdimlen
@@ -4,6 +4,7 @@
 # 2019-10-17
 # script to return length of requested dimension
 # for specified netCDF file
+import os
 import argparse
 import gsi_utils
 
@@ -13,5 +14,7 @@ if __name__ == '__main__':
   parser.add_argument('ncfile', help='path to input netCDF file', type=str)
   parser.add_argument('dimname', help='name of dimension (ex: grid_xt)', type=str)
   args = parser.parse_args()
+  if not os.path.isfile(args.ncfile):
+      parser.error(f"FATAL ERROR: input netcdf file {args.ncfile} is missing")
   FileDims = gsi_utils.get_ncdims(args.ncfile)
   print(FileDims[args.dimname])


### PR DESCRIPTION

# Description
It was found in the realtime ecflow parallel that if the echgres job were to run without the ensemble forecast files present, the job would have a silent failure when calling `ush/getncdimlen`. This PR adds a file check to this utility script. This change successfully allows the call to `ush/getncdimlen` and the echgres job to fail loudly if the required netcdf file is missing. 

Resolves #5170 for gfsv17
# Type of change
- [ ] Bug fix (fixes something broken)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 
# How has this been tested?
A C96C48_hybatmDA ci test on wcoss2 ran successfully as normal and then failed as expected when the echgres job was rerun with missing input data

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
