### PR TITLE
(dev/gfs.v17) Remove reliance on NDATE, setpdy.sh, and modules from ecflow cleanup

### DIFF
--- a/dev/ush/gfsv17_ecflow_rt_cleanup.sh
+++ b/dev/ush/gfsv17_ecflow_rt_cleanup.sh
@@ -18,19 +18,13 @@ else
     exit 1
 fi
 
-module reset
-module load prod_envir prod_util
-
-module list
-
 set -x
 
-DATA=/lfs/h2/emc/ptmp/${USER}/gfs_v17_cleanup.$$
 COMROOT=/lfs/h2/emc/gfstemp/emc.global/ecflow/comroot/ops/para/com/gfs/v17.0
 DATAROOT=/lfs/h2/emc/gfstemp/emc.global/ecflow/rundirs
 
-mkdir -p "${DATA}" "${DATAROOT}"
-PDY=$("${NDATE}" | cut -c1-8)
+mkdir -p "${DATAROOT}"
+PDY=$(date +%Y%m%d)
 export PDY
 export cycle=t00z
 
@@ -40,10 +34,10 @@ found=0
 attempts=0
 while [[ ${found} -eq 0 && ${attempts} -lt ${max_tries} ]]; do
     attempts=$((attempts + 1))
+    hours=$((attempts * 24))
     if [[ ! -d "${COMROOT}/enkfgdas.${PDY}/06" ]]; then
         echo "WARNING: The ${COMROOT}/enkfgdas.${PDY}/06 was not found; subtracting 1 from PDY and trying again"
-        PDY=$("${NDATE}" -24 | cut -c1-8)
-        export PDY
+        PDY=$(date +%Y%m%d --date="${hours} hours ago")
     else
         found=1
     fi
@@ -54,10 +48,8 @@ if [[ ${found} -ne 1 ]]; then
     exit 9
 fi
 
-cd "${DATA}"
-setpdy.sh
-source PDY
-# PDYm1 PDY PDYp1
+PDY=$(date +%Y%m%d)
+PDYm1=$(date +%Y%m%d --date="24 hours ago")
 
 echo "Start cleanup at $(date)"
 


### PR DESCRIPTION
# Description
This uses `date` instead of `ndate` to determine how to clean up ecflow COM and DATAROOT directories. This will help with the emc.global crontab.

# Type of change
- [ ] Bug fix (fixes something broken)
- [ ] New feature (adds functionality)
- [x] Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this change expected to change outputs NO
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
I ran the cleanup script with `--dry-run` before and after making this change. I then compared outputs and verified the same files would be cleaned up in both cases.

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code, including function, input, and output descriptions
- [ ] My changes generate no new warnings
- [ ] N/A New and existing tests pass with my changes
- [ ] NO This change is covered by an existing CI test or a new one has been added