### PR TITLE
(dev/gfs.v17) HOTFIX: Correct cycle_begin trigger logic

### DIFF
--- a/dev/ush/ecflow_time_triggers.py
+++ b/dev/ush/ecflow_time_triggers.py
@@ -112,16 +112,15 @@ def task_missed_launch_window(time_attributes, PDYcyc):
                 year=PDYcyc_dt.year, month=PDYcyc_dt.month, day=PDYcyc_dt.day
             )
 
-            if last_time_dt < current_dt:
+            if last_time_dt < current_dt and not ( last_time < "0600" and PDYcyc_dt.hour == 18 ):
                 return True
             else:
                 # It is possible for the trigger to be on the next day
                 # If last_time is less than "0600" and $cyc is "18", then the trigger is
                 # for the next day.
-                if last_time < "0600" and PDYcyc_dt.hour == 18:
-                    last_time_dt_next_day = last_time_dt + datetime.timedelta(days=1)
-                    if last_time_dt_next_day < current_dt:
-                        return True
+                last_time_dt_next_day = last_time_dt + datetime.timedelta(days=1)
+                if last_time_dt_next_day < current_dt:
+                    return True
 
             # TODO: Expand this to handle more complex expressions and make use of
             #       the logical_ops list to evaluate the entire expression correctly.

--- a/dev/ush/ecflow_time_triggers.py
+++ b/dev/ush/ecflow_time_triggers.py
@@ -112,7 +112,7 @@ def task_missed_launch_window(time_attributes, PDYcyc):
                 year=PDYcyc_dt.year, month=PDYcyc_dt.month, day=PDYcyc_dt.day
             )
 
-            if last_time_dt < current_dt and not ( last_time < "0600" and PDYcyc_dt.hour == 18 ):
+            if last_time_dt < current_dt and not (last_time < "0600" and PDYcyc_dt.hour == 18):
                 return True
             else:
                 # It is possible for the trigger to be on the next day


### PR DESCRIPTION
# Description
This fixes the logic behind triggering jobs that have missed their launch window in ecflow when those jobs have a window on the following day of the cycle (i.e. cycle 18z with windows at/after 0000z).

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs? NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Triggered manual tests of ecflow_time_triggers.py for the 18z and 12z cycles.

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary