### PR TITLE
(develop) Allow for missing ozone data in GFS diag, arch, and vrfy jobs

### DIFF
--- a/dev/scripts/exgdas_atmos_verfozn.sh
+++ b/dev/scripts/exgdas_atmos_verfozn.sh
@@ -41,8 +41,7 @@ if [[ -s "${oznstat}" ]]; then
     fi
 
 else
-    # oznstat file not found
-    export err=1
-    err_exit "${oznstat} does not exist!"
+    echo "WARNING: Oznstat file not found"
+    echo "WARNING: Exiting without performing ozone verification"
 fi
 exit 0

--- a/dev/scripts/exgdas_atmos_verfozn.sh
+++ b/dev/scripts/exgdas_atmos_verfozn.sh
@@ -41,7 +41,7 @@ if [[ -s "${oznstat}" ]]; then
     fi
 
 else
-    echo "WARNING: Oznstat file not found"
+    echo "WARNING: ${oznstat} not found"
     echo "WARNING: Exiting without performing ozone verification"
 fi
 exit 0

--- a/dev/scripts/exglobal_diag.sh
+++ b/dev/scripts/exglobal_diag.sh
@@ -234,6 +234,9 @@ if [[ "${DIAG_TARBALL}" == "YES" ]]; then
                 pgm=tar
                 err_exit "Unable to create ${diagfile[n]}!"
             fi
+        else
+            echo "WARNING: No diagnostic files found for type ${n} = ${diaglist[n]#list}"
+            echo "WARNING: Unable to create ${diagfile[n]}"
         fi
     done
     echo "END tar diagnostic files"

--- a/dev/scripts/exglobal_enkf_update.sh
+++ b/dev/scripts/exglobal_enkf_update.sh
@@ -123,7 +123,9 @@ cpreq "${COMIN_ATMOS_ANALYSIS_STAT}/${ABIASe}" "satbias_in"
 flist="${CNVSTAT} ${OZNSTAT} ${RADSTAT}"
 for ftype in ${flist}; do
     fname="${COMIN_ATMOS_ANALYSIS_STAT}/${ftype}"
-    tar -xvf "${fname}"
+    if [[ -s "${fname}" ]]; then
+        tar -xvf "${fname}"
+    fi
 done
 
 nfhrs="${IAUFHRS_ENKF//,/ }"

--- a/parm/archive/enkf.yaml.j2
+++ b/parm/archive/enkf.yaml.j2
@@ -79,7 +79,6 @@ enkf:
             {% set da_stat_files = ["enkfstat.txt",
                                     "gsistat_ensmean.txt",
                                     "cnvstat_ensmean.tar",
-                                    "oznstat_ensmean.tar",
                                     "radstat_ensmean.tar"] %}
             {% set da_conf_files = [] %}
         {% else %}
@@ -167,4 +166,8 @@ enkf:
         - "{{ COMIN_ICE_ANALYSIS_ENSSTAT }}/{{ head }}ensvar_post.nc"
         - "{{ COMIN_ICE_ANALYSIS_ENSSTAT }}/{{ head }}ensmean_incr.nc"
         {% endif %}
+        {% endif %}
+    optional:
+        {% if not DO_JEDIATMENS %}
+        - "{{ COMIN_ATMOS_ANALYSIS_ENSSTAT | relpath(ROTDIR) }}/{{ head }}oznstat_ensmean.tar"
         {% endif %}

--- a/parm/archive/gdas.yaml.j2
+++ b/parm/archive/gdas.yaml.j2
@@ -122,16 +122,6 @@ gdas:
         - "{{ COMIN_SNOW_ANLMON }}/{{ head }}snow_analysis.ioda_hofx_stats.tar.gz"
             {% endif %}
 
-        # Ozone verification
-            {% if DO_VERFOZN %}
-        - "{{ COMIN_ATMOS_OZNMON }}/time/bad_cnt.{{ cycle_YMDH }}"
-        - "{{ COMIN_ATMOS_OZNMON }}/time/bad_diag.{{ cycle_YMDH }}"
-        - "{{ COMIN_ATMOS_OZNMON }}/time/bad_pen.{{ cycle_YMDH }}"
-        - "{{ COMIN_ATMOS_OZNMON }}/time/stdout.time.tar.gz"
-        - "{{ COMIN_ATMOS_OZNMON }}/horiz/stdout.horiz.tar.gz"
-        - "logs/{{ cycle_YMDH }}/{{ RUN }}_verfozn.log"
-            {% endif %}
-
         # Radiance verification
             {% if DO_VERFRAD %}
         - "{{ COMIN_ATMOS_RADMON }}/radmon_angle.tar.gz"
@@ -197,7 +187,14 @@ gdas:
         - "{{ COMIN_ATMOS_RADMON }}/warning.{{ cycle_YMDH }}"
             {% endif %}
 
+            # Ozone verification
             {% if DO_VERFOZN %}
+        - "{{ COMIN_ATMOS_OZNMON }}/time/bad_cnt.{{ cycle_YMDH }}"
+        - "{{ COMIN_ATMOS_OZNMON }}/time/bad_diag.{{ cycle_YMDH }}"
+        - "{{ COMIN_ATMOS_OZNMON }}/time/bad_pen.{{ cycle_YMDH }}"
+        - "{{ COMIN_ATMOS_OZNMON }}/time/stdout.time.tar.gz"
+        - "{{ COMIN_ATMOS_OZNMON }}/horiz/stdout.horiz.tar.gz"
+        - "logs/{{ cycle_YMDH }}/{{ RUN }}_verfozn.log"
                 # Not all of these ozone instruments always produce data
                 {% set oznmon_types = [
                    "gome_metop-b", "omi_aura", "ompslp_npp", "ompsnp_n20",


### PR DESCRIPTION
# Description

There are occasions where there will be no ozone assimilated in the GSI and the GFS should not fail when those rare instances occur.  The ex scripts for the diag and verfozn jobs have been updated to output a warning but not fail.  The archive yamls have also been updated to make the ozone files optional.

This is the develop companion PR for #4883 and #4888, which were merged to the dev/gfs.v17 branch.

Edit: Added PR #4880 as well.

Resolves #4881


# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
CI on Gaea and WCOSS passed, ran a full cycle on Gaea with the ozone data purposefully removed.

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
