### PR TITLE
(ci/cd) derecho got dropped on update to pipeline in gfs.v17

### DIFF
--- a/dev/ci/cases/pr/C48_ATM_ecflow.yaml
+++ b/dev/ci/cases/pr/C48_ATM_ecflow.yaml
@@ -18,6 +18,7 @@ skip_ci_on_hosts:
   - gaeac6
   - orion
   - hercules
+  - derecho
   - awsepicglobalworkflow
 
 workflow:

--- a/dev/ci/cases/pr/C48_S2SWA_gefs.yaml
+++ b/dev/ci/cases/pr/C48_S2SWA_gefs.yaml
@@ -25,6 +25,7 @@ skip_ci_on_hosts:
   - hercules
   - ursa
   - awsepicglobalworkflow
+  - derecho
 
 workflow:
   engine: rocoto

--- a/dev/ci/cases/pr/C48_S2SWA_gefs_RT.yaml
+++ b/dev/ci/cases/pr/C48_S2SWA_gefs_RT.yaml
@@ -27,6 +27,7 @@ skip_ci_on_hosts:
   - hera
   - ursa
   - orion
+  - derecho
   - awsepicglobalworkflow
 
 workflow:

--- a/dev/ci/cases/pr/C48_S2SW_extended.yaml
+++ b/dev/ci/cases/pr/C48_S2SW_extended.yaml
@@ -18,6 +18,7 @@ skip_ci_on_hosts:
   - gaeac6
   - orion
   - hercules
+  - derecho
   - awsepicglobalworkflow
 
 workflow:

--- a/dev/ci/cases/pr/C96_atm3DVar_extended.yaml
+++ b/dev/ci/cases/pr/C96_atm3DVar_extended.yaml
@@ -21,6 +21,7 @@ skip_ci_on_hosts:
   - gaeac6
   - orion
   - hercules
+  - derecho
   - awsepicglobalworkflow
 
 workflow:

--- a/dev/ci/cases/pr/C96_gcafs_cycled.yaml
+++ b/dev/ci/cases/pr/C96_gcafs_cycled.yaml
@@ -22,6 +22,7 @@ skip_ci_on_hosts:
   - orion
   - hercules
   - ursa
+  - derecho
   - awsepicglobalworkflow
 
 workflow:

--- a/dev/ci/cases/pr/C96_gcafs_cycled_noDA.yaml
+++ b/dev/ci/cases/pr/C96_gcafs_cycled_noDA.yaml
@@ -22,6 +22,7 @@ skip_ci_on_hosts:
   - orion
   - hercules
   - ursa
+  - derecho
   - awsepicglobalworkflow
 
 workflow:

--- a/dev/ci/gitlab-ci-hosts.yml
+++ b/dev/ci/gitlab-ci-hosts.yml
@@ -40,7 +40,7 @@
   - caseName: ["C48_ATM", "C48_S2SW", "C48mx500_3DVarAOWCDA", "C48mx500_hybAOWCDA", "C96C48_hybatmDA", "C96C48_hybatmsnowDA", "C96C48_hybatmsoilDA", "C96C48_ufsgsi_hybatmDA", "C96C48_ufs_hybatmDA", "C96C48mx500_S2SW_cyc_gfs", "C96_atm3DVar", "C96mx100_S2S"]
 
 .derecho_cases_matrix: &derecho_cases
-  - caseName: ["C48_ATM", "C48_S2SW", "C48_S2SWA_gefs", "C48mx500_3DVarAOWCDA", "C48mx500_hybAOWCDA", "C96C48_hybatmDA", "C96C48_hybatmsnowDA", "C96C48_hybatmsoilDA", "C96C48_ufsgsi_hybatmDA", "C96C48_ufs_hybatmDA", "C96C48mx500_S2SW_cyc_gfs", "C96_atm3DVar", "C96mx100_S2S", "C96_gcafs_cycled", "C96_gcafs_cycled_noDA"]
+  - caseName: ["C48_ATM", "C48_S2SW", "C48mx500_3DVarAOWCDA", "C48mx500_hybAOWCDA", "C96C48_hybatmDA", "C96C48_hybatmsnowDA", "C96C48_hybatmsoilDA", "C96C48_ufsgsi_hybatmDA", "C96C48_ufs_hybatmDA", "C96C48mx500_S2SW_cyc_gfs", "C96_atm3DVar", "C96mx100_S2S"]
 
 
 # Host: Hera - Standard Cases

--- a/dev/ci/gitlab-ci-hosts.yml
+++ b/dev/ci/gitlab-ci-hosts.yml
@@ -39,6 +39,10 @@
 .ursa_cases_matrix: &ursa_cases
   - caseName: ["C48_ATM", "C48_S2SW", "C48mx500_3DVarAOWCDA", "C48mx500_hybAOWCDA", "C96C48_hybatmDA", "C96C48_hybatmsnowDA", "C96C48_hybatmsoilDA", "C96C48_ufsgsi_hybatmDA", "C96C48_ufs_hybatmDA", "C96C48mx500_S2SW_cyc_gfs", "C96_atm3DVar", "C96mx100_S2S"]
 
+.derecho_cases_matrix: &derecho_cases
+  - caseName: ["C48_ATM", "C48_S2SW", "C48_S2SWA_gefs", "C48mx500_3DVarAOWCDA", "C48mx500_hybAOWCDA", "C96C48_hybatmDA", "C96C48_hybatmsnowDA", "C96C48_hybatmsoilDA", "C96C48_ufsgsi_hybatmDA", "C96C48_ufs_hybatmDA", "C96C48mx500_S2SW_cyc_gfs", "C96_atm3DVar", "C96mx100_S2S", "C96_gcafs_cycled", "C96_gcafs_cycled_noDA"]
+
+
 # Host: Hera - Standard Cases
 setup_experiments-hera:
   extends: .setup_experiment_template


### PR DESCRIPTION
When the Gitlab Pipeline on dev/gfs.v17 was updated the anchored `derecho_cases_matrix` was left out in the ci host file