### PR TITLE
(dev/gfs.v17) Disable UFS DA tests on Hera and Ursa

### DIFF
--- a/dev/ci/cases/pr/C96C48_ufs_hybatmDA.yaml
+++ b/dev/ci/cases/pr/C96C48_ufs_hybatmDA.yaml
@@ -20,6 +20,8 @@ skip_ci_on_hosts:
   - gaeac6
   - orion
   - hercules
+  - hera
+  - ursa
   - awsepicglobalworkflow
   - wcoss2
 

--- a/dev/ci/cases/pr/C96C48_ufsgsi_hybatmDA.yaml
+++ b/dev/ci/cases/pr/C96C48_ufsgsi_hybatmDA.yaml
@@ -21,6 +21,8 @@ skip_ci_on_hosts:
   - orion
   - hercules
   - awsepicglobalworkflow
+  - hera
+  - ursa
   - wcoss2
 
 workflow:

--- a/dev/ci/gitlab-ci-hosts.yml
+++ b/dev/ci/gitlab-ci-hosts.yml
@@ -25,7 +25,7 @@
 # GEFS (C48_S2SWA_gefs) and GCAFS (C96_gcafs_cycled, C96_gcafs_cycled_noDA)
 # cases are intentionally excluded on this branch.
 .hera_cases_matrix: &hera_cases
-  - caseName: ["C48_ATM", "C48_S2SW", "C48mx500_3DVarAOWCDA", "C48mx500_hybAOWCDA", "C96C48_hybatmDA", "C96C48_hybatmsnowDA", "C96C48_hybatmsoilDA", "C96C48_ufsgsi_hybatmDA", "C96C48_ufs_hybatmDA", "C96C48mx500_S2SW_cyc_gfs", "C96_atm3DVar", "C96mx100_S2S"]
+  - caseName: ["C48_ATM", "C48_S2SW", "C48mx500_3DVarAOWCDA", "C48mx500_hybAOWCDA", "C96C48_hybatmDA", "C96C48_hybatmsnowDA", "C96C48_hybatmsoilDA", "C96C48mx500_S2SW_cyc_gfs", "C96_atm3DVar", "C96mx100_S2S"]
 
 .gaeac6_cases_matrix: &gaeac6_cases
   - caseName: ["C48_ATM", "C48_S2SW", "C48mx500_3DVarAOWCDA", "C48mx500_hybAOWCDA", "C96C48_hybatmDA", "C96C48_hybatmsnowDA", "C96C48_hybatmsoilDA", "C96C48mx500_S2SW_cyc_gfs", "C96_atm3DVar", "C96mx100_S2S"]
@@ -37,7 +37,7 @@
   - caseName: ["C48_ATM", "C48_S2SW", "C48mx500_3DVarAOWCDA", "C48mx500_hybAOWCDA", "C96C48_hybatmDA", "C96C48mx500_S2SW_cyc_gfs", "C96_atm3DVar", "C96mx100_S2S"]
 
 .ursa_cases_matrix: &ursa_cases
-  - caseName: ["C48_ATM", "C48_S2SW", "C48mx500_3DVarAOWCDA", "C48mx500_hybAOWCDA", "C96C48_hybatmDA", "C96C48_hybatmsnowDA", "C96C48_hybatmsoilDA", "C96C48_ufsgsi_hybatmDA", "C96C48_ufs_hybatmDA", "C96C48mx500_S2SW_cyc_gfs", "C96_atm3DVar", "C96mx100_S2S"]
+  - caseName: ["C48_ATM", "C48_S2SW", "C48mx500_3DVarAOWCDA", "C48mx500_hybAOWCDA", "C96C48_hybatmDA", "C96C48_hybatmsnowDA", "C96C48_hybatmsoilDA", "C96C48mx500_S2SW_cyc_gfs", "C96_atm3DVar", "C96mx100_S2S"]
 
 # Host: Hera - Standard Cases
 setup_experiments-hera:


### PR DESCRIPTION
# Description
UFS DA tests do not work on Ursa or Hera (and may not work in general in the dev/gfs.v17 branch). This PR disables these tests.

Resolves #5178

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? Sort of. It disables tests that cannot run. It's not clear at this time if they should or not.
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Launched CI tests on Ursa (with `-G`) and verified that the UFS tests were not included.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added