### PR TITLE
(dev/gfs.v17) Update GSI dependency on tropcy

### DIFF
--- a/ecf/defs/gfs_prod.def
+++ b/ecf/defs/gfs_prod.def
@@ -56,8 +56,8 @@ suite gfs_v17_nco
             edit WGF 'atmos'
             task jgfs_atmos_anal
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
-              #trigger  /gfs_v17_0/primary/00/obsproc/v1.3/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete and  ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../../../18/enkfgdas/ensstat==complete
-              trigger ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../../../18/enkfgdas/ensstat==complete and ../../../../18/gdas/forecast==complete
+              #trigger  /gfs_v17_0/primary/00/obsproc/v1.3/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete and ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../prep/atmos/jgfs_atmos_tropcy_qc==complete and ../../../../18/enkfgdas/ensstat==complete
+              trigger ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../prep/atmos/jgfs_atmos_tropcy_qc==complete and ../../../../18/enkfgdas/ensstat==complete and ../../../../18/gdas/forecast==complete
             task jgfs_atmos_anal_sfc_gcycle
               trigger jgfs_atmos_anal==complete and ../snow/jgfs_snow_anal==complete
             task jgfs_atmos_anal_calc
@@ -5383,8 +5383,8 @@ suite gfs_v17_nco
           family atmos
             task jgdas_atmos_anal
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
-              #trigger /gfs_v17_0/primary/00/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../../prep/atmos/jgdas_atmos_prep_sfc == complete and ../../../../18/enkfgdas/ensstat==complete
-              trigger ../../prep/atmos/jgdas_atmos_prep_sfc==complete and ../../../../18/enkfgdas/ensstat==complete and ../../../../18/gdas/forecast==complete
+              #trigger /gfs_v17_0/primary/00/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../../prep/atmos/jgdas_atmos_prep_sfc == complete and ../../prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../18/enkfgdas/ensstat==complete
+              trigger ../../prep/atmos/jgdas_atmos_prep_sfc==complete and ../../prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../18/enkfgdas/ensstat==complete and ../../../../18/gdas/forecast==complete
             task jgdas_atmos_anal_diag
               trigger jgdas_atmos_anal==complete
             task jgdas_atmos_anal_wdqms
@@ -5614,8 +5614,8 @@ suite gfs_v17_nco
           family create
             task jenkfgdas_atmos_ens_observer
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
-              #trigger /gfs_v17_0/primary/00/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep==complete and ../../../../18/enkfgdas/ensstat==complete
-              trigger ../../../gdas/prep/atmos/jgdas_atmos_prep_sfc==complete and ../../../../18/enkfgdas/ensstat==complete
+              #trigger /gfs_v17_0/primary/00/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep==complete and ../../../gdas/prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../18/enkfgdas/ensstat==complete
+              trigger ../../../gdas/prep/atmos/jgdas_atmos_prep_sfc==complete and ../../../gdas/prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../18/enkfgdas/ensstat==complete
             task jenkfgdas_snow_ens_anal
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
               #trigger /gfs_v17_0/primary/00/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep==complete and ../../../../18/enkfgdas/ensstat==complete
@@ -6287,8 +6287,8 @@ suite gfs_v17_nco
             edit WGF 'atmos'
             task jgfs_atmos_anal
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
-              #trigger  /gfs_v17_0/primary/06/obsproc/v1.3/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete and  ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../../../00/enkfgdas/ensstat==complete
-              trigger ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../../../00/enkfgdas/ensstat==complete and ../../../../00/gdas/forecast==complete
+              #trigger  /gfs_v17_0/primary/06/obsproc/v1.3/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete and ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../prep/atmos/jgfs_atmos_tropcy_qc==complete and ../../../../00/enkfgdas/ensstat==complete
+              trigger ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../prep/atmos/jgfs_atmos_tropcy_qc==complete and ../../../../00/enkfgdas/ensstat==complete and ../../../../00/gdas/forecast==complete
             task jgfs_atmos_anal_sfc_gcycle
               trigger jgfs_atmos_anal==complete and ../snow/jgfs_snow_anal==complete
             task jgfs_atmos_anal_calc
@@ -11613,8 +11613,8 @@ suite gfs_v17_nco
           family atmos
             task jgdas_atmos_anal
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
-              #trigger /gfs_v17_0/primary/06/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../../prep/atmos/jgdas_atmos_prep_sfc == complete and ../../../../00/enkfgdas/ensstat==complete
-              trigger ../../prep/atmos/jgdas_atmos_prep_sfc==complete and ../../../../00/enkfgdas/ensstat==complete and ../../../../00/gdas/forecast==complete
+              #trigger /gfs_v17_0/primary/06/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../../prep/atmos/jgdas_atmos_prep_sfc == complete and ../../prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../00/enkfgdas/ensstat==complete
+              trigger ../../prep/atmos/jgdas_atmos_prep_sfc==complete and ../../prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../00/enkfgdas/ensstat==complete and ../../../../00/gdas/forecast==complete
             task jgdas_atmos_anal_diag
               trigger jgdas_atmos_anal==complete
             task jgdas_atmos_anal_wdqms
@@ -11844,8 +11844,8 @@ suite gfs_v17_nco
           family create
             task jenkfgdas_atmos_ens_observer
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
-              #trigger /gfs_v17_0/primary/06/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep==complete and ../../../../00/enkfgdas/ensstat==complete
-              trigger ../../../gdas/prep/atmos/jgdas_atmos_prep_sfc==complete and ../../../../00/enkfgdas/ensstat==complete
+              #trigger /gfs_v17_0/primary/06/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep==complete and ../../../gdas/prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../00/enkfgdas/ensstat==complete
+              trigger ../../../gdas/prep/atmos/jgdas_atmos_prep_sfc==complete and ../../../gdas/prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../00/enkfgdas/ensstat==complete
             task jenkfgdas_snow_ens_anal
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
               #trigger /gfs_v17_0/primary/06/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep==complete and ../../../../00/enkfgdas/ensstat==complete
@@ -12517,8 +12517,8 @@ suite gfs_v17_nco
             edit WGF 'atmos'
             task jgfs_atmos_anal
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
-              #trigger  /gfs_v17_0/primary/12/obsproc/v1.3/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete and  ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../../../06/enkfgdas/ensstat==complete
-              trigger ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../../../06/enkfgdas/ensstat==complete and ../../../../06/gdas/forecast==complete
+              #trigger  /gfs_v17_0/primary/12/obsproc/v1.3/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete and ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../prep/atmos/jgfs_atmos_tropcy_qc==complete and ../../../../06/enkfgdas/ensstat==complete
+              trigger ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../prep/atmos/jgfs_atmos_tropcy_qc==complete and ../../../../06/enkfgdas/ensstat==complete and ../../../../06/gdas/forecast==complete
             task jgfs_atmos_anal_sfc_gcycle
               trigger jgfs_atmos_anal==complete and ../snow/jgfs_snow_anal==complete
             task jgfs_atmos_anal_calc
@@ -17843,8 +17843,8 @@ suite gfs_v17_nco
           family atmos
             task jgdas_atmos_anal
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
-              #trigger /gfs_v17_0/primary/12/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../../prep/atmos/jgdas_atmos_prep_sfc == complete and ../../../../06/enkfgdas/ensstat==complete
-              trigger ../../prep/atmos/jgdas_atmos_prep_sfc==complete and ../../../../06/enkfgdas/ensstat==complete and ../../../../06/gdas/forecast==complete
+              #trigger /gfs_v17_0/primary/12/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../../prep/atmos/jgdas_atmos_prep_sfc == complete and ../../prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../06/enkfgdas/ensstat==complete
+              trigger ../../prep/atmos/jgdas_atmos_prep_sfc==complete and ../../prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../06/enkfgdas/ensstat==complete and ../../../../06/gdas/forecast==complete
             task jgdas_atmos_anal_diag
               trigger jgdas_atmos_anal==complete
             task jgdas_atmos_anal_wdqms
@@ -18074,8 +18074,8 @@ suite gfs_v17_nco
           family create
             task jenkfgdas_atmos_ens_observer
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
-              #trigger /gfs_v17_0/primary/12/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep==complete and ../../../../06/enkfgdas/ensstat==complete
-              trigger ../../../gdas/prep/atmos/jgdas_atmos_prep_sfc==complete and ../../../../06/enkfgdas/ensstat==complete
+              #trigger /gfs_v17_0/primary/12/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep==complete and ../../../gdas/prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../06/enkfgdas/ensstat==complete
+              trigger ../../../gdas/prep/atmos/jgdas_atmos_prep_sfc==complete and ../../../gdas/prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../06/enkfgdas/ensstat==complete
             task jenkfgdas_snow_ens_anal
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
               #trigger /gfs_v17_0/primary/12/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep==complete and ../../../../06/enkfgdas/ensstat==complete
@@ -18747,8 +18747,8 @@ suite gfs_v17_nco
             edit WGF 'atmos'
             task jgfs_atmos_anal
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
-              #trigger  /gfs_v17_0/primary/18/obsproc/v1.3/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete and  ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../../../12/enkfgdas/ensstat==complete
-              trigger ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../../../12/enkfgdas/ensstat==complete and ../../../../12/gdas/forecast==complete
+              #trigger  /gfs_v17_0/primary/18/obsproc/v1.3/gfs/atmos/prep/jobsproc_gfs_atmos_prep == complete and ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../prep/atmos/jgfs_atmos_tropcy_qc==complete and ../../../../12/enkfgdas/ensstat==complete
+              trigger ../../prep/atmos/jgfs_atmos_prep_sfc==complete and ../../prep/atmos/jgfs_atmos_tropcy_qc==complete and ../../../../12/enkfgdas/ensstat==complete and ../../../../12/gdas/forecast==complete
             task jgfs_atmos_anal_sfc_gcycle
               trigger jgfs_atmos_anal==complete and ../snow/jgfs_snow_anal==complete
             task jgfs_atmos_anal_calc
@@ -24074,8 +24074,8 @@ suite gfs_v17_nco
           family atmos
             task jgdas_atmos_anal
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
-              #trigger /gfs_v17_0/primary/18/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../../prep/atmos/jgdas_atmos_prep_sfc == complete and ../../../../12/enkfgdas/ensstat==complete
-              trigger ../../prep/atmos/jgdas_atmos_prep_sfc==complete and ../../../../12/enkfgdas/ensstat==complete and ../../../../12/gdas/forecast==complete
+              #trigger /gfs_v17_0/primary/18/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep == complete and ../../prep/atmos/jgdas_atmos_prep_sfc == complete and ../../prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../12/enkfgdas/ensstat==complete
+              trigger ../../prep/atmos/jgdas_atmos_prep_sfc==complete and ../../prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../12/enkfgdas/ensstat==complete and ../../../../12/gdas/forecast==complete
             task jgdas_atmos_anal_diag
               trigger jgdas_atmos_anal==complete
             task jgdas_atmos_anal_wdqms
@@ -24305,8 +24305,8 @@ suite gfs_v17_nco
           family create
             task jenkfgdas_atmos_ens_observer
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
-              #trigger /gfs_v17_0/primary/18/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep==complete and ../../../../12/enkfgdas/ensstat==complete
-              trigger ../../../gdas/prep/atmos/jgdas_atmos_prep_sfc==complete and ../../../../12/enkfgdas/ensstat==complete
+              #trigger /gfs_v17_0/primary/18/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep==complete and ../../../gdas/prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../12/enkfgdas/ensstat==complete
+              trigger ../../../gdas/prep/atmos/jgdas_atmos_prep_sfc==complete and ../../../gdas/prep/atmos/jgdas_atmos_tropcy_qc == complete and ../../../../12/enkfgdas/ensstat==complete
             task jenkfgdas_snow_ens_anal
               #NCO/Ops should use obsproc trigger.  Sfc prep trigger is a workaround for development
               #trigger /gfs_v17_0/primary/18/obsproc/v1.3/gdas/atmos/prep/jobsproc_gdas_atmos_prep==complete and ../../../../12/enkfgdas/ensstat==complete


### PR DESCRIPTION
# Description
This PR updates the dependencies of the GSI analysis and observer jobs to wait for the completion of the tropcy_qc job in ecflow.  Typically this dependency is implicitly satisfied when the system is running smoothly due to timed triggers, but if jobs fail/get behind, this additional dependency is needed.

Resolves https://github.com/NOAA-EMC/global-workflow/issues/5098


# Type of change
- [x] Bug fix (fixes something broken)

# Change characteristics
<!-- Choose YES or NO from each of the following and delete the other -->
- Is this change expected to change outputs (e.g. value changes to existing outputs, new files stored in COM, files removed from COM, filename changes, additions/subtractions to archives)? NO 
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO 

# How has this been tested?
Was run alongside tests for #5240 in ecflow.  The tropcy_qc job was deliberately not run and ecflow appropriately did not trigger the atm analysis jobs.

gw CI -G tests were run on WCOSS2 and GaeaC6 and all passed.


# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] This change is covered by an existing CI test or a new one has been added
- [x] Any new scripts have been added to the .github/CODEOWNERS file with owners
- [x] I have made corresponding changes to the system documentation if necessary
