### PR TITLE
(dev/gfs.v17) Remove COMROOT declarations from the workflow

### DIFF
--- a/ush/dataroot_com_path.sh
+++ b/ush/dataroot_com_path.sh
@@ -4,8 +4,8 @@
 # dataroot_com_path.sh
 #
 # This utility is to be used to create a COM structure in the DATAROOT.
-# It will replace the root path (up to $COMROOT) with $DATAROOT.
-# Use realpath --relative-to to get the relative path from $COMROOT to the target file
+# It will replace the root path (up to $ROTDIR) with $DATAROOT.
+# Use realpath --relative-to to get the relative path from $ROTDIR to the target file
 # and then prepend $DATAROOT to that path to get the new target path.
 #
 # Syntax:
@@ -32,13 +32,13 @@ dataroot_com_path() {
 
     local original_com_path=${1}
 
-    if [[ -z "${COMROOT:-}" || -z "${DATAROOT:-}" ]]; then
-        echo "FATAL ERROR in dataroot_com_path: COMROOT and DATAROOT must be defined!"
+    if [[ -z "${ROTDIR:-}" || -z "${DATAROOT:-}" ]]; then
+        echo "FATAL ERROR in dataroot_com_path: ROTDIR and DATAROOT must be defined!"
         exit 2
     fi
 
     local relative_path
-    relative_path=$(realpath --relative-to="${COMROOT}" "${original_com_path}")
+    relative_path=$(realpath --relative-to="${ROTDIR}" "${original_com_path}")
     local new_com_path="${DATAROOT}/${relative_path}"
 
     echo "${new_com_path}"

--- a/ush/jjob_standard_vars.sh
+++ b/ush/jjob_standard_vars.sh
@@ -79,7 +79,6 @@ ver_var="${NET}_var"
 ROTDIR=${ROTDIR:-$(compath.py "${envir}/${NET}/${!ver_var}")}
 export ROTDIR
 unset ver_var
-export COMROOT=${ROTDIR}
 
 ##############################################
 # Temporal variables


### PR DESCRIPTION
# Description
This removes COMROOT from the workflow. For temporary shared directories under DATAROOT, the workflow now used `ROTDIR` instead of `COMROOT` to construct the directory names. This retains the required `RUN.PDY/cyc` structure.

Resolves #5152 

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
CI tests on WCOSS2 all passed.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added