### PR TITLE
(dev/gfs.v17) Increase genesis wallclock requests

### DIFF
--- a/dev/parm/config/gfs/config.resources
+++ b/dev/parm/config/gfs/config.resources
@@ -1117,7 +1117,7 @@ case ${step} in
     ;;
 
   "genesis")
-    walltime="00:40:00"
+    walltime="01:10:00"
     ntasks=1
     threads_per_task=1
     tasks_per_node=1

--- a/dev/workflow/aux/aux.xml.j2
+++ b/dev/workflow/aux/aux.xml.j2
@@ -76,7 +76,7 @@
 	<jobname><cyclestr>&PSLOT;_gfs_genesis_@H</cyclestr></jobname>
 	<account>GFS-DEV</account>
 	<queue>dev</queue>
-	<walltime>00:40:00</walltime>
+	<walltime>01:10:00</walltime>
 	<nodes>1:ppn=1:tpp=1</nodes>
 	<memory>25G</memory>
 	<native>-l place=vscatter:shared</native>


### PR DESCRIPTION
# Description
This adds wallclock to the gfs_genesis jobs so they can run to completion.

Resolves #5238

# Type of change
- [x] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [ ] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs? NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
Ran genesis jobs with the extended wallclcok successfully.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary