### PR TITLE
(develop) Temporarily disable METplus verification

### DIFF
--- a/dev/parm/config/gfs/config.base.j2
+++ b/dev/parm/config/gfs/config.base.j2
@@ -490,13 +490,10 @@ export binary_diag=".false."
 export DO_CA="YES"
 
 # Verification options
-# TODO: Enable METplus on Ursa when verif-global has been upgraded to spack-stack 1.9.x+
-# TODO: Clean this up by allowing DO_METP to be system-specific and/or allow overriding that parameter
-# export DO_METP="{{ DO_METP }}"   # Run METPLUS jobs - set METPLUS settings in config.metp
-case "${machine}" in
-    URSA | GAEAC6 | ORION | HERCULES | DERECHO | AWS-EC2) export DO_METP=NO;;
-    *) export DO_METP="{{ DO_METP }}";;
-esac
+# Temporarily disable METplus verification. This will be reenabled on all platforms when
+# migration to MET 12/METplus 6 is complete.
+# export DO_METP={{ DO_METP }}
+export DO_METP=NO
 export DO_FIT2OBS="YES"      # Run fit to observations package
 
 #--online archive of netcdf files for fit2obs verification


### PR DESCRIPTION
# Description
This temporarily disables METplus verification while an upgrade to statistics files (required for the MET v12 upgrade) is underway. Verification will be reenabled after the upgrade to MET is completed during the week of August 31, 2026.

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs? YES
  - [x] GFS - .stat files will not be generated. Users may use EMC_verif-global offline to generated these files.
- Is this a breaking change (a change in existing functionality)? YES - temporarily disables METplus verification
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Generated a C96_atm3DVar_extended XML and verified that no *metp* jobs were included.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added