### PR TITLE
[dev/gfs.v17] BUGFIX: Add jedi bufr python path to marine bufr obs 

### DIFF
--- a/dev/jobs/JGLOBAL_MARINE_OBS_BUFR_DUMP
+++ b/dev/jobs/JGLOBAL_MARINE_OBS_BUFR_DUMP
@@ -18,8 +18,17 @@ source "${USHglobal}/set_strict.sh"
 ##############################################
 # Set variables used in the script
 ##############################################
-# Setup Python path for pygfs
-PYTHONPATH="${HOMEglobal}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"
+# Setup Python path for pyioda and pygfs
+# Detect the Python major.minor version
+_regex="[0-9]+\.[0-9]+"
+if [[ $(python --version) =~ ${_regex} ]]; then
+    export PYTHON_VERSION="${BASH_REMATCH[0]}"
+else
+    err_exit "FATAL ERROR: Could not detect the python version"
+fi
+pyiodaPATH="${HOMEglobal}/lib/python${PYTHON_VERSION}/"
+pybufrPATH="${HOMEglobal}/lib/python${PYTHON_VERSION}/site-packages/"
+PYTHONPATH="${pyiodaPATH}:${pybufrPATH}:${HOMEglobal}/ush/python${PYTHONPATH:+:${PYTHONPATH}}"
 export PYTHONPATH
 LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${HOMEglobal}/lib"
 export LD_LIBRARY_PATH


### PR DESCRIPTION

# Description
It was discovered that the marine_obs_bufr_dump job was silently failing looking for a bufr python path. This PR adds this needed path to this job that was similarly added to other jedi/ioda based obs processing in #5208  

Refs #5237 

# Type of change
- [ ] Bug fix (fixes something broken)


# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 
# How has this been tested?
Successfully ran the the marine_obs_bufr_dump ecflow job without seeing an import bufr error in the log file


# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
