### PR TITLE
[dev/gfs.v17] Add fcst_manager dependency to echgres

### DIFF
--- a/dev/workflow/rocoto/gfs_tasks.py
+++ b/dev/workflow/rocoto/gfs_tasks.py
@@ -3234,6 +3234,8 @@ class GFSTasks(Tasks):
         deps = []
         dep_dict = {'type': 'metatask', 'name': f'{self.run}_efcs_manager'}
         deps.append(rocoto.add_dependency(dep_dict))
+        dep_dict = {'type': 'metatask', 'name': 'gdas_fcst_manager'}
+        deps.append(rocoto.add_dependency(dep_dict))
         dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
 
         cycledef = 'gdas_half,gdas' if self.run in ['enkfgdas'] else self.run


### PR DESCRIPTION

# Description
Recently it was observed in rocoto runs that the ecghres job only had a dependency on the efcst_manager and was missing a gdas_fcst_manger dependency. This PR adds this gdas dependency to the rocoto-based ecghres jobs. Note that the ecflow change res job already had a gdas_fcst_manager and efcst_manger dependency.

Resolves #5241 for dev/gfs.v17

# Type of change
- [ ] Bug fix (fixes something broken)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
Successfully generated a proper xml file. Need to run the ci tests

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] This change is covered by an existing CI test or a new one has been added
- [ ] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [ ] I have made corresponding changes to the system documentation if necessary
