### PR TITLE
(pipeline test) no op for testing pipeline hash PR mismatch on checkout in v17 pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,7 @@
 # The host configuration in .gitlab-ci-hosts.yml is designed to be easily 
 # extended with new computing platforms and allows per-host specification 
 # of which test cases to run.
+# no op to test v17 pipeline for hash mismatches for PR checkouts
 
 stages:
   - build


### PR DESCRIPTION
This PR is for testing v17 pipelines (no review needed at this time).