### PR TITLE
[dev/gfs.v17] Move enkf sfc dbn alert

### DIFF
--- a/dev/jobs/JGLOBAL_FORECAST
+++ b/dev/jobs/JGLOBAL_FORECAST
@@ -129,17 +129,6 @@ if [[ ${err} -ne 0 ]]; then
     err_exit "Failed to run the ${RUN} forecast for ${PDY}${cyc}"
 fi
 
-# Send DBN alerts for EnKF
-# TODO: Should these be in post manager instead?
-if [[ "${RUN}" =~ "enkf" ]] && [[ "${SENDDBN:-}" == YES ]]; then
-    for ((fhr = FHOUT; fhr <= FHMAX; fhr = fhr + FHOUT)); do
-        if ((fhr % 3 == 0)); then
-            fhr3=$(printf %03i "${fhr}")
-            "${DBNROOT}/bin/dbn_alert" MODEL GFS_ENKF "${job}" "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.sfc.f${fhr3}.nc"
-        fi
-    done
-fi
-
 ##############################################
 # End JOB SPECIFIC work
 ##############################################

--- a/dev/jobs/JGLOBAL_FORECAST_MANAGER
+++ b/dev/jobs/JGLOBAL_FORECAST_MANAGER
@@ -89,6 +89,16 @@ if [[ ${err} -ne 0 ]]; then
     err_exit "Failed to run the ${RUN} forecast manager for ${PDY}${cyc}"
 fi
 
+# Send DBN alerts for EnKF
+if [[ "${RUN}" =~ "enkf" ]] && [[ "${SENDDBN:-}" == YES ]]; then
+    for ((fhr = FHOUT; fhr <= FHMAX; fhr = fhr + FHOUT)); do
+        if ((fhr % 3 == 0)); then
+            fhr3=$(printf %03i "${fhr}")
+            "${DBNROOT}/bin/dbn_alert" MODEL GFS_ENKF "${job}" "${COMOUT_ATMOS_HISTORY}/${RUN}.t${cyc}z.sfc.f${fhr3}.nc"
+        fi
+    done
+fi
+
 ##############################################
 # End JOB SPECIFIC work
 ##############################################


### PR DESCRIPTION

# Description
#5168 identified that running with dbn alerts on in the current would cause a failure in the enkf forecast job as the forecast would finish and call for the alert before the forecast manager would finish copying the files to `COM`. This PR moves this dbn alert section to the forecast manager so it will successfully sends alerts once files are present in `COM`. 

Resolves #5168 for dev/gfsv17

# Type of change
- [ ] Bug fix (fixes something broken)


# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?
NRT 06z cycle in ecflow was run with dbn alerts on. Alerts were successfully created for the enkf surface files in  /lfs/h2/emc/ptmp/travis.j.elless/gfs/test_enkf_dbn/ops/para/com/gfs/v17.0/gfs/v17.0/enkfgdas.20260730/dbnlogs

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
